### PR TITLE
fix(analytics): keep measures total consistent with the sum of its facet buckets

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/StatsQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/StatsQueryCommand.java
@@ -57,12 +57,18 @@ public class StatsQueryCommand extends AbstractElasticsearchQueryCommand<StatsRe
         final StatsResponse statsResponse = new StatsResponse();
         if (response.getAggregations() != null && !response.getAggregations().isEmpty()) {
             final Aggregation aggregation = response.getAggregations().entrySet().iterator().next().getValue();
-            statsResponse.setAvg(aggregation.getAvg());
-            statsResponse.setCount(aggregation.getCount());
-            statsResponse.setMax(aggregation.getMax());
-            statsResponse.setMin(aggregation.getMin());
-            statsResponse.setSum(aggregation.getSum());
+            statsResponse.setAvg(toFloat(aggregation.getAvg()));
+            statsResponse.setCount(toFloat(aggregation.getCount()));
+            statsResponse.setMax(toFloat(aggregation.getMax()));
+            statsResponse.setMin(toFloat(aggregation.getMin()));
+            statsResponse.setSum(toFloat(aggregation.getSum()));
         }
         return statsResponse;
+    }
+
+    // StatsResponse is part of the repository API and still exposes floats; narrowing here keeps
+    // this legacy command unchanged rather than rippling a type change through its consumers.
+    private static Float toFloat(final Double value) {
+        return value == null ? null : value.floatValue();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/StatsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/StatsQueryAdapter.java
@@ -114,10 +114,12 @@ public class StatsQueryAdapter {
 
         float count = agg.getCount().longValue();
 
-        float sum = agg.getSum();
-        float avg = agg.getAvg();
-        float min = agg.getMin();
-        float max = agg.getMax();
+        // StatsAggregate is part of the repository API and still exposes floats; narrowing here
+        // keeps this adapter unchanged rather than rippling a type change through its consumers.
+        float sum = agg.getSum().floatValue();
+        float avg = agg.getAvg().floatValue();
+        float min = agg.getMin().floatValue();
+        float max = agg.getMax().floatValue();
 
         float rps = count / this.seconds;
         float rpm = rps * 60L;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
@@ -345,19 +345,19 @@ public class AggregationAdapter {
     private static Aggregation toAggregation(JsonNode aggNode) {
         var aggregation = new Aggregation();
         if (aggNode.hasNonNull(ES_VALUE_PROP) && aggNode.get(ES_VALUE_PROP).isNumber()) {
-            aggregation.setValue(aggNode.get(ES_VALUE_PROP).floatValue());
+            aggregation.setValue(aggNode.get(ES_VALUE_PROP).doubleValue());
         }
         if (aggNode.hasNonNull(ES_COUNT_PROP) && aggNode.get(ES_COUNT_PROP).isNumber()) {
-            aggregation.setCount(aggNode.get(ES_COUNT_PROP).floatValue());
+            aggregation.setCount(aggNode.get(ES_COUNT_PROP).doubleValue());
         }
         if (aggNode.hasNonNull(ES_VALUES_PROP) && aggNode.get(ES_VALUES_PROP).isObject()) {
-            var values = new HashMap<String, Float>();
+            var values = new HashMap<String, Double>();
             var jsonValues = aggNode.get(ES_VALUES_PROP);
             jsonValues
                 .fields()
                 .forEachRemaining(entry -> {
                     if (entry.getValue().isNumber()) {
-                        values.put(entry.getKey(), entry.getValue().floatValue());
+                        values.put(entry.getKey(), entry.getValue().doubleValue());
                     }
                 });
             aggregation.setValues(values);
@@ -414,7 +414,7 @@ public class AggregationAdapter {
         return ofNullable(agg.getValues())
             .flatMap(keyValues -> ofNullable(keyValues.values()))
             .flatMap(values -> values.stream().filter(Objects::nonNull).findFirst())
-            .map(Float::floatValue);
+            .map(Double::doubleValue);
     }
 
     private static Metric getMetricFromName(String aggregationName) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
@@ -375,7 +375,7 @@ class ElasticsearchTracingRepositoryTest {
         assertThat(page.getTotalElements()).isEqualTo(200L);
     }
 
-    private static Aggregation cardinalityAggregation(float value) {
+    private static Aggregation cardinalityAggregation(double value) {
         Aggregation agg = new Aggregation();
         agg.setValue(value);
         return agg;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapterTest.java
@@ -211,11 +211,11 @@ class SearchRequestResponseTimeAdapterTest {
         @Test
         void should_return_request_response_time_aggregate() {
             final Aggregation minResponseTimeAggregation = new Aggregation();
-            minResponseTimeAggregation.setValue(20.0f);
+            minResponseTimeAggregation.setValue(20.0d);
             final Aggregation maxResponseTimeAggregation = new Aggregation();
-            maxResponseTimeAggregation.setValue(1200.0f);
+            maxResponseTimeAggregation.setValue(1200.0d);
             final Aggregation avgResponseTimeAggregation = new Aggregation();
-            avgResponseTimeAggregation.setValue(335.23f);
+            avgResponseTimeAggregation.setValue(335.23d);
 
             searchResponse.setAggregations(
                 Map.of(
@@ -239,7 +239,7 @@ class SearchRequestResponseTimeAdapterTest {
                 soft.assertThat(result.getRequestsTotal()).isEqualTo(4);
                 soft.assertThat(result.getResponseMinTime()).isEqualTo(20.0);
                 soft.assertThat(result.getResponseMaxTime()).isEqualTo(1200.0);
-                soft.assertThat(result.getResponseAvgTime()).isEqualTo(335.2300109863281);
+                soft.assertThat(result.getResponseAvgTime()).isEqualTo(335.23);
             });
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/StatsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/StatsQueryAdapterTest.java
@@ -131,11 +131,11 @@ class StatsQueryAdapterTest {
             );
 
             Aggregation agg = new Aggregation();
-            agg.setCount(3600f);
-            agg.setSum(100f);
-            agg.setAvg(10f);
-            agg.setMin(1f);
-            agg.setMax(20f);
+            agg.setCount(3600d);
+            agg.setSum(100d);
+            agg.setAvg(10d);
+            agg.setMin(1d);
+            agg.setMax(20d);
 
             HashMap<String, Aggregation> aggs = new HashMap<>();
             aggs.put("by_response-time", agg);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.elasticsearch.model.Aggregation;
@@ -25,6 +26,7 @@ import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.Facet;
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
+import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.TimeRange;
 import java.time.Instant;
@@ -134,6 +136,54 @@ class AggregationAdapterTest {
         var buckets = result.get(0).buckets();
         assertThat(buckets).hasSize(1);
         assertThat(buckets.get(0).measures().get(Measure.COUNT).doubleValue()).isEqualTo(42.0);
+    }
+
+    @Test
+    void should_report_the_same_total_for_measures_and_for_the_sum_of_its_facet_buckets() throws Exception {
+        // Counts on a busy API run well past 2^24, where a float can no longer hold every integer.
+        var applicationCounts = Map.of("application-a", 120_800_000L, "application-b", 12_767L);
+        var total = applicationCounts.values().stream().mapToLong(Long::longValue).sum();
+
+        var measuresQuery = new MeasuresQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)))
+        );
+        // Deserialized the way the Elasticsearch client does, so a regression in the aggregation
+        // model is caught here too.
+        var totalAgg = JSON.readValue("{\"value\":" + total + "}", Aggregation.class);
+
+        var measures = AggregationAdapter.toMetricsAndMeasures(Map.of("HTTP_REQUESTS#COUNT", totalAgg), measuresQuery);
+
+        var facetsQuery = new FacetsQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT))),
+            List.of(Facet.APPLICATION)
+        );
+        var applicationAgg = new Aggregation();
+        applicationAgg.setBuckets(
+            applicationCounts
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    var bucket = JSON.createObjectNode().put("key", entry.getKey()).put("doc_count", entry.getValue());
+                    bucket.putObject("HTTP_REQUESTS#COUNT").put("value", entry.getValue());
+                    return (JsonNode) bucket;
+                })
+                .toList()
+        );
+
+        var facets = AggregationAdapter.toMetricsAndBuckets(Map.of("HTTP_REQUESTS#APPLICATION", applicationAgg), facetsQuery);
+
+        var facetsSum = facets
+            .get(0)
+            .buckets()
+            .stream()
+            .mapToLong(bucket -> bucket.measures().get(Measure.COUNT).longValue())
+            .sum();
+
+        assertThat(measures.get(Metric.HTTP_REQUESTS).get(Measure.COUNT).longValue()).isEqualTo(total).isEqualTo(facetsSum);
     }
 
     private static ObjectNode buildBucketWithFilterAgg(String key, int docCount, String metricName, String measureName, double value) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapterTest.java
