### PR TITLE
fix(dictionary): prevent key/id collision from evicting another dictionary

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManager.java
@@ -19,6 +19,7 @@ import io.gravitee.gateway.dictionary.model.Dictionary;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import lombok.CustomLog;
 
 /**
@@ -34,13 +35,24 @@ public class MultiEnvironmentDictionaryManager implements DictionaryManager {
     @Override
     public void deploy(Dictionary dictionary) {
         String environmentId = dictionary.getEnvironmentId();
-        //fallback on legacy events
-        String key = dictionary.getKey() == null ? dictionary.getId() : dictionary.getKey();
+        String key = runtimeKey(dictionary);
 
         dictionaries.putIfAbsent(environmentId, new HashMap<>());
         values.putIfAbsent(environmentId, new HashMap<>());
 
         Dictionary existing = dictionaries.get(environmentId).get(key);
+        if (existing != null && !Objects.equals(existing.getId(), dictionary.getId())) {
+            log.error(
+                "Dictionary {} (name={}) collides on runtime key '{}' in environment {} with existing dictionary {} (name={}). Incoming deploy is rejected; occupant is kept",
+                dictionary.getId(),
+                dictionary.getName(),
+                key,
+                environmentId,
+                existing.getId(),
+                existing.getName()
+            );
+            return;
+        }
         if (existing == null || dictionary.getDeployedAt().after(existing.getDeployedAt())) {
             if (dictionary.getProperties() == null) {
                 dictionary.setProperties(Collections.emptyMap());
@@ -55,28 +67,47 @@ public class MultiEnvironmentDictionaryManager implements DictionaryManager {
     @Override
     public void undeploy(Dictionary dictionary) {
         String environmentId = dictionary.getEnvironmentId();
-        //fallback on legacy events
-        String key = dictionary.getKey() == null ? dictionary.getId() : dictionary.getKey();
+        String key = runtimeKey(dictionary);
         Map<String, Dictionary> envDictionaries = dictionaries.get(environmentId);
         if (envDictionaries != null) {
-            Dictionary removed = envDictionaries.remove(key);
+            Dictionary occupant = envDictionaries.get(key);
+            if (occupant == null) {
+                return;
+            }
+            if (!Objects.equals(occupant.getId(), dictionary.getId())) {
+                log.debug(
+                    "Dictionary {} was requested for undeploy but runtime key '{}' is occupied by dictionary {} — ignoring",
+                    dictionary.getId(),
+                    key,
+                    occupant.getId()
+                );
+                return;
+            }
 
+            envDictionaries.remove(key);
             if (envDictionaries.isEmpty()) {
                 dictionaries.remove(environmentId);
             }
 
-            if (removed != null) {
-                Map<String, Map<String, String>> envValues = values.get(environmentId);
-                if (envValues != null) {
-                    envValues.remove(key);
-                    if (envValues.isEmpty()) {
-                        values.remove(environmentId);
-                    }
+            Map<String, Map<String, String>> envValues = values.get(environmentId);
+            if (envValues != null) {
+                envValues.remove(key);
+                if (envValues.isEmpty()) {
+                    values.remove(environmentId);
                 }
-
-                log.info("A dictionary has been undeployed: {}", removed);
             }
+
+            log.info("A dictionary has been undeployed: {}", dictionary);
         }
+    }
+
+    /**
+     * Runtime map key: prefer the dictionary {@code key} when present, otherwise fall back to {@code id}
+     * for legacy events that predate the key field.
+     */
+    private static String runtimeKey(Dictionary dictionary) {
+        String key = dictionary.getKey();
+        return key == null || key.isBlank() ? dictionary.getId() : key;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManagerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.dictionary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.dictionary.model.Dictionary;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MultiEnvironmentDictionaryManagerTest {
+
+    private static final String ENV = "DEFAULT";
+    private static final String OTHER_ENV = "OTHER";
+
+    private MultiEnvironmentDictionaryManager cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new MultiEnvironmentDictionaryManager();
+    }
+
+    @Nested
+    class DeployTest {
+
+        @Test
+        void should_index_console_dictionary_by_id_when_key_is_null() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+        }
+
+        @Test
+        void should_keep_both_dictionaries_when_runtime_keys_differ() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+            cut.deploy(dictionary("uuid-tf", "tf_idp-server-details", ENV, "tf-value", 2L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+            assertThat(property(ENV, "tf_idp-server-details")).isEqualTo("tf-value");
+        }
+
+        @Test
+        void should_keep_incumbent_when_another_dictionary_collides_on_runtime_key() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+            cut.deploy(dictionary("uuid-tf", "idp-server-details", ENV, "second-value", 2L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+        }
+
+        @Test
+        void should_replace_properties_when_same_dictionary_is_redeployed() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+            cut.deploy(dictionary("idp-server-details", null, ENV, "updated-value", 2L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("updated-value");
+        }
+
+        @Test
+        void should_not_overwrite_when_same_dictionary_deployed_at_is_older() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 2L));
+            cut.deploy(dictionary("idp-server-details", null, ENV, "second-value", 1L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+        }
+
+        @Test
+        void should_isolate_dictionaries_per_environment() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "default-value", 1L));
+            cut.deploy(dictionary("idp-server-details", null, OTHER_ENV, "other-value", 1L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("default-value");
+            assertThat(property(OTHER_ENV, "idp-server-details")).isEqualTo("other-value");
+        }
+    }
+
+    @Nested
+    class UndeployTest {
+
+        @Test
+        void should_undeploy_when_occupant_id_matches() {
+            Dictionary console = dictionary("idp-server-details", null, ENV, "first-value", 1L);
+            cut.deploy(console);
+
+            cut.undeploy(console);
+
+            assertThat(cut.getDictionaries(ENV)).isNullOrEmpty();
+        }
+
+        @Test
+        void should_keep_incumbent_when_rejected_dictionary_is_undeployed() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+            Dictionary terraform = dictionary("uuid-tf", "idp-server-details", ENV, "second-value", 2L);
+            cut.deploy(terraform);
+
+            cut.undeploy(terraform);
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+        }
+
+        @Test
+        void should_keep_occupant_when_undeploy_targets_a_different_dictionary() {
+            cut.deploy(dictionary("uuid-tf", "idp-server-details", ENV, "tf-value", 1L));
+
+            cut.undeploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("tf-value");
+        }
+
+        @Test
+        void should_keep_the_other_dictionary_when_one_of_two_is_undeployed() {
+            cut.deploy(dictionary("idp-server-details", null, ENV, "first-value", 1L));
+            Dictionary terraform = dictionary("uuid-tf", "tf_idp-server-details", ENV, "tf-value", 2L);
+            cut.deploy(terraform);
+
+            cut.undeploy(terraform);
+
+            assertThat(property(ENV, "idp-server-details")).isEqualTo("first-value");
+            assertThat(cut.getDictionaries(ENV)).doesNotContainKey("tf_idp-server-details");
+        }
+    }
+
+    private String property(String environmentId, String runtimeKey) {
+        Map<String, Map<String, String>> envValues = cut.getDictionaries(environmentId);
+        assertThat(envValues).isNotNull();
+        assertThat(envValues).containsKey(runtimeKey);
+        return envValues.get(runtimeKey).get("MY_PROP");
+    }
+
+    private static Dictionary dictionary(String id, String key, String environmentId, String propertyValue, long deployedAt) {
+        Dictionary dictionary = new Dictionary();
+        dictionary.setId(id);
+        dictionary.setKey(key);
+        dictionary.setEnvironmentId(environmentId);
+        dictionary.setName(id);
+        dictionary.setDeployedAt(new Date(deployedAt));
+        dictionary.setProperties(Map.of("MY_PROP", propertyValue));
+        return dictionary;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryKeyCollidesWithIdException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryKeyCollidesWithIdException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.dictionary;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Map;
+
+public class DictionaryKeyCollidesWithIdException extends AbstractManagementException {
+
+    private final String key;
+    private final String existingDictionaryId;
+    private final String existingDictionaryName;
+
+    public DictionaryKeyCollidesWithIdException(String key, String existingDictionaryId, String existingDictionaryName) {
+        this.key = key;
+        this.existingDictionaryId = existingDictionaryId;
+        this.existingDictionaryName = existingDictionaryName;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return (
+            "A dictionary with key [" +
+            key +
+            "] cannot be created because dictionary [" +
+            existingDictionaryName +
+            "] already uses that value as its id in this environment."
+        );
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "dictionary.keyCollidesWithId";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Map.of(
+            "key",
+            key,
+            "existingDictionaryId",
+            existingDictionaryId,
+            "existingDictionaryName",
+            String.valueOf(existingDictionaryName)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -239,30 +239,13 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             final Dictionary dictionary;
             if (newDictionaryEntity.getKey() == null) {
                 String key = IdGenerator.generate(newDictionaryEntity.getName());
-
-                // Make sure the derived key does not already exist in the same environment
-                // That would mean that a legacy dictionary (prior to multi tenant management) was created with the same name.
                 Optional<Dictionary> idDictionary = dictionaryRepository.findById(key);
-                if (
-                    idDictionary.isPresent() && idDictionary.get().getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId())
-                ) {
-                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
-                }
-                // Make sure the derived key does not already exist in any environment using the key field which is how it is checked
-                // uniqueness after the multi tenant management is implemented.
-                Optional<Dictionary> optDictionary = dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId());
-                if (optDictionary.isPresent()) {
-                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
-                }
+                ensureRuntimeKeyIsAvailable(executionContext, key, newDictionaryEntity.getName(), idDictionary, false);
                 dictionary = convert(newDictionaryEntity, key, idDictionary.isEmpty());
             } else {
                 String key = newDictionaryEntity.getKey();
-                // We shouldn't be here if the caller checked the key uniqueness
-                // But for to respect the contract, we check again
-                Optional<Dictionary> optDictionary = dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId());
-                if (optDictionary.isPresent()) {
-                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
-                }
+                Optional<Dictionary> idDictionary = dictionaryRepository.findById(key);
+                ensureRuntimeKeyIsAvailable(executionContext, key, newDictionaryEntity.getName(), idDictionary, true);
                 dictionary = convert(newDictionaryEntity, key, false);
                 // if ID is already set, let's use it
                 if (newDictionaryEntity.getId() != null) {
@@ -471,6 +454,30 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         }
 
         return dictionaryEntityBuilder.build();
+    }
+
+    /**
+     * Console dictionaries store a null key, so the gateway indexes them by id. Reject create when
+     * {@code key} is already used in this environment as an id or as a key.
+     */
+    private void ensureRuntimeKeyIsAvailable(
+        ExecutionContext executionContext,
+        String key,
+        String dictionaryName,
+        Optional<Dictionary> dictionaryById,
+        boolean explicitKey
+    ) throws TechnicalException {
+        dictionaryById
+            .filter(d -> d.getEnvironmentId() != null && d.getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId()))
+            .ifPresent(existing -> {
+                if (explicitKey) {
+                    throw new DictionaryKeyCollidesWithIdException(key, existing.getId(), existing.getName());
+                }
+                throw new DictionaryAlreadyExistsException(dictionaryName);
+            });
+        if (dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId()).isPresent()) {
+            throw new DictionaryAlreadyExistsException(dictionaryName);
+        }
     }
 
     private Dictionary convert(UpdateDictionaryEntity updateDictionaryEntity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_CreateTest.java
@@ -74,6 +74,7 @@ public class DictionaryServiceImpl_CreateTest {
         newDictionary.setType(DictionaryType.MANUAL);
         newDictionary.setProperties(Map.of("foo", "bar"));
 
+        when(dictionaryRepository.findById("my-key")).thenReturn(Optional.empty());
         when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
         when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -99,6 +100,7 @@ public class DictionaryServiceImpl_CreateTest {
         Dictionary existingById = new Dictionary();
         existingById.setId("my-key");
         existingById.setEnvironmentId("OTHER_ENV");
+        when(dictionaryRepository.findById("my-key")).thenReturn(Optional.of(existingById));
         when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
         when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -136,6 +138,7 @@ public class DictionaryServiceImpl_CreateTest {
 
         Dictionary existing = new Dictionary();
         existing.setEnvironmentId(ENVIRONMENT_ID);
+        when(dictionaryRepository.findById("my-key")).thenReturn(Optional.empty());
         when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.of(existing));
 
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
@@ -145,21 +148,24 @@ public class DictionaryServiceImpl_CreateTest {
     }
 
     @Test
-    public void shouldNotCreateWhenIdAlreadyExistsInSameEnvironment() throws TechnicalException {
+    public void shouldNotCreateWhenExplicitKeyMatchesExistingIdInSameEnvironment() throws TechnicalException {
         NewDictionaryEntity newDictionary = new NewDictionaryEntity();
-        newDictionary.setKey("my-key");
-        newDictionary.setName("My Dictionary");
+        newDictionary.setKey("idp-server-details");
+        newDictionary.setName("tf_idp-server-details");
         newDictionary.setType(DictionaryType.MANUAL);
 
         Dictionary existingById = new Dictionary();
-        existingById.setKey("my-key");
+        existingById.setId("idp-server-details");
+        existingById.setName("idp-server-details");
         existingById.setEnvironmentId(ENVIRONMENT_ID);
-        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.of(existingById));
+        when(dictionaryRepository.findById("idp-server-details")).thenReturn(Optional.of(existingById));
 
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        assertThatThrownBy(() -> dictionaryService.create(executionContext, newDictionary)).isInstanceOf(
-            DictionaryAlreadyExistsException.class
-        );
+        assertThatThrownBy(() -> dictionaryService.create(executionContext, newDictionary))
+            .isInstanceOf(DictionaryKeyCollidesWithIdException.class)
+            .hasMessage(
+                "A dictionary with key [idp-server-details] cannot be created because dictionary [idp-server-details] already uses that value as its id in this environment."
+            );
     }
 
     @Test
@@ -169,6 +175,7 @@ public class DictionaryServiceImpl_CreateTest {
         newDictionary.setName("My Dictionary");
         newDictionary.setType(DictionaryType.DYNAMIC);
 
+        when(dictionaryRepository.findById("my-key")).thenReturn(Optional.empty());
         when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
         when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14821

## Description

Two dictionaries in the same environment could share one gateway runtime slot when one dictionary’s key equalled another’s id (typical Console + Terraform mix). Deploying the second silently replaced the first. Undeploying or deleting either one emptied the slot, so #dictionaries['…'] started 500ing until a gateway restart.

This PR:

- Rejects create when an explicit key (v2/v4 API / Terraform) matches another dictionary’s id in the same environment.
- Undeploys a gateway slot only if the occupant’s id is the dictionary being removed; otherwise logs a warning and leaves it.
- show in DEBUG logs when deploy overwrites a different dictionary, and logs the dictionary that was actually requested on undeploy.

## Additional context 


- showing the complete flow [creating client's current similar situation]  [video with audio]

https://github.com/user-attachments/assets/cf9095f7-ae35-493b-a067-3edfbacd1d13


- Rejecting the creation 
<img width="3326" height="1916" alt="image (14)" src="https://github.com/user-attachments/assets/c2cae60c-0e15-4558-8358-64c4e49cd7f8" />

- logs
<img width="1663" height="499" alt="image" src="https://github.com/user-attachments/assets/ee0ffbd4-7062-4ce7-afdc-3ffb8c6607b0" />

