### PR TITLE
fix(gateway): retry once on closed/reset pooled connection

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
 
@@ -99,6 +100,20 @@ public class HttpConnector implements ProxyConnector {
         TRAILER,
         UPGRADE
     );
+
+    /**
+     * RFC 9110 section 9.2.2 — "PUT, DELETE, and safe request methods are idempotent". An allowlist rather than a
+     * POST/PATCH denylist: an unrecognised verb resolves to OTHER, which must not be re-sent either.
+     */
+    private static final Set<io.gravitee.common.http.HttpMethod> IDEMPOTENT_METHODS = Set.of(
+        io.gravitee.common.http.HttpMethod.GET,
+        io.gravitee.common.http.HttpMethod.HEAD,
+        io.gravitee.common.http.HttpMethod.OPTIONS,
+        io.gravitee.common.http.HttpMethod.TRACE,
+        io.gravitee.common.http.HttpMethod.PUT,
+        io.gravitee.common.http.HttpMethod.DELETE
+    );
+
     private final String relativeTarget;
     protected final String defaultHost;
     protected final int defaultPort;
@@ -156,7 +171,8 @@ public class HttpConnector implements ProxyConnector {
             // timeout fires. From the response head onward, cancellation is handled by the response chunks'
             // doOnCancel (see getEndpointResponseChunks).
             final AtomicReference<HttpClientRequest> pendingUpstreamRequest = new AtomicReference<>();
-            return acquireUpstreamRequest(ctx, options, pendingUpstreamRequest, absoluteUri)
+            final AtomicBoolean cancelled = new AtomicBoolean(false);
+            final Single<HttpClientResponse> endpointExchange = acquireUpstreamRequest(ctx, options, pendingUpstreamRequest, absoluteUri)
                 // The upstream request resolves once a connection/stream is acquired from the pool: from here on, a
                 // request-level timeout is a backend read timeout, not a connection-acquisition timeout (APIM-12769).
                 .doOnSuccess(acquiredRequest -> ctx.setInternalAttribute(ATTR_INTERNAL_UPSTREAM_CONNECTION_ACQUIRED, Boolean.TRUE))
@@ -164,7 +180,9 @@ public class HttpConnector implements ProxyConnector {
                 .flatMap(httpClientRequest -> {
                     observableHttpClientRequest.httpClientRequest(httpClientRequest.getDelegate());
                     return sendEndpointRequestChunks(httpClientRequest, request);
-                })
+                });
+
+            return retryOnceOnConnectionClosedByPeer(ctx, absoluteUri, request, endpointExchange, cancelled)
                 .doOnSuccess(endpointResponse -> {
                     // The response chunks' doOnCancel owns cancellation from here; reset() being a no-op on a
                     // completed stream makes the race with a concurrent disposal benign.
@@ -190,10 +208,77 @@ public class HttpConnector implements ProxyConnector {
                 })
                 .doOnError(throwable -> ctx.getTracer().endOnError(httpRequestSpan, throwable))
                 .ignoreElement()
-                .doOnDispose(() -> resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri));
+                .doOnDispose(() -> {
+                    // Set before the reset below so the retry predicate can tell this self-inflicted stream reset
+                    // (our own cancellation — e.g. a request timeout — tearing down the in-flight request) apart from
+                    // a genuine peer-initiated close/reset; otherwise disposal can race an onError into the still-live
+                    // retry() and send an unwanted extra request on a chain that's already being torn down.
+                    cancelled.set(true);
+                    resetPendingUpstreamRequest(ctx, pendingUpstreamRequest, absoluteUri);
+                });
         } catch (Exception e) {
             return Completable.error(e);
         }
