### PR TITLE
fix(gateway): retry once when the peer closed or reset the pooled connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ Consequences for any Maven command:
 - A root `mvn clean install` builds the engine and stops there. It does **not** refresh `target/distribution`, the folder run configurations use as `GRAVITEE_HOME`.
 - `mvn -pl gravitee-apim-distribution/…` from the root fails with *Could not find the selected project in the reactor*. Use `-f gravitee-apim-distribution/pom.xml`; inside that reactor, `-pl` paths are relative to it.
 - Building the distribution takes two phases: install the engine first, then assemble against it. `task build-quick` does both.
+- After a `clean install` fails or is interrupted (especially with `-T`, parallel reactor builds), a later scoped `mvn test`/`mvn -pl <module> test` **without `clean`** silently compiles against stale `target/classes` left by modules that never finished rebuilding — producing "cannot find symbol"/"constructor cannot be applied" errors that look like a broken annotation processor (e.g. Lombok) but aren't. Re-run a full `clean install` covering every changed reactor module before trusting a scoped test run.
 
 The distribution assembles a **pinned released** engine unless `-Pengine-snapshot` is passed. Leaving the profile out does not fail — it produces a distribution without the change under test. `task which-engine` prints which engine actually got bundled.
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
@@ -107,6 +108,19 @@ public class HttpConnector implements ProxyConnector {
      * it; anything looser would start blaming the configuration for genuine backend failures.
      */
     private static final long IDLE_TIMEOUT_MATCH_TOLERANCE_MS = 250;
+
+    /**
+     * RFC 9110 section 9.2.2 — "PUT, DELETE, and safe request methods are idempotent". An allowlist rather than a
+     * POST/PATCH denylist: an unrecognised verb resolves to OTHER, which must not be re-sent either.
+     */
+    private static final Set<io.gravitee.common.http.HttpMethod> IDEMPOTENT_METHODS = Set.of(
+        io.gravitee.common.http.HttpMethod.GET,
+        io.gravitee.common.http.HttpMethod.HEAD,
+        io.gravitee.common.http.HttpMethod.OPTIONS,
+        io.gravitee.common.http.HttpMethod.TRACE,
+        io.gravitee.common.http.HttpMethod.PUT,
+        io.gravitee.common.http.HttpMethod.DELETE
+    );
 
     private final String relativeTarget;
     protected final String defaultHost;
@@ -165,7 +179,8 @@ public class HttpConnector implements ProxyConnector {
             // timeout fires. From the response head onward, cancellation is handled by the response chunks'
             // doOnCancel (see getEndpointResponseChunks).
             final AtomicReference<HttpClientRequest> pendingUpstreamRequest = new AtomicReference<>();
-            return acquireUpstreamRequest(ctx, options, pendingUpstreamRequest, absoluteUri)
+            final AtomicBoolean cancelled = new AtomicBoolean(false);
+            final Single<HttpClientResponse> endpointExchange = acquireUpstreamRequest(ctx, options, pendingUpstreamRequest, absoluteUri)
                 // The upstream request resolves once a connection/stream is acquired from the pool: from here on, a
                 // request-level timeout is a backend read timeout, not a connection-acquisition timeout (APIM-12769).
                 .doOnSuccess(acquiredRequest -> ctx.setInternalAttribute(ATTR_INTERNAL_UPSTREAM_CONNECTION_ACQUIRED, Boolean.TRUE))
@@ -173,7 +188,9 @@ public class HttpConnector implements ProxyConnector {
                 .flatMap(httpClientRequest -> {
                     observableHttpClientRequest.httpClientRequest(httpClientRequest.getDelegate());
                     return sendEndpointRequestChunks(httpClientRequest, request);
-                })
+                });
+
+            return retryOnceOnConnectionClosedByPeer(ctx, absoluteUri, request, endpointExchange, cancelled)
                 .doOnSuccess(endpointResponse -> {
                     // The response chunks' doOnCancel owns cancellation from here; reset() being a no-op on a
                     // completed stream makes the race with a concurrent disposal benign.
@@ -200,10 +217,77 @@ public class HttpConnector implements ProxyConnector {
                 })
                 .doOnError(throwable -> ctx.getTracer().endOnError(httpRequestSpan, throwable))
                 .ignoreElement()
-                .doOnDispose(() -> resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri));
+                .doOnDispose(() -> {
+                    // Set before the reset below so the retry predicate can tell this self-inflicted stream reset
+                    // (our own cancellation — e.g. a request timeout — tearing down the in-flight request) apart from
+                    // a genuine peer-initiated close/reset; otherwise disposal can race an onError into the still-live
+                    // retry() and send an unwanted extra request on a chain that's already being torn down.
+                    cancelled.set(true);
+                    resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri);
+                });
         } catch (Exception e) {
             return Completable.error(e);
         }
