### PR TITLE
feat(gamma): added list env alert

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.spec.tsx
@@ -18,16 +18,17 @@ import { render, screen } from '@testing-library/react';
 import { AlertsEducationalEmptyState } from './AlertsEducationalEmptyState';
 
 describe('AlertsEducationalEmptyState', () => {
-    it('renders the why/how-it-works/capabilities content', () => {
+    it('renders the why/how-it-works/capabilities content with classic env rules', () => {
         render(<AlertsEducationalEmptyState />);
 
         expect(screen.getByText('Why configure alerts?')).not.toBeNull();
         expect(screen.getByText('How it works')).not.toBeNull();
         expect(screen.getByText('Alert rule')).not.toBeNull();
         expect(screen.getByText('Email · Slack · Webhook')).not.toBeNull();
-        expect(screen.getByText('What you can alert on')).not.toBeNull();
+        expect(screen.getByText('Available alert rules')).not.toBeNull();
         expect(screen.getByText('Key capabilities')).not.toBeNull();
-        expect(screen.getByText(/Node lifecycle/)).not.toBeNull();
+        expect(screen.getByText(/Alert when the lifecycle status of a node has changed/)).not.toBeNull();
         expect(screen.getByText('Send notifications via email, Slack, or webhook')).not.toBeNull();
+        expect(screen.getByText('How it works').closest('div')?.className).toMatch(/border-primary/);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsEducationalEmptyState.tsx
@@ -25,11 +25,7 @@ import {
 } from '@gravitee/graphene-core/icons';
 import type { ComponentType } from 'react';
 
-const RULE_CATEGORIES = [
-    'Node lifecycle — when a gateway node starts, stops, or its health status changes',
-    'Node heartbeat metrics — CPU, memory, and other node metrics rising above a threshold',
-    'Health-check status — when an endpoint health check transitions between UP and DOWN',
-] as const;
+import { ALERT_RULES } from '../constants/alertRules';
 
 const CAPABILITIES = [
     'Send notifications via email, Slack, or webhook',
@@ -64,7 +60,7 @@ export function AlertsEducationalEmptyState() {
                 </p>
             </div>
 
-            <div className="rounded-xl p-5 bg-primary/10" style={{ border: '2px solid hsl(var(--primary))' }}>
+            <div className="rounded-xl border-2 border-primary bg-primary/10 p-5">
                 <p className="mb-4 text-xs font-semibold text-primary">How it works</p>
                 <div className="flex items-center justify-center gap-3">
                     <FlowNode icon={ActivityIcon} label="Platform events" />
@@ -90,12 +86,14 @@ export function AlertsEducationalEmptyState() {
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <div className="space-y-3">
-                    <p className="text-xs font-semibold">What you can alert on</p>
+                    <p className="text-xs font-semibold">Available alert rules</p>
                     <ul className="space-y-2.5">
-                        {RULE_CATEGORIES.map(category => (
-                            <li key={category} className="flex items-start gap-2">
+                        {ALERT_RULES.map(rule => (
+                            <li key={rule.id} className="flex items-start gap-2">
                                 <BellIcon className="mt-0.5 size-3.5 shrink-0 text-primary" aria-hidden="true" />
-                                <span className="text-xs text-muted-foreground">{category}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    {rule.description} <span className="text-muted-foreground/60">({rule.category})</span>
+                                </span>
                             </li>
                         ))}
                     </ul>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SeverityBadge.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SeverityBadge.spec.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { SeverityBadge } from './SeverityBadge';
+
+describe('SeverityBadge', () => {
+    it.each([
+        ['CRITICAL', 'critical'],
+        ['WARNING', 'warning'],
+        ['INFO', 'info'],
+    ] as const)('renders %s as a lowercase badge label', (severity, label) => {
+        render(<SeverityBadge severity={severity} />);
+
+        expect(screen.getByText(label)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SeverityBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SeverityBadge.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge } from '@gravitee/graphene-core';
+
+import type { AlertSeverity } from '../types/alert';
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+const SEVERITY_CONFIG: Record<AlertSeverity, { label: string; variant: BadgeVariant }> = {
+    CRITICAL: { label: 'critical', variant: 'destructive' },
+    WARNING: { label: 'warning', variant: 'secondary' },
+    INFO: { label: 'info', variant: 'outline' },
+};
+
+/** Colored severity pill for the env alerts list (and later create/edit). */
+export function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+    const config = SEVERITY_CONFIG[severity] ?? { label: severity.toLowerCase(), variant: 'outline' as BadgeVariant };
+    return (
+        <Badge variant={config.variant} className="text-xs font-normal capitalize">
+            {config.label}
+        </Badge>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertRules.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertRules.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Environment-scoped alert rules from classic Console (`entities/alerts/rule.metrics.ts`).
+ * Used for list rule labels and the educational empty state.
+ */
+export type AlertRuleCategory = 'API metrics' | 'Health-check' | 'Node';
+
+export interface AlertRuleDefinition {
+    id: string;
+    source: string;
+    type: string;
+    description: string;
+    category: AlertRuleCategory;
+}
+
+export const ALERT_RULES: AlertRuleDefinition[] = [
+    {
+        id: 'REQUEST@METRICS_SIMPLE_CONDITION',
+        source: 'REQUEST',
+        type: 'METRICS_SIMPLE_CONDITION',
+        description: 'Alert when a metric of the request validates a condition',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@MISSING_DATA',
+        source: 'REQUEST',
+        type: 'MISSING_DATA',
+        description: 'Alert when there is no request matching filters received for a period of time',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@METRICS_AGGREGATION',
+        source: 'REQUEST',
+        type: 'METRICS_AGGREGATION',
+        description: 'Alert when the aggregated value of a request metric rises a threshold',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@METRICS_RATE',
+        source: 'REQUEST',
+        type: 'METRICS_RATE',
+        description: 'Alert when the rate of a given condition rises a threshold',
+        category: 'API metrics',
+    },
+    {
+        id: 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED',
+        source: 'ENDPOINT_HEALTH_CHECK',
+        type: 'API_HC_ENDPOINT_STATUS_CHANGED',
+        description: 'Alert when the health status of an endpoint has changed',
+        category: 'Health-check',
+    },
+    {
+        id: 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED',
+        source: 'NODE_LIFECYCLE',
+        type: 'NODE_LIFECYCLE_CHANGED',
+        description: 'Alert when the lifecycle status of a node has changed',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_SIMPLE_CONDITION',
+        description: 'Alert when a metric of the node validates a condition',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_AGGREGATION',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_AGGREGATION',
+        description: 'Alert when the aggregated value of a node metric rises a threshold',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_RATE',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_RATE',
+        description: 'Alert when the rate of a given condition rises a threshold',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEALTHCHECK@NODE_HEALTHCHECK',
+        source: 'NODE_HEALTHCHECK',
+        type: 'NODE_HEALTHCHECK',
+        description: 'Alert on the health status of the node',
+        category: 'Node',
+    },
+];
+
+export function getAlertRuleLabel(source: string, type: string): string {
+    const ruleId = `${source}@${type}`;
+    return ALERT_RULES.find(rule => rule.id === ruleId)?.description ?? `${source} / ${type}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { listPlatformAlerts, updatePlatformAlert } from './alerts';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { AlertTrigger } from '../types/alert';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+const ALERT: AlertTrigger = {
+    id: 'alert-1',
+    name: 'Node down',
+    description: 'Gateway stopped',
+    severity: 'CRITICAL',
+    enabled: true,
+    source: 'NODE_LIFECYCLE',
+    type: 'NODE_LIFECYCLE_CHANGED',
+    conditions: [],
+    filters: [],
+    notifications: [],
+    notificationPeriods: [],
+    dampening: { mode: 'STRICT_COUNT', trueEvaluations: 1 },
+};
+
+describe('platform alerts service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+    });
+
+    describe('listPlatformAlerts', () => {
+        it('GETs /platform/alerts with event counts enabled', async () => {
+            await listPlatformAlerts('env-1');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts?event_counts=true');
+        });
+    });
+
+    describe('updatePlatformAlert', () => {
+        it('PUTs the alert entity to /platform/alerts/{id}', async () => {
+            const updated = { ...ALERT, enabled: false };
+            await updatePlatformAlert('env-1', updated);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/alert-1', {
+                method: 'PUT',
+                body: JSON.stringify(updated),
+            });
+        });
+
+        it('URL-encodes the alert id', async () => {
+            await updatePlatformAlert('env-1', { ...ALERT, id: 'a/b' });
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/a%2Fb', expect.any(Object));
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { AlertTrigger } from '../types/alert';
+
+/** Lists environment / platform alerts. Mirrors classic `AlertService.listAlerts(Scope.ENVIRONMENT, true)`. */
+export async function listPlatformAlerts(environmentId: string): Promise<AlertTrigger[]> {
+    return apimFetchJsonV1Env<AlertTrigger[]>(environmentId, '/platform/alerts?event_counts=true');
+}
+
+/** Updates a platform alert (used for enable/disable toggles on the list page). */
+export async function updatePlatformAlert(environmentId: string, alert: AlertTrigger): Promise<AlertTrigger> {
+    if (!alert.id) {
+        throw new Error('Cannot update a platform alert without an id');
+    }
+    return apimFetchJsonV1Env<AlertTrigger>(environmentId, `/platform/alerts/${encodeURIComponent(alert.id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(alert),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AlertSeverity = 'INFO' | 'WARNING' | 'CRITICAL';
+
+export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
+export type AlertTimeUnit = 'SECONDS' | 'MINUTES' | 'HOURS';
+
+export interface AlertDampening {
+    mode: AlertDampeningMode;
+    trueEvaluations?: number;
+    totalEvaluations?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+}
+
+/** Condition shape returned by the management API (opaque to the list page). */
+export type AlertApiCondition = Record<string, unknown>;
+
+export interface AlertApiNotification {
+    type: string;
+    configuration?: Record<string, unknown>;
+}
+
+export interface AlertApiPeriod {
+    days: number[];
+    beginHour: number;
+    endHour: number;
+    zoneId?: string;
+}
+
+/** Platform / environment alert trigger entity from `/platform/alerts`. */
+export interface AlertTrigger {
+    id?: string;
+    name: string;
+    description?: string;
+    severity: AlertSeverity;
+    enabled: boolean;
+    source: string;
+    type: string;
+    reference_type?: string;
+    reference_id?: string;
+    conditions?: AlertApiCondition[];
+    filters?: AlertApiCondition[];
+    notifications?: AlertApiNotification[];
+    notificationPeriods?: AlertApiPeriod[];
+    dampening?: AlertDampening;
+    projections?: unknown[];
+    template?: boolean;
+    event_rules?: unknown[];
+    counters?: Record<string, number>;
+    last_alert_at?: string | null;
+    last_alert_message?: string | null;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertListFormat.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertListFormat.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatAlertCounters, formatAlertCountersTooltip, formatLastAlertAt, formatLastAlertMessage } from './alertListFormat';
+
+describe('alertListFormat', () => {
+    it('formats counters as 5m / 1h / 1d / 1M', () => {
+        expect(formatAlertCounters({ '5m': 1, '1h': 2, '1d': 3, '1M': 4 })).toBe('1 / 2 / 3 / 4');
+        expect(formatAlertCounters(undefined)).toBe('—');
+        expect(formatAlertCountersTooltip({ '5m': 1, '1h': 0, '1d': 0, '1M': 0 })).toContain('during the last 5 minutes');
+    });
+
+    it('formats last alert timestamp and message with em dash fallbacks', () => {
+        expect(formatLastAlertAt(undefined)).toBe('—');
+        expect(formatLastAlertAt('not-a-date')).toBe('—');
+        expect(formatLastAlertAt('2026-08-12T10:00:00.000Z')).not.toBe('—');
+        expect(formatLastAlertMessage(undefined)).toBe('—');
+        expect(formatLastAlertMessage('Node stopped')).toBe('Node stopped');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertListFormat.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertListFormat.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const EMPTY = '—';
+
+/** Formats classic alert event counters as `5m / 1h / 1d / 1M`. */
+export function formatAlertCounters(counters: Record<string, number> | undefined): string {
+    if (!counters) {
+        return EMPTY;
+    }
+    return `${counters['5m'] ?? 0} / ${counters['1h'] ?? 0} / ${counters['1d'] ?? 0} / ${counters['1M'] ?? 0}`;
+}
+
+export function formatAlertCountersTooltip(counters: Record<string, number> | undefined): string | undefined {
+    if (!counters) {
+        return undefined;
+    }
+    return (
+        `${counters['5m'] ?? 0} during the last 5 minutes / ` +
+        `${counters['1h'] ?? 0} during the last 1 hour / ` +
+        `${counters['1d'] ?? 0} during the last 1 day / ` +
+        `${counters['1M'] ?? 0} during the last 1 month`
+    );
+}
+
+/** Formats `last_alert_at` for the list (classic medium datetime). */
+export function formatLastAlertAt(value: string | null | undefined): string {
+    if (value === undefined || value === null || value === '') {
+        return EMPTY;
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return EMPTY;
+    }
+    return date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+    });
+}
+
+export function formatLastAlertMessage(message: string | null | undefined): string {
+    if (message === undefined || message === null || message === '') {
+        return EMPTY;
+    }
+    return message;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const platformAlertKeys = {
+    all: ['platform-alerts'] as const,
+    list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { render, screen } from '@testing-library/react';
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 
 import { AlertsPage } from './AlertsPage';
+import { listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
+import type { AlertTrigger } from '../features/alerts/types/alert';
+import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
     useHasPermission: jest.fn(),
 }));
 
@@ -29,19 +34,47 @@ jest.mock('react-router-dom', () => ({
     useNavigate: jest.fn(),
 }));
 
+jest.mock('../features/alerts/services/alerts', () => ({
+    listPlatformAlerts: jest.fn(),
+    updatePlatformAlert: jest.fn(),
+}));
+
 jest.mock('../features/alerts/components/AlertsEducationalEmptyState', () => ({
     AlertsEducationalEmptyState: () => <div data-testid="alerts-educational-empty-state" />,
 }));
 
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockNavigate = jest.fn();
+const mockListPlatformAlerts = jest.mocked(listPlatformAlerts);
+const mockUpdatePlatformAlert = jest.mocked(updatePlatformAlert);
+
+const ALERT: AlertTrigger = {
+    id: 'alert-1',
+    name: 'Node stopped',
+    description: 'When a gateway node stops',
+    severity: 'CRITICAL',
+    enabled: true,
+    source: 'NODE_LIFECYCLE',
+    type: 'NODE_LIFECYCLE_CHANGED',
+    counters: { '5m': 1, '1h': 2, '1d': 3, '1M': 4 },
+    last_alert_at: '2026-08-12T10:00:00.000Z',
+    last_alert_message: 'Node apim-gateway stopped',
+};
 
 function renderPage() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     return render(
-        <MemoryRouter>
-            <AlertsPage />
-        </MemoryRouter>,
+        <QueryClientProvider client={client}>
+            <MemoryRouter>
+                <AlertsPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
     );
 }
 
@@ -49,39 +82,130 @@ describe('AlertsPage', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockUseNavigate.mockReturnValue(mockNavigate);
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
         mockUseHasPermission.mockReturnValue(true);
+        mockListPlatformAlerts.mockResolvedValue([]);
+        mockUpdatePlatformAlert.mockResolvedValue(ALERT);
     });
 
-    it('renders the page header and the educational empty state', () => {
+    it('renders the page header', async () => {
         renderPage();
 
         expect(screen.getByText('Alerts')).not.toBeNull();
         expect(screen.getByText('Get notified when your gateways or platform need attention.')).not.toBeNull();
-        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
+        await waitFor(() => expect(mockListPlatformAlerts).toHaveBeenCalledWith('env-1'));
     });
 
-    it('shows Add alert when the user has create permission', () => {
+    it('shows the educational empty state when there are no alerts', async () => {
+        mockListPlatformAlerts.mockResolvedValue([]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull());
+        expect(screen.queryByRole('table')).toBeNull();
+    });
+
+    it('shows Add alert when the user has create permission', async () => {
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.includes('environment-alert-c'));
         renderPage();
 
-        expect(screen.getByRole('button', { name: /Add alert/i })).not.toBeNull();
-        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
+        await waitFor(() => expect(screen.getByRole('button', { name: /Add alert/i })).not.toBeNull());
     });
 
-    it('hides Add alert when the user lacks create permission', () => {
+    it('hides Add alert when the user lacks create permission', async () => {
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-alert-c'));
         renderPage();
 
+        await waitFor(() => expect(mockListPlatformAlerts).toHaveBeenCalled());
         expect(screen.queryByRole('button', { name: /Add alert/i })).toBeNull();
-        expect(screen.getByTestId('alerts-educational-empty-state')).not.toBeNull();
     });
 
-    it('navigates to new when Add alert is clicked', async () => {
-        const user = userEvent.setup();
-        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.includes('environment-alert-c'));
+    it('renders the alerts table when alerts exist', async () => {
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
         renderPage();
 
-        await user.click(screen.getByRole('button', { name: /Add alert/i }));
-        expect(mockNavigate).toHaveBeenCalledWith('new');
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        expect(screen.getByText('Alert when the lifecycle status of a node has changed')).not.toBeNull();
+        expect(screen.getByText('1 / 2 / 3 / 4')).not.toBeNull();
+        expect(screen.getByText('Node apim-gateway stopped')).not.toBeNull();
+        expect(screen.getByText('critical')).not.toBeNull();
+        expect(screen.getByRole('columnheader', { name: 'Last 5m / 1h / 1d / 1M' })).not.toBeNull();
+        expect(screen.getByRole('columnheader', { name: 'Last alert' })).not.toBeNull();
+        expect(screen.getByRole('columnheader', { name: 'Last message' })).not.toBeNull();
+        expect(screen.queryByTestId('alerts-educational-empty-state')).toBeNull();
+        expect(screen.queryByText('When a gateway node stops')).toBeNull();
+    });
+
+    it('shows Edit and Delete as disabled actions', async () => {
+        const user = userEvent.setup();
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        await user.click(screen.getByRole('button', { name: 'Actions for Node stopped' }));
+
+        const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+        const deleteItem = screen.getByRole('menuitem', { name: 'Delete alert' });
+        expect(editItem.getAttribute('aria-disabled') ?? editItem.getAttribute('data-disabled')).toBeTruthy();
+        expect(deleteItem.getAttribute('aria-disabled') ?? deleteItem.getAttribute('data-disabled')).toBeTruthy();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows an error message when the list request fails', async () => {
+        mockListPlatformAlerts.mockRejectedValue(new Error('boom'));
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Failed to load alerts. Please try again.')).not.toBeNull());
+    });
+
+    it('toggles enabled state when the switch is clicked', async () => {
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
+        mockUpdatePlatformAlert.mockResolvedValue({ ...ALERT, enabled: false });
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        const toggle = screen.getByRole('switch');
+        fireEvent.click(toggle);
+
+        await waitFor(() =>
+            expect(mockUpdatePlatformAlert).toHaveBeenCalledWith('env-1', expect.objectContaining({ id: 'alert-1', enabled: false })),
+        );
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Alert "Node stopped" disabled.'));
+    });
+
+    it('does not allow enabling or disabling a template alert', async () => {
+        mockListPlatformAlerts.mockResolvedValue([{ ...ALERT, id: 'tpl-1', name: 'API template', template: true }]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('API template')).not.toBeNull());
+        const toggle = screen.getByRole('switch');
+        expect(toggle).toHaveProperty('disabled', true);
+        fireEvent.click(toggle);
+        expect(mockUpdatePlatformAlert).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast when enable/disable fails', async () => {
+        const failure = new Error('toggle failed');
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
+        mockUpdatePlatformAlert.mockRejectedValue(failure);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        fireEvent.click(screen.getByRole('switch'));
+
+        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(failure, 'Failed to update alert.'));
+        expect(notify.success).not.toHaveBeenCalled();
+    });
+
+    it('hides the actions column when the user cannot update or delete', async () => {
+        mockUseHasPermission.mockImplementation(
+            ({ anyOf }: { anyOf: string[] }) =>
+                !anyOf.includes('environment-alert-u') && !anyOf.includes('environment-alert-d') && !anyOf.includes('environment-alert-c'),
+        );
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        expect(screen.queryByRole('columnheader', { name: 'Actions' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Actions for Node stopped' })).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
@@ -13,26 +13,112 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Button } from '@gravitee/graphene-core';
-import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import {
+    Button,
+    Card,
+    CardContent,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Skeleton,
+    Switch,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { AlertsEducationalEmptyState } from '../features/alerts/components/AlertsEducationalEmptyState';
-import { ENVIRONMENT_ALERT_CREATE_PERMISSION } from '../features/alerts/utils/alertPermissions';
+import { SeverityBadge } from '../features/alerts/components/SeverityBadge';
+import { getAlertRuleLabel } from '../features/alerts/constants/alertRules';
+import { listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
+import type { AlertTrigger } from '../features/alerts/types/alert';
+import {
+    formatAlertCounters,
+    formatAlertCountersTooltip,
+    formatLastAlertAt,
+    formatLastAlertMessage,
+} from '../features/alerts/utils/alertListFormat';
+import {
+    ENVIRONMENT_ALERT_CREATE_PERMISSION,
+    ENVIRONMENT_ALERT_DELETE_PERMISSION,
+    ENVIRONMENT_ALERT_UPDATE_PERMISSION,
+} from '../features/alerts/utils/alertPermissions';
+import { platformAlertKeys } from '../features/alerts/utils/queryKeys';
+import { notify } from '../shared/notify';
+
+/** Classic `md-tooltip` on the counters cell: `N during the last 5 minutes / …`. */
+function AlertCountersCell({ counters }: { counters: AlertTrigger['counters'] }) {
+    const label = formatAlertCounters(counters);
+    const tooltip = formatAlertCountersTooltip(counters);
+
+    if (!tooltip) {
+        return <span className="text-sm text-muted-foreground">{label}</span>;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className="text-sm text-muted-foreground">{label}</span>
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+        </Tooltip>
+    );
+}
 
 /**
- * Environment-level Alerts landing page.
+ * Environment-level Alerts landing page (APIM-14911).
  *
- * Skeleton for APIM-14910 (educational UX): the alert list and activity views land in
- * follow-up tickets (APIM-14911 and beyond), so this page currently always renders the
- * educational content that introduces the feature. Create is gated here so users with
- * environment-alert-c see Add alert (same as API Alerts empty state); the form route
- * lands in a follow-up ticket.
+ * Loads `/platform/alerts`, shows the educational empty state when none exist,
+ * and otherwise lists alerts with enable/disable.
+ * Edit / delete stay in the actions menu but disabled until follow-up tickets
+ * (create/edit form + delete confirm modal).
  */
 export function AlertsPage() {
     const navigate = useNavigate();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const environmentId = env?.id ?? '';
+
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_CREATE_PERMISSION] });
+    const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_UPDATE_PERMISSION] });
+    const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_DELETE_PERMISSION] });
+    const showActions = canUpdate || canDelete;
+
+    const {
+        data: alerts,
+        isLoading,
+        isError,
+    } = useQuery({
+        queryKey: platformAlertKeys.list(environmentId),
+        queryFn: () => listPlatformAlerts(environmentId),
+        enabled: !!environmentId,
+    });
+
+    const toggleMutation = useMutation({
+        mutationFn: (alert: AlertTrigger) => updatePlatformAlert(environmentId, { ...alert, enabled: !alert.enabled }),
+        onSuccess: updated => {
+            queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
+            notify.success(updated.enabled ? `Alert "${updated.name}" enabled.` : `Alert "${updated.name}" disabled.`);
+        },
+        onError: error => {
+            notify.error(error, 'Failed to update alert.');
+        },
+    });
+
+    const handleAdd = () => navigate('new');
 
     return (
         <div className="space-y-6">
@@ -43,7 +129,7 @@ export function AlertsPage() {
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                     {canCreate && (
-                        <Button type="button" size="sm" onClick={() => navigate('new')}>
+                        <Button type="button" size="sm" onClick={handleAdd}>
                             <PlusIcon className="size-4" aria-hidden="true" />
                             Add alert
                         </Button>
@@ -51,7 +137,108 @@ export function AlertsPage() {
                 </div>
             </div>
 
-            <AlertsEducationalEmptyState />
+            {isLoading && (
+                <div className="space-y-3">
+                    {[1, 2, 3].map(i => (
+                        <Skeleton key={i} className="h-16 w-full rounded-lg" />
+                    ))}
+                </div>
+            )}
+
+            {isError && (
+                <Card>
+                    <CardContent className="pt-4 pb-4">
+                        <p className="text-sm text-destructive">Failed to load alerts. Please try again.</p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {!isLoading && !isError && (!alerts || alerts.length === 0) && <AlertsEducationalEmptyState />}
+
+            {!isLoading && !isError && alerts && alerts.length > 0 && (
+                <div className="rounded-lg border">
+                    <TooltipProvider delayDuration={200}>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Rule</TableHead>
+                                    <TableHead>Last 5m / 1h / 1d / 1M</TableHead>
+                                    <TableHead>Last alert</TableHead>
+                                    <TableHead>Last message</TableHead>
+                                    <TableHead>Severity</TableHead>
+                                    <TableHead>Enabled</TableHead>
+                                    {showActions && <TableHead className="w-12 text-right">Actions</TableHead>}
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {alerts.map(alert => (
+                                    <TableRow key={alert.id}>
+                                        <TableCell>
+                                            <p className="text-sm font-medium">{alert.name}</p>
+                                        </TableCell>
+                                        <TableCell>
+                                            <span className="text-sm text-muted-foreground">
+                                                {getAlertRuleLabel(alert.source, alert.type)}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell>
+                                            <AlertCountersCell counters={alert.counters} />
+                                        </TableCell>
+                                        <TableCell>
+                                            <span className="text-sm text-muted-foreground">{formatLastAlertAt(alert.last_alert_at)}</span>
+                                        </TableCell>
+                                        <TableCell>
+                                            <span className="text-sm text-muted-foreground line-clamp-1">
+                                                {formatLastAlertMessage(alert.last_alert_message)}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell>
+                                            <SeverityBadge severity={alert.severity} />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Switch
+                                                checked={alert.enabled}
+                                                disabled={
+                                                    !canUpdate ||
+                                                    !!alert.template ||
+                                                    (toggleMutation.isPending && toggleMutation.variables?.id === alert.id)
+                                                }
+                                                onCheckedChange={() => toggleMutation.mutate(alert)}
+                                            />
+                                        </TableCell>
+                                        {showActions && (
+                                            <TableCell>
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="size-8"
+                                                            aria-label={`Actions for ${alert.name}`}
+                                                        >
+                                                            <MoreHorizontalIcon className="size-4" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent align="end">
+                                                        {canUpdate && <DropdownMenuItem disabled>Edit</DropdownMenuItem>}
+                                                        {canUpdate && canDelete && <DropdownMenuSeparator />}
+                                                        {canDelete && (
+                                                            <DropdownMenuItem disabled className="text-destructive focus:text-destructive">
+                                                                Delete alert
+                                                            </DropdownMenuItem>
+                                                        )}
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            </TableCell>
+                                        )}
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TooltipProvider>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14911

## Description

Lists environment alerts in Gamma when any exist, using `GET /platform/alerts`.
Table columns: **Name · Rule · Last 5m / 1h / 1d / 1M · Last alert · Last message · Severity · Enabled · Actions**.
- **Rule** shows the classic human-readable rule description (`source@type`)
- **Counters** show `5m / 1h / 1d / 1M` with the classic hover tooltip
- **Enabled** toggle calls `PUT /platform/alerts/{id}` and shows a success/error snackbar
- **Actions** keeps Edit / Delete alert (permission-gated) but **disabled** for now — edit form and delete confirm modal land in follow-up tickets
- Empty list still uses the educational empty state (driven by classic env alert rules)
- Loading and error states covered
Stacked on APIM-14910 (educational UX / route / nav).
## Additional context


https://github.com/user-attachments/assets/a9b27f3c-921a-41c0-86dc-aa82041efbaf


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>