### PR TITLE
feat: integrate API products into My Subscriptions

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 import { DropdownSearchComponentHarness } from '../../../components/dropdown-search/dropdown-search.component.harness';
@@ -26,6 +27,9 @@ export class SubscriptionsComponentHarness extends ComponentHarness {
   private getEmptyFiltered = this.locatorForOptional(DivHarness.with({ selector: '.subscriptions__empty-filtered' }));
   private getTable = this.locatorForOptional(MatTableHarness);
   private getAllDropdownFilters = this.locatorForAll(DropdownSearchComponentHarness);
+  private getSearchInput = this.locatorFor(MatInputHarness);
+  private getCount = this.locatorForOptional('.subscriptions__count');
+  private getError = this.locatorForOptional('.subscriptions__error');
 
   public async isEmptyStateDisplayed(): Promise<boolean> {
     return (await this.getEmptyState()) !== null;
@@ -55,8 +59,8 @@ export class SubscriptionsComponentHarness extends ComponentHarness {
     return Promise.all(cells.map(cell => cell.getText()));
   }
 
-  /** API filter dropdown (first app-dropdown-search). */
-  public async getApiFilter(): Promise<DropdownSearchComponentHarness> {
+  /** Type filter dropdown (first app-dropdown-search). */
+  public async getTypeFilter(): Promise<DropdownSearchComponentHarness> {
     const dropdowns = await this.getAllDropdownFilters();
     return dropdowns[0];
   }
@@ -73,11 +77,11 @@ export class SubscriptionsComponentHarness extends ComponentHarness {
     return dropdowns[2];
   }
 
-  /** Opens the API filter and selects the option at the given index. */
-  public async selectApiFilter(index: number): Promise<void> {
-    const filter = await this.getApiFilter();
+  /** Opens the Type filter and selects the options whose labels match the given values. */
+  public async selectTypeFilter(labels: string[]): Promise<void> {
+    const filter = await this.getTypeFilter();
     const overlay = await filter.getOverlayHarness();
-    await overlay.selectOptionByIndex(index);
+    await overlay.selectOptionsByLabels(labels);
   }
 
   /** Opens the Application filter and selects the option at the given index. */
@@ -92,5 +96,32 @@ export class SubscriptionsComponentHarness extends ComponentHarness {
     const filter = await this.getStatusFilter();
     const overlay = await filter.getOverlayHarness();
     await overlay.selectOptionsByLabels(labels);
+  }
+
+  public async setSearchTerm(value: string): Promise<void> {
+    const input = await this.getSearchInput();
+    await input.setValue(value);
+  }
+
+  public async getCountText(): Promise<string | null> {
+    return (await this.getCount())?.text() ?? null;
+  }
+
+  public async isErrorDisplayed(): Promise<boolean> {
+    return (await this.getError()) !== null;
+  }
+
+  public async clickTableRow(index: number): Promise<void> {
+    const table = await this.getTable();
+    if (!table) {
+      throw new Error('Subscriptions table is not displayed');
+    }
+    const rows = await table.getRows();
+    const row = rows[index];
+    if (!row) {
+      throw new Error(`Subscription table row ${index} is not displayed`);
+    }
+    const host = await row.host();
+    await host.click();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
@@ -16,18 +16,19 @@
 
 -->
 <div class="subscriptions">
-  @if (hasSubscriptions()) {
-    <!-- Filters -->
+  @if (shouldShowSubscriptionsContent()) {
     <div class="subscriptions__filters">
+      <app-search-bar class="subscriptions__filter" [searchParam]="filters().query" (searchTerm)="onSearchTermChange($event)" />
+
       <app-dropdown-search
         class="subscriptions__filter"
-        i18n-label="@@subscriptionFilterApi"
-        label="API"
-        i18n-placeholder="@@subscriptionFilterApiPlaceholder"
-        placeholder="Search APIs..."
-        [resultsLoader]="apiResultsLoader"
-        [formControl]="apiFilter"
-        id="subscriptions-api-filter"
+        i18n-label="@@subscriptionFilterType"
+        label="Type"
+        i18n-placeholder="@@subscriptionFilterTypePlaceholder"
+        placeholder="Search types..."
+        [options]="typeOptions"
+        [formControl]="typeFilter"
+        id="subscriptions-type-filter"
       />
 
       <app-dropdown-search
@@ -57,13 +58,18 @@
 
     @if (isLoadingSubscriptions()) {
       <app-loader />
+    } @else if (subscriptionsResource.error()) {
+      <div class="subscriptions__error next-gen-body" role="alert" i18n="@@subscriptionsLoadError">
+        An error occurred while loading subscriptions. Try again later or contact your Portal administrator.
+      </div>
     } @else if (rows().length === 0) {
       <div class="subscriptions__empty-filtered">
         <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">filter_list_off</span>
         <h2 class="m3-title-large" i18n="@@subscriptionsNoResultsTitle">No subscriptions found</h2>
-        <p i18n="@@subscriptionsNoResultsDescription">Try adjusting your filters to find subscriptions.</p>
+        <p i18n="@@subscriptionsNoResultsDescription">Try adjusting your search or filters to find subscriptions.</p>
       </div>
     } @else {
+      <p class="subscriptions__count next-gen-small-bold" aria-live="polite">{{ subscriptionCountLabel() }}</p>
       <app-paginated-table
         [columns]="tableColumns"
         [rows]="rows()"
@@ -72,13 +78,19 @@
         [pageSize]="pageSize()"
         (pageChange)="onPageChange($event)"
         (pageSizeChange)="onPageSizeChange($event)"
-      />
+      >
+        <ng-template appTableCell="targetType" let-row>
+          <app-badge [label]="row.targetType" />
+        </ng-template>
+      </app-paginated-table>
     }
   } @else {
     <div class="subscriptions__empty-state">
       <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">search</span>
-      <h2 class="m3-title-large" i18n="@@subscriptionsEmptyTitle">No API subscriptions yet</h2>
-      <p i18n="@@subscriptionsEmptyDescription">Browse the catalog to discover available APIs and subscribe with an application.</p>
+      <h2 class="m3-title-large" i18n="@@subscriptionsEmptyTitle">No subscriptions yet</h2>
+      <p i18n="@@subscriptionsEmptyDescription">
+        Browse the catalog to discover available APIs and API Products and subscribe with an application.
+      </p>
     </div>
   }
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
@@ -28,6 +28,7 @@
 
   &__filters {
     display: flex;
+    flex-wrap: wrap;
     max-width: 50rem;
     align-items: center;
     margin-bottom: 24px;
@@ -36,6 +37,15 @@
 
   &__filter {
     flex: 1 1 200px;
+  }
+
+  &__count {
+    margin: 0 0 16px;
+  }
+
+  &__error {
+    padding: 24px 0;
+    color: app-theme.$error-main-color;
   }
 
   &__empty-state,

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
@@ -16,6 +16,7 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, provideRouter, Router } from '@angular/router';
@@ -29,10 +30,12 @@ import { fakeApplication, fakeApplicationsResponse } from '../../../entities/app
 import { SubscriptionConsumerStatusEnum, SubscriptionStatusEnum } from '../../../entities/subscription';
 import { fakeSubscriptionResponse } from '../../../entities/subscription/subscription.fixture';
 import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
-import { ApiService } from '../../../services/api.service';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 
 const emptySubscriptions = { data: [], links: { self: '' }, metadata: {} };
+
+@Component({ template: '' })
+class SubscriptionDetailsRouteStubComponent {}
 
 describe('SubscriptionsComponent', () => {
   let fixture: ComponentFixture<SubscriptionsComponent>;
@@ -42,7 +45,12 @@ describe('SubscriptionsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SubscriptionsComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideNoopAnimations(), provideRouter([])],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([{ path: ':subscriptionId', component: SubscriptionDetailsRouteStubComponent }]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubscriptionsComponent);
@@ -110,10 +118,14 @@ describe('SubscriptionsComponent', () => {
         {
           id: 'sub-1',
           api: 'api-1',
+          reference_id: 'api-1',
+          reference_type: 'API',
           application: 'app-1',
           plan: 'plan-1',
           status: 'ACCEPTED',
           created_at: '2026-02-03T23:00:00Z',
+          start_at: '2026-02-04T23:00:00Z',
+          end_at: '2027-02-04T23:00:00Z',
           consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
         },
       ],
@@ -129,12 +141,130 @@ describe('SubscriptionsComponent', () => {
     expect(fixture.componentInstance.rows().length).toBe(1);
     expect(fixture.componentInstance.rows()[0]).toEqual({
       id: 'sub-1',
-      api: 'API One',
+      targetName: 'API One',
+      targetType: 'API',
       plan: 'Plan One',
       application: 'App One',
-      created_at: '2026-02-03T23:00:00Z',
+      startAt: '2026-02-04T23:00:00Z',
+      endAt: '2027-02-04T23:00:00Z',
       status: 'Accepted',
     });
+  });
+
+  it('should map API and API Product subscriptions using their reference identity', async () => {
+    const response: SubscriptionsResponse = {
+      data: [
+        {
+          id: 'api-subscription',
+          api: 'legacy-api-id',
+          reference_id: 'api-id',
+          reference_type: 'API',
+          application: 'app-id',
+          plan: 'api-plan-id',
+          status: 'ACCEPTED',
+          start_at: '2026-02-01T00:00:00Z',
+          consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
+        },
+        {
+          id: 'product-subscription',
+          reference_id: 'product-id',
+          reference_type: 'API_PRODUCT',
+          application: 'app-id',
+          plan: 'product-plan-id',
+          status: 'PENDING',
+          end_at: '2027-02-01T00:00:00Z',
+          consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
+        },
+      ],
+      metadata: {
+        'api-id': { name: 'Payments API' },
+        'product-id': { name: 'Payments Product' },
+        'app-id': { name: 'Consumer App' },
+        'api-plan-id': { name: 'API Plan' },
+        'product-plan-id': { name: 'Product Plan' },
+        paginateMetaData: { totalElements: 2 },
+      },
+      links: { self: '' },
+    };
+
+    await setup(response);
+
+    expect(fixture.componentInstance.rows()).toEqual([
+      expect.objectContaining({ targetName: 'Payments API', targetType: 'API' }),
+      expect.objectContaining({ targetName: 'Payments Product', targetType: 'API Product' }),
+    ]);
+    expect(fixture.componentInstance.totalElements()).toBe(2);
+  });
+
+  it('should show a safe fallback when subscription target metadata is unavailable', async () => {
+    await setup(
+      fakeSubscriptionResponse({
+        data: [
+          {
+            id: 'product-subscription',
+            reference_id: 'deleted-product-id',
+            reference_type: 'API_PRODUCT',
+            application: 'app-id',
+            plan: 'plan-id',
+            status: 'CLOSED',
+            consumerStatus: SubscriptionConsumerStatusEnum.STOPPED,
+          },
+        ],
+        metadata: {},
+      }),
+    );
+
+    expect(fixture.componentInstance.rows()[0].targetName).toBe('Unavailable API Product');
+  });
+
+  it('should display the backend subscription count', async () => {
+    await setup(
+      fakeSubscriptionResponse({
+        metadata: {
+          paginateMetaData: { totalElements: 37 },
+        },
+      }),
+    );
+    fixture.detectChanges();
+    await getHarness();
+
+    expect(await harness.getCountText()).toBe('37 subscriptions');
+  });
+
+  it('should display an accessible error when subscriptions cannot be loaded', async () => {
+    fixture.detectChanges();
+    http.expectOne(req => req.url.includes('/applications')).flush({ data: [] });
+    http.expectOne(req => req.url.includes('/subscriptions')).flush('error', { status: 500, statusText: 'Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await getHarness();
+
+    expect(await harness.isErrorDisplayed()).toBe(true);
+  });
+
+  it('should navigate an API Product subscription row through the existing subscription details route', async () => {
+    await setup(
+      fakeSubscriptionResponse({
+        data: [
+          {
+            id: 'product-subscription',
+            reference_id: 'product-id',
+            reference_type: 'API_PRODUCT',
+            application: 'app-id',
+            plan: 'plan-id',
+            status: 'ACCEPTED',
+            consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
+          },
+        ],
+        metadata: { 'product-id': { name: 'Payments Product' } },
+      }),
+    );
+    fixture.detectChanges();
+    await getHarness();
+
+    await harness.clickTableRow(0);
+
+    expect(TestBed.inject(Router).url).toBe('/product-subscription');
   });
 
   it('should have default filters and pagination', async () => {
@@ -142,9 +272,20 @@ describe('SubscriptionsComponent', () => {
 
     expect(fixture.componentInstance.currentPage()).toBe(1);
     expect(fixture.componentInstance.pageSize()).toBe(10);
-    expect(fixture.componentInstance.apiFilter.value).toBeNull();
+    expect(fixture.componentInstance.filters().query).toBe('');
+    expect(fixture.componentInstance.typeFilter.value).toEqual([]);
     expect(fixture.componentInstance.applicationFilter.value).toBeNull();
     expect(fixture.componentInstance.statusFilter.value).toEqual([]);
+  });
+
+  it('should explicitly request API and API Product subscriptions by default', async () => {
+    fixture.detectChanges();
+    http.expectOne(req => req.url.includes('/applications')).flush({ data: [] });
+    const request = http.expectOne(req => req.url.includes('/subscriptions'));
+
+    expect(request.request.params.getAll('referenceTypes')).toEqual(['API', 'API_PRODUCT']);
+    request.flush(emptySubscriptions);
+    await fixture.whenStable();
   });
 
   it('should clear filters and reset page', async () => {
@@ -152,7 +293,13 @@ describe('SubscriptionsComponent', () => {
     await getHarness();
 
     await TestBed.inject(Router).navigate([], {
-      queryParams: { apiIds: ['api-1'], applicationIds: ['app-1'], statuses: SubscriptionStatusEnum.ACCEPTED, page: 3 },
+      queryParams: {
+        query: 'payments',
+        referenceTypes: ['API_PRODUCT'],
+        applicationIds: ['app-1'],
+        statuses: SubscriptionStatusEnum.ACCEPTED,
+        page: 3,
+      },
       queryParamsHandling: 'merge',
     });
     await fixture.whenStable();
@@ -162,14 +309,15 @@ describe('SubscriptionsComponent', () => {
     await fixture.whenStable();
     flushSubscriptions(emptySubscriptions as SubscriptionsResponse);
 
-    expect(fixture.componentInstance.apiFilter.value).toBeNull();
+    expect(fixture.componentInstance.filters().query).toBe('');
+    expect(fixture.componentInstance.typeFilter.value).toEqual([]);
     expect(fixture.componentInstance.applicationFilter.value).toBeNull();
     expect(fixture.componentInstance.statusFilter.value).toEqual([]);
     expect(fixture.componentInstance.currentPage()).toBe(1);
   });
 
   it('should init filters from URL query params', async () => {
-    const params = { apiIds: ['api-1'], statuses: 'ACCEPTED', page: '2', size: '20' };
+    const params = { query: 'payment', referenceTypes: ['API_PRODUCT'], statuses: 'ACCEPTED', page: '2', size: '20' };
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [SubscriptionsComponent],
@@ -188,7 +336,8 @@ describe('SubscriptionsComponent', () => {
     c.expectOne(req => req.url.includes('/applications')).flush({ data: [] });
     c.expectOne(req => req.url.includes('/subscriptions')).flush(emptySubscriptions);
 
-    expect(f.componentInstance.apiFilter.value).toEqual(['api-1']);
+    expect(f.componentInstance.filters().query).toBe('payment');
+    expect(f.componentInstance.typeFilter.value).toEqual(['API_PRODUCT']);
     expect(f.componentInstance.statusFilter.value).toEqual(['ACCEPTED']);
     expect(f.componentInstance.currentPage()).toBe(2);
     expect(f.componentInstance.pageSize()).toBe(20);
@@ -212,16 +361,16 @@ describe('SubscriptionsComponent', () => {
     expect(fixture.componentInstance.currentPage()).toBe(1);
   });
 
-  it('should expose API, Application, Status filter dropdowns via harness', async () => {
+  it('should expose Type, Application, and Status filter dropdowns via harness', async () => {
     await setup(fakeSubscriptionResponse());
     await getHarness();
-    const api = await harness.getApiFilter();
+    const type = await harness.getTypeFilter();
     const app = await harness.getApplicationFilter();
     const status = await harness.getStatusFilter();
-    expect(api).toBeTruthy();
+    expect(type).toBeTruthy();
     expect(app).toBeTruthy();
     expect(status).toBeTruthy();
-    expect(await api.getTriggerText()).toBeTruthy();
+    expect(await type.getTriggerText()).toBeTruthy();
   });
 
   it('should update status filter when selecting via harness', async () => {
@@ -241,39 +390,14 @@ describe('SubscriptionsComponent', () => {
     expect(fixture.componentInstance.applicationFilter.value).toContain('app-1');
   });
 
-  it('should update API filter when selecting via harness', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [SubscriptionsComponent],
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        provideNoopAnimations(),
-        provideRouter([]),
-        {
-          provide: ApiService,
-          useValue: {
-            search: () =>
-              of({
-                data: [{ id: 'api-1', name: 'API One' }],
-                metadata: { pagination: { current_page: 1, total_pages: 1 } },
-              }),
-          },
-        },
-      ],
-    }).compileComponents();
-    const f = TestBed.createComponent(SubscriptionsComponent);
-    const c = TestBed.inject(HttpTestingController);
-    f.detectChanges();
-    c.expectOne(req => req.url.includes('/applications')).flush({ data: [] });
-    c.expectOne(req => req.url.includes('/subscriptions')).flush(fakeSubscriptionResponse());
-    await f.whenStable();
+  it('should update target type filter when selecting via harness', async () => {
+    await setup(fakeSubscriptionResponse());
+    await getHarness();
 
-    const h = await TestbedHarnessEnvironment.harnessForFixture(f, SubscriptionsComponentHarness);
-    await withFlush(h.selectApiFilter(0), c);
-    f.detectChanges();
-    expect(f.componentInstance.apiFilter.value).toContain('api-1');
-    c.verify();
+    await withFlush(harness.selectTypeFilter(['API Product']));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.typeFilter.value).toEqual(['API_PRODUCT']);
   });
 
   it('should not navigate when form values match URL filters', async () => {
@@ -291,7 +415,7 @@ describe('SubscriptionsComponent', () => {
     const router = TestBed.inject(Router);
     const navigateSpy = jest.spyOn(router, 'navigate');
 
-    fixture.componentInstance.apiFilter.setValue(['api-1'], { emitEvent: false });
+    fixture.componentInstance.typeFilter.setValue(['API_PRODUCT'], { emitEvent: false });
     fixture.componentInstance.applicationFilter.setValue(['app-1'], { emitEvent: false });
     fixture.componentInstance.statusFilter.setValue([SubscriptionStatusEnum.ACCEPTED], { emitEvent: false });
     (fixture.componentInstance as unknown as { syncUrlToForm: () => void }).syncUrlToForm();
@@ -299,12 +423,28 @@ describe('SubscriptionsComponent', () => {
     expect(navigateSpy).toHaveBeenCalledWith([], {
       relativeTo: TestBed.inject(ActivatedRoute),
       queryParams: {
-        apiIds: ['api-1'],
+        query: null,
+        referenceTypes: ['API_PRODUCT'],
         applicationIds: ['app-1'],
         statuses: [SubscriptionStatusEnum.ACCEPTED],
         page: 1,
         size: 10,
       },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  });
+
+  it('should reset pagination when search changes', async () => {
+    await setup(fakeSubscriptionResponse());
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    fixture.componentInstance.onSearchTermChange('payment');
+
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { query: 'payment', page: 1 },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
@@ -334,14 +474,28 @@ describe('SubscriptionsComponent', () => {
     c.verify();
   });
 
-  it('should send view=documentation when loading API filter options', async () => {
-    await setup();
+  it('should ignore invalid reference types from URL query params', async () => {
+    const params = { referenceTypes: ['API_PRODUCT', 'UNKNOWN'], page: '1', size: '10' };
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [SubscriptionsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: params }, queryParams: of(params) } },
+      ],
+    }).compileComponents();
 
-    fixture.componentInstance.apiResultsLoader({ searchTerm: 'payment', page: 1 }).subscribe();
+    const f = TestBed.createComponent(SubscriptionsComponent);
+    const c = TestBed.inject(HttpTestingController);
+    f.detectChanges();
+    c.expectOne(req => req.url.includes('/applications')).flush({ data: [] });
+    c.expectOne(req => req.url.includes('/subscriptions')).flush(emptySubscriptions);
 
-    const req = http.expectOne(req => req.url.includes('/apis/_search'));
-    expect(req.request.params.get('view')).toBe('documentation');
-    req.flush({ data: [], metadata: {} });
+    expect(f.componentInstance.typeFilter.value).toEqual(['API_PRODUCT']);
+    c.verify();
   });
 
   it('hasSubscriptions is false when no data and no filters', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -19,35 +19,54 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { ActivatedRoute, Router } from '@angular/router';
 import { merge } from 'rxjs';
-import { debounceTime, map } from 'rxjs/operators';
+import { debounceTime } from 'rxjs/operators';
 
 import { subscriptionListBreadcrumb } from './subscription-breadcrumbs';
-import {
-  DropdownSearchComponent,
-  ResultsLoaderInput,
-  ResultsLoaderOutput,
-} from '../../../components/dropdown-search/dropdown-search.component';
+import { BadgeComponent } from '../../../components/badge/badge.component';
+import { DropdownSearchComponent } from '../../../components/dropdown-search/dropdown-search.component';
 import { LoaderComponent } from '../../../components/loader/loader.component';
 import { PaginatedTableComponent, TableColumn } from '../../../components/paginated-table/paginated-table.component';
-import { SubscriptionMetadata, SubscriptionStatusEnum } from '../../../entities/subscription';
-import { ApiService } from '../../../services/api.service';
+import { TableCellDirective } from '../../../components/paginated-table/table-cell.directive';
+import { SearchBarComponent } from '../../../components/search-bar/search-bar.component';
+import { Subscription, SubscriptionMetadata, SubscriptionReferenceType, SubscriptionStatusEnum } from '../../../entities/subscription';
 import { ApplicationService } from '../../../services/application.service';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
 import { areFiltersEqual, parseArrayParam, parsePageParam, parseSizeParam, toTitleCase } from '../../../utils/common.utils';
 
 type SubscriptionFilters = {
-  apiIds: string[] | undefined;
+  query: string;
+  referenceTypes: SubscriptionReferenceType[] | null;
   applicationIds: string[] | undefined;
   statuses: SubscriptionStatusEnum[] | null;
   page: number;
   size: number;
 };
 
+interface SubscriptionTableRow {
+  id: string;
+  targetName: string;
+  targetType: string;
+  plan: string;
+  application: string;
+  startAt: string | null;
+  endAt: string | null;
+  status: string;
+}
+
 @Component({
   selector: 'app-subscriptions',
   standalone: true,
-  imports: [MatButton, ReactiveFormsModule, LoaderComponent, PaginatedTableComponent, DropdownSearchComponent],
+  imports: [
+    BadgeComponent,
+    DropdownSearchComponent,
+    LoaderComponent,
+    MatButton,
+    PaginatedTableComponent,
+    ReactiveFormsModule,
+    SearchBarComponent,
+    TableCellDirective,
+  ],
   templateUrl: './subscriptions.component.html',
   styleUrl: './subscriptions.component.scss',
 })
@@ -55,93 +74,102 @@ export default class SubscriptionsComponent {
   private static readonly DEFAULT_PAGE_SIZE = 10;
   private static readonly DEFAULT_PAGE = 1;
   private static readonly MAX_PAGE_SIZE = 100;
+  private static readonly ALL_REFERENCE_TYPES: SubscriptionReferenceType[] = ['API', 'API_PRODUCT'];
 
-  private subscriptionService = inject(SubscriptionService);
-  private applicationService = inject(ApplicationService);
-  private apiService = inject(ApiService);
-  private router = inject(Router);
-  private activatedRoute = inject(ActivatedRoute);
-  private destroyRef = inject(DestroyRef);
+  private readonly subscriptionService = inject(SubscriptionService);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
   private readonly breadcrumbService = inject(BreadcrumbService);
 
-  subscriptionStatusesList = Object.values(SubscriptionStatusEnum);
-  statusOptions = this.subscriptionStatusesList.map(status => ({
+  readonly subscriptionStatusesList = Object.values(SubscriptionStatusEnum);
+  readonly statusOptions = this.subscriptionStatusesList.map(status => ({
     value: status,
     label: toTitleCase(status),
   }));
-  tableColumns: TableColumn[] = [
-    { id: 'api', label: 'Subscribed API' },
-    { id: 'plan', label: 'Plan' },
-    { id: 'application', label: 'Application' },
-    { id: 'created_at', label: 'Created', type: 'date' },
-    { id: 'status', label: 'Status' },
+  readonly typeOptions = [
+    { value: 'API', label: $localize`:@@subscriptionTypeApi:API` },
+    { value: 'API_PRODUCT', label: $localize`:@@subscriptionTypeApiProduct:API Product` },
+  ];
+  readonly tableColumns: TableColumn[] = [
+    { id: 'targetName', label: $localize`:@@subscriptionTargetColumn:Subscription target` },
+    { id: 'targetType', label: $localize`:@@subscriptionTypeColumn:Type` },
+    { id: 'plan', label: $localize`:@@subscriptionPlanColumn:Plan` },
+    { id: 'application', label: $localize`:@@subscriptionApplicationColumn:Application` },
+    { id: 'startAt', label: $localize`:@@subscriptionStartDateColumn:Start date`, type: 'date' },
+    { id: 'endAt', label: $localize`:@@subscriptionEndDateColumn:End date`, type: 'date' },
+    { id: 'status', label: $localize`:@@subscriptionStatusColumn:Status` },
   ];
 
   // Form controls for filters (UI view of URL state)
-  apiFilter = new FormControl<string[] | null>(null);
-  applicationFilter = new FormControl<string[] | null>(null);
-  statusFilter = new FormControl<SubscriptionStatusEnum[] | null>([]);
+  readonly typeFilter = new FormControl<SubscriptionReferenceType[] | null>([]);
+  readonly applicationFilter = new FormControl<string[] | null>(null);
+  readonly statusFilter = new FormControl<SubscriptionStatusEnum[] | null>([]);
 
-  private queryParams = toSignal(this.activatedRoute.queryParams, { initialValue: {} as Record<string, unknown> });
+  private readonly queryParams = toSignal(this.activatedRoute.queryParams, { initialValue: {} as Record<string, unknown> });
 
-  filters = computed(() => this.parseParamsToFilters(this.queryParams()));
+  readonly filters = computed(() => this.parseParamsToFilters(this.queryParams()));
 
-  pageSize = computed(() => this.filters().size);
-  currentPage = computed(() => this.filters().page);
+  readonly pageSize = computed(() => this.filters().size);
+  readonly currentPage = computed(() => this.filters().page);
 
   // Available options for filters
-  private availableApplicationsResource = rxResource({
+  private readonly availableApplicationsResource = rxResource({
     stream: () => this.applicationService.list(1, -1),
   });
-  availableApplications = computed(() => this.availableApplicationsResource.value()?.data ?? []);
-  applicationOptions = computed(() =>
+  readonly availableApplications = computed(() => this.availableApplicationsResource.value()?.data ?? []);
+  readonly applicationOptions = computed(() =>
     (this.availableApplications() ?? []).map(app => ({
       value: app.id,
       label: app.name,
     })),
   );
 
-  isLoadingSubscriptions = computed(() => this.subscriptionsResource.isLoading());
+  readonly isLoadingSubscriptions = computed(() => this.subscriptionsResource.isLoading());
 
-  subscriptionsResource = rxResource({
+  readonly subscriptionsResource = rxResource({
     params: () => this.filters(),
-    stream: ({ params }) => this.subscriptionService.list(params),
+    stream: ({ params }) =>
+      this.subscriptionService.list({
+        ...params,
+        referenceTypes: params.referenceTypes ?? SubscriptionsComponent.ALL_REFERENCE_TYPES,
+      }),
   });
 
-  totalElements = computed(() => {
+  readonly totalElements = computed(() => {
     const response = this.subscriptionsResource.value();
     return response?.metadata?.['paginateMetaData']?.totalElements ?? response?.data?.length ?? 0;
   });
 
-  hasSubscriptions = computed(() => {
-    const response = this.subscriptionsResource.value();
-    const { apiIds, applicationIds, statuses } = this.filters();
-    const isFiltered = (apiIds?.length ?? 0) > 0 || (applicationIds?.length ?? 0) > 0 || (statuses?.length ?? 0) > 0;
-
-    if (this.isLoadingSubscriptions()) {
-      return true;
-    }
-
-    if (!isFiltered) {
-      return (response?.data?.length ?? 0) > 0 || this.totalElements() > 0;
-    }
-    return true;
+  readonly subscriptionCountLabel = computed(() => {
+    const count = this.totalElements();
+    return count === 1
+      ? $localize`:@@subscriptionsSingleResult:1 subscription`
+      : $localize`:@@subscriptionsResultCount:${count}:count: subscriptions`;
   });
 
-  rows = computed(() => {
+  readonly isFiltered = computed(() => {
+    const { query, referenceTypes, applicationIds, statuses } = this.filters();
+    return query.length > 0 || (referenceTypes?.length ?? 0) > 0 || (applicationIds?.length ?? 0) > 0 || (statuses?.length ?? 0) > 0;
+  });
+
+  readonly hasSubscriptions = computed(() => {
+    const response = this.subscriptionsResource.value();
+    return (response?.data?.length ?? 0) > 0 || this.totalElements() > 0;
+  });
+
+  readonly shouldShowSubscriptionsContent = computed(
+    () => this.isLoadingSubscriptions() || !!this.subscriptionsResource.error() || this.hasSubscriptions() || this.isFiltered(),
+  );
+
+  readonly rows = computed<SubscriptionTableRow[]>(() => {
     const response = this.subscriptionsResource.value();
     if (!response?.data) {
       return [];
     }
 
-    return response.data.map(sub => ({
-      id: sub.id,
-      api: sub.api ? this.retrieveMetadataName(sub.api, response.metadata) : '',
-      plan: this.retrieveMetadataName(sub.plan, response.metadata),
-      application: this.retrieveMetadataName(sub.application, response.metadata),
-      created_at: sub.created_at ?? '',
-      status: toTitleCase(sub.status),
-    }));
+    return response.data.map(subscription => this.mapSubscriptionRow(subscription, response.metadata));
   });
 
   constructor() {
@@ -149,18 +177,15 @@ export default class SubscriptionsComponent {
     this.setupUrlSync();
   }
 
-  apiResultsLoader = ({ searchTerm, page }: ResultsLoaderInput) =>
-    this.apiService.search(page, 'all', searchTerm ?? '', 10).pipe(
-      map(
-        (response): ResultsLoaderOutput => ({
-          data: (response.data ?? []).map(api => ({ value: api.id, label: api.name })),
-          hasNextPage: (response.metadata?.pagination?.current_page ?? 1) < (response.metadata?.pagination?.total_pages ?? 1),
-        }),
-      ),
-    );
-
   retrieveMetadataName(id: string, metadata?: SubscriptionMetadata): string {
     return metadata?.[id]?.name ?? id;
+  }
+
+  onSearchTermChange(query: string): void {
+    const normalizedQuery = query.trim();
+    if (normalizedQuery !== this.filters().query) {
+      this.updateQueryParams({ query: normalizedQuery || null, page: 1 }, true);
+    }
   }
 
   onPageChange(page: number): void {
@@ -173,7 +198,8 @@ export default class SubscriptionsComponent {
 
   clearFilters(): void {
     this.updateQueryParams({
-      apiIds: null,
+      query: null,
+      referenceTypes: null,
       applicationIds: null,
       statuses: null,
       page: 1,
@@ -185,28 +211,29 @@ export default class SubscriptionsComponent {
       this.applyFiltersToForm(this.filters());
     });
 
-    merge(this.apiFilter.valueChanges, this.applicationFilter.valueChanges, this.statusFilter.valueChanges)
+    merge(this.typeFilter.valueChanges, this.applicationFilter.valueChanges, this.statusFilter.valueChanges)
       .pipe(debounceTime(0), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.syncUrlToForm());
   }
 
   private applyFiltersToForm(filters: SubscriptionFilters) {
-    this.apiFilter.setValue(filters.apiIds ?? null, { emitEvent: false });
+    this.typeFilter.setValue(filters.referenceTypes ?? [], { emitEvent: false });
     this.applicationFilter.setValue(filters.applicationIds ?? null, { emitEvent: false });
     this.statusFilter.setValue(filters.statuses ?? [], { emitEvent: false });
   }
 
   private syncUrlToForm() {
     const currentFilters = this.filters();
-    const apiIds = this.apiFilter.value ?? [];
+    const referenceTypes = this.typeFilter.value ?? [];
     const applicationIds = this.applicationFilter.value ?? [];
     const statuses = this.statusFilter.value ?? [];
 
     const nextFilters: SubscriptionFilters = {
-      apiIds: apiIds.length ? apiIds : undefined,
+      query: currentFilters.query,
+      referenceTypes: referenceTypes.length ? referenceTypes : null,
       applicationIds: applicationIds.length ? applicationIds : undefined,
       statuses: statuses.length ? statuses : null,
-      page: currentFilters.page,
+      page: 1,
       size: currentFilters.size,
     };
 
@@ -225,12 +252,14 @@ export default class SubscriptionsComponent {
   }
 
   private parseParamsToFilters(params: Record<string, unknown>): SubscriptionFilters {
-    const apiIds = parseArrayParam(params['apiIds']);
+    const query = typeof params['query'] === 'string' ? params['query'].trim() : '';
+    const referenceTypes = this.parseReferenceTypeParam(params['referenceTypes']);
     const applicationIds = parseArrayParam(params['applicationIds']);
     const statuses = this.parseStatusParam(params['statuses']);
 
     return {
-      apiIds: apiIds.length ? apiIds : undefined,
+      query,
+      referenceTypes: referenceTypes.length ? referenceTypes : null,
       applicationIds: applicationIds.length ? applicationIds : undefined,
       statuses: statuses.length ? statuses : null,
       page: parsePageParam(params['page'], SubscriptionsComponent.DEFAULT_PAGE),
@@ -240,7 +269,8 @@ export default class SubscriptionsComponent {
 
   private toRouterQueryParams(filters: SubscriptionFilters): Record<string, unknown> {
     return {
-      apiIds: filters.apiIds ?? null,
+      query: filters.query || null,
+      referenceTypes: filters.referenceTypes ?? null,
       applicationIds: filters.applicationIds ?? null,
       statuses: filters.statuses ?? null,
       page: filters.page,
@@ -251,5 +281,52 @@ export default class SubscriptionsComponent {
   private parseStatusParam(param: unknown): SubscriptionStatusEnum[] {
     const values = parseArrayParam(param);
     return values.filter((v): v is SubscriptionStatusEnum => Object.values(SubscriptionStatusEnum).includes(v as SubscriptionStatusEnum));
+  }
+
+  private parseReferenceTypeParam(param: unknown): SubscriptionReferenceType[] {
+    const values = parseArrayParam(param);
+    return values.filter((value): value is SubscriptionReferenceType =>
+      SubscriptionsComponent.ALL_REFERENCE_TYPES.includes(value as SubscriptionReferenceType),
+    );
+  }
+
+  private mapSubscriptionRow(subscription: Subscription, metadata?: SubscriptionMetadata): SubscriptionTableRow {
+    return {
+      id: subscription.id,
+      targetName: this.resolveTargetName(subscription, metadata),
+      targetType: this.resolveTargetTypeLabel(subscription.reference_type),
+      plan: this.retrieveMetadataName(subscription.plan, metadata),
+      application: this.retrieveMetadataName(subscription.application, metadata),
+      startAt: subscription.start_at ?? null,
+      endAt: subscription.end_at ?? null,
+      status: toTitleCase(subscription.status),
+    };
+  }
+
+  private resolveTargetName(subscription: Subscription, metadata?: SubscriptionMetadata): string {
+    const targetName = subscription.reference_id ? metadata?.[subscription.reference_id]?.name : undefined;
+    if (targetName) {
+      return targetName;
+    }
+
+    switch (subscription.reference_type) {
+      case 'API':
+        return $localize`:@@unavailableApiSubscriptionTarget:Unavailable API`;
+      case 'API_PRODUCT':
+        return $localize`:@@unavailableApiProductSubscriptionTarget:Unavailable API Product`;
+      default:
+        return $localize`:@@unavailableSubscriptionTarget:Unavailable subscription target`;
+    }
+  }
+
+  private resolveTargetTypeLabel(referenceType?: SubscriptionReferenceType): string {
+    switch (referenceType) {
+      case 'API':
+        return $localize`:@@subscriptionTypeApi:API`;
+      case 'API_PRODUCT':
+        return $localize`:@@subscriptionTypeApiProduct:API Product`;
+      default:
+        return $localize`:@@subscriptionTypeUnknown:Unknown`;
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -23,6 +23,8 @@ export interface Subscription {
   application: string;
   closed_at?: string;
   created_at?: string;
+  start_at?: string;
+  end_at?: string;
   updated_at?: string;
   plan: string;
   reason?: string;

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -66,6 +66,43 @@ describe('SubscriptionService', () => {
     req.flush(subscriptionResponse);
   });
 
+  it('should search API and API Product subscriptions in one backend page', done => {
+    const subscriptionResponse: SubscriptionsResponse = fakeSubscriptionResponse();
+
+    service
+      .list({
+        referenceTypes: ['API', 'API_PRODUCT'],
+        query: 'payment',
+        applicationIds: ['application-id'],
+        statuses: ['ACCEPTED'],
+        page: 2,
+        size: 20,
+      })
+      .subscribe(response => {
+        expect(response).toEqual(subscriptionResponse);
+        done();
+      });
+
+    const req = httpTestingController.expectOne(
+      `${TESTING_BASE_URL}/subscriptions?referenceTypes=API&referenceTypes=API_PRODUCT&query=payment&applicationIds=application-id&statuses=ACCEPTED&size=20&page=2`,
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(subscriptionResponse);
+  });
+
+  it('should omit a blank subscription target query', done => {
+    const subscriptionResponse: SubscriptionsResponse = fakeSubscriptionResponse();
+
+    service.list({ referenceTypes: ['API', 'API_PRODUCT'], query: '   ', statuses: null }).subscribe(response => {
+      expect(response).toEqual(subscriptionResponse);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions?referenceTypes=API&referenceTypes=API_PRODUCT`);
+    expect(req.request.method).toEqual('GET');
+    req.flush(subscriptionResponse);
+  });
+
   it('should close subscription', done => {
     service.close('subscriptionId').subscribe(() => {
       done();

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -21,6 +21,7 @@ import { ConfigService } from './config.service';
 import {
   CreateSubscription,
   Subscription,
+  SubscriptionReferenceType,
   SubscriptionsResponse,
   SubscriptionStatusEnum,
   UpdateSubscription,
@@ -38,6 +39,8 @@ export class SubscriptionService {
   list(queryParams: {
     apiIds?: string[];
     apiProductIds?: string[];
+    referenceTypes?: SubscriptionReferenceType[];
+    query?: string;
     applicationIds?: string[];
     statuses: SubscriptionStatusEnum[] | null;
     size?: number;
@@ -46,6 +49,8 @@ export class SubscriptionService {
     const params = {
       ...(queryParams.apiIds?.length ? { apiIds: queryParams.apiIds } : {}),
       ...(queryParams.apiProductIds?.length ? { apiProductIds: queryParams.apiProductIds } : {}),
+      ...(queryParams.referenceTypes?.length ? { referenceTypes: queryParams.referenceTypes } : {}),
+      ...(queryParams.query?.trim() ? { query: queryParams.query.trim() } : {}),
       ...(queryParams.applicationIds?.length ? { applicationIds: queryParams.applicationIds } : {}),
       ...(queryParams.statuses?.length ? { statuses: queryParams.statuses } : {}),
       ...(queryParams.size != null ? { size: queryParams.size } : {}),

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCriteria.java
@@ -41,9 +41,13 @@ public class SubscriptionCriteria {
 
     private final Collection<String> apis;
 
+    private final Collection<String> apiProducts;
+
     private final Collection<String> referenceIds;
 
     private final SubscriptionReferenceType referenceType;
+
+    private final Set<SubscriptionReferenceType> referenceTypes;
 
     private final Collection<String> plans;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -478,7 +478,11 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
 
         started = addStringsWhereClause(criteria.getPlans(), "s." + escapeReservedWord("plan"), argsList, builder, started);
         started = addStringsWhereClause(criteria.getApplications(), "s.application", argsList, builder, started);
-        if (criteria.getReferenceType() != null) {
+        if (!isEmpty(criteria.getReferenceTypes())) {
+            builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            appendReferenceTypesFilter(criteria, builder, argsList);
+            started = true;
+        } else if (criteria.getReferenceType() != null) {
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
             if (
                 isEmpty(criteria.getReferenceIds()) &&
@@ -617,6 +621,44 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
         argsList.add(io.gravitee.repository.management.model.SubscriptionReferenceType.API.name());
         argsList.addAll(referenceIds); // for reference_id IN
         argsList.addAll(referenceIds); // for api IN
+    }
+
+    private void appendReferenceTypesFilter(SubscriptionCriteria criteria, StringBuilder builder, List<Object> argsList) {
+        boolean filterByReferenceIds = !isEmpty(criteria.getApis()) || !isEmpty(criteria.getApiProducts());
+        builder.append("(");
+        boolean appended = false;
+
+        if (criteria.getReferenceTypes().contains(SubscriptionReferenceType.API)) {
+            if (!filterByReferenceIds || !isEmpty(criteria.getApis())) {
+                if (filterByReferenceIds) {
+                    appendApiReferenceIdsFilter(criteria.getApis(), builder, argsList);
+                } else {
+                    builder.append("( s.reference_type = ? OR s.reference_type IS NULL )");
+                    argsList.add(SubscriptionReferenceType.API.name());
+                }
+                appended = true;
+            }
+        }
+
+        if (criteria.getReferenceTypes().contains(SubscriptionReferenceType.API_PRODUCT)) {
+            if (!filterByReferenceIds || !isEmpty(criteria.getApiProducts())) {
+                if (appended) {
+                    builder.append(" OR ");
+                }
+                builder.append("( s.reference_type = ?");
+                argsList.add(SubscriptionReferenceType.API_PRODUCT.name());
+                if (filterByReferenceIds) {
+                    builder.append(" AND s.reference_id IN (").append(getOrm().buildInClause(criteria.getApiProducts())).append(")");
+                    argsList.addAll(criteria.getApiProducts());
+                }
+                builder.append(" )");
+                appended = true;
+            }
+        }
+        if (!appended) {
+            builder.append("1 = 0");
+        }
+        builder.append(")");
     }
 
     private void storeMetadata(Subscription subscription, boolean deleteFirst) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -86,10 +86,11 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         List<Bson> dataPipeline = new ArrayList<>(filterPipeline);
         // set sortable
         if (sortable != null) {
+            String sortableField = "id".equals(sortable.field()) ? "_id" : FieldUtils.toCamelCase(sortable.field());
             if (sortable.order().equals(Order.ASC)) {
-                dataPipeline.add(sort(Sorts.ascending(FieldUtils.toCamelCase(sortable.field()))));
+                dataPipeline.add(sort(Sorts.ascending(sortableField)));
             } else {
-                dataPipeline.add(sort(Sorts.descending(FieldUtils.toCamelCase(sortable.field()))));
+                dataPipeline.add(sort(Sorts.descending(sortableField)));
             }
         } else {
             dataPipeline.add(sort(Sorts.descending("createdAt")));
@@ -139,7 +140,9 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             }
         }
 
-        if (criteria.getReferenceType() != null) {
+        if (!CollectionUtils.isEmpty(criteria.getReferenceTypes())) {
+            addReferenceTypesFilter(dataPipeline, criteria);
+        } else if (criteria.getReferenceType() != null) {
             if (criteria.getReferenceIds() == null || criteria.getReferenceIds().isEmpty()) {
                 // Filter by type only (e.g. Portal API-only): include legacy subscriptions with null referenceType
                 if (criteria.getReferenceType() == SubscriptionReferenceType.API) {
@@ -370,6 +373,42 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         Bson migratedFilter = and(eq("referenceType", SubscriptionReferenceType.API.name()), referenceIdFilter);
         Bson legacyFilter = and(or(eq("referenceType", null), exists("referenceType", false)), apiFilter);
         dataPipeline.add(match(or(migratedFilter, legacyFilter)));
+    }
+
+    private void addReferenceTypesFilter(List<Bson> dataPipeline, SubscriptionCriteria criteria) {
+        boolean filterByReferenceIds = !CollectionUtils.isEmpty(criteria.getApis()) || !CollectionUtils.isEmpty(criteria.getApiProducts());
+        List<Bson> referenceFilters = new ArrayList<>();
+
+        if (criteria.getReferenceTypes().contains(SubscriptionReferenceType.API)) {
+            if (!filterByReferenceIds || !CollectionUtils.isEmpty(criteria.getApis())) {
+                Bson referenceTypeFilter = or(
+                    eq("referenceType", SubscriptionReferenceType.API.name()),
+                    eq("referenceType", null),
+                    exists("referenceType", false)
+                );
+                if (filterByReferenceIds) {
+                    Bson migratedFilter = and(
+                        eq("referenceType", SubscriptionReferenceType.API.name()),
+                        in("referenceId", criteria.getApis())
+                    );
+                    Bson legacyFilter = and(or(eq("referenceType", null), exists("referenceType", false)), in("api", criteria.getApis()));
+                    referenceTypeFilter = or(migratedFilter, legacyFilter);
+                }
+                referenceFilters.add(referenceTypeFilter);
+            }
+        }
+
+        if (criteria.getReferenceTypes().contains(SubscriptionReferenceType.API_PRODUCT)) {
+            if (!filterByReferenceIds || !CollectionUtils.isEmpty(criteria.getApiProducts())) {
+                Bson referenceTypeFilter = eq("referenceType", SubscriptionReferenceType.API_PRODUCT.name());
+                if (filterByReferenceIds) {
+                    referenceTypeFilter = and(referenceTypeFilter, in("referenceId", criteria.getApiProducts()));
+                }
+                referenceFilters.add(referenceTypeFilter);
+            }
+        }
+
+        dataPipeline.add(match(referenceFilters.isEmpty() ? exists("_id", false) : or(referenceFilters)));
     }
 
     private Page<SubscriptionMongo> buildSubscriptionsPage(Pageable pageable, AggregateIterable<Document> dataAggregate, Long totalCount) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
@@ -619,6 +619,72 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
     }
 
     @Test
+    public void should_search_api_and_api_product_subscriptions_by_reference_types() throws TechnicalException {
+        List<Subscription> subscriptions = this.subscriptionRepository.search(
+            SubscriptionCriteria.builder()
+                .referenceTypes(Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT))
+                .build()
+        );
+
+        Set<String> ids = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+
+        assertTrue(ids.contains("sub1"), "Should include API subscriptions");
+        assertTrue(ids.contains("sub-legacy-push"), "Should include legacy API subscriptions");
+        assertTrue(ids.contains("sub-api-product-1"), "Should include API Product subscriptions");
+        assertTrue(ids.contains("sub-api-product-2"), "Should include API Product subscriptions");
+    }
+
+    @Test
+    public void should_search_api_and_api_product_subscriptions_by_typed_reference_ids() throws TechnicalException {
+        List<Subscription> subscriptions = this.subscriptionRepository.search(
+            SubscriptionCriteria.builder()
+                .referenceTypes(Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT))
+                .apis(Set.of("api1"))
+                .apiProducts(Set.of("c45b8e66-4d2a-47ad-9b8e-664d2a97ad88"))
+                .build()
+        );
+
+        Set<String> ids = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+
+        assertTrue(ids.contains("sub1"), "Should include migrated API subscriptions");
+        assertTrue(ids.contains("sub-legacy-push"), "Should include legacy API subscriptions");
+        assertTrue(ids.contains("sub-api-product-1"), "Should include API Product subscriptions");
+        assertTrue(ids.contains("sub-api-product-2"), "Should include API Product subscriptions");
+    }
+
+    @Test
+    public void should_page_api_and_api_product_subscriptions_with_an_accurate_total() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder()
+            .referenceTypes(Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT))
+            .applications(Set.of("app4"))
+            .build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Page<Subscription> firstPage = subscriptionRepository.search(
+            criteria,
+            sortable,
+            new PageableBuilder().pageNumber(0).pageSize(2).build()
+        );
+        Page<Subscription> secondPage = subscriptionRepository.search(
+            criteria,
+            sortable,
+            new PageableBuilder().pageNumber(1).pageSize(2).build()
+        );
+
+        assertEquals(2, firstPage.getContent().size());
+        assertEquals(firstPage.getTotalElements(), secondPage.getTotalElements());
+        assertTrue(firstPage.getTotalElements() > firstPage.getContent().size());
+        assertTrue(
+            firstPage
+                .getContent()
+                .stream()
+                .map(Subscription::getId)
+                .noneMatch(secondPage.getContent().stream().map(Subscription::getId).toList()::contains),
+            "Pages must not overlap"
+        );
+    }
+
+    @Test
     public void shouldSearchByReferenceIdsAndType() throws TechnicalException {
         // Criteria with referenceIds/referenceType for API subscriptions
         // Expects both the migrated subscription (referenceId/referenceType set) and the legacy one (only api field set)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -201,6 +201,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.domain_service.ValidateSubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -506,6 +507,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionSearchQueryService subscriptionSearchQueryService() {
         return new SubscriptionSearchQueryServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionTargetSearchQueryService subscriptionTargetSearchQueryService() {
+        return mock(SubscriptionTargetSearchQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -243,6 +243,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.domain_service.ValidateSubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -536,6 +537,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionSearchQueryService subscriptionSearchQueryService(SubscriptionService subscriptionService) {
         return new SubscriptionSearchQueryServiceImpl(subscriptionService);
+    }
+
+    @Bean
+    public SubscriptionTargetSearchQueryService subscriptionTargetSearchQueryService() {
+        return mock(SubscriptionTargetSearchQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -172,6 +172,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.domain_service.ValidateSubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -589,6 +590,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionSearchQueryService subscriptionSearchQueryService() {
         return new SubscriptionSearchQueryServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionTargetSearchQueryService subscriptionTargetSearchQueryService() {
+        return mock(SubscriptionTargetSearchQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/subscription/SubscriptionQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/subscription/SubscriptionQuery.java
@@ -16,9 +16,11 @@
 package io.gravitee.rest.api.model.subscription;
 
 import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import lombok.*;
 
 /**
@@ -58,6 +60,16 @@ public class SubscriptionQuery {
      * Reference type (API or API_PRODUCT) for generic filtering.
      */
     private GenericPlanEntity.ReferenceType referenceType;
+
+    /**
+     * Reference types used by searches that return multiple target types in one result page.
+     */
+    private Set<GenericPlanEntity.ReferenceType> referenceTypes;
+
+    /**
+     * Optional repository sort used by callers that require stable pagination.
+     */
+    private Sortable sortable;
 
     private long from = -1;
     private long to = -1;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -16,13 +16,13 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.portal_page.domain_service.PortalApiProductAccessDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -36,7 +36,6 @@ import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
-import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.portal.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.portal.rest.mapper.KeyMapper;
@@ -69,9 +68,8 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
-import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
@@ -87,6 +85,9 @@ public class SubscriptionsResource extends AbstractResource {
 
     @Inject
     private CreateSubscriptionUseCase createSubscriptionUseCase;
+
+    @Inject
+    private SearchPortalSubscriptionsUseCase searchPortalSubscriptionsUseCase;
 
     @Inject
     private PlanSearchService planSearchService;
@@ -208,6 +209,8 @@ public class SubscriptionsResource extends AbstractResource {
         @Deprecated @QueryParam("applicationId") String applicationId,
         @QueryParam("apiIds") List<String> apiIds,
         @QueryParam("apiProductIds") List<String> apiProductIds,
+        @QueryParam("referenceTypes") List<String> referenceTypes,
+        @QueryParam("query") String targetNameQuery,
         @QueryParam("applicationIds") List<String> applicationIds,
         @QueryParam("statuses") List<SubscriptionStatus> statuses,
         @BeanParam PaginationParam paginationParam
@@ -221,16 +224,7 @@ public class SubscriptionsResource extends AbstractResource {
             throw new BadRequestException("API and API Product filters cannot be used together.");
         }
 
-        final SubscriptionQuery query = new SubscriptionQuery();
-        if (hasApiProductFilter) {
-            query.setApiProducts(apiProductIds);
-        } else {
-            if (hasApiFilter) {
-                query.setApis(effectiveApiIds);
-            }
-            query.setReferenceType(GenericPlanEntity.ReferenceType.API);
-        }
-        query.setStatuses(statuses);
+        Set<SubscriptionReferenceType> effectiveReferenceTypes = resolveReferenceTypes(referenceTypes, hasApiFilter, hasApiProductFilter);
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (effectiveApplicationIds == null || effectiveApplicationIds.isEmpty()) {
@@ -238,17 +232,28 @@ public class SubscriptionsResource extends AbstractResource {
             if (applications == null || applications.isEmpty()) {
                 return createListResponse(executionContext, emptyList(), paginationParam, paginationParam.hasPagination());
             }
-            query.setApplications(applications.stream().map(ApplicationListItem::getId).collect(toSet()));
+            effectiveApplicationIds = applications.stream().map(ApplicationListItem::getId).toList();
         } else {
             for (String appId : effectiveApplicationIds) {
                 if (!hasPermission(executionContext, RolePermission.APPLICATION_SUBSCRIPTION, appId, RolePermissionAction.READ)) {
                     throw new ForbiddenAccessException();
                 }
             }
-            query.setApplications(effectiveApplicationIds);
         }
 
-        final Page<SubscriptionEntity> pagedResult = fetchSubscriptions(paginationParam, query);
+        var output = searchPortalSubscriptionsUseCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                executionContext,
+                Set.copyOf(effectiveApplicationIds),
+                statuses == null ? null : Set.copyOf(statuses),
+                effectiveReferenceTypes,
+                hasApiFilter ? Set.copyOf(effectiveApiIds) : null,
+                hasApiProductFilter ? Set.copyOf(apiProductIds) : null,
+                targetNameQuery,
+                paginationParam.hasPagination() ? new PageableImpl(paginationParam.getPage(), paginationParam.getSize()) : null
+            )
+        );
+        final Page<SubscriptionEntity> pagedResult = output.page();
         List<SubscriptionEntity> subscriptions = pagedResult.getContent();
         long totalElements = pagedResult.getTotalElements();
 
@@ -317,19 +322,29 @@ public class SubscriptionsResource extends AbstractResource {
         return emptyList();
     }
 
-    private Page<SubscriptionEntity> fetchSubscriptions(PaginationParam paginationParam, SubscriptionQuery query) {
-        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        if (!paginationParam.hasPagination()) {
-            Collection<SubscriptionEntity> resp = subscriptionService.search(executionContext, query);
-            return new Page<>(resp.stream().toList(), 0, resp.size(), resp.size());
+    private static Set<SubscriptionReferenceType> resolveReferenceTypes(
+        List<String> referenceTypes,
+        boolean hasApiFilter,
+        boolean hasApiProductFilter
+    ) {
+        if (referenceTypes == null || referenceTypes.isEmpty()) {
+            return Set.of(hasApiProductFilter ? SubscriptionReferenceType.API_PRODUCT : SubscriptionReferenceType.API);
         }
 
-        Page<SubscriptionEntity> pagedSubscriptions = subscriptionService.search(
-            executionContext,
-            query,
-            new PageableImpl(paginationParam.getPage(), paginationParam.getSize())
-        );
-        return Objects.requireNonNullElseGet(pagedSubscriptions, () -> new Page<>(emptyList(), 0, 0, 0));
+        Set<SubscriptionReferenceType> types = new LinkedHashSet<>();
+        try {
+            referenceTypes.forEach(value -> types.add(SubscriptionReferenceType.valueOf(value.trim())));
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new BadRequestException("Unsupported subscription reference type.");
+        }
+
+        if (hasApiFilter && !types.equals(Set.of(SubscriptionReferenceType.API))) {
+            throw new BadRequestException("The API ID filter can only be used with the API reference type.");
+        }
+        if (hasApiProductFilter && !types.equals(Set.of(SubscriptionReferenceType.API_PRODUCT))) {
+            throw new BadRequestException("The API Product ID filter can only be used with the API_PRODUCT reference type.");
+        }
+        return Set.copyOf(types);
     }
 
     @Path("{subscriptionId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -2501,13 +2501,16 @@ paths:
                 - $ref: "#/components/parameters/applicationIdQueryParam"
                 - $ref: "#/components/parameters/apiIdsQueryParam"
                 - $ref: "#/components/parameters/apiProductIdsQueryParam"
+                - $ref: "#/components/parameters/subscriptionReferenceTypesQueryParam"
+                - $ref: "#/components/parameters/subscriptionQueryParam"
                 - $ref: "#/components/parameters/applicationIdsQueryParam"
                 - $ref: "#/components/parameters/subscriptionStatusesQueryParam"
                 - $ref: "#/components/parameters/pageNumberParam"
                 - $ref: "#/components/parameters/pageSizeParam"
             description: |
-                List all ACCEPTED, PAUSED & PENDING subscriptions, filtered by API, API Product and/or application.
-                API and API Product filters cannot be used together. When neither is provided, only API subscriptions are returned.
+                List subscriptions filtered by target type, target name, API, API Product and/or application.
+                API and API Product ID filters cannot be used together. When no target type or target ID filter is provided,
+                only API subscriptions are returned for backward compatibility.
 
                 User must have the APPLICATION_SUBSCRIPTION[READ] permission to list subscription with application query param.\
                 User must have the API_SUBSCRIPTION[READ] permission to list subscription with api query param.
@@ -4323,6 +4326,27 @@ components:
                 type: array
                 items:
                     type: string
+        subscriptionReferenceTypesQueryParam:
+            name: referenceTypes
+            in: query
+            required: false
+            description: |
+                Subscription target types to include. Repeat the parameter to return API and API Product subscriptions in one page.
+                When omitted, API subscriptions are returned unless apiProductIds is specified.
+            schema:
+                type: array
+                items:
+                    type: string
+                    enum:
+                        - API
+                        - API_PRODUCT
+        subscriptionQueryParam:
+            name: query
+            in: query
+            required: false
+            description: Case-insensitive search applied to API and API Product names before subscription pagination.
+            schema:
+                type: string
         applicationIdsQueryParam:
             name: applicationIds
             in: query

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertif
 import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
@@ -130,6 +131,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected CreateSubscriptionUseCase createSubscriptionUseCase;
+
+    @Autowired
+    protected SearchPortalSubscriptionsUseCase searchPortalSubscriptionsUseCase;
 
     @Autowired
     protected GetClientCertificatesUseCase getClientCertificatesUseCase;
@@ -380,6 +384,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected void resetAllMocks() {
         reset(
             createSubscriptionUseCase,
+            searchPortalSubscriptionsUseCase,
             getClientCertificatesUseCase,
             getClientCertificateUseCase,
             createClientCertificateUseCase,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
@@ -32,6 +32,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
@@ -98,6 +100,12 @@ class SubscriptionResourceTest extends AbstractResourceTest {
 
         when(keyMapper.convert(any(ApiKeyEntity.class))).thenReturn(new Key());
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    private void mockSubscriptionSearch(List<SubscriptionEntity> subscriptions) {
+        doReturn(new SearchPortalSubscriptionsUseCase.Output(new Page<>(subscriptions, 0, subscriptions.size(), subscriptions.size())))
+            .when(searchPortalSubscriptionsUseCase)
+            .execute(any(SearchPortalSubscriptionsUseCase.Input.class));
     }
 
     @Nested
@@ -513,7 +521,7 @@ class SubscriptionResourceTest extends AbstractResourceTest {
         @Test
         public void shouldReturnEmptyWhenNoSubscriptions() {
             doReturn(true).when(permissionService).hasPermission(any(), any(), any(), any());
-            doReturn(Collections.emptyList()).when(subscriptionService).search(any(), any());
+            mockSubscriptionSearch(Collections.emptyList());
 
             final Response response = target().queryParam("apiId", API).queryParam("applicationId", APPLICATION).request().get();
 
@@ -527,7 +535,7 @@ class SubscriptionResourceTest extends AbstractResourceTest {
             SubscriptionEntity subscription = new SubscriptionEntity();
             subscription.setId("sub-id");
             subscription.setStatus(SubscriptionStatus.ACCEPTED);
-            doReturn(Collections.singletonList(subscription)).when(subscriptionService).search(any(), any());
+            mockSubscriptionSearch(Collections.singletonList(subscription));
             doReturn(new Metadata()).when(subscriptionService).getMetadata(any(), any());
 
             final Response response = target().queryParam("apiId", API).queryParam("applicationId", APPLICATION).request().get();
@@ -541,7 +549,7 @@ class SubscriptionResourceTest extends AbstractResourceTest {
             SubscriptionEntity subscription = new SubscriptionEntity();
             subscription.setId("sub-id");
             subscription.setStatus(SubscriptionStatus.ACCEPTED);
-            doReturn(Collections.singletonList(subscription)).when(subscriptionService).search(any(), any());
+            mockSubscriptionSearch(Collections.singletonList(subscription));
             doReturn(new Metadata()).when(subscriptionService).getMetadata(any(), any());
 
             final Response response = target()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -41,6 +41,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
@@ -53,7 +54,6 @@ import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
-import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.portal.rest.model.ApiKeyModeEnum;
 import io.gravitee.rest.api.portal.rest.model.Key;
@@ -69,6 +69,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.junit.jupiter.api.AfterEach;
@@ -123,6 +124,9 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         );
         doReturn(subscriptionPage.getContent()).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(subscriptionPage).when(subscriptionService).search(any(), any(), any());
+        doReturn(new SearchPortalSubscriptionsUseCase.Output(subscriptionPage))
+            .when(searchPortalSubscriptionsUseCase)
+            .execute(any(SearchPortalSubscriptionsUseCase.Input.class));
 
         // Core subscription entity returned by UseCase
         SubscriptionEntity coreSubscriptionEntity = SubscriptionEntity.builder().id(SUBSCRIPTION).build();
@@ -172,6 +176,10 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoSubscription() {
+        doReturn(new SearchPortalSubscriptionsUseCase.Output(new Page<>(emptyList(), 10, 0, 0)))
+            .when(searchPortalSubscriptionsUseCase)
+            .execute(any(SearchPortalSubscriptionsUseCase.Input.class));
+
         final Response response = target().queryParam("page", 10).queryParam("size", 1).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
@@ -182,7 +190,9 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetNoPublishedApiAndNoLink() {
         final Page<io.gravitee.rest.api.model.SubscriptionEntity> subscriptionPage = new Page<>(emptyList(), 0, 1, 2);
-        doReturn(subscriptionPage).when(subscriptionService).search(any(), any(), any());
+        doReturn(new SearchPortalSubscriptionsUseCase.Output(subscriptionPage))
+            .when(searchPortalSubscriptionsUseCase)
+            .execute(any(SearchPortalSubscriptionsUseCase.Input.class));
 
         //Test with default limit
         final Response response = target().queryParam("apiId", API).request().get();
@@ -306,11 +316,16 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
 
         assertEquals(OK_200, response.getStatus());
 
-        ArgumentCaptor<SubscriptionQuery> queryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
-        verify(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), queryCaptor.capture(), any());
-        assertEquals(List.of(API_PRODUCT, ANOTHER_API_PRODUCT), queryCaptor.getValue().getApiProducts());
-        assertNull(queryCaptor.getValue().getApis());
-        assertNull(queryCaptor.getValue().getReferenceType());
+        ArgumentCaptor<SearchPortalSubscriptionsUseCase.Input> queryCaptor = ArgumentCaptor.forClass(
+            SearchPortalSubscriptionsUseCase.Input.class
+        );
+        verify(searchPortalSubscriptionsUseCase).execute(queryCaptor.capture());
+        assertEquals(Set.of(API_PRODUCT, ANOTHER_API_PRODUCT), queryCaptor.getValue().apiProductIds());
+        assertNull(queryCaptor.getValue().apiIds());
+        assertEquals(
+            Set.of(io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API_PRODUCT),
+            queryCaptor.getValue().referenceTypes()
+        );
 
         ArgumentCaptor<SubscriptionMetadataQuery> metadataQueryCaptor = ArgumentCaptor.forClass(SubscriptionMetadataQuery.class);
         verify(subscriptionService).getMetadata(eq(GraviteeContext.getExecutionContext()), metadataQueryCaptor.capture());
@@ -329,6 +344,64 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         Response response = target().queryParam("apiId", API).queryParam("apiProductIds", API_PRODUCT).request().get();
 
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    void shouldDefaultToApiSubscriptionsForBackwardCompatibility() {
+        mockCurrentUserApplication();
+        Metadata metadata = new Metadata();
+        doReturn(metadata).when(subscriptionService).getMetadata(eq(GraviteeContext.getExecutionContext()), any());
+
+        Response response = target().request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        ArgumentCaptor<SearchPortalSubscriptionsUseCase.Input> inputCaptor = ArgumentCaptor.forClass(
+            SearchPortalSubscriptionsUseCase.Input.class
+        );
+        verify(searchPortalSubscriptionsUseCase).execute(inputCaptor.capture());
+        assertEquals(
+            Set.of(io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API),
+            inputCaptor.getValue().referenceTypes()
+        );
+    }
+
+    @Test
+    void shouldSearchApiAndApiProductSubscriptionsByTargetName() {
+        mockCurrentUserApplication();
+        Metadata metadata = new Metadata();
+        doReturn(metadata).when(subscriptionService).getMetadata(eq(GraviteeContext.getExecutionContext()), any());
+
+        Response response = target()
+            .queryParam("referenceTypes", "API", "API_PRODUCT")
+            .queryParam("query", "payment")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .get();
+
+        assertEquals(OK_200, response.getStatus());
+        ArgumentCaptor<SearchPortalSubscriptionsUseCase.Input> inputCaptor = ArgumentCaptor.forClass(
+            SearchPortalSubscriptionsUseCase.Input.class
+        );
+        verify(searchPortalSubscriptionsUseCase).execute(inputCaptor.capture());
+        assertEquals(
+            Set.of(
+                io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API,
+                io.gravitee.apim.core.subscription.model.SubscriptionReferenceType.API_PRODUCT
+            ),
+            inputCaptor.getValue().referenceTypes()
+        );
+        assertEquals("payment", inputCaptor.getValue().query());
+        assertEquals(1, inputCaptor.getValue().pageable().getPageNumber());
+        assertEquals(10, inputCaptor.getValue().pageable().getPageSize());
+    }
+
+    @Test
+    void shouldRejectAnUnsupportedReferenceType() {
+        Response response = target().queryParam("referenceTypes", "UNKNOWN").request().get();
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        verify(searchPortalSubscriptionsUseCase, never()).execute(any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -196,6 +196,7 @@ import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.DeleteSubscriptionSpecUseCase;
 import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionCRDUseCase;
+import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
@@ -1492,6 +1493,11 @@ public class ResourceContextConfiguration {
     @Bean
     public CreateSubscriptionUseCase createSubscriptionUseCase() {
         return mock(CreateSubscriptionUseCase.class);
+    }
+
+    @Bean
+    public SearchPortalSubscriptionsUseCase searchPortalSubscriptionsUseCase() {
+        return mock(SearchPortalSubscriptionsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionSearchQueryService.java
@@ -34,4 +34,16 @@ public interface SubscriptionSearchQueryService {
         String apiKey,
         Pageable pageable
     );
+
+    Page<SubscriptionEntity> search(ExecutionContext executionContext, Criteria criteria, Pageable pageable);
+
+    record Criteria(
+        Set<SubscriptionReferenceType> referenceTypes,
+        Set<String> apiIds,
+        Set<String> apiProductIds,
+        Set<String> applicationIds,
+        Set<String> planIds,
+        Set<SubscriptionStatus> statuses,
+        String apiKey
+    ) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionTargetSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionTargetSearchQueryService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.query_service;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+
+public interface SubscriptionTargetSearchQueryService {
+    MatchingTargetIds search(ExecutionContext executionContext, String query, Set<SubscriptionReferenceType> referenceTypes);
+
+    record MatchingTargetIds(Set<String> apiIds, Set<String> apiProductIds) {
+        public MatchingTargetIds {
+            apiIds = apiIds == null ? Set.of() : Set.copyOf(apiIds);
+            apiProductIds = apiProductIds == null ? Set.of() : Set.copyOf(apiProductIds);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/SearchPortalSubscriptionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/SearchPortalSubscriptionsUseCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class SearchPortalSubscriptionsUseCase {
+
+    private final SubscriptionSearchQueryService subscriptionSearchQueryService;
+    private final SubscriptionTargetSearchQueryService subscriptionTargetSearchQueryService;
+
+    public Output execute(Input input) {
+        Set<SubscriptionReferenceType> referenceTypes = input.referenceTypes() == null || input.referenceTypes().isEmpty()
+            ? Set.of(SubscriptionReferenceType.API)
+            : Set.copyOf(input.referenceTypes());
+        Set<String> apiIds = copyOrNull(input.apiIds());
+        Set<String> apiProductIds = copyOrNull(input.apiProductIds());
+
+        Optional<String> query = Optional.ofNullable(input.query())
+            .map(String::trim)
+            .filter(value -> !value.isEmpty());
+        if (query.isPresent()) {
+            var matchingTargetIds = subscriptionTargetSearchQueryService.search(input.executionContext(), query.get(), referenceTypes);
+            apiIds = intersect(apiIds, matchingTargetIds.apiIds());
+            apiProductIds = intersect(apiProductIds, matchingTargetIds.apiProductIds());
+            if (apiIds.isEmpty() && apiProductIds.isEmpty()) {
+                int pageNumber = input.pageable() == null ? 0 : input.pageable().getPageNumber();
+                return new Output(new Page<>(List.of(), pageNumber, 0, 0));
+            }
+        }
+
+        var criteria = new SubscriptionSearchQueryService.Criteria(
+            referenceTypes,
+            apiIds,
+            apiProductIds,
+            input.applicationIds(),
+            null,
+            input.statuses(),
+            null
+        );
+        Page<SubscriptionEntity> page = subscriptionSearchQueryService.search(input.executionContext(), criteria, input.pageable());
+
+        return new Output(page.map(this::normalizeLegacyApiReference));
+    }
+
+    private Set<String> intersect(Set<String> requestedIds, Set<String> matchingIds) {
+        if (requestedIds == null || requestedIds.isEmpty()) {
+            return matchingIds;
+        }
+        Set<String> intersection = new HashSet<>(requestedIds);
+        intersection.retainAll(matchingIds);
+        return Set.copyOf(intersection);
+    }
+
+    private Set<String> copyOrNull(Set<String> values) {
+        return values == null || values.isEmpty() ? null : Set.copyOf(values);
+    }
+
+    private SubscriptionEntity normalizeLegacyApiReference(SubscriptionEntity subscription) {
+        if (subscription.getApi() == null || subscription.getApi().isBlank()) {
+            return subscription;
+        }
+        if (subscription.getReferenceType() != null && !SubscriptionReferenceType.API.name().equals(subscription.getReferenceType())) {
+            return subscription;
+        }
+        return subscription
+            .toBuilder()
+            .referenceId(subscription.getReferenceId() == null ? subscription.getApi() : subscription.getReferenceId())
+            .referenceType(SubscriptionReferenceType.API.name())
+            .build();
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        Set<String> applicationIds,
+        Set<SubscriptionStatus> statuses,
+        Set<SubscriptionReferenceType> referenceTypes,
+        Set<String> apiIds,
+        Set<String> apiProductIds,
+        String query,
+        Pageable pageable
+    ) {}
+
+    public record Output(Page<SubscriptionEntity> page) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImpl.java
@@ -21,11 +21,13 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -56,6 +58,32 @@ public class SubscriptionSearchQueryServiceImpl implements SubscriptionSearchQue
             .apiKey(apiKey)
             .build();
 
+        return subscriptionService.search(executionContext, query, pageable, false, false);
+    }
+
+    @Override
+    public Page<SubscriptionEntity> search(ExecutionContext executionContext, Criteria criteria, Pageable pageable) {
+        SubscriptionQuery query = SubscriptionQuery.builder()
+            .referenceTypes(
+                criteria
+                    .referenceTypes()
+                    .stream()
+                    .map(type -> GenericPlanEntity.ReferenceType.valueOf(type.name()))
+                    .collect(Collectors.toSet())
+            )
+            .apis(criteria.apiIds())
+            .apiProducts(criteria.apiProductIds())
+            .applications(criteria.applicationIds())
+            .plans(criteria.planIds())
+            .statuses(criteria.statuses())
+            .apiKey(criteria.apiKey())
+            .sortable(criteria.referenceTypes().size() > 1 ? new SortableImpl("id", true) : null)
+            .build();
+
+        if (pageable == null) {
+            var subscriptions = subscriptionService.search(executionContext, query);
+            return new Page<>(subscriptions.stream().toList(), 0, subscriptions.size(), subscriptions.size());
+        }
         return subscriptionService.search(executionContext, query, pageable, false, false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionTargetSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionTargetSearchQueryServiceImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.subscription;
+
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionTargetSearchQueryServiceImpl implements SubscriptionTargetSearchQueryService {
+
+    private final ApiSearchService apiSearchService;
+    private final SearchEngineService searchEngineService;
+
+    @Override
+    public MatchingTargetIds search(ExecutionContext executionContext, String query, Set<SubscriptionReferenceType> referenceTypes) {
+        Set<String> apiIds = referenceTypes.contains(SubscriptionReferenceType.API)
+            ? new LinkedHashSet<>(apiSearchService.searchIds(executionContext, query, Map.of(), null))
+            : Set.of();
+        Set<String> apiProductIds = referenceTypes.contains(SubscriptionReferenceType.API_PRODUCT)
+            ? searchApiProductIds(executionContext, query)
+            : Set.of();
+
+        return new MatchingTargetIds(apiIds, apiProductIds);
+    }
+
+    private Set<String> searchApiProductIds(ExecutionContext executionContext, String query) {
+        QueryBuilder<IndexableApiProduct> queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
+        queryBuilder.setQuery(query);
+        return new LinkedHashSet<>(searchEngineService.search(executionContext, queryBuilder.build()).getDocuments());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1875,7 +1875,11 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             }
             builder.ids(subscriptionsIds);
 
-            Stream<SubscriptionEntity> subscriptionsStream = subscriptionRepository.search(builder.build()).stream().map(this::convert);
+            var criteria = builder.build();
+            var subscriptions = query.getSortable() == null
+                ? subscriptionRepository.search(criteria)
+                : subscriptionRepository.search(criteria, convert(query.getSortable()));
+            Stream<SubscriptionEntity> subscriptionsStream = subscriptions.stream().map(this::convert);
 
             return subscriptionsStream.collect(toList());
         } catch (TechnicalException ex) {
@@ -1923,7 +1927,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 var pageSubscription = subscriptionRepository
                     .search(
                         builder.build(),
-                        null,
+                        convert(query.getSortable()),
                         new PageableBuilder().pageNumber(pageable.getPageNumber() - 1).pageSize(pageable.getPageSize()).build()
                     )
                     .map(this::convert);
@@ -1989,7 +1993,17 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             .includeWithoutEnd(query.isIncludeWithoutEnd())
             .excludedApis(query.getExcludedApis());
 
-        if (query.getReferenceId() != null && query.getReferenceType() != null) {
+        if (query.getReferenceTypes() != null && !query.getReferenceTypes().isEmpty()) {
+            builder.referenceTypes(
+                query
+                    .getReferenceTypes()
+                    .stream()
+                    .map(type -> SubscriptionReferenceType.valueOf(type.name()))
+                    .collect(toSet())
+            );
+            builder.apis(query.getApis());
+            builder.apiProducts(query.getApiProducts());
+        } else if (query.getReferenceId() != null && query.getReferenceType() != null) {
             builder.referenceIds(Collections.singleton(query.getReferenceId()));
             builder.referenceType(SubscriptionReferenceType.valueOf(query.getReferenceType().name()));
             if (query.getReferenceType() == GenericPlanEntity.ReferenceType.API) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionSearchQueryServiceInMemory.java
@@ -42,4 +42,11 @@ public class SubscriptionSearchQueryServiceInMemory implements SubscriptionSearc
         int pageSize = pageable != null ? pageable.getPageSize() : 10;
         return new Page<>(Collections.emptyList(), pageNumber + 1, pageSize, 0);
     }
+
+    @Override
+    public Page<SubscriptionEntity> search(ExecutionContext executionContext, Criteria criteria, Pageable pageable) {
+        int pageNumber = pageable != null ? pageable.getPageNumber() : 0;
+        int pageSize = pageable != null ? pageable.getPageSize() : 10;
+        return new Page<>(Collections.emptyList(), pageNumber, pageSize, 0);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/SearchPortalSubscriptionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/SearchPortalSubscriptionsUseCaseTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionTargetSearchQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchPortalSubscriptionsUseCaseTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+    private static final PageableImpl PAGEABLE = new PageableImpl(2, 10);
+
+    @Mock
+    private SubscriptionSearchQueryService subscriptionSearchQueryService;
+
+    @Mock
+    private SubscriptionTargetSearchQueryService subscriptionTargetSearchQueryService;
+
+    @Captor
+    private ArgumentCaptor<SubscriptionSearchQueryService.Criteria> criteriaCaptor;
+
+    private SearchPortalSubscriptionsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new SearchPortalSubscriptionsUseCase(subscriptionSearchQueryService, subscriptionTargetSearchQueryService);
+    }
+
+    @Test
+    void should_default_to_api_subscriptions() {
+        var page = new Page<SubscriptionEntity>(List.of(), 2, 0, 0);
+        when(
+            subscriptionSearchQueryService.search(
+                EXECUTION_CONTEXT,
+                new SubscriptionSearchQueryService.Criteria(
+                    Set.of(SubscriptionReferenceType.API),
+                    null,
+                    null,
+                    Set.of("app-id"),
+                    null,
+                    Set.of(SubscriptionStatus.ACCEPTED),
+                    null
+                ),
+                PAGEABLE
+            )
+        ).thenReturn(page);
+
+        var output = useCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                EXECUTION_CONTEXT,
+                Set.of("app-id"),
+                Set.of(SubscriptionStatus.ACCEPTED),
+                null,
+                null,
+                null,
+                null,
+                PAGEABLE
+            )
+        );
+
+        assertThat(output.page().getContent()).isEmpty();
+        assertThat(output.page().getPageNumber()).isEqualTo(page.getPageNumber());
+        assertThat(output.page().getTotalElements()).isEqualTo(page.getTotalElements());
+        verify(subscriptionTargetSearchQueryService, never()).search(EXECUTION_CONTEXT, null, Set.of(SubscriptionReferenceType.API));
+    }
+
+    @Test
+    void should_resolve_matching_target_ids_before_searching_subscriptions() {
+        Set<SubscriptionReferenceType> referenceTypes = Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT);
+        when(subscriptionTargetSearchQueryService.search(EXECUTION_CONTEXT, "payment", referenceTypes)).thenReturn(
+            new SubscriptionTargetSearchQueryService.MatchingTargetIds(Set.of("api-1", "api-2"), Set.of("product-1"))
+        );
+        when(
+            subscriptionSearchQueryService.search(
+                org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq(PAGEABLE)
+            )
+        ).thenReturn(new Page<>(List.of(), 2, 0, 3));
+
+        useCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                EXECUTION_CONTEXT,
+                Set.of("app-id"),
+                Set.of(SubscriptionStatus.ACCEPTED),
+                referenceTypes,
+                null,
+                null,
+                " payment ",
+                PAGEABLE
+            )
+        );
+
+        verify(subscriptionSearchQueryService).search(
+            org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+            criteriaCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq(PAGEABLE)
+        );
+        assertThat(criteriaCaptor.getValue().apiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+        assertThat(criteriaCaptor.getValue().apiProductIds()).containsExactly("product-1");
+        assertThat(criteriaCaptor.getValue().referenceTypes()).isEqualTo(referenceTypes);
+    }
+
+    @Test
+    void should_intersect_name_matches_with_explicit_target_ids() {
+        when(subscriptionTargetSearchQueryService.search(EXECUTION_CONTEXT, "payment", Set.of(SubscriptionReferenceType.API))).thenReturn(
+            new SubscriptionTargetSearchQueryService.MatchingTargetIds(Set.of("api-1", "api-2"), Set.of())
+        );
+        when(
+            subscriptionSearchQueryService.search(
+                org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq(PAGEABLE)
+            )
+        ).thenReturn(new Page<>(List.of(), 2, 0, 1));
+
+        useCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                EXECUTION_CONTEXT,
+                Set.of("app-id"),
+                null,
+                Set.of(SubscriptionReferenceType.API),
+                Set.of("api-2", "api-3"),
+                null,
+                "payment",
+                PAGEABLE
+            )
+        );
+
+        verify(subscriptionSearchQueryService).search(
+            org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+            criteriaCaptor.capture(),
+            org.mockito.ArgumentMatchers.eq(PAGEABLE)
+        );
+        assertThat(criteriaCaptor.getValue().apiIds()).containsExactly("api-2");
+    }
+
+    @Test
+    void should_return_an_empty_page_without_searching_subscriptions_when_no_target_matches() {
+        when(
+            subscriptionTargetSearchQueryService.search(EXECUTION_CONTEXT, "missing", Set.of(SubscriptionReferenceType.API_PRODUCT))
+        ).thenReturn(new SubscriptionTargetSearchQueryService.MatchingTargetIds(Set.of(), Set.of()));
+
+        var output = useCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                EXECUTION_CONTEXT,
+                Set.of("app-id"),
+                null,
+                Set.of(SubscriptionReferenceType.API_PRODUCT),
+                null,
+                null,
+                "missing",
+                PAGEABLE
+            )
+        );
+
+        assertThat(output.page().getContent()).isEmpty();
+        assertThat(output.page().getPageNumber()).isEqualTo(2);
+        assertThat(output.page().getTotalElements()).isZero();
+        verify(subscriptionSearchQueryService, never()).search(
+            org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(PAGEABLE)
+        );
+    }
+
+    @Test
+    void should_normalize_legacy_api_subscription_reference() {
+        SubscriptionEntity legacySubscription = SubscriptionEntity.builder().id("subscription-id").api("api-id").build();
+        when(
+            subscriptionSearchQueryService.search(
+                org.mockito.ArgumentMatchers.eq(EXECUTION_CONTEXT),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.eq(PAGEABLE)
+            )
+        ).thenReturn(new Page<>(List.of(legacySubscription), 2, 1, 1));
+
+        var output = useCase.execute(
+            new SearchPortalSubscriptionsUseCase.Input(
+                EXECUTION_CONTEXT,
+                Set.of("app-id"),
+                null,
+                Set.of(SubscriptionReferenceType.API),
+                null,
+                null,
+                null,
+                PAGEABLE
+            )
+        );
+
+        SubscriptionEntity normalized = output.page().getContent().getFirst();
+        assertThat(normalized.getApi()).isEqualTo("api-id");
+        assertThat(normalized.getReferenceId()).isEqualTo("api-id");
+        assertThat(normalized.getReferenceType()).isEqualTo("API");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionSearchQueryServiceImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionSearchQueryServiceImplTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    private SubscriptionSearchQueryServiceImpl queryService;
+
+    @BeforeEach
+    void setUp() {
+        queryService = new SubscriptionSearchQueryServiceImpl(subscriptionService);
+    }
+
+    @Test
+    void should_search_multiple_target_types_with_stable_sorting() {
+        var criteria = new SubscriptionSearchQueryService.Criteria(
+            Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT),
+            Set.of("api-id"),
+            Set.of("api-product-id"),
+            Set.of("application-id"),
+            Set.of("plan-id"),
+            Set.of(SubscriptionStatus.ACCEPTED),
+            null
+        );
+        when(subscriptionService.search(eq(EXECUTION_CONTEXT), org.mockito.ArgumentMatchers.any(SubscriptionQuery.class))).thenReturn(
+            List.of()
+        );
+
+        queryService.search(EXECUTION_CONTEXT, criteria, null);
+
+        var queryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+        verify(subscriptionService).search(eq(EXECUTION_CONTEXT), queryCaptor.capture());
+        assertThat(queryCaptor.getValue()).satisfies(query -> {
+            assertThat(query.getReferenceTypes()).containsExactlyInAnyOrder(
+                GenericPlanEntity.ReferenceType.API,
+                GenericPlanEntity.ReferenceType.API_PRODUCT
+            );
+            assertThat(query.getApis()).containsExactly("api-id");
+            assertThat(query.getApiProducts()).containsExactly("api-product-id");
+            assertThat(query.getSortable().getField()).isEqualTo("id");
+            assertThat(query.getSortable().isAscOrder()).isTrue();
+        });
+    }
+
+    @Test
+    void should_preserve_existing_sorting_for_a_single_target_type() {
+        var criteria = new SubscriptionSearchQueryService.Criteria(
+            Set.of(SubscriptionReferenceType.API),
+            null,
+            null,
+            Set.of("application-id"),
+            null,
+            null,
+            null
+        );
+        when(subscriptionService.search(eq(EXECUTION_CONTEXT), org.mockito.ArgumentMatchers.any(SubscriptionQuery.class))).thenReturn(
+            List.of()
+        );
+
+        queryService.search(EXECUTION_CONTEXT, criteria, null);
+
+        var queryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+        verify(subscriptionService).search(eq(EXECUTION_CONTEXT), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().getSortable()).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionTargetSearchQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionTargetSearchQueryServiceImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionTargetSearchQueryServiceImplTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+
+    @Mock
+    private ApiSearchService apiSearchService;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    private SubscriptionTargetSearchQueryServiceImpl queryService;
+
+    @BeforeEach
+    void setUp() {
+        queryService = new SubscriptionTargetSearchQueryServiceImpl(apiSearchService, searchEngineService);
+    }
+
+    @Test
+    void should_search_api_names_only_when_api_type_is_selected() {
+        when(apiSearchService.searchIds(EXECUTION_CONTEXT, "payment", Map.of(), null)).thenReturn(List.of("api-1"));
+
+        var result = queryService.search(EXECUTION_CONTEXT, "payment", Set.of(SubscriptionReferenceType.API));
+
+        assertThat(result.apiIds()).containsExactly("api-1");
+        assertThat(result.apiProductIds()).isEmpty();
+        verifyNoInteractions(searchEngineService);
+    }
+
+    @Test
+    void should_search_api_product_names_only_when_api_product_type_is_selected() {
+        when(searchEngineService.search(eq(EXECUTION_CONTEXT), any())).thenReturn(new SearchResult(List.of("product-1")));
+
+        var result = queryService.search(EXECUTION_CONTEXT, "payment", Set.of(SubscriptionReferenceType.API_PRODUCT));
+
+        assertThat(result.apiIds()).isEmpty();
+        assertThat(result.apiProductIds()).containsExactly("product-1");
+        verify(apiSearchService, never()).searchIds(any(), any(), any(), any());
+    }
+
+    @Test
+    void should_search_both_target_types() {
+        when(apiSearchService.searchIds(EXECUTION_CONTEXT, "payment", Map.of(), null)).thenReturn(List.of("api-1"));
+        when(searchEngineService.search(eq(EXECUTION_CONTEXT), any())).thenReturn(new SearchResult(List.of("product-1")));
+
+        var result = queryService.search(
+            EXECUTION_CONTEXT,
+            "payment",
+            Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT)
+        );
+
+        assertThat(result.apiIds()).containsExactly("api-1");
+        assertThat(result.apiProductIds()).containsExactly("product-1");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -61,6 +61,8 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.ApiProduct;
@@ -95,6 +97,7 @@ import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
 import io.gravitee.rest.api.model.application.TlsSettings;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.subscription.ReferenceDisplayInfo;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
@@ -3044,6 +3047,29 @@ public class SubscriptionServiceTest {
                     criteria.getReferenceIds().contains("c45b8e66-4d2a-47ad-9b8e-664d2a97ad88") &&
                     criteria.getReferenceType() == SubscriptionReferenceType.API_PRODUCT
             )
+        );
+    }
+
+    @Test
+    public void should_search_with_multiple_reference_types_and_typed_reference_ids() throws Exception {
+        SubscriptionQuery query = SubscriptionQuery.builder()
+            .referenceTypes(Set.of(GenericPlanEntity.ReferenceType.API, GenericPlanEntity.ReferenceType.API_PRODUCT))
+            .apis(Set.of(API_ID))
+            .apiProducts(Set.of("api-product-id"))
+            .sortable(new SortableImpl("id", true))
+            .build();
+        when(subscriptionRepository.search(any(SubscriptionCriteria.class), any(Sortable.class))).thenReturn(List.of());
+
+        subscriptionService.search(GraviteeContext.getExecutionContext(), query);
+
+        verify(subscriptionRepository).search(
+            argThat(
+                criteria ->
+                    criteria.getReferenceTypes().equals(Set.of(SubscriptionReferenceType.API, SubscriptionReferenceType.API_PRODUCT)) &&
+                    criteria.getApis().equals(Set.of(API_ID)) &&
+                    criteria.getApiProducts().equals(Set.of("api-product-id"))
+            ),
+            argThat(sortable -> sortable.field().equals("id") && sortable.order() == Order.ASC)
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-119

## Summary

Integrates API Product subscriptions into the Portal Next **My Subscriptions** view alongside existing API subscriptions.

## Changes

- Display API and API Product subscriptions in a unified list.
- Add search by API or API Product name.
- Add subscription target type filtering.
- Preserve application and status filters.
- Synchronize search, filters, pagination, and page size with URL parameters.
- Display target name, type, plan, application, start date, end date, and status.
- Add empty, loading, error, and missing-metadata states.
- Extend the subscription service with unified search parameters.
- Add component, service, and harness test coverage.


## Dependency

This is a stacked PR based on the unified subscription search introduced by PORTAL-120.


https://github.com/user-attachments/assets/3636e9a1-29ed-4216-b64d-aba5ccd5edaf


