### PR TITLE
fix(mapi): missing HRID in application

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -471,6 +471,9 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         } else {
             application.setId(UuidString.generateRandom());
         }
+        if (isBlank(application.getHrid())) {
+            application.setHrid(application.getId());
+        }
         application.setStatus(ApplicationStatus.ACTIVE);
         metadata.forEach((key, value) -> application.getMetadata().put(key, value));
 
@@ -678,7 +681,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             Application application = applicationConverter.toApplication(updateApplicationEntity);
             application.setId(applicationId);
-            application.setHrid(applicationToUpdate.getHrid());
+            application.setHrid(isBlank(applicationToUpdate.getHrid()) ? applicationToUpdate.getId() : applicationToUpdate.getHrid());
             application.setEnvironmentId(applicationToUpdate.getEnvironmentId());
             application.setStatus(ApplicationStatus.ACTIVE);
             application.setType(applicationToUpdate.getType());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationMissingHridUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationMissingHridUpgrader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills {@code hrid} for applications created after {@link ApplicationHRIDUpgrader} ran without an explicit hrid.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+@CustomLog
+public class ApplicationMissingHridUpgrader implements Upgrader {
+
+    @Lazy
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
+    @Lazy
+    @Autowired
+    private EnvironmentRepository environmentRepository;
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::setMissingHrids);
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.APPLICATION_MISSING_HRID_UPGRADER;
+    }
+
+    private boolean setMissingHrids() throws TechnicalException {
+        var updatedCount = 0;
+        for (var environment : environmentRepository.findAll()) {
+            updatedCount += setMissingHridsForEnvironment(new ExecutionContext(environment));
+        }
+        log.info("Application missing HRID upgrader completed. Total applications updated: {}", updatedCount);
+        return true;
+    }
+
+    private int setMissingHridsForEnvironment(ExecutionContext executionContext) throws TechnicalException {
+        var updatedCount = 0;
+        for (var application : applicationRepository.findAllByEnvironment(executionContext.getEnvironmentId())) {
+            if (!isBlank(application.getHrid())) {
+                continue;
+            }
+            application.setHrid(application.getId());
+            applicationRepository.update(application);
+            updatedCount++;
+        }
+        return updatedCount;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -81,4 +81,5 @@ public class UpgraderOrder {
     public static final int GAMMA_IDENTITY_ROLES_UPGRADER = 956;
     public static final int GAMMA_AUTHZ_ROLES_UPGRADER = 957;
     public static final int AI_CATALOG_ROLES_UPGRADER = 958;
+    public static final int APPLICATION_MISSING_HRID_UPGRADER = 959;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -179,6 +179,121 @@ public class ApplicationService_CreateTest {
     }
 
     @Test
+    public void shouldSetHridToApplicationIdWhenNotProvided() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(newApplication.getDescription()).thenReturn("My description");
+        when(newApplication.getHrid()).thenReturn(null);
+        when(newApplication.getId()).thenReturn(null);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(UserEntity.class));
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApplicationEntity applicationEntity = applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+
+        assertNotNull(applicationEntity.getId());
+        assertEquals(applicationEntity.getId(), applicationEntity.getHrid());
+        verify(applicationRepository).create(argThat(app -> app.getId().equals(app.getHrid())));
+    }
+
+    @Test
+    public void shouldSetHridToApplicationIdWhenHridIsEmpty() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(newApplication.getDescription()).thenReturn("My description");
+        when(newApplication.getHrid()).thenReturn("");
+        when(newApplication.getId()).thenReturn(null);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(UserEntity.class));
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApplicationEntity applicationEntity = applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+
+        assertNotNull(applicationEntity.getId());
+        assertEquals(applicationEntity.getId(), applicationEntity.getHrid());
+        verify(applicationRepository).create(argThat(app -> app.getId().equals(app.getHrid())));
+    }
+
+    @Test
+    public void shouldSetHridToApplicationIdWhenHridIsWhitespace() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(newApplication.getDescription()).thenReturn("My description");
+        when(newApplication.getHrid()).thenReturn(" ");
+        when(newApplication.getId()).thenReturn(null);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(UserEntity.class));
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApplicationEntity applicationEntity = applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+
+        assertNotNull(applicationEntity.getId());
+        assertEquals(applicationEntity.getId(), applicationEntity.getHrid());
+        verify(applicationRepository).create(argThat(app -> app.getId().equals(app.getHrid())));
+    }
+
+    @Test
+    public void shouldPreserveProvidedHrid() throws TechnicalException {
+        String hrid = "my-application-hrid";
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(newApplication.getDescription()).thenReturn("My description");
+        when(newApplication.getHrid()).thenReturn(hrid);
+        when(newApplication.getId()).thenReturn(null);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(UserEntity.class));
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApplicationEntity applicationEntity = applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+
+        assertEquals(hrid, applicationEntity.getHrid());
+        verify(applicationRepository).create(argThat(app -> hrid.equals(app.getHrid())));
+    }
+
+    @Test
+    public void shouldSetHridToExplicitIdWhenNotProvided() throws TechnicalException {
+        String explicitId = "explicit-application-id";
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(newApplication.getDescription()).thenReturn("My description");
+        when(newApplication.getHrid()).thenReturn(null);
+        when(newApplication.getId()).thenReturn(explicitId);
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(UserEntity.class));
+        when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApplicationEntity applicationEntity = applicationService.create(GraviteeContext.getExecutionContext(), newApplication, USER_NAME);
+
+        assertEquals(explicitId, applicationEntity.getId());
+        assertEquals(explicitId, applicationEntity.getHrid());
+    }
+
+    @Test
     public void shouldCreateAppWithDefaultGroup() throws TechnicalException {
         ApplicationSettings settings = new ApplicationSettings();
         SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -254,6 +254,68 @@ public class ApplicationService_UpdateTest {
     }
 
     @Test
+    public void shouldSetHridToApplicationIdOnUpdateWhenStoredHridIsNull() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+
+        Application existing = new Application();
+        existing.setId(APPLICATION_ID);
+        existing.setName(APPLICATION_NAME);
+        existing.setStatus(ApplicationStatus.ACTIVE);
+        existing.setType(ApplicationType.SIMPLE);
+        existing.setApiKeyMode(ApiKeyMode.UNSPECIFIED);
+        existing.setHrid(null);
+
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existing));
+        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(getConsoleConfigEntity(false));
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(getPrimaryOwner()));
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(updateApplication.getDescription()).thenReturn("My description");
+        when(updateApplication.getGroups()).thenReturn(Set.of());
+        when(applicationRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
+
+        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+
+        verify(applicationRepository).update(argThat(application -> APPLICATION_ID.equals(application.getHrid())));
+    }
+
+    @Test
+    public void shouldPreserveStoredHridOnUpdate() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+
+        Application existing = new Application();
+        existing.setId(APPLICATION_ID);
+        existing.setName(APPLICATION_NAME);
+        existing.setStatus(ApplicationStatus.ACTIVE);
+        existing.setType(ApplicationType.SIMPLE);
+        existing.setApiKeyMode(ApiKeyMode.UNSPECIFIED);
+        existing.setHrid("gitops-hrid");
+
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existing));
+        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(getConsoleConfigEntity(false));
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(getPrimaryOwner()));
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(updateApplication.getDescription()).thenReturn("My description");
+        when(updateApplication.getGroups()).thenReturn(Set.of());
+        when(applicationRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
+
+        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+
+        verify(applicationRepository).update(argThat(application -> "gitops-hrid".equals(application.getHrid())));
+    }
+
+    @Test
     public void shouldThrowExceptionWhenUserGroupsRequiredButNotPresent() {
         ApplicationSettings settings = new ApplicationSettings();
         ConsoleConfigEntity config = getConsoleConfigEntity(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationMissingHridUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationMissingHridUpgraderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.repository.management.model.Environment;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+class ApplicationMissingHridUpgraderTest {
+
+    private static final String ENV_ID = "DEFAULT";
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    @InjectMocks
+    private ApplicationMissingHridUpgrader upgrader;
+
+    @Test
+    void should_set_hrid_to_id_when_missing() throws TechnicalException, UpgraderException {
+        var application = Application.builder().id("app-id").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(application));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(Application.class);
+        verify(applicationRepository).update(captor.capture());
+        assertThat(captor.getValue().getHrid()).isEqualTo("app-id");
+    }
+
+    @Test
+    void should_skip_application_with_existing_hrid() throws TechnicalException, UpgraderException {
+        var application = Application.builder().id("app-id").hrid("gitops-hrid").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(application));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(applicationRepository, never()).update(any());
+    }
+
+    @Test
+    void should_update_only_applications_with_missing_hrid_in_mixed_set() throws TechnicalException, UpgraderException {
+        var withoutHrid = Application.builder().id("app-without-hrid").environmentId(ENV_ID).build();
+        var withHrid = Application.builder().id("app-with-hrid").hrid("existing-hrid").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(withoutHrid, withHrid));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(applicationRepository).update(
+            argThat(app -> "app-without-hrid".equals(app.getId()) && "app-without-hrid".equals(app.getHrid()))
+        );
+        verify(applicationRepository, times(1)).update(any());
+    }
+
+    @Test
+    void should_set_hrid_to_id_when_hrid_is_empty() throws TechnicalException, UpgraderException {
+        var application = Application.builder().id("app-id").hrid("").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(application));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(applicationRepository).update(argThat(app -> "app-id".equals(app.getId()) && "app-id".equals(app.getHrid())));
+    }
+
+    @Test
+    void should_set_hrid_to_id_when_hrid_is_whitespace() throws TechnicalException, UpgraderException {
+        var application = Application.builder().id("app-id").hrid(" ").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(application));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(applicationRepository).update(argThat(app -> "app-id".equals(app.getId()) && "app-id".equals(app.getHrid())));
+    }
+
+    @Test
+    void should_throw_upgrader_exception_when_find_all_environments_fails() throws TechnicalException {
+        when(environmentRepository.findAll()).thenThrow(new TechnicalException("failure"));
+
+        assertThatThrownBy(() -> upgrader.upgrade())
+            .isInstanceOf(UpgraderException.class)
+            .hasMessageContaining("failure");
+    }
+
+    @Test
+    void should_throw_upgrader_exception_when_update_fails() throws TechnicalException {
+        var application = Application.builder().id("app-id").environmentId(ENV_ID).build();
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.builder().id(ENV_ID).build()));
+        when(applicationRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(application));
+        when(applicationRepository.update(any())).thenThrow(new TechnicalException("update failed"));
+
+        assertThatThrownBy(() -> upgrader.upgrade())
+            .isInstanceOf(UpgraderException.class)
+            .hasMessageContaining("update failed");
+    }
+
+    @Test
+    void should_have_correct_order() {
+        assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.APPLICATION_MISSING_HRID_UPGRADER);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14894

