### PR TITLE
fix(rest-api): send the registration email only once the request is approved

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.html
@@ -88,6 +88,11 @@
           </div>
           @if (error() === 400) {
             <mat-error i18n="@@registrationConfirmationBadPassword">Invalid password</mat-error>
+          } @else if (error() === 409) {
+            <mat-error i18n="@@registrationConfirmationPendingApproval"
+              >Your registration request is awaiting approval by an administrator. You will receive an email once it has been
+              reviewed.</mat-error
+            >
           }
           <div class="registration-confirmation__form__buttons">
             <button

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.spec.ts
@@ -15,12 +15,14 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpErrorResponse } from '@angular/common/http';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatCardHarness } from '@angular/material/card/testing';
 import { MatErrorHarness } from '@angular/material/form-field/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
+import { throwError } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { RegistrationConfirmationComponent } from './registration-confirmation.component';
@@ -36,7 +38,11 @@ describe('RegistrationConfirmationComponent', () => {
 
   let httpTestingController: HttpTestingController;
 
-  const init = async (params?: { token?: string; parsedToken?: { firstname: string; lastname: string; email: string } | null }) => {
+  const init = async (params?: {
+    token?: string;
+    parsedToken?: { firstname: string; lastname: string; email: string } | null;
+    finalizeRegistrationError?: HttpErrorResponse;
+  }) => {
     const token = params?.token ?? 'token-123';
 
     const defaultParsed = { firstname: 'John', lastname: 'Doe', email: 'john@doe.com' };
@@ -47,7 +53,9 @@ describe('RegistrationConfirmationComponent', () => {
     };
 
     const usersServiceMock = {
-      finalizeRegistration: jest.fn().mockReturnValue(of({})),
+      finalizeRegistration: jest
+        .fn()
+        .mockReturnValue(params?.finalizeRegistrationError ? throwError(() => params.finalizeRegistrationError) : of({})),
     };
 
     await TestBed.configureTestingModule({
@@ -139,5 +147,50 @@ describe('RegistrationConfirmationComponent', () => {
     const cardText = await card.getText();
     expect(cardText).toContain('Your account has been successfully activated.');
     expect(cardText).toContain('Back to login');
+  });
+
+  const submitRegistration = async () => {
+    const passwordInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    const confirmInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="confirmedPassword"]' }));
+
+    await passwordInput.setValue('P@ssw0rd!');
+    await confirmInput.setValue('P@ssw0rd!');
+
+    const submitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Complete registration' }));
+    await submitBtn.click();
+
+    fixture.detectChanges();
+  };
+
+  it('should tell the user the registration is awaiting approval when finalization is refused', async () => {
+    await init({
+      token: 'token-123',
+      parsedToken: defaultParsed,
+      finalizeRegistrationError: new HttpErrorResponse({
+        status: 409,
+        error: { errors: [{ code: 'errors.user.registration.pendingApproval' }] },
+      }),
+    });
+
+    await submitRegistration();
+
+    const errorEl = await harnessLoader.getHarness(MatErrorHarness);
+    expect(await errorEl.getText()).toContain('awaiting approval by an administrator');
+  });
+
+  it('should report any other conflict as an invalid password', async () => {
+    await init({
+      token: 'token-123',
+      parsedToken: defaultParsed,
+      finalizeRegistrationError: new HttpErrorResponse({
+        status: 409,
+        error: { errors: [{ code: 'errors.user.state.conflict' }] },
+      }),
+    });
+
+    await submitRegistration();
+
+    const errorEl = await harnessLoader.getHarness(MatErrorHarness);
+    expect(await errorEl.getText()).toContain('Invalid password');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration-confirmation/registration-confirmation.component.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, effect, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
@@ -46,6 +47,12 @@ interface RegistrationConfirmationFormValue {
   password: string;
   customFields?: { [key: string]: string };
 }
+
+const PENDING_APPROVAL_ERROR_CODE = 'errors.user.registration.pendingApproval';
+
+// A registration can also conflict for other reasons, only the pending approval one has a dedicated message.
+const isPendingApproval = (error: HttpErrorResponse): boolean =>
+  error.status === 409 && error.error?.errors?.[0]?.code === PENDING_APPROVAL_ERROR_CODE;
 
 @Component({
   selector: 'app-registration-confirmation',
@@ -113,8 +120,8 @@ export class RegistrationConfirmationComponent {
         })
         .pipe(
           tap(_ => this.submitted.set(true)),
-          catchError(_ => {
-            this.error.set(400);
+          catchError((error: HttpErrorResponse) => {
+            this.error.set(isPendingApproval(error) ? 409 : 400);
             return EMPTY;
           }),
           takeUntilDestroyed(this.destroyRef),

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.html
@@ -86,19 +86,35 @@
     </mat-card-content>
   } @else {
     <mat-card-header class="registration__form__header">
-      <mat-card-title class="registration__form__title m3-headline-small" i18n="@@registrationSuccessHeader">
-        Check your email
-      </mat-card-title>
+      @if (isApprovalRequired) {
+        <mat-card-title class="registration__form__title m3-headline-small" i18n="@@registrationPendingApprovalHeader">
+          Registration request sent
+        </mat-card-title>
+      } @else {
+        <mat-card-title class="registration__form__title m3-headline-small" i18n="@@registrationSuccessHeader">
+          Check your email
+        </mat-card-title>
+      }
     </mat-card-header>
     <mat-card-content class="registration__form__content">
       <div class="registration__success__container">
-        <div class="registration__success__text m3-body-medium" i18n="@@registrationSuccessLabel">
-          We've sent you a confirmation link to:
-        </div>
-        <div class="registration__success__email m3-title-small">{{ sentToEmail() }}</div>
-        <div class="registration__success__text m3-body-medium" i18n="@@registrationSuccessHint">
-          Please follow the link to activate your account.
-        </div>
+        @if (isApprovalRequired) {
+          <div class="registration__success__text m3-body-medium" i18n="@@registrationPendingApprovalLabel">
+            Your registration request is awaiting approval by an administrator for:
+          </div>
+          <div class="registration__success__email m3-title-small">{{ sentToEmail() }}</div>
+          <div class="registration__success__text m3-body-medium" i18n="@@registrationPendingApprovalHint">
+            You will receive an email with an activation link once it has been approved.
+          </div>
+        } @else {
+          <div class="registration__success__text m3-body-medium" i18n="@@registrationSuccessLabel">
+            We've sent you a confirmation link to:
+          </div>
+          <div class="registration__success__email m3-title-small">{{ sentToEmail() }}</div>
+          <div class="registration__success__text m3-body-medium" i18n="@@registrationSuccessHint">
+            Please follow the link to activate your account.
+          </div>
+        }
         <a i18n="@@registrationBackAction" class="registration__success__action internal-link" routerLink="/log-in">Back to login</a>
       </div>
     </mat-card-content>

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.spec.ts
@@ -27,8 +27,9 @@ import { of } from 'rxjs/internal/observable/of';
 import { RegistrationComponent } from './registration.component';
 import { CustomUserField } from '../../entities/user/custom-user-field';
 import { User } from '../../entities/user/user';
+import { ConfigService } from '../../services/config.service';
 import { UsersService } from '../../services/users.service';
-import { AppTestingModule } from '../../testing/app-testing.module';
+import { AppTestingModule, ConfigServiceStub } from '../../testing/app-testing.module';
 
 describe('RegistrationComponent', () => {
   let fixture: ComponentFixture<RegistrationComponent>;
@@ -39,7 +40,7 @@ describe('RegistrationComponent', () => {
     registerNewUser: jest.Mock;
   };
 
-  const init = async (opts?: { customUserFields?: CustomUserField[]; register$?: Observable<User> }) => {
+  const init = async (opts?: { customUserFields?: CustomUserField[]; register$?: Observable<User>; automaticValidation?: boolean }) => {
     usersServiceMock = {
       listCustomUserFields: jest.fn().mockReturnValue(of(opts?.customUserFields ?? [])),
       registerNewUser: jest.fn().mockReturnValue(opts?.register$ ?? of({})),
@@ -47,7 +48,22 @@ describe('RegistrationComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [RegistrationComponent, AppTestingModule],
-      providers: [{ provide: UsersService, useValue: usersServiceMock }],
+      providers: [
+        { provide: UsersService, useValue: usersServiceMock },
+        {
+          provide: ConfigService,
+          useFactory: () => {
+            const stub = new ConfigServiceStub();
+            if (opts?.automaticValidation !== undefined) {
+              stub.configuration = {
+                ...stub.configuration,
+                portal: { userCreation: { enabled: true, automaticValidation: { enabled: opts.automaticValidation } } },
+              };
+            }
+            return stub;
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RegistrationComponent);
@@ -150,5 +166,49 @@ describe('RegistrationComponent', () => {
     expect(cardText).toContain("We've sent you a confirmation link to:");
     expect(cardText).toContain('john@doe.com');
     expect(cardText).toContain('Please follow the link to activate your account.');
+  });
+
+  it('register() should tell the user the request awaits approval when automatic validation is disabled', async () => {
+    await init({ customUserFields: [], register$: of({}), automaticValidation: false });
+
+    const firstnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="firstname"]' }));
+    const lastnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="lastname"]' }));
+    const emailInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="email"]' }));
+    const signUp = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Sign up' }));
+
+    await firstnameInput.setValue('John');
+    await lastnameInput.setValue('Doe');
+    await emailInput.setValue('john@doe.com');
+    await signUp.click();
+
+    fixture.detectChanges();
+
+    const successCard = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.registration__form__container' }));
+    expect(await successCard.getTitleText()).toContain('Registration request sent');
+
+    const cardText = await successCard.getText();
+    expect(cardText).toContain('Your registration request is awaiting approval by an administrator for:');
+    expect(cardText).toContain('john@doe.com');
+    expect(cardText).toContain('You will receive an email with an activation link once it has been approved.');
+    expect(cardText).not.toContain("We've sent you a confirmation link to:");
+  });
+
+  it('register() should keep the "check your email" message when registrations are automatically validated', async () => {
+    await init({ customUserFields: [], register$: of({}), automaticValidation: true });
+
+    const firstnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="firstname"]' }));
+    const lastnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="lastname"]' }));
+    const emailInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="email"]' }));
+    const signUp = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Sign up' }));
+
+    await firstnameInput.setValue('John');
+    await lastnameInput.setValue('Doe');
+    await emailInput.setValue('john@doe.com');
+    await signUp.click();
+
+    fixture.detectChanges();
+
+    const successCard = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.registration__form__container' }));
+    expect(await successCard.getTitleText()).toContain('Check your email');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/registration.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,6 +26,7 @@ import { catchError, EMPTY, tap } from 'rxjs';
 
 import { MobileClassDirective } from '../../directives/mobile-class.directive';
 import { CustomUserField } from '../../entities/user/custom-user-field';
+import { ConfigService } from '../../services/config.service';
 import { UsersService } from '../../services/users.service';
 
 interface UserRegistrationFormValue {
@@ -51,8 +52,15 @@ interface UserRegistrationFormValue {
   styleUrl: './registration.component.scss',
 })
 export class RegistrationComponent implements OnInit {
+  private readonly configService = inject(ConfigService);
+
   submitted = signal(false);
   sentToEmail = signal('');
+
+  /**
+   * Without automatic validation, the activation email is only sent once an administrator has approved the request.
+   */
+  isApprovalRequired = this.configService.configuration.portal?.userCreation?.automaticValidation?.enabled === false;
 
   customUserFields = signal<CustomUserField[]>([]);
 

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-user-creation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-user-creation.ts
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConfigurationPortalUserCreation } from './configuration-portal-user-creation';
+import { Enabled } from './enabled';
 
-export class ConfigurationPortal {
-  apikeyHeader?: string;
-  kafkaSaslMechanisms?: string[];
-  userCreation?: ConfigurationPortalUserCreation;
+export interface ConfigurationPortalUserCreation {
+  /**
+   * true, if users can register themselves
+   */
+  enabled?: boolean;
+  /**
+   * when disabled, a registration request has to be approved by an administrator
+   */
+  automaticValidation?: Enabled;
 }

--- a/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.html
@@ -114,13 +114,18 @@
   <ng-container *ngIf="isSubmitted">
     <div class="page__box">
       <div class="page__box-title">
-        <h3>{{ 'registration.success.title' | translate }}</h3>
+        <h3>{{ (isApprovalRequired ? 'registration.pendingApproval.title' : 'registration.success.title') | translate }}</h3>
       </div>
 
       <div class="page__box-content">
         <div class="form__message">
-          <gv-icon shape="communication:sending-mail"></gv-icon>
-          <h2>{{ 'registration.success.message' | translate: { email: this.registrationForm.value.email } }}</h2>
+          <gv-icon [shape]="isApprovalRequired ? 'home:clock' : 'communication:sending-mail'"></gv-icon>
+          <h2>
+            {{
+              (isApprovalRequired ? 'registration.pendingApproval.message' : 'registration.success.message')
+                | translate: { email: this.registrationForm.value.email }
+            }}
+          </h2>
           <gv-button link routerLink="/" [innerHTML]="'registration.backHome' | translate"></gv-button>
         </div>
       </div>

--- a/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.spec.ts
@@ -15,7 +15,7 @@
  */
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { RouterTestingModule } from '@angular/router/testing';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
@@ -43,5 +43,36 @@ describe('RegistrationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('once the registration request has been sent', () => {
+    const displaySubmittedView = (automaticValidation: boolean) => {
+      spectator.inject(ConfigurationService).get.mockReturnValue(automaticValidation);
+      component.ngOnInit();
+      component.registrationForm = new FormGroup({
+        firstname: new FormControl('John'),
+        lastname: new FormControl('Doe'),
+        email: new FormControl('john@doe.com'),
+      });
+      component.isSubmitted = true;
+      component.canDisplayForm = true;
+      spectator.detectChanges();
+    };
+
+    it('should tell the user the request awaits approval when automatic validation is disabled', () => {
+      displaySubmittedView(false);
+
+      expect(component.isApprovalRequired).toBe(true);
+      expect(spectator.query('.page__box-title').textContent).toContain('registration.pendingApproval.title');
+      expect(spectator.query('.form__message').textContent).toContain('registration.pendingApproval.message');
+    });
+
+    it('should keep the sent email message when registrations are automatically validated', () => {
+      displaySubmittedView(true);
+
+      expect(component.isApprovalRequired).toBe(false);
+      expect(spectator.query('.page__box-title').textContent).toContain('registration.success.title');
+      expect(spectator.query('.form__message').textContent).toContain('registration.success.message');
+    });
   });
 });

--- a/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/registration/registration.component.ts
@@ -17,6 +17,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { RegisterUserInput, UsersService, CustomUserFields } from '../../../../projects/portal-webclient-sdk/src/lib';
+import { ConfigurationService } from '../../services/configuration.service';
 import { ReCaptchaService } from '../../services/recaptcha.service';
 
 type RegistrationFormType = FormGroup<{
@@ -39,14 +40,20 @@ export class RegistrationComponent implements OnInit {
   // boolean used to display the form only once the FormGroup is completed using the CustomUserFields.
   canDisplayForm = false;
 
+  // without automatic validation, the activation email is only sent once an administrator has approved the request.
+  isApprovalRequired = false;
+
   constructor(
     private usersService: UsersService,
     private reCaptchaService: ReCaptchaService,
+    private configurationService: ConfigurationService,
   ) {
     this.isSubmitted = false;
   }
 
   ngOnInit() {
+    this.isApprovalRequired = this.configurationService.get('portal.userCreation.automaticValidation.enabled', true) === false;
+
     const formDescriptor: FormGroup = new FormGroup({
       firstname: new FormControl('', Validators.required),
       lastname: new FormControl('', Validators.required),

--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -816,6 +816,9 @@
     "user": {
       "exists": "E-mail již existuje uživatel: {user}",
       "finalized": "Účet již byl dokončen",
+      "registration": {
+        "pendingApproval": "Žádost o registraci čeká na schválení správcem. Jakmile bude posouzena, obdržíte e-mail."
+      },
       "resetpassword": "Obnovte již požadované heslo, zkontrolujte e-maily a před novým pokusem počkejte několik minut."
     }
   },
@@ -1031,6 +1034,10 @@
     "email": "Email",
     "firstname": "Křestní jméno",
     "lastname": "Přijmení",
+    "pendingApproval": {
+      "message": "Vaše žádost o registraci pro {email} čeká na schválení správcem. Jakmile bude schválena, obdržíte e-mail s aktivačním odkazem.",
+      "title": "Žádost o registraci odeslána"
+    },
     "success": {
       "message": "E-mail byl odeslán na adresu: {email}",
       "title": "Registrace potvrzena!"

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -824,6 +824,9 @@
     "user": {
       "exists": "There is already a user with the email: {user}",
       "finalized": "The account has already been finalized",
+      "registration": {
+        "pendingApproval": "The registration request is awaiting approval by an administrator. You will receive an email once it has been reviewed."
+      },
       "resetpassword": "Reset password already requested, please check your emails and wait a few minutes before a new attempt."
     }
   },
@@ -1039,6 +1042,10 @@
     "email": "Email",
     "firstname": "First name",
     "lastname": "Last name",
+    "pendingApproval": {
+      "message": "Your registration request for {email} is awaiting approval by an administrator. You will receive an email with an activation link once it has been approved.",
+      "title": "Registration request sent"
+    },
     "success": {
       "message": "An email has been sent to: {email}",
       "title": "Registration confirmed!"

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -816,6 +816,9 @@
     "user": {
       "exists": "Il existe déjà un utilisateur avec l'email : {user}",
       "finalized": "Le compte a déjà été finalisé",
+      "registration": {
+        "pendingApproval": "La demande d'inscription est en attente d'approbation par un administrateur. Vous recevrez un email dès qu'elle aura été traitée."
+      },
       "resetpassword": "Une demande a déjà été prise en compte, merci de vérifier vos emails avant de refaire une demande dans quelques minutes"
     }
   },
@@ -1031,6 +1034,10 @@
     "email": "Adresse email",
     "firstname": "Prénom",
     "lastname": "Nom",
+    "pendingApproval": {
+      "message": "Votre demande d'inscription pour {email} est en attente d'approbation par un administrateur. Vous recevrez un email contenant un lien d'activation dès qu'elle aura été approuvée.",
+      "title": "Demande d'inscription envoyée"
+    },
     "success": {
       "message": "Un email a été envoyé à : {email}",
       "title": "Enregistrement confirmé !"

--- a/gravitee-apim-portal-webui/src/assets/i18n/it.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/it.json
@@ -824,6 +824,9 @@
     "user": {
       "exists": "Esiste già un utente con l'e-mail: {user}",
       "finalized": "L'account è già stato finalizzato",
+      "registration": {
+        "pendingApproval": "La richiesta di registrazione è in attesa di approvazione da parte di un amministratore. Riceverai un'e-mail non appena sarà stata esaminata."
+      },
       "resetpassword": "Ripristino della password già richiesto; controlla la tua e-mail e attendi qualche minuto prima di un nuovo tentativo."
     }
   },
@@ -1039,6 +1042,10 @@
     "email": "E-mail",
     "firstname": "Nome",
     "lastname": "Cognome",
+    "pendingApproval": {
+      "message": "La tua richiesta di registrazione per {email} è in attesa di approvazione da parte di un amministratore. Riceverai un'e-mail con un link di attivazione non appena sarà stata approvata.",
+      "title": "Richiesta di registrazione inviata"
+    },
     "success": {
       "message": "È stata inviata un'e-mail a: {email}",
       "title": "Registrazione confermata!"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/main/java/io/gravitee/rest/api/idp/repository/authentication/RepositoryAuthenticationProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/main/java/io/gravitee/rest/api/idp/repository/authentication/RepositoryAuthenticationProvider.java
@@ -21,7 +21,6 @@ import io.gravitee.rest.api.idp.repository.authentication.spring.RepositoryAuthe
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,6 +28,7 @@ import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider;
@@ -92,7 +92,8 @@ public class RepositoryAuthenticationProvider
                     );
                 }
                 if (user.getStatus().toUpperCase().equals("PENDING")) {
-                    throw new UnauthorizedAccessException();
+                    log.warn("Authentication failed: registration of user '{}' is still awaiting approval", username);
+                    throw new DisabledException("User account is awaiting approval");
                 }
                 return mapUserEntityToUserDetails(user);
             } else {
@@ -100,6 +101,8 @@ public class RepositoryAuthenticationProvider
             }
         } catch (UserNotFoundException notFound) {
             throw new UsernameNotFoundException(String.format("User '%s' not found", username), notFound);
+        } catch (AuthenticationException authenticationFailure) {
+            throw authenticationFailure;
         } catch (Exception repositoryProblem) {
             log.error("Failed to retrieveUser : {}", username, repositoryProblem);
             throw new InternalAuthenticationServiceException(repositoryProblem.getMessage(), repositoryProblem);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/test/java/io/gravitee/rest/api/idp/repository/authentication/RepositoryAuthenticationProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/src/test/java/io/gravitee/rest/api/idp/repository/authentication/RepositoryAuthenticationProviderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.idp.repository.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.idp.repository.RepositoryIdentityProvider;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RepositoryAuthenticationProviderTest {
+
+    private static final String USERNAME = "user@example.com";
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private RepositoryAuthenticationProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new RepositoryAuthenticationProvider();
+        ReflectionTestUtils.setField(provider, "userService", userService);
+        ReflectionTestUtils.setField(provider, "passwordEncoder", passwordEncoder);
+    }
+
+    @Test
+    void should_reject_a_user_whose_registration_is_awaiting_approval_as_an_authentication_failure() {
+        when(
+            userService.findBySource(nullable(String.class), eq(RepositoryIdentityProvider.PROVIDER_TYPE), eq(USERNAME), eq(true))
+        ).thenReturn(aUser("PENDING"));
+
+        assertThatThrownBy(() -> provider.authenticate(new UsernamePasswordAuthenticationToken(USERNAME, "password")))
+            .isInstanceOf(DisabledException.class)
+            .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void should_report_an_unknown_user_as_a_bad_credentials_failure() {
+        when(
+            userService.findBySource(nullable(String.class), eq(RepositoryIdentityProvider.PROVIDER_TYPE), eq(USERNAME), eq(true))
+        ).thenThrow(new UserNotFoundException(USERNAME));
+
+        assertThatThrownBy(() -> provider.authenticate(new UsernamePasswordAuthenticationToken(USERNAME, "password"))).isInstanceOf(
+            BadCredentialsException.class
+        );
+    }
+
+    @Test
+    void should_authenticate_an_active_user() {
+        when(
+            userService.findBySource(nullable(String.class), eq(RepositoryIdentityProvider.PROVIDER_TYPE), eq(USERNAME), eq(true))
+        ).thenReturn(aUser("ACTIVE"));
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+
+        var authentication = provider.authenticate(new UsernamePasswordAuthenticationToken(USERNAME, "password"));
+
+        assertThat(authentication.isAuthenticated()).isTrue();
+    }
+
+    private static UserEntity aUser(String status) {
+        UserEntity user = new UserEntity();
+        user.setId("user-1");
+        user.setSource(RepositoryIdentityProvider.PROVIDER_TYPE);
+        user.setSourceId(USERNAME);
+        user.setEmail(USERNAME);
+        user.setPassword("$2a$10$encoded");
+        user.setStatus(status);
+        return user;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -143,7 +143,7 @@ public class ConfigurationMapper {
         configuration.setUploadMedia(convert(portal.getUploadMedia()));
         configuration.setRating(convert(portal.getRating()));
         configuration.setSupport(convert(portal.getSupport()));
-        configuration.setUserCreation(convert(portal.getUserCreation().getEnabled()));
+        configuration.setUserCreation(convert(portal.getUserCreation()));
         configuration.setHomepageTitle(portal.getHomepageTitle());
 
         PortalApplicationSettings.ApplicationTypes types = application.getTypes();
@@ -160,6 +160,15 @@ public class ConfigurationMapper {
             configuration.setApplicationCreation(convert(true));
         }
 
+        return configuration;
+    }
+
+    private ConfigurationPortalUserCreation convert(Portal.PortalUserCreation userCreation) {
+        ConfigurationPortalUserCreation configuration = new ConfigurationPortalUserCreation();
+        configuration.setEnabled(userCreation.getEnabled());
+        if (!Objects.isNull(userCreation.getAutomaticValidation())) {
+            configuration.setAutomaticValidation(convert(userCreation.getAutomaticValidation()));
+        }
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5613,7 +5613,7 @@ components:
                 applicationCreation:
                     $ref: "#/components/schemas/Enabled"
                 userCreation:
-                    $ref: "#/components/schemas/Enabled"
+                    $ref: "#/components/schemas/ConfigurationPortalUserCreation"
                 apis:
                     $ref: "#/components/schemas/ConfigurationPortalApis"
                 analytics:
@@ -5625,6 +5625,15 @@ components:
                 homepageTitle:
                     description: Main phrase to display on the homepage.
                     type: string
+        ConfigurationPortalUserCreation:
+            type: object
+            description: Configuration of the user registration
+            properties:
+                enabled:
+                    description: User registration is enabled
+                    type: boolean
+                automaticValidation:
+                    $ref: "#/components/schemas/Enabled"
         ConfigurationPortalNext:
             properties:
                 siteTitle:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -9,7 +9,10 @@
       "enabled" : true
     },
     "userCreation" : {
-      "enabled" : true
+      "enabled" : true,
+      "automaticValidation" : {
+        "enabled" : false
+      }
     },
     "apis" : {
       "tilesMode" : {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
@@ -113,7 +113,10 @@
       "enabled" : false
     },
     "userCreation" : {
-      "enabled" : true
+      "enabled" : true,
+      "automaticValidation" : {
+        "enabled" : false
+      }
     },
     "apis" : {
       "tilesMode" : {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/UserRegistrationPendingApprovalException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/UserRegistrationPendingApprovalException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class UserRegistrationPendingApprovalException extends AbstractManagementException {
+
+    private final String userId;
+
+    public UserRegistrationPendingApprovalException(String userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.CONFLICT_409;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The registration request is awaiting approval by an administrator.";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "user.registration.pendingApproval";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("user", userId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1094,15 +1094,20 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         UserEntity userToProcess = findById(executionContext, userId);
         UserEntity processedUser = this.changeUserStatus(executionContext, userId, accepted ? UserStatus.ACTIVE : UserStatus.REJECTED);
         final Map<String, Object> params = new NotificationParamsBuilder().user(processedUser).build();
-        emailService.sendAsyncEmailNotification(
-            executionContext,
-            new EmailNotificationBuilder()
-                .to(userToProcess.getEmail())
-                .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION_REQUEST_PROCESSED)
-                .params(params)
-                .param("registrationStatus", accepted ? "accepted" : "rejected")
-                .build()
-        );
+        // An accepted user still having to choose a password gets the registration email instead: telling them they can
+        // sign in would be misleading, and the registration email is the one carrying the activation link.
+        final boolean registrationEmailToSend = accepted && !processedUser.isHasPassword();
+        if (!registrationEmailToSend) {
+            emailService.sendAsyncEmailNotification(
+                executionContext,
+                new EmailNotificationBuilder()
+                    .to(userToProcess.getEmail())
+                    .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION_REQUEST_PROCESSED)
+                    .params(params)
+                    .param("registrationStatus", accepted ? "accepted" : "rejected")
+                    .build()
+            );
+        }
         auditService.createAuditLog(
             executionContext,
             AuditService.AuditLogData.builder()
@@ -1114,7 +1119,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .build()
         );
 
-        if (accepted && !processedUser.isHasPassword()) {
+        if (registrationEmailToSend) {
             sendRegistrationEmail(
                 executionContext,
                 processedUser,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService.DEFAULT_CONSOLE_URL;
+import static io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService.DEFAULT_PORTAL_URL;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.USER;
 import static io.gravitee.repository.management.model.User.AuditEvent.PASSWORD_CHANGED;
 import static io.gravitee.repository.management.model.User.AuditEvent.PASSWORD_RESET;
@@ -137,6 +138,7 @@ import io.gravitee.rest.api.service.exceptions.UserAlreadyFinalizedException;
 import io.gravitee.rest.api.service.exceptions.UserNotActiveException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UserNotInternallyManagedException;
+import io.gravitee.rest.api.service.exceptions.UserRegistrationPendingApprovalException;
 import io.gravitee.rest.api.service.exceptions.UserRegistrationUnavailableException;
 import io.gravitee.rest.api.service.exceptions.UserStateConflictException;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
@@ -199,6 +201,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     private static final String TEMPLATE_ENGINE_PROFILE_ATTRIBUTE = "profile";
     private static final String TEMPLATE_ENGINE_ACCESSTOKEN_ATTRIBUTE = "accessToken";
     private static final String TEMPLATE_ENGINE_IDTOKEN_ATTRIBUTE = "idToken";
+    private static final String PORTAL_REGISTRATION_CONFIRMATION_PATH = "/user/registration/confirm";
 
     // Dirty hack: only used to force class loading
     static {
@@ -570,6 +573,12 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 user = userRepository.findById(username).orElseThrow(() -> new UserNotFoundException(username));
                 if (StringUtils.isNotBlank(user.getPassword())) {
                     throw new UserAlreadyFinalizedException(executionContext.getOrganizationId());
+                }
+                if (UserStatus.PENDING == user.getStatus()) {
+                    throw new UserRegistrationPendingApprovalException(username);
+                }
+                if (UserStatus.REJECTED == user.getStatus() || UserStatus.ARCHIVED == user.getStatus()) {
+                    throw new UserStateConflictException("Registration of user " + username + " cannot be finalized anymore");
                 }
             }
 
@@ -1011,17 +1020,8 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                     action,
                     confirmationPageUrl
                 );
-                emailService.sendAsyncEmailNotification(
-                    executionContext,
-                    new EmailNotificationBuilder()
-                        .to(userEntity.getEmail())
-                        .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION)
-                        .params(params)
-                        .param("registrationAction", USER_REGISTRATION.equals(action) ? "registration" : "creation")
-                        .build()
-                );
-
                 if (autoRegistrationEnabled) {
+                    sendRegistrationEmail(executionContext, userEntity, action, params);
                     notifierService.trigger(
                         executionContext,
                         ACTION.USER_REGISTRATION.equals(action) ? PortalHook.USER_REGISTERED : PortalHook.USER_CREATED,
@@ -1038,6 +1038,55 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         }
 
         return userEntity;
+    }
+
+    private void sendRegistrationEmail(
+        ExecutionContext executionContext,
+        final UserEntity userEntity,
+        final ACTION action,
+        final Map<String, Object> params
+    ) {
+        emailService.sendAsyncEmailNotification(
+            executionContext,
+            new EmailNotificationBuilder()
+                .to(userEntity.getEmail())
+                .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION)
+                .params(params)
+                .param("registrationAction", USER_REGISTRATION.equals(action) ? "registration" : "creation")
+                .build()
+        );
+    }
+
+    private String registrationEnvironmentId(ExecutionContext executionContext, String userId) {
+        // The approval request is organization scoped, but the user got a membership on the environment they registered on.
+        Set<String> environmentIds = membershipService.getReferenceIdsByMemberAndReference(
+            MembershipMemberType.USER,
+            userId,
+            MembershipReferenceType.ENVIRONMENT
+        );
+        if (environmentIds != null && environmentIds.size() == 1) {
+            return environmentIds.iterator().next();
+        }
+        return executionContext.hasEnvironmentId() ? executionContext.getEnvironmentId() : GraviteeContext.getDefaultEnvironment();
+    }
+
+    private String portalRegistrationConfirmationUrl(ExecutionContext executionContext, String userId) {
+        // The URL given at registration time is not kept, so the confirmation page is rebuilt from the environment.
+        final String environmentId = registrationEnvironmentId(executionContext, userId);
+        String portalUrl = installationAccessQueryService.getPortalUrl(environmentId);
+        // Registrations can also be requested from the console, and the 'Portal URL' may not be configured for this
+        // environment: without an explicit one, the email falls back to the console registration link.
+        if (isEmpty(portalUrl) || DEFAULT_PORTAL_URL.equals(portalUrl)) {
+            log.warn(
+                "No 'Portal URL' configured for environment {}, the registration email will link to the console. You may want to change this default configuration in the Settings.",
+                environmentId
+            );
+            return null;
+        }
+        if (portalUrl.endsWith("/")) {
+            portalUrl = portalUrl.substring(0, portalUrl.length() - 1);
+        }
+        return portalUrl + PORTAL_REGISTRATION_CONFIRMATION_PATH;
     }
 
     @Override
@@ -1064,6 +1113,21 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .newValue(processedUser)
                 .build()
         );
+
+        if (accepted && !processedUser.isHasPassword()) {
+            sendRegistrationEmail(
+                executionContext,
+                processedUser,
+                USER_REGISTRATION,
+                getTokenRegistrationParams(
+                    executionContext,
+                    processedUser,
+                    REGISTRATION_PATH,
+                    USER_REGISTRATION,
+                    portalRegistrationConfirmationUrl(executionContext, userId)
+                )
+            );
+        }
 
         return processedUser;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_REGISTRATION;
+import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER;
+import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_ISSUER;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_REGISTRATION_URL;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.repository.management.model.UserStatus;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.NewExternalUserEntity;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.model.RegisterUserEntity;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EmailNotification;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.PasswordValidator;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserMetadataService;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.JWTHelper;
+import io.gravitee.rest.api.service.converter.UserConverter;
+import io.gravitee.rest.api.service.exceptions.UserRegistrationPendingApprovalException;
+import io.gravitee.rest.api.service.exceptions.UserStateConflictException;
+import io.gravitee.rest.api.service.notification.PortalHook;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserServiceRegistrationApprovalTest {
+
+    private static final String ORGANIZATION = "DEFAULT";
+    private static final String ENVIRONMENT = "DEFAULT";
+    private static final ExecutionContext PORTAL_CONTEXT = new ExecutionContext(ORGANIZATION, ENVIRONMENT);
+    private static final ExecutionContext CONSOLE_CONTEXT = new ExecutionContext(ORGANIZATION);
+    private static final String USER_ID = "user-1";
+    private static final String EMAIL = "user@example.com";
+    private static final String JWT_SECRET = "VERYSECURE";
+    private static final String PORTAL_URL = "https://portal.example.com";
+    private static final String CONSOLE_URL = "https://console.example.com";
+    private static final String OTHER_ENVIRONMENT = "production";
+    private static final String OTHER_PORTAL_URL = "https://portal.production.example.com";
+
+    @InjectMocks
+    private UserServiceImpl userService = new UserServiceImpl();
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private NotifierService notifierService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private OrganizationService organizationService;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private UserMetadataService userMetadataService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private InstallationAccessQueryService installationAccessQueryService;
+
+    @Mock
+    private PasswordValidator passwordValidator;
+
+    @Mock
+    private UserConverter userConverter;
+
+    @BeforeEach
+    void setUp() {
+        when(userConverter.toUser(any(NewExternalUserEntity.class))).thenCallRealMethod();
+        when(userConverter.toUserEntity(any(User.class), any())).thenCallRealMethod();
+        when(environment.getProperty("jwt.secret")).thenReturn(JWT_SECRET);
+        when(
+            environment.getProperty("user.creation.token.expire-after", Integer.class, DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER)
+        ).thenReturn(3600);
+        when(environment.getProperty("jwt.issuer", DEFAULT_JWT_ISSUER)).thenReturn(DEFAULT_JWT_ISSUER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    void should_not_send_the_registration_email_when_the_request_has_to_be_approved() throws TechnicalException {
+        givenUserRegistrationEnabled(false);
+
+        userService.register(PORTAL_CONTEXT, newExternalUser());
+
+        verify(emailService, never()).sendAsyncEmailNotification(eq(PORTAL_CONTEXT), any());
+        verify(notifierService).trigger(eq(PORTAL_CONTEXT), eq(PortalHook.USER_REGISTRATION_REQUEST), any());
+    }
+
+    @Test
+    void should_create_a_pending_user_when_the_request_has_to_be_approved() throws TechnicalException {
+        givenUserRegistrationEnabled(false);
+
+        userService.register(PORTAL_CONTEXT, newExternalUser());
+
+        verify(userRepository).create(argThat(user -> user.getStatus() == UserStatus.PENDING));
+    }
+
+    @Test
+    void should_send_the_registration_email_when_registrations_are_automatically_validated() throws TechnicalException {
+        givenUserRegistrationEnabled(true);
+
+        userService.register(PORTAL_CONTEXT, newExternalUser());
+
+        assertThat(capturedEmails()).anyMatch(this::isRegistrationEmail);
+        verify(notifierService).trigger(eq(PORTAL_CONTEXT), eq(PortalHook.USER_REGISTERED), any());
+    }
+
+    @Test
+    void should_send_the_registration_email_once_the_request_is_approved() throws TechnicalException {
+        givenPendingUser(null);
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(PORTAL_URL);
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
+
+        EmailNotification registrationEmail = capturedEmails()
+            .stream()
+            .filter(this::isRegistrationEmail)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no registration email has been sent"));
+
+        assertThat(registrationEmail.getTo()).containsExactly(EMAIL);
+        assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(
+            PORTAL_URL + "/user/registration/confirm/"
+        );
+    }
+
+    @Test
+    void should_not_send_the_registration_email_when_the_approved_user_already_has_a_password() throws TechnicalException {
+        givenPendingUser("$2a$10$encoded");
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
+
+        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail);
+    }
+
+    @Test
+    void should_not_send_the_registration_email_when_the_request_is_rejected() throws TechnicalException {
+        givenPendingUser(null);
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, false);
+
+        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail);
+    }
+
+    @Test
+    void should_reject_the_finalization_of_a_registration_awaiting_approval() throws TechnicalException {
+        when(
+            parameterService.findAsBoolean(PORTAL_CONTEXT, Key.PORTAL_USERCREATION_ENABLED, ENVIRONMENT, ParameterReferenceType.ENVIRONMENT)
+        ).thenReturn(Boolean.TRUE);
+        when(passwordValidator.validate(any())).thenReturn(true);
+        when(userRepository.findById(USER_ID)).thenReturn(of(pendingUser(null)));
+
+        RegisterUserEntity registerUserEntity = new RegisterUserEntity();
+        registerUserEntity.setToken(registrationToken());
+        registerUserEntity.setPassword("gh2gyf8!zjfnz");
+
+        assertThatThrownBy(() -> userService.finalizeRegistration(PORTAL_CONTEXT, registerUserEntity)).isInstanceOf(
+            UserRegistrationPendingApprovalException.class
+        );
+
+        verify(userRepository, never()).update(any());
+    }
+
+    @Test
+    void should_reject_the_finalization_of_a_rejected_registration() throws TechnicalException {
+        when(
+            parameterService.findAsBoolean(PORTAL_CONTEXT, Key.PORTAL_USERCREATION_ENABLED, ENVIRONMENT, ParameterReferenceType.ENVIRONMENT)
+        ).thenReturn(Boolean.TRUE);
+        when(passwordValidator.validate(any())).thenReturn(true);
+        User rejectedUser = pendingUser(null);
+        rejectedUser.setStatus(UserStatus.REJECTED);
+        when(userRepository.findById(USER_ID)).thenReturn(of(rejectedUser));
+
+        RegisterUserEntity registerUserEntity = new RegisterUserEntity();
+        registerUserEntity.setToken(registrationToken());
+        registerUserEntity.setPassword("gh2gyf8!zjfnz");
+
+        assertThatThrownBy(() -> userService.finalizeRegistration(PORTAL_CONTEXT, registerUserEntity)).isInstanceOf(
+            UserStateConflictException.class
+        );
+
+        verify(userRepository, never()).update(any());
+    }
+
+    @Test
+    void should_link_the_registration_email_to_the_portal_of_the_environment_the_user_registered_on() throws TechnicalException {
+        givenPendingUser(null);
+        when(
+            membershipService.getReferenceIdsByMemberAndReference(MembershipMemberType.USER, USER_ID, MembershipReferenceType.ENVIRONMENT)
+        ).thenReturn(Set.of(OTHER_ENVIRONMENT));
+        when(installationAccessQueryService.getPortalUrl(OTHER_ENVIRONMENT)).thenReturn(OTHER_PORTAL_URL);
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
+
+        EmailNotification registrationEmail = capturedEmails()
+            .stream()
+            .filter(this::isRegistrationEmail)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no registration email has been sent"));
+
+        assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(
+            OTHER_PORTAL_URL + "/user/registration/confirm/"
+        );
+    }
+
+    @Test
+    void should_link_the_registration_email_to_the_console_when_no_portal_url_is_configured() throws TechnicalException {
+        givenPendingUser(null);
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(InstallationAccessQueryService.DEFAULT_PORTAL_URL);
+        when(installationAccessQueryService.getConsoleUrl(ORGANIZATION)).thenReturn(CONSOLE_URL);
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
+
+        EmailNotification registrationEmail = capturedEmails()
+            .stream()
+            .filter(this::isRegistrationEmail)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no registration email has been sent"));
+
+        assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(CONSOLE_URL + REGISTRATION_PATH);
+    }
+
+    private void givenUserRegistrationEnabled(boolean automaticValidation) throws TechnicalException {
+        when(
+            parameterService.findAsBoolean(PORTAL_CONTEXT, Key.PORTAL_USERCREATION_ENABLED, ENVIRONMENT, ParameterReferenceType.ENVIRONMENT)
+        ).thenReturn(Boolean.TRUE);
+        when(
+            parameterService.findAsBoolean(
+                PORTAL_CONTEXT,
+                Key.PORTAL_USERCREATION_AUTOMATICVALIDATION_ENABLED,
+                ENVIRONMENT,
+                ParameterReferenceType.ENVIRONMENT
+            )
+        ).thenReturn(automaticValidation);
+        when(organizationService.findById(ORGANIZATION)).thenReturn(new OrganizationEntity());
+        when(userRepository.findBySource("gravitee", EMAIL, ORGANIZATION)).thenReturn(Optional.empty());
+        when(userRepository.create(any(User.class))).thenAnswer(returnsFirstArg());
+        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
+            List.of(RoleEntity.builder().scope(RoleScope.ORGANIZATION).name("USER").build())
+        );
+    }
+
+    private void givenPendingUser(String password) throws TechnicalException {
+        User user = pendingUser(password);
+        when(userRepository.findById(USER_ID)).thenReturn(of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+    }
+
+    private User pendingUser(String password) {
+        User user = new User();
+        user.setId(USER_ID);
+        user.setOrganizationId(ORGANIZATION);
+        user.setSource("gravitee");
+        user.setSourceId(EMAIL);
+        user.setEmail(EMAIL);
+        user.setFirstname("Joe");
+        user.setLastname("Bar");
+        user.setPassword(password);
+        user.setStatus(UserStatus.PENDING);
+        user.setCreatedAt(new Date());
+        user.setUpdatedAt(user.getCreatedAt());
+        return user;
+    }
+
+    private NewExternalUserEntity newExternalUser() {
+        NewExternalUserEntity newExternalUserEntity = new NewExternalUserEntity();
+        newExternalUserEntity.setEmail(EMAIL);
+        newExternalUserEntity.setFirstname("Joe");
+        newExternalUserEntity.setLastname("Bar");
+        return newExternalUserEntity;
+    }
+
+    private String registrationToken() {
+        return JWT.create()
+            .withIssuer(DEFAULT_JWT_ISSUER)
+            .withSubject(USER_ID)
+            .withClaim(JWTHelper.Claims.EMAIL, EMAIL)
+            .withClaim(JWTHelper.Claims.ACTION, USER_REGISTRATION.name())
+            .withExpiresAt(new Date(System.currentTimeMillis() + 3600_000))
+            .sign(Algorithm.HMAC256(JWT_SECRET));
+    }
+
+    private boolean isRegistrationEmail(EmailNotification email) {
+        return EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION.getLinkedHook()
+            .getTemplate()
+            .equals(email.getTemplate());
+    }
+
+    private List<EmailNotification> capturedEmails() {
+        ArgumentCaptor<EmailNotification> captor = ArgumentCaptor.forClass(EmailNotification.class);
+        verify(emailService, atLeastOnce()).sendAsyncEmailNotification(any(), captor.capture());
+        return captor.getAllValues();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
@@ -213,12 +213,22 @@ class UserServiceRegistrationApprovalTest {
     }
 
     @Test
+    void should_only_send_the_registration_email_once_the_request_is_approved() throws TechnicalException {
+        givenPendingUser(null);
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(PORTAL_URL);
+
+        userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
+
+        assertThat(capturedEmails()).hasSize(1).noneMatch(this::isRequestProcessedEmail);
+    }
+
+    @Test
     void should_not_send_the_registration_email_when_the_approved_user_already_has_a_password() throws TechnicalException {
         givenPendingUser("$2a$10$encoded");
 
         userService.processRegistration(CONSOLE_CONTEXT, USER_ID, true);
 
-        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail);
+        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail).anyMatch(this::isRequestProcessedEmail);
     }
 
     @Test
@@ -227,7 +237,7 @@ class UserServiceRegistrationApprovalTest {
 
         userService.processRegistration(CONSOLE_CONTEXT, USER_ID, false);
 
-        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail);
+        assertThat(capturedEmails()).noneMatch(this::isRegistrationEmail).anyMatch(this::isRequestProcessedEmail);
     }
 
     @Test
@@ -366,6 +376,12 @@ class UserServiceRegistrationApprovalTest {
             .withClaim(JWTHelper.Claims.ACTION, USER_REGISTRATION.name())
             .withExpiresAt(new Date(System.currentTimeMillis() + 3600_000))
             .sign(Algorithm.HMAC256(JWT_SECRET));
+    }
+
+    private boolean isRequestProcessedEmail(EmailNotification email) {
+        return EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_REGISTRATION_REQUEST_PROCESSED.getLinkedHook()
+            .getTemplate()
+            .equals(email.getTemplate());
     }
 
     private boolean isRegistrationEmail(EmailNotification email) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14920

## Description

When automatic validation of registration requests is disabled, the activation email was sent at submission instead of after approval, and `finalizeRegistration` never inspected `UserStatus`: a `PENDING` user could set a password and then fail to log in, with nothing telling them why.

- the registration email is sent when the request is approved, not at submission
- `finalizeRegistration` refuses a `PENDING` user (409, awaiting approval) and a `REJECTED`/`ARCHIVED` one
- a pending account attempting to log in gets a 401 instead of a 500
- both portals tell the user their registration awaits approval
- approving sends a single email, the one carrying the activation link

## Additional context

https://github.com/user-attachments/assets/f9465548-fb7c-46b2-bb15-a18f94f21e3e