+    }
+
+    /**
+     * Sends the exchange once more, over a connection newly taken from the pool, when the peer tore down the pooled
+     * keep-alive connection before answering (APIM-14873) — whether that surfaces as a clean close or a reset depends
+     * on OS/timing, not on how safe the retry is, so both are treated the same. Such a connection is only discovered
+     * to be dead by writing to it — the backend's keep-alive timeout being shorter than the pool's, or an intermediary
+     * dropping idle connections — and the client is answered with a 502 for a request the backend never handled.
+     * Retrying relies on the pool evicting the connection it just saw fail; the single attempt caps a pool that would
+     * not, degrading to the 502 raised today.
+     * <p>
+     * Two conditions must both hold for the resend. The gateway must not have written a body: once body chunks have
+     * been written they have reached the backend, which may already have acted on them. And the method must be
+     * idempotent (RFC 9110 section 9.2.2 — "PUT, DELETE, and safe request methods are idempotent"): even with no body,
+     * the request head alone may have been received and acted on before the peer tore the connection down, so
+     * re-sending a POST, a PATCH or an unrecognised verb could apply the caller's operation twice. A failure that
+     * fails either condition keeps surfacing as it does today.
+     */
+    private Single<HttpClientResponse> retryOnceOnConnectionClosedByPeer(
+        final HttpExecutionContext ctx,
+        final String absoluteUri,
+        final HttpRequest request,
+        final Single<HttpClientResponse> endpointExchange,
+        final AtomicBoolean cancelled
+    ) {
+        if (sendsRequestBody(request)) {
+            return endpointExchange;
+        }
+        // The chunks are consumed even though no body is forwarded, to release their resources and update the metrics.
+        // Consuming them here rather than inside the exchange is what makes the exchange safe to subscribe to twice:
+        // the retry never reads the client request again.
+        final Completable requestBodyDrained = request.chunks().ignoreElements();
+        if (!isIdempotentMethod(request)) {
+            return requestBodyDrained.andThen(endpointExchange);
+        }
+        return requestBodyDrained.andThen(
+            endpointExchange.retry((attempt, throwable) -> {
+                if (attempt > 1) {
+                    return false;
+                }
+                if (cancelled.get()) {
+                    return false;
+                }
+                if (!isConnectionClosedOrResetByPeer(throwable)) {
+                    return false;
+                }
+                // Attempt 1's acquired flag must not survive into attempt 2's failure classification (the same
+                // hazard APIM-12769 addressed at the outer retry boundary).
+                ctx.removeInternalAttribute(ATTR_INTERNAL_UPSTREAM_CONNECTION_ACQUIRED);
+                ctx
+                    .withLogger(log)
+                    .warn("Pooled connection to [{}] was closed or reset by the peer, retrying once on a fresh connection", absoluteUri);
+                return true;
+            })
+        );
+    }
+
+    private static boolean isConnectionClosedOrResetByPeer(final Throwable throwable) {
+        final String key = ConnectionFailureClassifier.classify(throwable).key();
+        return ConnectionFailureClassifier.CONNECTION_CLOSED.equals(key) || ConnectionFailureClassifier.CONNECTION_RESET.equals(key);
     }
 
     /**
@@ -266,16 +351,26 @@ public class HttpConnector implements ProxyConnector {
                     return httpClientRequest.rxSend(new io.vertx.rxjava3.core.buffer.Buffer(BufferImpl.buffer(body.getNativeBuffer())));
                 });
         }
-        if (hasBodyHeaders(request) || request.version() == io.gravitee.common.http.HttpVersion.HTTP_2) {
-            // For HTTP1.1, the presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding header (https://www.rfc-editor.org/rfc/rfc9112#section-6-4).
-            // For HTTP2, Data frames are used (https://www.rfc-editor.org/rfc/rfc9113#section-8.1-7).
+        if (sendsRequestBody(request)) {
             return httpClientRequest.rxSend(
                 request.chunks().map(buffer -> new io.vertx.rxjava3.core.buffer.Buffer(BufferImpl.buffer(buffer.getNativeBuffer())))
             );
-        } else {
-            // Always consume the request body, even when empty, to ensure resources are released and metrics are updated correctly.
-            return request.chunks().ignoreElements().andThen(httpClientRequest.rxSend());
         }
+        // The request body has already been consumed by the caller, which owns it so that the send stays replayable.
+        return httpClientRequest.rxSend();
+    }
+
+    /**
+     * For HTTP1.1, the presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding
+     * header (https://www.rfc-editor.org/rfc/rfc9112#section-6-4). For HTTP2, Data frames are used
+     * (https://www.rfc-editor.org/rfc/rfc9113#section-8.1-7).
+     */
+    private static boolean sendsRequestBody(final HttpRequest request) {
+        return hasBodyHeaders(request) || request.version() == io.gravitee.common.http.HttpVersion.HTTP_2;
+    }
+
+    private static boolean isIdempotentMethod(final HttpRequest request) {
+        return IDEMPOTENT_METHODS.contains(request.method());
     }
 
     private @NonNull Flowable<Buffer> getEndpointResponseChunks(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -23,7 +23,10 @@ import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.
 import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.REQUEST_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -60,6 +63,8 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
@@ -81,6 +86,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -545,6 +551,49 @@ class HttpProxyEndpointConnectorTest {
                 .assertComplete();
             verify(spyHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
             verify(spyGrpcHttpClientFactory, never()).getOrBuildHttpClient(any(), any(), any());
+        }
+
+        @Test
+        void should_report_a_connect_timeout_when_the_retried_attempt_times_out_before_acquiring_a_connection() {
+            givenContextStoringInternalAttributes();
+            when(ctx.withLogger(any())).thenReturn(mock(Logger.class));
+
+            final HttpClientRequest pooledUpstreamRequest = mock(HttpClientRequest.class);
+            when(pooledUpstreamRequest.send()).thenReturn(Future.failedFuture(new HttpClosedException("Connection was closed")));
+            // First attempt takes a pooled connection the peer then closes without answering, which is what makes the
+            // connector retry; the retried attempt never gets a connection of its own before the timeout fires.
+            when(mockDelegateHttpClient.request(any(RequestOptions.class)))
+                .thenReturn(Future.succeededFuture(pooledUpstreamRequest))
+                .thenReturn(
+                    Future.failedFuture(
+                        new NoStackTraceTimeoutException("The timeout period of 10000ms has been exceeded while executing GET /team")
+                    )
+                );
+
+            cut.connect(ctx).test().assertComplete();
+
+            verify(ctx).interruptWith(failureCaptor.capture());
+            final ExecutionFailure capturedFailure = failureCaptor.getValue();
+            assertThat(capturedFailure.statusCode()).isEqualTo(HttpStatusCode.GATEWAY_TIMEOUT_504);
+            assertThat(capturedFailure.key()).isEqualTo(ConnectionFailureClassifier.CONNECT_TIMEOUT);
+            assertThat(capturedFailure.parameters()).containsEntry(ConnectionFailureClassifier.PARENT_ERROR_KEY_PARAMETER, REQUEST_TIMEOUT);
+        }
+
+        private void givenContextStoringInternalAttributes() {
+            final Map<String, Object> internalAttributes = new ConcurrentHashMap<>();
+            when(ctx.getInternalAttribute(anyString())).thenAnswer(invocation -> internalAttributes.get(invocation.getArgument(0)));
+            doAnswer(invocation -> {
+                internalAttributes.put(invocation.getArgument(0), invocation.getArgument(1));
+                return null;
+            })
+                .when(ctx)
+                .setInternalAttribute(anyString(), any());
+            doAnswer(invocation -> {
+                internalAttributes.remove(invocation.getArgument(0));
+                return null;
+            })
+                .when(ctx)
+                .removeInternalAttribute(anyString());
         }
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.connector;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.request;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -43,10 +47,15 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.buffer.Buffer;
@@ -65,15 +74,20 @@ import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
+import io.gravitee.plugin.endpoint.http.proxy.failure.ConnectionFailureClassifier;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.Vertx;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,8 +96,12 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -102,6 +120,26 @@ class HttpConnectorTest {
     protected static final String BACKEND_RESPONSE_BODY = "response from backend";
     public static final int TIMEOUT_SECONDS = 60;
     private static final String ERROR_ENDPOINT = "/error";
+    /**
+     * Path of the stubs that answer late. Their serve outlives the test that started it and re-enters the request
+     * journal after the class-level reset, so it is kept off the path every other test counts requests on.
+     */
+    private static final String SLOW_ENDPOINT = "/slow";
+    private static final int BACKEND_FIXED_DELAY_MS = 2_000;
+    private static final long READ_TIMEOUT_MS = 500;
+    private static final long NO_FURTHER_REQUEST_WINDOW_MS = 1_000;
+    private static final long REQUEST_JOURNAL_POLL_INTERVAL_MS = 10;
+    /** Port nothing listens on, to exercise a connection that cannot be acquired. */
+    private static final int UNBOUND_PORT = 1;
+    /**
+     * How long to let doFinally's action land. Draining the chunks returns as soon as the subscriber sees the terminal
+     * signal, which doFinally propagates before running its own action — so the measure is set just after, on a
+     * schedule the test does not control.
+     */
+    private static final long VERIFY_TIMEOUT_MS = 5_000;
+    private static final String POOLED_CONNECTION_SCENARIO = "pooled keep-alive connection";
+    private static final String PEER_CLOSED_THE_POOLED_CONNECTION = "peer closed the pooled connection";
+    private static final String PEER_ACCEPTS_A_FRESH_CONNECTION = "peer accepts a fresh connection";
     private static WireMockServer wiremock;
     private static Vertx vertx;
 
@@ -159,6 +197,8 @@ class HttpConnectorTest {
         lenient().when(ctx.response()).thenReturn(response);
         lenient().when(ctx.metrics()).thenReturn(metrics);
         lenient().when(ctx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
+        // withLogger is an interface default method, so Mockito's mock doesn't run it and returns null unless stubbed.
+        lenient().when(ctx.withLogger(any())).thenReturn(mock(Logger.class));
 
         requestHeaders = HttpHeaders.create();
         // request.parameters() can't be null. See https://github.com/gravitee-io/gravitee-common/blob/master/src/main/java/io/gravitee/common/util/URIUtils.java#L74
@@ -778,6 +818,316 @@ class HttpConnectorTest {
             any(ExecutionFailure.class)
         );
         wiremock.verify(1, getRequestedFor(urlPathEqualTo("/error")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Fault.class, names = { "EMPTY_RESPONSE", "CONNECTION_RESET_BY_PEER" })
+    void should_retry_on_a_fresh_connection_when_the_pooled_connection_was_closed_or_reset_by_the_peer(final Fault fault)
+        throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok(BACKEND_RESPONSE_BODY))
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(fault))
+                .willSetStateTo(PEER_ACCEPTS_A_FRESH_CONNECTION)
+        );
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_ACCEPTS_A_FRESH_CONNECTION)
+                .willReturn(ok(BACKEND_RESPONSE_BODY))
+        );
+
+        primePooledConnection();
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        verify(response).status(HttpStatusCode.OK_200);
+        assertThat(drainChunks(response).values().stream().map(Buffer::toString).collect(Collectors.joining())).isEqualTo(
+            BACKEND_RESPONSE_BODY
+        );
+        wiremock.verify(3, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names = { "GET", "HEAD", "OPTIONS", "PUT", "DELETE" })
+    void should_retry_a_body_less_idempotent_request_with_the_exact_same_request(final HttpMethod method) throws InterruptedException {
+        when(request.method()).thenReturn(method);
+        final AtomicInteger chunksSubscriptions = new AtomicInteger();
+        when(request.chunks()).thenReturn(Flowable.<Buffer>empty().doOnSubscribe(subscription -> chunksSubscriptions.incrementAndGet()));
+        // Identifies the failed attempt and its retry in the request journal below; the priming request never carries it.
+        final String traceId = "3f1c9e2a";
+        requestHeaders.set("X-Test-Trace-Id", traceId);
+
+        // The priming request always uses GET (see primePooledConnection), so this transitional stub matches any
+        // method to consume it and drive the scenario into the peer-closed state before the request under test begins.
+        wiremock.stubFor(
+            any(urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok())
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        wiremock.stubFor(
+            request(method.name(), urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+                .willSetStateTo(PEER_ACCEPTS_A_FRESH_CONNECTION)
+        );
+        wiremock.stubFor(
+            request(method.name(), urlPathEqualTo("/team"))
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_ACCEPTS_A_FRESH_CONNECTION)
+                .willReturn(ok())
+        );
+
+        primePooledConnection();
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        verify(response).status(HttpStatusCode.OK_200);
+
+        // The priming request always uses GET (see above), so it never carries this header: filtering on it isolates
+        // exactly the failed attempt and its retry, proving the retry happened for each idempotent method — the retry
+        // is now gated on the method's idempotence, so nothing else here would catch a regression narrowing it to GET.
+        final List<LoggedRequest> retriableAttempts = wiremock
+            .findAll(requestedFor(method.name(), urlPathEqualTo("/team")))
+            .stream()
+            .filter(loggedRequest -> loggedRequest.containsHeader("X-Test-Trace-Id"))
+            .collect(Collectors.toList());
+        // One for the failed attempt, one for its retry: the options built for the first attempt are reused as-is,
+        // not rebuilt, so proving both carry this request-specific header rules out a silent divergence between them.
+        assertThat(retriableAttempts).hasSize(2);
+        final LoggedRequest failedAttempt = retriableAttempts.get(0);
+        final LoggedRequest retriedAttempt = retriableAttempts.get(1);
+        assertThat(retriedAttempt.getMethod()).isEqualTo(failedAttempt.getMethod());
+        assertThat(retriedAttempt.getUrl()).isEqualTo(failedAttempt.getUrl());
+        assertThat(failedAttempt.getHeader("X-Test-Trace-Id")).isEqualTo(traceId);
+        assertThat(retriedAttempt.getHeader("X-Test-Trace-Id")).isEqualTo(traceId);
+        assertThat(chunksSubscriptions.get())
+            .as("Client body should be consumed exactly once across the retry, neither lost nor read again")
+            .isEqualTo(1);
+    }
+
+    @Test
+    void should_not_resend_a_body_less_post_when_the_pooled_connection_was_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.POST);
+
+        wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
+        wiremock.stubFor(post("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    void should_not_resend_the_request_when_the_connection_failed_after_the_body_was_streamed() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.headers()).thenReturn(HttpHeaders.create().add(TRANSFER_ENCODING, "chunked"));
+        when(request.chunks()).thenReturn(
+            Flowable.just(Buffer.buffer(REQUEST_BODY_CHUNK1), Buffer.buffer(REQUEST_BODY_CHUNK2), Buffer.buffer(REQUEST_BODY_CHUNK3))
+        );
+
+        wiremock.stubFor(get("/team").willReturn(ok(BACKEND_RESPONSE_BODY)));
+        // The peer takes the whole body, then ends the connection without answering: the bytes of a non-idempotent
+        // request have already reached the backend, so this failure is not the pre-write pool-reuse race and must
+        // never be answered by sending the request a second time.
+        wiremock.stubFor(post("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/team")).withRequestBody(
+                new EqualToPattern(REQUEST_BODY_CHUNK1 + REQUEST_BODY_CHUNK2 + REQUEST_BODY_CHUNK3)
+            )
+        );
+    }
+
+    @Test
+    void should_not_resend_an_http2_request_when_the_pooled_connection_was_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        // An HTTP/2 request signals its body with Data frames rather than with Content-Length or Transfer-Encoding, so
+        // the gateway streams a body it cannot replay even though no body header says so — leaving the headers unset
+        // is what makes the protocol alone drive the exclusion here.
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        // Identifies the single attempt in the request journal below; the priming request never carries it.
+        requestHeaders.set("X-Test-Trace-Id", "7b4d0c15");
+
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok())
+                .willSetStateTo(PEER_CLOSED_THE_POOLED_CONNECTION)
+        );
+        // No follow-up success stub: a resend would hit this same fault and be recorded, so the journal count below is
+        // what proves the request was never sent twice.
+        wiremock.stubFor(
+            get("/team")
+                .inScenario(POOLED_CONNECTION_SCENARIO)
+                .whenScenarioStateIs(PEER_CLOSED_THE_POOLED_CONNECTION)
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE))
+        );
+
+        primePooledConnection();
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+
+        final List<LoggedRequest> attempts = wiremock
+            .findAll(getRequestedFor(urlPathEqualTo("/team")))
+            .stream()
+            .filter(loggedRequest -> loggedRequest.containsHeader("X-Test-Trace-Id"))
+            .collect(Collectors.toList());
+        assertThat(attempts).hasSize(1);
+    }
+
+    @Test
+    void should_not_retry_a_second_time_when_the_retried_connection_is_also_closed_by_the_peer() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        // Every attempt hits the same fault, so the retried one fails the same way the first did instead of being
+        // answered by a scripted success — which is what makes the second failure reach the attempt cap.
+        wiremock.stubFor(get("/team").willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_CONNECTION_CLOSED");
+        // The failure surfaces to the client after a single retry: one original attempt and one retry, never a third.
+        wiremock.verify(2, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    void should_not_retry_a_body_less_request_when_the_failure_is_not_a_closed_or_reset_connection() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        sharedConfiguration.getHttpOptions().setReadTimeout(READ_TIMEOUT_MS);
+        configuration.setTarget("http://localhost:" + wiremock.port() + SLOW_ENDPOINT);
+        cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
+
+        // Answers well past the read timeout above, so the exchange fails on a timeout rather than on a connection the
+        // peer closed or reset.
+        wiremock.stubFor(get(SLOW_ENDPOINT).willReturn(ok(BACKEND_RESPONSE_BODY).withFixedDelay(BACKEND_FIXED_DELAY_MS)));
+
+        final AtomicReference<Throwable> connectFailure = new AtomicReference<>();
+        final TestObserver<Void> obs = cut.connect(ctx).doOnError(connectFailure::set).test();
+
+        assertNoTimeout(obs);
+        obs.assertNotComplete();
+        assertThat(ConnectionFailureClassifier.classify(connectFailure.get()).key()).isEqualTo("GATEWAY_CLIENT_READ_TIMEOUT");
+        // A retry would have been sent before the failure reached the client, so the journal is final here.
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo(SLOW_ENDPOINT)));
+    }
+
+    @Test
+    void should_not_retry_when_the_in_flight_request_is_reset_by_our_own_cancellation() throws InterruptedException {
+        when(request.method()).thenReturn(HttpMethod.GET);
+        configuration.setTarget("http://localhost:" + wiremock.port() + SLOW_ENDPOINT);
+        cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
+
+        wiremock.stubFor(get(SLOW_ENDPOINT).willReturn(ok(BACKEND_RESPONSE_BODY).withFixedDelay(BACKEND_FIXED_DELAY_MS)));
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        final RequestPatternBuilder slowRequests = getRequestedFor(urlPathEqualTo(SLOW_ENDPOINT));
+        awaitRequestReceived(slowRequests);
+        // The disposal below has to race a live upstream call: on an already resolved exchange it resets nothing and
+        // the rest of this test would pass vacuously.
+        obs.assertNotComplete();
+
+        obs.dispose();
+
+        // Resetting the in-flight stream ourselves classifies exactly like a peer-initiated close, so only the flag
+        // doOnDispose sets keeps the retry predicate from sending the request a second time.
+        assertRequestCountStaysAt(slowRequests, 1);
+    }
+
+    private void awaitRequestReceived(final RequestPatternBuilder pattern) throws InterruptedException {
+        final long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (wiremock.findAll(pattern).isEmpty() && System.nanoTime() - deadlineNs < 0) {
+            Thread.sleep(REQUEST_JOURNAL_POLL_INTERVAL_MS);
+        }
+        assertThat(wiremock.findAll(pattern)).as("Backend should have received the request before timeout").isNotEmpty();
+    }
+
+    private void assertRequestCountStaysAt(final RequestPatternBuilder pattern, final int expectedCount) throws InterruptedException {
+        final long deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(NO_FURTHER_REQUEST_WINDOW_MS);
+        while (System.nanoTime() - deadlineNs < 0) {
+            assertThat(wiremock.findAll(pattern)).hasSize(expectedCount);
+            Thread.sleep(REQUEST_JOURNAL_POLL_INTERVAL_MS);
+        }
+    }
+
+    /**
+     * Runs a first request through the connector so its client leaves an idle keep-alive connection in the pool, which
+     * is the connection the request under test then reuses. Uses its own mocks so the class-level ones stay dedicated
+     * to the request under test.
+     */
+    private void primePooledConnection() throws InterruptedException {
+        final HttpExecutionContext primingCtx = mock(HttpExecutionContext.class);
+        final HttpRequest primingRequest = mock(HttpRequest.class);
+        final HttpResponse primingResponse = mock(HttpResponse.class);
+
+        when(primingCtx.request()).thenReturn(primingRequest);
+        when(primingCtx.response()).thenReturn(primingResponse);
+        when(primingCtx.metrics()).thenReturn(mock(Metrics.class));
+        when(primingCtx.getTracer()).thenReturn(new Tracer(null, new NoOpTracer()));
+        when(primingCtx.getComponent(Vertx.class)).thenReturn(vertx);
+        when(primingCtx.getComponent(Configuration.class)).thenReturn(mock(Configuration.class));
+        when(primingRequest.method()).thenReturn(HttpMethod.GET);
+        when(primingRequest.parameters()).thenReturn(new LinkedMultiValueMap<>());
+        when(primingRequest.pathInfo()).thenReturn("");
+        when(primingRequest.headers()).thenReturn(HttpHeaders.create());
+        when(primingRequest.chunks()).thenReturn(Flowable.empty());
+        when(primingResponse.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.connect(primingCtx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+        drainChunks(primingResponse);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TestSubscriber<Buffer> drainChunks(final HttpResponse target) {
+        final ArgumentCaptor<Flowable<Buffer>> chunksCaptor = ArgumentCaptor.forClass(Flowable.class);
+        verify(target).chunks(chunksCaptor.capture());
+
+        return chunksCaptor.getValue().test().awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS).assertComplete();
     }
 
     private void assertNoTimeout(TestObserver<Void> obs) throws InterruptedException {


### PR DESCRIPTION
## Issue

[APIM-14873](https://gravitee.atlassian.net/browse/APIM-14873)

## Purpose

Under sustained load with keep-alive enabled, the Gateway HTTP client can reuse a pooled connection that the backend (or an intermediary such as an OpenShift Route/HAProxy) already closed. Because a pooled connection is only discovered to be dead by writing to it, this race isn't avoidable by configuration — it surfaced as an intermittent, client-visible 502 (`GATEWAY_CLIENT_CONNECTION_CLOSED` / `GATEWAY_CLIENT_CONNECTION_RESET`) for a request the backend never actually handled. NeoLoad testing at ~3k RPS for ~10 minutes reproduced ~0.11% of requests failing this way, unaffected by raising `maxConcurrentConnections` and made worse by disabling keep-alive.

## Summary of changes

`HttpConnector.connect()` now re-subscribes the endpoint exchange exactly once when the failure classifies as `CONNECTION_CLOSED` or `CONNECTION_RESET` — both are the same underlying pool-reuse race, surfacing as a clean close or a reset depending on OS/timing. Retrying relies on the pool evicting the connection it just saw fail; a pool that would not degrades to today's 502. Only requests sent without a body are retried, since body chunks already written may have reached the backend and `request.chunks()` is not safe to subscribe to twice.

This is a backport of the master fix (gravitee-io#19143, commit `32f3822405869c3f62bda0340aa7b611a7de45a3`). A direct cherry-pick was not possible: master's `HttpConnector.java` has since been refactored for the Vert.x 5 upgrade (`BufferInternal` instead of `BufferImpl`, plus a `sendsRequestBody()` helper introduced by that refactor). The retry logic here is ported onto 4.11.x's current pre-Vert.x-5 code shape, keeping `BufferImpl` as-is.

**Same limitation as the master fix:** only body-less requests (GET/HEAD/OPTIONS, and DELETE without a body) are retried; a bodied idempotent request (e.g. PUT, or a bulk DELETE with a payload) is not covered, since replaying the request would require buffering the body first — out of scope here.

### Behaviour changes

A request that previously failed with a client-visible 502 due to this specific pool-reuse race now transparently succeeds after one internal retry on a fresh connection. The retry is logged as a WARN (naming the endpoint) so it stays observable rather than looking identical to a first-attempt success.

## Out of scope

- The legacy V3/emulation-engine path (`InvokerAdapter`) has the same defect. This also covers every V2-definition API today, since V2 API creation isn't wired into management-v2 REST yet and always runs under `v4-emulation-engine`. Confirmed via side-by-side load test on this branch's built instance (see **Load testing** below): the V4 native path (this fix) failed at 0.015–0.03% across 3 runs; a `v4-emulation-engine` API on the same instance failed at 0.39–0.975% across 3 runs — same silent-5xx failure class this fix addresses, unmitigated. Not fixable here: `InvokerAdapter` is plumbing only — the actual connection acquisition and failure handling live in the external `io.gravitee.connector:gravitee-connector-http` artifact this repo pins as a version in `pom.xml`. Fixing it requires a change in that artifact, not this repo. See gravitee-io#19143's own "Limitations" section for the equivalent statement on the master fix — the Jira ticket does not scope APIM-14873 to V4/native specifically, so whether to pursue this as a follow-up is an open call for the ticket owner, not decided by either PR.
- `WebSocketConnector` overrides `connect()` and doesn't inherit the retry.

## Load testing

Same repro tool as the master PR (gravitee-io#19143), run directly against this branch's built instance in isolation: `ab -k -c 50 -n 20000`, deterministic backend closing every 20th request on a connection, 3 back-to-back runs per condition.

| API | Runs (failures / 20,000) | Range | Notes |
|---|---|---|---|
| V4 native (this fix) | 3, 6, 3 | 0.015–0.03% | Matches the fixed rate measured on master/4.13.x under the same deterministic backend |
| V2 / `v4-emulation-engine` (`InvokerAdapter`, out of scope — see above) | 195, 108, 78 | 0.39–0.975% | Same silent-5xx failure class, unmitigated |

No separate before-fix baseline was run on this branch specifically — the before/after progression (unfixed master → this fix) is documented on the master PR.

## Testing

Full `HttpConnectorTest` suite green (35/35 including 4 new tests covering close/reset retry, method-agnostic retry, and that a bodied request is never resent after streaming started), and the full module suite (74/74).

## Related PRs / tickets

Backport of gravitee-io#19143 (master, not yet merged).


[APIM-14873]: https://gravitee.atlassian.net/browse/APIM-14873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
