### PR TITLE
fix: reuse a single net client across health check executions

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/healthcheck/HttpServerProbe.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/healthcheck/HttpServerProbe.java
@@ -42,6 +42,8 @@ public class HttpServerProbe implements Probe {
     @Autowired
     private Vertx vertx;
 
+    private NetClient client;
+
     @Override
     public String id() {
         return "http-server";
@@ -51,21 +53,29 @@ public class HttpServerProbe implements Probe {
     public CompletionStage<Result> check() {
         Promise<Result> promise = Promise.promise();
 
-        NetClientOptions options = new NetClientOptions().setConnectTimeout(500);
-        NetClient client = vertx.createNetClient(options);
-
-        client
+        netClient()
             .connect(port, host)
             .onComplete(res -> {
                 if (res.succeeded()) {
                     promise.complete(Result.healthy());
+                    res.result().close();
                 } else {
                     promise.complete(Result.unhealthy(res.cause()));
                 }
-
-                client.close();
             });
 
         return promise.future().toCompletionStage();
+    }
+
+    /**
+     * Vert.x holds on to every client it creates until the owner it was created from is closed, so a client per
+     * check would accumulate for as long as the node runs. A single client serves them all and is released when
+     * Vert.x itself stops.
+     */
+    private synchronized NetClient netClient() {
+        if (client == null) {
+            client = vertx.createNetClient(new NetClientOptions().setConnectTimeout(500));
+        }
+        return client;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/healthcheck/HttpServerProbeTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/healthcheck/HttpServerProbeTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.healthcheck.Result;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetServer;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpServerProbeTest {
+
+    private static final int TIMEOUT_SECONDS = 10;
+
+    private Vertx vertx;
+    private NetServer server;
+    private CountDownLatch serverSideClose;
+    private HttpServerProbe cut;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        vertx = Vertx.vertx();
+        serverSideClose = new CountDownLatch(1);
+        server = await(
+            vertx
+                .createNetServer()
+                .connectHandler(socket -> socket.closeHandler(event -> serverSideClose.countDown()))
+                .listen(0, "localhost")
+        );
+
+        cut = new HttpServerProbe();
+        setField(cut, "vertx", vertx);
+        setField(cut, "host", "localhost");
+        setField(cut, "port", server.actualPort());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        await(vertx.close());
+    }
+
+    @Test
+    void should_report_healthy_when_the_server_accepts_the_connection() throws Exception {
+        assertThat(check().isHealthy()).isTrue();
+    }
+
+    @Test
+    void should_report_unhealthy_when_no_server_accepts_the_connection() throws Exception {
+        await(server.close());
+
+        assertThat(check().isHealthy()).isFalse();
+    }
+
+    @Test
+    void should_close_the_connection_it_opened() throws Exception {
+        check();
+
+        assertThat(serverSideClose.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void should_not_register_a_new_net_client_on_every_check() throws Exception {
+        check();
+        long afterFirstCheck = registeredNetClients();
+
+        for (int i = 0; i < 9; i++) {
+            check();
+        }
+
+        assertThat(registeredNetClients()).isEqualTo(afterFirstCheck);
+    }
+
+    private Result check() throws Exception {
+        return cut.check().toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Vert.x keeps every client it creates in the private {@code children} map of its owner's close future, and
+     * only releases them when that owner closes. Counting them is the only way to observe from a test that a
+     * client is retained for the whole life of the node rather than released after the check that created it.
+     */
+    private long registeredNetClients() throws Exception {
+        Object closeFuture = ((VertxInternal) vertx).closeFuture();
+        Field childrenField = closeFuture.getClass().getDeclaredField("children");
+        childrenField.setAccessible(true);
+        Map<?, ?> children = (Map<?, ?>) childrenField.get(closeFuture);
+        return children == null ? 0 : children.keySet().stream().filter(NetClient.class::isInstance).count();
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/healthcheck/GraviteeApisProbe.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/healthcheck/GraviteeApisProbe.java
@@ -42,6 +42,8 @@ public class GraviteeApisProbe implements Probe {
     @Autowired
     private Vertx vertx;
 
+    private NetClient client;
+
     @Override
     public String id() {
         return "gravitee-apis";
@@ -51,21 +53,29 @@ public class GraviteeApisProbe implements Probe {
     public CompletionStage<Result> check() {
         Promise<Result> promise = Promise.promise();
 
-        NetClientOptions options = new NetClientOptions().setConnectTimeout(500);
-        NetClient client = vertx.createNetClient(options);
-
-        client
+        netClient()
             .connect(port, host)
             .onComplete(res -> {
                 if (res.succeeded()) {
                     promise.complete(Result.healthy());
+                    res.result().close();
                 } else {
                     promise.complete(Result.unhealthy(res.cause()));
                 }
-
-                client.close();
             });
 
         return promise.future().toCompletionStage().toCompletableFuture();
+    }
+
+    /**
+     * Vert.x holds on to every client it creates until the owner it was created from is closed, so a client per
+     * check would accumulate for as long as the node runs. A single client serves them all and is released when
+     * Vert.x itself stops.
+     */
+    private synchronized NetClient netClient() {
+        if (client == null) {
+            client = vertx.createNetClient(new NetClientOptions().setConnectTimeout(500));
+        }
+        return client;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/test/java/io/gravitee/rest/api/standalone/healthcheck/GraviteeApisProbeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/test/java/io/gravitee/rest/api/standalone/healthcheck/GraviteeApisProbeTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.standalone.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.healthcheck.Result;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetServer;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GraviteeApisProbeTest {
+
+    private static final int TIMEOUT_SECONDS = 10;
+
+    private Vertx vertx;
+    private NetServer server;
+    private CountDownLatch serverSideClose;
+    private GraviteeApisProbe cut;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        vertx = Vertx.vertx();
+        serverSideClose = new CountDownLatch(1);
+        server = await(
+            vertx
+                .createNetServer()
+                .connectHandler(socket -> socket.closeHandler(event -> serverSideClose.countDown()))
+                .listen(0, "localhost")
+        );
+
+        cut = new GraviteeApisProbe();
+        setField(cut, "vertx", vertx);
+        setField(cut, "host", "localhost");
+        setField(cut, "port", server.actualPort());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        await(vertx.close());
+    }
+
+    @Test
+    void should_report_healthy_when_the_server_accepts_the_connection() throws Exception {
+        assertThat(check().isHealthy()).isTrue();
+    }
+
+    @Test
+    void should_report_unhealthy_when_no_server_accepts_the_connection() throws Exception {
+        await(server.close());
+
+        assertThat(check().isHealthy()).isFalse();
+    }
+
+    @Test
+    void should_close_the_connection_it_opened() throws Exception {
+        check();
+
+        assertThat(serverSideClose.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void should_not_register_a_new_net_client_on_every_check() throws Exception {
+        check();
+        long afterFirstCheck = registeredNetClients();
+
+        for (int i = 0; i < 9; i++) {
+            check();
+        }
+
+        assertThat(registeredNetClients()).isEqualTo(afterFirstCheck);
+    }
+
+    private Result check() throws Exception {
+        return cut.check().toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Vert.x keeps every client it creates in the private {@code children} map of its owner's close future, and
+     * only releases them when that owner closes. Counting them is the only way to observe from a test that a
+     * client is retained for the whole life of the node rather than released after the check that created it.
+     */
+    private long registeredNetClients() throws Exception {
+        Object closeFuture = ((VertxInternal) vertx).closeFuture();
+        Field childrenField = closeFuture.getClass().getDeclaredField("children");
+        childrenField.setAccessible(true);
+        Map<?, ?> children = (Map<?, ?>) childrenField.get(closeFuture);
+        return children == null ? 0 : children.keySet().stream().filter(NetClient.class::isInstance).count();
+    }
+
+    private static <T> T await(Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14921

## Description

Both node health check probes created a Vert.x `NetClient` on every execution and closed it right after. Since Vert.x 5 that client is never released: `VertxImpl.createNetClient` registers the `NetClientImpl` itself in the strong `children` map of its owner's close future, and `NetClientImpl` is not a `NestedCloseable`, so nothing ever removes it — `close()` only tears the connections down. The gateway and the Management API therefore retained one client per health check, one every 5 seconds by default, until the node stopped, and the heap grew until `OutOfMemoryError`.

Vert.x 4 registered a dedicated `CloseFuture` per client instead, kept in a `WeakHashMap` and removed when the client completed its close sequence. Both safety nets disappeared with the 4.5.21 → 5.0.12 upgrade, which is why this starts at 4.12; 4.11.x still runs Vert.x 4.5.27 and is unaffected.

Each probe now creates a single client for its lifetime and closes the socket every check opens — something `client.close()` used to take care of. The client itself is released by Vert.x when the node stops. The probes are not Spring beans (`SpringFactoriesLoader` calls `BeanUtils.instantiateClass` then `autowireBean`), so no `@PostConstruct` or `@PreDestroy` callback is available and the client is created lazily on the first check.

## Additional context

Reproduced by a unit test rather than the 45-minute heap dump procedure from the ticket. `should_not_register_a_new_net_client_on_every_check` counts the clients Vert.x retains in the close future and fails with `expected: 1L but was: 10L` before the fix — one leaked client per check, the same ratio as the 516 instances over 43 minutes reported on 4.12.13.

Each probe gets four tests: healthy, unreachable, connection closed after a check, and no client registered per check. The "connection closed" one guards the risk that sharing a client introduces, since leaving the socket open would trade a client leak for a socket leak.

Worth noting beyond the ticket: `NodeHealthCheckManagementEndpoint` evaluates the probes from an event loop, so uncached calls to `/_node/health` leaked on the request context's close future as well.

The underlying Vert.x regression is not addressed here — any repeated `createNetClient` / `close()` sequence leaks the same way on Vert.x 5.0.12.
A bug has been opened here: https://github.com/eclipse-vertx/vert.x/issues/6311