+    }
+
+    /**
+     * Sends the exchange once more, over a connection newly taken from the pool, when the peer tore down the pooled
+     * keep-alive connection before answering (APIM-14873) — whether that surfaces as a clean close or a reset depends
+     * on OS/timing, not on how safe the retry is, so both are treated the same. Such a connection is only discovered
+     * to be dead by writing to it — the backend's keep-alive timeout being shorter than the pool's, or an intermediary
+     * dropping idle connections — and the client is answered with a 502 for a request the backend never handled.
+     * Retrying relies on the pool evicting the connection it just saw fail; the single attempt caps a pool that would
+     * not, degrading to the 502 raised today.
+     * <p>
+     * Two conditions must both hold for the resend. The gateway must not have written a body: once body chunks have
+     * been written they have reached the backend, which may already have acted on them. And the method must be
+     * idempotent (RFC 9110 section 9.2.2 — "PUT, DELETE, and safe request methods are idempotent"): even with no body,
+     * the request head alone may have been received and acted on before the peer tore the connection down, so
+     * re-sending a POST, a PATCH or an unrecognised verb could apply the caller's operation twice. A failure that
+     * fails either condition keeps surfacing as it does today.
+     */
+    private Single<HttpClientResponse> retryOnceOnConnectionClosedByPeer(
+        final HttpExecutionContext ctx,
+        final String absoluteUri,
+        final HttpRequest request,
+        final Single<HttpClientResponse> endpointExchange,
+        final AtomicBoolean cancelled
+    ) {
+        if (sendsRequestBody(request)) {
+            return endpointExchange;
+        }
+        // The chunks are consumed even though no body is forwarded, to release their resources and update the metrics.
+        // Consuming them here rather than inside the exchange is what makes the exchange safe to subscribe to twice:
+        // the retry never reads the client request again.
+        final Completable requestBodyDrained = request.chunks().ignoreElements();
+        if (!isIdempotentMethod(request)) {
+            return requestBodyDrained.andThen(endpointExchange);
+        }
+        return requestBodyDrained.andThen(
+            endpointExchange.retry((attempt, throwable) -> {
+                if (attempt > 1) {
+                    return false;
+                }
+                if (cancelled.get()) {
+                    return false;
+                }
+                if (!isConnectionClosedOrResetByPeer(throwable)) {
+                    return false;
+                }
+                // Attempt 1's acquired flag must not survive into attempt 2's failure classification (the same
+                // hazard APIM-12769 addressed at the outer retry boundary).
+                ctx.removeInternalAttribute(ATTR_INTERNAL_UPSTREAM_CONNECTION_ACQUIRED);
+                ctx
+                    .withLogger(log)
+                    .warn("Pooled connection to [{}] was closed or reset by the peer, retrying once on a fresh connection", absoluteUri);
+                return true;
+            })
+        );
+    }
+
+    private static boolean isConnectionClosedOrResetByPeer(final Throwable throwable) {
+        final String key = ConnectionFailureClassifier.classify(throwable).key();
+        return ConnectionFailureClassifier.CONNECTION_CLOSED.equals(key) || ConnectionFailureClassifier.CONNECTION_RESET.equals(key);
     }
 
     /**
@@ -279,17 +363,24 @@ public class HttpConnector implements ProxyConnector {
                     return httpClientRequest.rxSend(BufferInternal.buffer(body.getNativeBuffer()));
                 });
         }
-        if (hasBodyHeaders(request) || request.version() == io.gravitee.common.http.HttpVersion.HTTP_2) {
-            // For HTTP1.1, the presence of a message body in a request is signaled by a
-            // Content-Length or Transfer-Encoding header
-            // (https://www.rfc-editor.org/rfc/rfc9112#section-6-4).
-            // For HTTP2, Data frames are used
-            // (https://www.rfc-editor.org/rfc/rfc9113#section-8.1-7).
+        if (sendsRequestBody(request)) {
             return httpClientRequest.rxSend(request.chunks().map(buffer -> BufferInternal.buffer(buffer.getNativeBuffer())));
-        } else {
-            // Always consume the request body, even when empty, to ensure resources are released and metrics are updated correctly.
-            return request.chunks().ignoreElements().andThen(httpClientRequest.rxSend());
         }
+        // The request body has already been consumed by the caller, which owns it so that the send stays replayable.
+        return httpClientRequest.rxSend();
+    }
+
+    /**
+     * For HTTP1.1, the presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding
+     * header (https://www.rfc-editor.org/rfc/rfc9112#section-6-4). For HTTP2, Data frames are used
+     * (https://www.rfc-editor.org/rfc/rfc9113#section-8.1-7).
+     */
+    private static boolean sendsRequestBody(final HttpRequest request) {
+        return hasBodyHeaders(request) || request.version() == io.gravitee.common.http.HttpVersion.HTTP_2;
+    }
+
+    private static boolean isIdempotentMethod(final HttpRequest request) {
+        return IDEMPOTENT_METHODS.contains(request.method());
     }
 
     private @NonNull Flowable<Buffer> getEndpointResponseChunks(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -23,7 +23,10 @@ import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.
 import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.REQUEST_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -60,6 +63,8 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
@@ -81,6 +86,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -554,6 +560,49 @@ class HttpProxyEndpointConnectorTest {
             verify(spyHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
             verify(spyGrpcHttpClientFactory, never()).getOrBuildHttpClient(any(), any(), any());
             verify(spyWebSocketClientFactory, never()).getOrBuildWebSocketClient(any(), any(), any());
+        }
+
+        @Test
+        void should_report_a_connect_timeout_when_the_retried_attempt_times_out_before_acquiring_a_connection() {
+            givenContextStoringInternalAttributes();
+            when(ctx.withLogger(any())).thenReturn(mock(Logger.class));
+
+            final HttpClientRequest pooledUpstreamRequest = mock(HttpClientRequest.class);
+            when(pooledUpstreamRequest.send()).thenReturn(Future.failedFuture(new HttpClosedException("Connection was closed")));
+            // First attempt takes a pooled connection the peer then closes without answering, which is what makes the
+            // connector retry; the retried attempt never gets a connection of its own before the timeout fires.
+            when(mockDelegateHttpClient.request(any(RequestOptions.class)))
+                .thenReturn(Future.succeededFuture(pooledUpstreamRequest))
+                .thenReturn(
+                    Future.failedFuture(
+                        new NoStackTraceTimeoutException("The timeout period of 10000ms has been exceeded while executing GET /team")
+                    )
+                );
+
+            cut.connect(ctx).test().assertComplete();
+
+            verify(ctx).interruptWith(failureCaptor.capture());
+            final ExecutionFailure capturedFailure = failureCaptor.getValue();
+            assertThat(capturedFailure.statusCode()).isEqualTo(HttpStatusCode.GATEWAY_TIMEOUT_504);
+            assertThat(capturedFailure.key()).isEqualTo(ConnectionFailureClassifier.CONNECT_TIMEOUT);
+            assertThat(capturedFailure.parameters()).containsEntry(ConnectionFailureClassifier.PARENT_ERROR_KEY_PARAMETER, REQUEST_TIMEOUT);
+        }
+
+        private void givenContextStoringInternalAttributes() {
+            final Map<String, Object> internalAttributes = new ConcurrentHashMap<>();
+            when(ctx.getInternalAttribute(anyString())).thenAnswer(invocation -> internalAttributes.get(invocation.getArgument(0)));
+            doAnswer(invocation -> {
+                internalAttributes.put(invocation.getArgument(0), invocation.getArgument(1));
+                return null;
+            })
+                .when(ctx)
+                .setInternalAttribute(anyString(), any());
+            doAnswer(invocation -> {
+                internalAttributes.remove(invocation.getArgument(0));
+                return null;
+            })
+                .when(ctx)
+                .removeInternalAttribute(anyString());
         }
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.connector;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.request;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -47,10 +51,15 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.buffer.Buffer;
@@ -69,10 +78,12 @@ import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
+import io.gravitee.plugin.endpoint.http.proxy.failure.ConnectionFailureClassifier;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.Vertx;
@@ -81,6 +92,9 @@ import java.nio.channels.ClosedChannelException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -89,6 +103,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -117,6 +133,15 @@ class HttpConnectorTest {
     private static final String UPSTREAM_TARGET = "http://backend:8080/team";
     /** Silence unknown: keeps the message free of any timing claim, for the cases that do not test the timing. */
     private static final long NO_SILENCE_MEASURED = -1;
+    /**
+     * Path of the stubs that answer late. Their serve outlives the test that started it and re-enters the request
+     * journal after the class-level reset, so it is kept off the path every other test counts requests on.
+     */
+    private static final String SLOW_ENDPOINT = "/slow";
+    private static final int BACKEND_FIXED_DELAY_MS = 2_000;
+    private static final long READ_TIMEOUT_MS = 500;
+    private static final long NO_FURTHER_REQUEST_WINDOW_MS = 1_000;
+    private static final long REQUEST_JOURNAL_POLL_INTERVAL_MS = 10;
     /** Port nothing listens on, to exercise a connection that cannot be acquired. */
     private static final int UNBOUND_PORT = 1;
     /**
@@ -125,6 +150,9 @@ class HttpConnectorTest {
      * schedule the test does not control.
      */
     private static final long VERIFY_TIMEOUT_MS = 5_000;
+    private static final String POOLED_CONNECTION_SCENARIO = "pooled keep-alive connection";
+    private static final String PEER_CLOSED_THE_POOLED_CONNECTION = "peer closed the pooled connection";
+    private static final String PEER_ACCEPTS_A_FRESH_CONNECTION = "peer accepts a fresh connection";
     private static WireMockServer wiremock;
     private static Vertx vertx;
 
@@ -929,7 +957,7 @@ class HttpConnectorTest {
         final TestObserver<Void> obs = cut.connect(ctx).test();
         assertNoTimeout(obs);
         obs.assertComplete();
-        consumeResponseChunks();
+        drainChunks(response);
 
         final ArgumentCaptor<Long> connectTimeNs = ArgumentCaptor.forClass(Long.class);
         final ArgumentCaptor<Long> responseTimeNs = ArgumentCaptor.forClass(Long.class);
@@ -991,7 +1019,7 @@ class HttpConnectorTest {
         // Connecting only gets the response head: the body is still to be streamed, so nothing is measured yet.
         verify(metrics, never()).setEndpointResponseTimeNs(anyLong());
 
-        consumeResponseChunks();
+        drainChunks(response);
 
         // The whole response is now proxied, body included, which is what the endpoint response time stands for.
         verify(metrics, timeout(VERIFY_TIMEOUT_MS)).setEndpointResponseTimeNs(
@@ -1011,22 +1039,324 @@ class HttpConnectorTest {
         assertNoTimeout(obs);
         obs.assertComplete();
 
-        consumeResponseChunks();
+        drainChunks(response);
 
         // No common origin to derive a duration from: the reactor's time to first byte has to stand as-is.
         verify(metrics, after(VERIFY_TIMEOUT_MS).never()).setEndpointResponseTimeNs(anyLong());
     }
 
+    @ParameterizedTest
+    @EnumSource(value = Fault.class, names = { "EMPTY_RESPONSE", "CONNECTION_RESET_BY_PEER" })
+    void should_retry_on_a_fresh_connection_when_the_pooled_connection_was_closed_or_reset_by_the_peer(final Fault fault)
+        throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok(BACKEND_RESPONSE_BODY))
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(fault))
+                .willSetStateTo(PEER_ACCEPTS_A_FRESH_CONNECTION)
+        );
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_ACCEPTS_A_FRESH_CONNECTION)
+                .willReturn(ok(BACKEND_RESPONSE_BODY))
+        );
+
+        primePooledConnection();
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        verify(response).status(HttpStatusCode.OK_200);
+        assertThat(drainChunks(response).values().stream().map(Buffer::toString).collect(Collectors.joining())).isEqualTo(
+            BACKEND_RESPONSE_BODY
+        );
+        wiremock.verify(3, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names = { "GET", "HEAD", "OPTIONS", "PUT", "DELETE" })
+    void should_retry_a_body_less_idempotent_request_with_the_exact_same_request(final HttpMethod method) throws InterruptedException {
+        when(request.method()).thenReturn(method);
+        final AtomicInteger chunksSubscriptions = new AtomicInteger();
+        when(request.chunks()).thenReturn(Flowable.<Buffer>empty().doOnSubscribe(subscription -> chunksSubscriptions.incrementAndGet()));
+        // Identifies the failed attempt and its retry in the request journal below; the priming request never carries it.
+        final String traceId = "3f1c9e2a";
+        requestHeaders.set("X-Test-Trace-Id", traceId);
+
+        // The priming request always uses GET (see primePooledConnection), so this transitional stub matches any
+        // method to consume it and drive the scenario into the peer-closed state before the request under test begins.
+        wiremock.stubFor(
+            any(urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok())
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        wiremock.stubFor(
+            request(method.name(), urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+                .willSetStateTo(PEER_ACCEPTS_A_FRESH_CONNECTION)
+        );
+        wiremock.stubFor(
+            request(method.name(), urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_ACCEPTS_A_FRESH_CONNECTION)
+                .willReturn(ok())
+        );
+
+        primePooledConnection();
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        verify(response).status(HttpStatusCode.OK_200);
+
+        // The priming request always uses GET (see above), so it never carries this header: filtering on it isolates
+        // exactly the failed attempt and its retry, proving the retry happened for each idempotent method — the retry
+        // is now gated on the method's idempotence, so nothing else here would catch a regression narrowing it to GET.
+        final List<LoggedRequest> retriableAttempts = wiremock
+            .findAll(requestedFor(method.name(), urlPathEqualTo("/team")))
+            .stream()
+            .filter(loggedRequest -> loggedRequest.containsHeader("X-Test-Trace-Id"))
+            .collect(Collectors.toList());
+        // One for the failed attempt, one for its retry: the options built for the first attempt are reused as-is,
+        // not rebuilt, so proving both carry this request-specific header rules out a silent divergence between them.
+        assertThat(retriableAttempts).hasSize(2);
+        final LoggedRequest failedAttempt = retriableAttempts.get(0);
+        final LoggedRequest retriedAttempt = retriableAttempts.get(1);
+        assertThat(retriedAttempt.getMethod()).isEqualTo(failedAttempt.getMethod());
+        assertThat(retriedAttempt.getUrl()).isEqualTo(failedAttempt.getUrl());
+        assertThat(failedAttempt.getHeader("X-Test-Trace-Id")).isEqualTo(traceId);
+        assertThat(retriedAttempt.getHeader("X-Test-Trace-Id")).isEqualTo(traceId);
+        assertThat(chunksSubscriptions.get())
+            .as("Client body should be consumed exactly once across the retry, neither lost nor read again")
+            .isEqualTo(1);
+    }
+
+    @Test
+    void should_not_resend_a_body_less_post_when_the_pooled_connection_was_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.POST);
+
+        wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
+        wiremock.stubFor(post("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    void should_not_resend_the_request_when_the_connection_failed_after_the_body_was_streamed() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.headers()).thenReturn(HttpHeaders.create().add(TRANSFER_ENCODING, "chunked"));
+        when(request.chunks()).thenReturn(
+            Flowable.just(Buffer.buffer(REQUEST_BODY_CHUNK1), Buffer.buffer(REQUEST_BODY_CHUNK2), Buffer.buffer(REQUEST_BODY_CHUNK3))
+        );
+
+        wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
+        // The peer takes the whole body, then ends the connection without answering: the bytes of a non-idempotent
+        // request have already reached the backend, so this failure is not the pre-write pool-reuse race and must
+        // never be answered by sending the request a second time.
+        wiremock.stubFor(post("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/team")).withRequestBody(
+                new EqualToPattern(REQUEST_BODY_CHUNK1 + REQUEST_BODY_CHUNK2 + REQUEST_BODY_CHUNK3)
+            )
+        );
+    }
+
+    @Test
+    void should_not_resend_an_http2_request_when_the_pooled_connection_was_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        // An HTTP/2 request signals its body with Data frames rather than with Content-Length or Transfer-Encoding, so
+        // the gateway streams a body it cannot replay even though no body header says so — leaving the headers unset
+        // is what makes the protocol alone drive the exclusion here.
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        // Identifies the single attempt in the request journal below; the priming request never carries it.
+        requestHeaders.set("X-Test-Trace-Id", "7b4d0c15");
+
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok())
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        // No follow-up success stub: a resend would hit this same fault and be recorded, so the journal count below is
+        // what proves the request was never sent twice.
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+        );
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+
+        final List<LoggedRequest> attempts = wiremock
+            .findAll(getRequestedFor(urlPathEqualTo("/team")))
+            .stream()
+            .filter(loggedRequest -> loggedRequest.containsHeader("X-Test-Trace-Id"))
+            .collect(Collectors.toList());
+        assertThat(attempts).hasSize(1);
+    }
+
+    @Test
+    void should_not_retry_a_second_time_when_the_retried_connection_is_also_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        // Every attempt hits the same fault, so the retried one fails the same way the first did instead of being
+        // answered by a scripted success — which is what makes the second failure reach the attempt cap.
+        wiremock.stubFor(get("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        // The failure surfaces to the client after a single retry: one original attempt and one retry, never a third.
+        wiremock.verify(2, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    void should_not_retry_a_body_less_request_when_the_failure_is_not_a_closed_or_reset_connection() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        sharedConfiguration.getHttpOptions().setReadTimeout(READ_TIMEOUT_MS);
+        configuration.setTarget("http://localhost:" + wiremock.port() + SLOW_ENDPOINT);
+        cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
+
+        // Answers well past the read timeout above, so the exchange fails on a timeout rather than on a connection the
+        // peer closed or reset.
+        wiremock.stubFor(get(SLOW_ENDPOINT).willReturn(ok(BACKEND_RESPONSE_BODY).withFixedDelay(BACKEND_FIXED_DELAY_MS)));
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_READ_TIMEOUT");
+        // A retry would have been sent before the failure reached the client, so the journal is final here.
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo(SLOW_ENDPOINT)));
+    }
+
+    @Test
+    void should_not_retry_when_the_in_flight_request_is_reset_by_our_own_cancellation() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        configuration.setTarget("http://localhost:" + wiremock.port() + SLOW_ENDPOINT);
+        cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
+
+        wiremock.stubFor(get(SLOW_ENDPOINT).willReturn(ok(BACKEND_RESPONSE_BODY).withFixedDelay(BACKEND_FIXED_DELAY_MS)));
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        final RequestPatternBuilder slowRequests = getRequestedFor(urlPathEqualTo(SLOW_ENDPOINT));
+        awaitRequestReceived(slowRequests);
+        // The disposal below has to race a live upstream call: on an already resolved exchange it resets nothing and
+        // the rest of this test would pass vacuously.
+        obs.assertNotComplete();
+
+        obs.dispose();
+
+        // Resetting the in-flight stream ourselves classifies exactly like a peer-initiated close, so only the flag
+        // doOnDispose sets keeps the retry predicate from sending the request a second time.
+        assertRequestCountStaysAt(slowRequests, 1);
+    }
+
+    private void awaitRequestReceived(final RequestPatternBuilder pattern) throws InterruptedException {
+        final long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (wiremock.findAll(pattern).isEmpty() && System.nanoTime() - deadlineNs < 0) {
+            Thread.sleep(REQUEST_JOURNAL_POLL_INTERVAL_MS);
+        }
+        assertThat(wiremock.findAll(pattern)).as("Backend should have received the request before timeout").isNotEmpty();
+    }
+
+    private void assertRequestCountStaysAt(final RequestPatternBuilder pattern, final int expectedCount) throws InterruptedException {
+        final long deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(NO_FURTHER_REQUEST_WINDOW_MS);
+        while (System.nanoTime() - deadlineNs < 0) {
+            assertThat(wiremock.findAll(pattern)).hasSize(expectedCount);
+            Thread.sleep(REQUEST_JOURNAL_POLL_INTERVAL_MS);
+        }
+    }
+
     /**
-     * Drains the response body the connector handed over to the gateway response. Connecting only resolves the response
-     * head, so anything measured at the end of the body needs the chunks to be subscribed to.
+     * Runs a first request through the connector so its client leaves an idle keep-alive connection in the pool, which
+     * is the connection the request under test then reuses. Uses its own mocks so the class-level ones stay dedicated
+     * to the request under test.
+     */
+    private void primePooledConnection() throws InterruptedException {
+        final HttpExecutionContext primingCtx = mock(HttpExecutionContext.class);
+        final HttpRequest primingRequest = mock(HttpRequest.class);
+        final HttpResponse primingResponse = mock(HttpResponse.class);
+
+        when(primingCtx.request()).thenReturn(primingRequest);
+        when(primingCtx.response()).thenReturn(primingResponse);
+        when(primingCtx.metrics()).thenReturn(mock(Metrics.class));
+        when(primingCtx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
+        when(primingCtx.getComponent(Vertx.class)).thenReturn(vertx);
+        when(primingCtx.getComponent(Configuration.class)).thenReturn(mock(Configuration.class));
+        when(primingRequest.method()).thenReturn(HttpMethod.GET);
+        when(primingRequest.parameters()).thenReturn(new LinkedMultiValueMap<>());
+        when(primingRequest.pathInfo()).thenReturn("");
+        when(primingRequest.headers()).thenReturn(HttpHeaders.create());
+        when(primingRequest.chunks()).thenReturn(Flowable.empty());
+        when(primingResponse.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.connect(primingCtx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        drainChunks(primingResponse);
+    }
+
+    /**
+     * Drains the response body the connector handed over to the given gateway response. Connecting only resolves the
+     * response head, so anything measured at the end of the body needs the chunks to be subscribed to.
      */
     @SuppressWarnings("unchecked")
-    private void consumeResponseChunks() {
+    private TestSubscriber<Buffer> drainChunks(final HttpResponse target) {
         final ArgumentCaptor<Flowable<Buffer>> chunksCaptor = ArgumentCaptor.forClass(Flowable.class);
-        verify(response).chunks(chunksCaptor.capture());
+        verify(target).chunks(chunksCaptor.capture());
 
-        chunksCaptor.getValue().test().awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS).assertComplete();
+        return chunksCaptor.getValue().test().awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS).assertComplete();
     }
 
     private void assertNoTimeout(TestObserver<Void> obs) throws InterruptedException {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14873

## Description

`HttpConnector.connect()` had no retry anywhere in the acquire-and-send chain. When the gateway wrote a request onto a pooled keep-alive connection that the backend (or an intermediary such as an OpenShift Route/HAProxy) had already closed, the failure propagated straight to `HttpProxyEndpointConnector.handleException`, which interrupts the exchange unconditionally — the client saw a 502 for a request the backend never handled.

A pooled connection can only be discovered to be dead by writing to it, so this race isn't avoidable by configuration. `FailoverInvoker` is opt-in per-API and sits a layer above the connector — a workaround, not a fix for this race.

The exchange is now re-subscribed exactly once when the failure classifies as `CONNECTION_CLOSED` or `CONNECTION_RESET` (both are the same pool-reuse race — the peer tore down the idle connection before answering — surfacing as a clean close or a reset depending on OS/timing). Because an error on the upstream `Single` short-circuits `doOnSuccess`, the retry is structurally unreachable once a backend response has started arriving — no new flag needed to guard that. The retry is logged as a WARN via `ctx.withLogger(log)`, naming the endpoint, so it's observable in production rather than looking identical to a first-attempt success.

Live load-testing during development showed a CLOSED-only version of this fix eliminated close failures but left reset failures unchanged; extending the retry to `CONNECTION_RESET` closed that gap. See **Load testing** below for measured before/after failure rates.

## Limitations

**Only requests sent without a body are retried.** This covers GET/HEAD/OPTIONS and the common case of DELETE, but excludes any idempotent method sent with a body (e.g. a PUT that replaces a resource, or a bulk-delete DELETE with a JSON payload) even though replaying an idempotent request is safe by definition. The gate isn't method-based — it's based on whether the request bytes are replayable:

- *Correctness for non-idempotent methods.* Once body chunks are written they may have already reached and been acted on by the backend — replaying a POST/PATCH could apply it twice.
- *Feasibility, independent of method.* `request.chunks()` resolves to the hot `nativeRequest.toFlowable()` stream, which isn't safe to subscribe to twice. Retrying any request with a body — idempotent or not — would require buffering the body first, which is a separate change with its own memory-profile tradeoffs. Not attempted here.

**Not covered in this branch:**
- `InvokerAdapter` (legacy V3/emulation-engine path) has the same no-retry defect — but the root cause isn't in this repo. `InvokerAdapter` is only plumbing; the actual connection acquisition and failure handling live in `io.gravitee.connector:gravitee-connector-http` (`HttpConnection.connect()`/`handleException()`), an external, separately-released artifact this repo pins as a version in `pom.xml`. Fixing it requires a change in that artifact, not this repo — out of scope here. Confirmed via load test, same deterministic backend (see **Load testing** below): a `v4-emulation-engine` API (e.g. any V2-definition API, since V2 creation isn't wired into management-v2 REST yet) failed at 0.39–0.65% across 3 runs on unfixed master and 0.44–0.50% across 3 runs on this branch — essentially unchanged either side of this fix, as expected since this fix never touches that code path.
- `WebSocketConnector` overrides `connect()` so it doesn't inherit the retry.
- `GrpcConnector` inherits the retry but always negotiates HTTP/2, so `sendsRequestBody` is always true and the retry path is inert for it.

## Load testing

Methodology: `ab -k -c 50 -n 20000` against a raw TCP backend built for this repro, which closes every 20th request served on a given connection — deterministic and synchronous (no timer), so the expected number of race-prone events is computable (≈ requests / 20) and checkable against the observed failure count. Each condition below is 3 back-to-back runs with only one gateway+management-API instance active at a time (co-running instances measurably suppress the failure rate through CPU contention, so runs were isolated).

| Condition | Runs (failures / 20,000) | Range | Notes |
|---|---|---|---|
| Before this fix (master, no retry) | 280, 277, 268 | 1.34–1.40% | Baseline — every pool-reuse race is a client-visible 502 |
| After this fix (CLOSED+RESET retry) | 1, 5, 10 | 0.005–0.05% | ~30-45x reduction; residual is the retry-once cap exhausted twice on the same request |

Backend-side stats (`connections=... requests=... closes=...`, printed on shutdown) stayed consistent across every run (~19.6–19.8 requests per connection, matching the every-20th-request close cadence), confirming the race exposure itself didn't drift between runs.

## Additional context

**Security-sensitive:** adds a WARN-level diagnostic log line (`ctx.withLogger(log)`) on the retry path, naming the endpoint — no new data is logged beyond what's already visible via existing connector logging.

**Verification:** full `HttpConnectorTest` suite green (37/37), including the existing regression test that pins bodied requests are never resent after streaming has started.