## Description

Applications created via Console, Developer Portal, or Management API were persisted without an `hrid`. Only Automation API / GitOps creates had one. That breaks Terraform import, which requires `hrid`.

### Root cause
`hrid` was introduced in 4.9. `ApplicationHRIDUpgrader` (order 958) backfilled `hrid = id` once for existing apps, but:
- `ApplicationServiceImpl.create()` never defaulted `hrid` for manual creates
- that one-time upgrader cannot run again, so apps created after it stayed without `hrid`
- re-running `ApplicationHRIDUpgrader` is unsafe: it overwrites every `hrid`, including GitOps ones

### Fix
Three complementary changes (repository-agnostic via `ApplicationRepository`; same for MongoDB and JDBC):
1. **Create** — if `hrid` is blank, set `hrid = id` in `ApplicationServiceImpl.create()`
2. **Update** — if the stored `hrid` is blank, heal it to `id` on update (preserve existing GitOps hrids)
3. **Upgrader** — new `ApplicationMissingHridUpgrader` (order 963) backfills **only** blank/missing `hrid` to `id`; leaves existing hrids untouched

Before:
<img width="1440" height="417" alt="image" src="https://github.com/user-attachments/assets/7c0278c4-ff82-4e25-9bca-b999022f4080" />

After:
<img width="1468" height="478" alt="image" src="https://github.com/user-attachments/assets/6987e4ec-0878-437d-86c8-ddd198902854" />