@@ -142,7 +142,7 @@ class FilterValuesResponseAdapterTest {
 
         if (totalCount > 0) {
             var totalCountAgg = new Aggregation();
-            totalCountAgg.setValue((float) totalCount);
+            totalCountAgg.setValue((double) totalCount);
             aggregations.put("total_count", totalCountAgg);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <gravitee-cloud-initializer.version>2.3.1</gravitee-cloud-initializer.version>
     <logback-ecs-encoder.version>1.7.0</logback-ecs-encoder.version>
     <gravitee-common.version>5.1.0</gravitee-common.version>
-    <gravitee-common-elasticsearch.version>7.0.0</gravitee-common-elasticsearch.version>
+    <gravitee-common-elasticsearch.version>7.0.1</gravitee-common-elasticsearch.version>
     <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
     <gravitee-connector-api.version>2.0.0</gravitee-connector-api.version>
     <gravitee-exchange.version>3.0.0</gravitee-exchange.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14851

## Description

Implements
https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/248

For the same filters, time range and metric, summing the APPLICATION facet COUNTs disagreed with the flat `analytics/measures` COUNT by ±1 to ±3 on tens of millions of requests — deterministically, and in either direction.

Root cause is float precision, not a race or a query mismatch. `HTTP_REQUESTS`/`COUNT` is a `value_count`, and the aggregation model held it as a `Float`: exact only below 2^24 (16,777,216). At ~120M the spacing between representable values is 8, so the flat total got snapped to the nearest multiple of 8 while the small per-application buckets stayed exact. Reproducing the reported example: Elasticsearch returns 120,812,767, the measures value deserializes to 120,812,768, the facets sum stays 120,812,767 — gap +1.

The lossy conversion happened during response deserialization inside `gravitee-common-elasticsearch`, so the primary fix lives there (`Float` → `Double`, linked below). This PR:

- bumps `gravitee-common-elasticsearch` to 7.0.1
- fixes the same truncation re-applied to facet bucket values in `AggregationAdapter`, which used `.floatValue()` when rebuilding aggregations from bucket JSON
- narrows explicitly at the two legacy stats call sites, whose repository-API models (`StatsResponse`, `StatsAggregate`) are still typed `float`
- adds a regression test asserting `measures total == sum(facet buckets)` at ~120M, deserializing through the real aggregation model so a revert upstream is caught here too

## Additional context

the `gravitee-common-elasticsearch` [PR](https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/248) must merge and release 7.0.1 before this one can build.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

