### PR TITLE
feat(gamma): add members to a group from user search

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersSheet.tsx
@@ -36,9 +36,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 
 import { MemberAvatar } from './MemberAvatar';
-import { isSameUser } from './memberHelpers';
-import { searchUsers } from '../../services/applicationMembers';
-import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import { searchUsers } from '../../../../shared/services/userSearch';
+import type { SearchableUser } from '../../../../shared/types/userSearch';
+import { isSameUser } from '../../../../shared/utils/userSearch';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
 import { applicationMemberKeys } from '../../utils/queryKeys';
 
 export function AddMembersSheet({

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipSheet.spec.tsx
@@ -17,7 +17,8 @@ import { useQuery } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { TransferOwnershipSheet } from './TransferOwnershipSheet';
-import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import type { SearchableUser } from '../../../../shared/types/userSearch';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
 import { querySheetHeading } from '../test/sheetSpecHelpers';
 
 jest.mock('@tanstack/react-query', () => ({

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipSheet.tsx
@@ -37,8 +37,9 @@ import { useDeferredValue, useMemo, useState } from 'react';
 
 import { MemberAvatar } from './MemberAvatar';
 import { isMemberPrimaryOwner } from './memberHelpers';
-import { searchUsers } from '../../services/applicationMembers';
-import type { ApplicationTransferOwnershipPayload, ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import { searchUsers } from '../../../../shared/services/userSearch';
+import type { SearchableUser } from '../../../../shared/types/userSearch';
+import type { ApplicationTransferOwnershipPayload, ApplicationUiMember } from '../../types/applicationMembers.types';
 import { applicationMemberKeys } from '../../utils/queryKeys';
 
 /** Matches AddMembersSheet search dropdown cap (~12rem). */

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.spec.ts
@@ -19,7 +19,6 @@ import {
     getApplicationRole,
     getGroupMemberRole,
     isMemberPrimaryOwner,
-    isSameUser,
 } from './memberHelpers';
 import type { ApplicationUiMember } from '../../types/applicationMembers.types';
 
@@ -73,17 +72,6 @@ describe('memberHelpers', () => {
                     roles: [{ name: 'USER', scope: 'APPLICATION' }],
                 }),
             ).toBe(false);
-        });
-    });
-
-    describe('isSameUser', () => {
-        it('matches by id when both ids are set', () => {
-            expect(isSameUser({ id: 'a', reference: 'ref-a' }, { id: 'a', reference: 'ref-b' })).toBe(true);
-            expect(isSameUser({ id: 'a', reference: 'ref-a' }, { id: 'b', reference: 'ref-a' })).toBe(false);
-        });
-
-        it('falls back to reference when ids are missing', () => {
-            expect(isSameUser({ id: null, reference: 'ref-1' }, { id: undefined, reference: 'ref-1' })).toBe(true);
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import type { SearchableUser } from '../../../../shared/types/userSearch';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
 
 const APPLICATION_SCOPE = 'APPLICATION';
 
@@ -30,11 +31,6 @@ export function getApplicationRole(member: ApplicationUiMember): string {
 
 export function isMemberPrimaryOwner(member: ApplicationUiMember): boolean {
     return member.roles?.some(role => role.name === 'PRIMARY_OWNER') ?? false;
-}
-
-export function isSameUser(userA: SearchableUser, userB: SearchableUser): boolean {
-    if (userA.id !== null && userA.id !== undefined && userB.id !== null && userB.id !== undefined) return userA.id === userB.id;
-    return userA.reference === userB.reference;
 }
 
 /** Group members carry roles keyed by scope (typically GROUP). */

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
@@ -24,7 +24,6 @@ import type {
     EnvironmentGroup,
     GroupMember,
     GroupsPagedResponse,
-    SearchableUser,
 } from '../types/applicationMembers.types';
 import { mapApplicationMemberToUiMember } from '../utils/applicationMemberMapper';
 
@@ -125,10 +124,6 @@ export async function getGroupMembers(environmentId: string, groupId: string): P
         displayName: m.displayName ?? '',
         roles: Object.fromEntries((m.roles ?? []).map(r => [r.scope ?? '', r.name ?? ''])),
     }));
-}
-
-export async function searchUsers(query: string): Promise<SearchableUser[]> {
-    return apimFetchJsonOrg<SearchableUser[]>(`/search/users?q=${encodeURIComponent(query)}`);
 }
 
 export async function updateApplicationGroups(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationMembers.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationMembers.types.ts
@@ -61,13 +61,6 @@ export interface GroupMember {
 
 export type GroupMembersMap = Record<string, GroupMember[]>;
 
-export interface SearchableUser {
-    id?: string | null;
-    reference: string;
-    displayName: string;
-    email?: string;
-}
-
 export interface ApplicationTransferOwnershipPayload {
     id?: string;
     reference?: string;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -1,0 +1,444 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupAddMembersSheet } from './GroupAddMembersSheet';
+import type { SearchableUser } from '../../../shared/types/userSearch';
+import type { GroupMember } from '../types/group';
+import { GROUP_SEARCH_DEBOUNCE_MS } from '../utils/paginationConstants';
+
+jest.mock('@tanstack/react-query', () => ({
+    ...jest.requireActual('@tanstack/react-query'),
+    useQuery: jest.fn(),
+}));
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+const mockUseQuery = jest.mocked(useQuery);
+
+const RESULTS: SearchableUser[] = [
+    { id: 'user-1', reference: 'user-1', displayName: 'Anna Schmidt', email: 'anna@lufthansa.com' },
+    { id: 'user-2', reference: 'user-2', displayName: 'Jonas Keller', email: 'jonas@lufthansa.com' },
+    { id: null, reference: 'ldap-anna', displayName: 'LDAP Anna', email: 'ldap@example.com' },
+];
+
+function typeSearch(value: string) {
+    fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value } });
+    act(() => {
+        jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS);
+    });
+}
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMembersSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupAddMembersSheet
+            open
+            groupName="API Team"
+            groupRoles={undefined}
+            members={[]}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            apiProductRoles={[{ name: 'USER', scope: 'API_PRODUCT' }]}
+            integrationRoles={[{ name: 'USER', scope: 'INTEGRATION' }]}
+            clusterRoles={[{ name: 'USER', scope: 'CLUSTER' }]}
+            explorerRoles={[{ name: 'USER', scope: 'EXPLORER' }]}
+            lockApiRole={false}
+            lockApiProductRole={false}
+            lockApplicationRole={false}
+            canOverrideLocks
+            maxInvitation={null}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupAddMembersSheet', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockUseQuery.mockReturnValue({ data: RESULTS, isFetching: false } as ReturnType<typeof useQuery>);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Add members' })).toBeNull();
+    });
+
+    it('has no "None" role option — classic\'s add-members-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    it('shows the group name in the description and the default-roles selects', () => {
+        renderSheet();
+        expect(screen.getByText('Search platform users and assign roles for membership in API Team.')).not.toBeNull();
+        expect(screen.getByText('API')).not.toBeNull();
+        expect(screen.getByText('API product')).not.toBeNull();
+        expect(screen.getByText('Application')).not.toBeNull();
+        expect(screen.getByText('Integration')).not.toBeNull();
+        expect(screen.getByText('Cluster')).not.toBeNull();
+        expect(screen.getByText('Explorer')).not.toBeNull();
+    });
+
+    it('has no "make selected users group admins" option — that only applies when editing an existing member', () => {
+        renderSheet();
+        expect(screen.queryByText(/group admin/i)).toBeNull();
+    });
+
+    it('prompts for at least 2 characters before showing results', () => {
+        renderSheet();
+        typeSearch('a');
+        expect(screen.queryByText('Type at least 2 characters to search for users.')).not.toBeNull();
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+    });
+
+    it('excludes users who are already members from the results', () => {
+        const existingMember: GroupMember = { id: 'user-1', displayName: 'Anna Schmidt', roles: {} };
+        renderSheet({ members: [existingMember] });
+        typeSearch('an');
+        expect(screen.queryByText('Anna Schmidt')).toBeNull();
+        expect(screen.queryByText('Jonas Keller')).not.toBeNull();
+    });
+
+    it('disables the submit button until at least one user is selected', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits selected users with all classic group-member role scopes', () => {
+        const { onSubmit } = renderSheet();
+
+        typeSearch('an');
+        fireEvent.click(screen.getByText('Anna Schmidt'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                id: 'user-1',
+                reference: 'user-1',
+                roles: [
+                    { scope: 'API', name: 'USER' },
+                    { scope: 'API_PRODUCT', name: 'USER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'INTEGRATION', name: 'USER' },
+                    { scope: 'CLUSTER', name: 'USER' },
+                    { scope: 'EXPLORER', name: 'USER' },
+                ],
+            },
+        ]);
+    });
+
+    it('omits id for LDAP users so the backend resolves via reference', () => {
+        const { onSubmit } = renderSheet();
+
+        typeSearch('ld');
+        fireEvent.click(screen.getByText('LDAP Anna'));
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+        expect(onSubmit).toHaveBeenCalledWith([
+            {
+                reference: 'ldap-anna',
+                roles: [
+                    { scope: 'API', name: 'USER' },
+                    { scope: 'API_PRODUCT', name: 'USER' },
+                    { scope: 'APPLICATION', name: 'USER' },
+                    { scope: 'INTEGRATION', name: 'USER' },
+                    { scope: 'CLUSTER', name: 'USER' },
+                    { scope: 'EXPLORER', name: 'USER' },
+                ],
+            },
+        ]);
+    });
+
+    describe('default role pre-fill', () => {
+        it('pre-fills API/API product/Application from the group’s configured default roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'USER' } });
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'OWNER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                        { scope: 'EXPLORER', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('falls back to USER for any scope missing from the group’s configured roles', () => {
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER' } });
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-1',
+                    reference: 'user-1',
+                    roles: [
+                        { scope: 'API', name: 'OWNER' },
+                        { scope: 'API_PRODUCT', name: 'USER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                        { scope: 'EXPLORER', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('always defaults Integration/Cluster/Explorer to USER — classic hardcodes these regardless of group config', () => {
+            const { onSubmit } = renderSheet();
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    roles: expect.arrayContaining([
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                        { scope: 'EXPLORER', name: 'USER' },
+                    ]),
+                }),
+            ]);
+        });
+    });
+
+    it('disables the PRIMARY_OWNER option for a scope that already has a primary owner', () => {
+        const existingOwner: GroupMember = { id: 'user-3', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({
+            members: [existingOwner],
+            apiRoles: [
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ],
+        });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('disables system roles other than PRIMARY_OWNER on API, and all system roles on Application', () => {
+        renderSheet({
+            apiPrimaryOwnerMode: 'GROUP',
+            apiProductPrimaryOwnerMode: 'GROUP',
+            apiRoles: [
+                { name: 'USER', scope: 'API' },
+                { name: 'ADMIN', scope: 'API', system: true },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ],
+            applicationRoles: [
+                { name: 'USER', scope: 'APPLICATION' },
+                { name: 'ADMIN', scope: 'APPLICATION', system: true },
+            ],
+        });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.getByRole('option', { name: 'ADMIN' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+
+        // Close the open listbox before opening Application.
+        fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+        fireEvent.click(screen.getAllByRole('combobox')[2]);
+        expect(screen.getByRole('option', { name: 'ADMIN' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'USER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('locks role selects and search while the add-members mutation is in flight', () => {
+        renderSheet({ isSaving: true });
+
+        expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        expect(screen.getByLabelText('Search users')).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+    });
+
+    it('associates the search label with the search input', () => {
+        renderSheet();
+        expect(screen.getByLabelText('Search users')).toHaveProperty('placeholder', 'Search by name or email…');
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    describe('lock flags', () => {
+        it('disables a locked role select without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        });
+
+        it('leaves a locked role select enabled with canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: true });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+
+        it('leaves an unlocked role select enabled without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: false, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+
+        it('disables Integration, Cluster, and Explorer without canOverrideLocks, regardless of lock flags', () => {
+            renderSheet({ canOverrideLocks: false });
+            const comboboxes = screen.getAllByRole('combobox');
+            expect(comboboxes[3]).toHaveProperty('disabled', true);
+            expect(comboboxes[4]).toHaveProperty('disabled', true);
+            expect(comboboxes[5]).toHaveProperty('disabled', true);
+        });
+    });
+
+    describe('member limit', () => {
+        it('disables the search input once existing members reach the limit', () => {
+            const existing: GroupMember = { id: 'user-9', displayName: 'Existing Member', roles: {} };
+            renderSheet({ members: [existing], maxInvitation: 1 });
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', true);
+            expect(screen.getByText('This group has reached its maximum number of members.')).not.toBeNull();
+        });
+
+        it('keeps selected users visible and removable when their selection reaches the limit', () => {
+            renderSheet({ maxInvitation: 1 });
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+
+            expect(screen.getByText('Anna Schmidt')).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Remove Anna Schmidt' })).not.toBeNull();
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', true);
+            expect(screen.getByText('Selection limit reached for this group.')).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove Anna Schmidt' }));
+
+            expect(screen.queryByRole('button', { name: 'Remove Anna Schmidt' })).toBeNull();
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', false);
+        });
+
+        it('leaves the search input enabled below the limit', () => {
+            const existing: GroupMember = { id: 'user-9', displayName: 'Existing Member', roles: {} };
+            renderSheet({ members: [existing], maxInvitation: 2 });
+            expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('disabled', false);
+        });
+    });
+
+    describe('primary owner constraints', () => {
+        const apiRolesWithOwner = [
+            { name: 'USER', scope: 'API' },
+            { name: 'OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+        ];
+
+        it('disables PRIMARY_OWNER while environment settings are still unknown', () => {
+            renderSheet({ apiRoles: apiRolesWithOwner });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+            expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+            expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+        });
+
+        it('disables PRIMARY_OWNER when the environment primary owner mode is USER, even with no owner yet', () => {
+            renderSheet({ apiPrimaryOwnerMode: 'USER', apiRoles: apiRolesWithOwner });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+            expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+            expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+        });
+
+        it('keeps only a single selected user once PRIMARY_OWNER is chosen', () => {
+            const { onSubmit } = renderSheet({
+                apiPrimaryOwnerMode: 'GROUP',
+                apiProductPrimaryOwnerMode: 'GROUP',
+                apiRoles: apiRolesWithOwner,
+            });
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'PRIMARY_OWNER' }));
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            fireEvent.click(screen.getByText('Jonas Keller'));
+
+            expect(screen.getByText('1 user selected')).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+            expect(onSubmit).toHaveBeenCalledWith([
+                {
+                    id: 'user-2',
+                    reference: 'user-2',
+                    roles: [
+                        { scope: 'API', name: 'PRIMARY_OWNER' },
+                        { scope: 'API_PRODUCT', name: 'USER' },
+                        { scope: 'APPLICATION', name: 'USER' },
+                        { scope: 'INTEGRATION', name: 'USER' },
+                        { scope: 'CLUSTER', name: 'USER' },
+                        { scope: 'EXPLORER', name: 'USER' },
+                    ],
+                },
+            ]);
+        });
+
+        it('clears the current selection when the API role changes', () => {
+            renderSheet({
+                apiPrimaryOwnerMode: 'GROUP',
+                apiProductPrimaryOwnerMode: 'GROUP',
+                apiRoles: apiRolesWithOwner,
+            });
+
+            typeSearch('an');
+            fireEvent.click(screen.getByText('Anna Schmidt'));
+            expect(screen.getByText('1 user selected')).not.toBeNull();
+
+            fireEvent.click(screen.getAllByRole('combobox')[0]);
+            fireEvent.click(screen.getByRole('option', { name: 'OWNER' }));
+
+            expect(screen.queryByText('1 user selected')).toBeNull();
+            expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Label,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+
+import { GroupScopedRoleSelects } from './GroupScopedRoleSelects';
+import { GroupUserSearchPicker } from './GroupUserSearchPicker';
+import { useGroupAddMembersForm } from '../hooks/useGroupAddMembersForm';
+import type { GroupMember, GroupMembershipPayload, GroupRole } from '../types/group';
+
+export function GroupAddMembersSheet({
+    open,
+    groupName,
+    groupRoles,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    explorerRoles,
+    lockApiRole,
+    lockApiProductRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    maxInvitation,
+    apiPrimaryOwnerMode,
+    apiProductPrimaryOwnerMode,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    groupName: string;
+    groupRoles: Record<string, string> | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    apiProductRoles: GroupRole[];
+    integrationRoles: GroupRole[];
+    clusterRoles: GroupRole[];
+    explorerRoles: GroupRole[];
+    lockApiRole: boolean;
+    lockApiProductRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    maxInvitation: number | null;
+    apiPrimaryOwnerMode?: string;
+    apiProductPrimaryOwnerMode?: string;
+    onClose: () => void;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+    isSaving: boolean;
+}>) {
+    const form = useGroupAddMembersForm({
+        open,
+        groupRoles,
+        members,
+        lockApiRole,
+        lockApiProductRole,
+        lockApplicationRole,
+        canOverrideLocks,
+        maxInvitation,
+        apiPrimaryOwnerMode,
+        apiProductPrimaryOwnerMode,
+        onSubmit,
+    });
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isSaving && onClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>Add members</SheetTitle>
+                    <SheetDescription>Search platform users and assign roles for membership in {groupName}.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    <div className="space-y-6 px-4 pb-4">
+                        <div className="space-y-3">
+                            <Label className="text-sm font-medium">Default roles for selected users</Label>
+                            <GroupScopedRoleSelects
+                                idPrefix="add-members-role"
+                                roles={{
+                                    api: apiRoles,
+                                    apiProduct: apiProductRoles,
+                                    application: applicationRoles,
+                                    integration: integrationRoles,
+                                    cluster: clusterRoles,
+                                    explorer: explorerRoles,
+                                }}
+                                values={form.roleValues}
+                                onChange={form.handleRoleChange}
+                                locks={form.roleLocks}
+                                disabled={isSaving}
+                                disabledOptionNames={form.disabledOptionNames}
+                            />
+                        </div>
+
+                        {form.primaryOwnerSelected && (
+                            <p className="text-xs text-muted-foreground">The primary owner role can be granted to a single member only.</p>
+                        )}
+
+                        <GroupUserSearchPicker
+                            search={form.search}
+                            onSearchChange={form.setSearch}
+                            debouncedQuery={form.debouncedQuery}
+                            isFetching={form.isFetching}
+                            candidates={form.candidates}
+                            selected={form.selected}
+                            onToggle={form.handleToggle}
+                            invitationLimitReached={form.invitationLimitReached}
+                            groupMemberCapReached={form.groupMemberCapReached}
+                            disabled={isSaving}
+                        />
+
+                        {form.selected.length > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                                {form.selected.length} user{form.selected.length !== 1 ? 's' : ''} selected
+                            </p>
+                        )}
+                    </div>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={form.handleSubmit} disabled={!form.canSubmit || isSaving}>
+                        {isSaving ? 'Adding…' : form.submitLabel}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.spec.tsx
@@ -31,7 +31,7 @@ const MIA: GroupMember = {
 };
 
 function renderTable(overrides: Partial<React.ComponentProps<typeof GroupMembersTable>> = {}) {
-    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} {...overrides} />);
+    return render(<GroupMembersTable members={[RAVI, MIA]} loading={false} canAddMembers {...overrides} />);
 }
 
 describe('GroupMembersTable', () => {
@@ -62,6 +62,13 @@ describe('GroupMembersTable', () => {
     it('shows a first-use empty state with no members', () => {
         renderTable({ members: [] });
         expect(screen.queryByText('No members available to display')).not.toBeNull();
+        expect(screen.queryByText('Use Add members above to search for users.')).not.toBeNull();
+    });
+
+    it('shows neutral empty-state copy when the user cannot add members', () => {
+        renderTable({ members: [], canAddMembers: false });
+        expect(screen.queryByText('No members available to display')).not.toBeNull();
+        expect(screen.queryByText('Use Add members above to search for users.')).toBeNull();
     });
 
     it('shows a no-results empty state when the search matches nothing', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembersTable.tsx
@@ -31,6 +31,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { GroupMember } from '../types/group';
+import { paginate, totalPagesFor } from '../utils/clientPagination';
 
 const PAGE_SIZE = 10;
 
@@ -89,19 +90,13 @@ function buildColumns(): DataTableProps<GroupMember>['columns'] {
     ];
 }
 
-function paginate(items: GroupMember[], page: number, pageSize: number): GroupMember[] {
-    const start = (page - 1) * pageSize;
-    return items.slice(start, start + pageSize);
-}
-
 interface GroupMembersTableProps {
     readonly members: GroupMember[];
     readonly loading: boolean;
+    readonly canAddMembers: boolean;
 }
 
-// Member management (add/invite/edit roles/remove) is added on top of this read-only view in a
-// follow-up PR (FOUND-106/FOUND-107) — this component intentionally has no action column yet.
-export function GroupMembersTable({ members, loading }: GroupMembersTableProps) {
+export function GroupMembersTable({ members, loading, canAddMembers }: GroupMembersTableProps) {
     const [search, setSearch] = useState('');
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(PAGE_SIZE);
@@ -112,7 +107,7 @@ export function GroupMembersTable({ members, loading }: GroupMembersTableProps) 
     }, [members, search]);
 
     const totalCount = filtered.length;
-    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+    const totalPages = totalPagesFor(totalCount, pageSize);
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
     const columns = useMemo(() => buildColumns(), []);
 
@@ -168,7 +163,11 @@ export function GroupMembersTable({ members, loading }: GroupMembersTableProps) 
                         }
                     />
                 ) : (
-                    <DataTableEmptyState variant="first-use" title="No members available to display" description="" />
+                    <DataTableEmptyState
+                        variant="first-use"
+                        title="No members available to display"
+                        description={canAddMembers ? 'Use Add members above to search for users.' : ''}
+                    />
                 )
             }
             toolbar={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupMembershipTable.tsx
@@ -30,6 +30,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
 import type { GroupMembershipItem } from '../types/group';
+import { paginate, totalPagesFor } from '../utils/clientPagination';
 
 const PAGE_SIZE = 10;
 
@@ -54,11 +55,6 @@ function buildColumns(showVersionColumn: boolean): DataTableProps<GroupMembershi
         });
     }
     return columns;
-}
-
-function paginate(items: GroupMembershipItem[], page: number, pageSize: number): GroupMembershipItem[] {
-    const start = (page - 1) * pageSize;
-    return items.slice(start, start + pageSize);
 }
 
 interface GroupMembershipTableProps {
@@ -91,7 +87,7 @@ export function GroupMembershipTable({
     }, [items, search]);
 
     const totalCount = filtered.length;
-    const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+    const totalPages = totalPagesFor(totalCount, pageSize);
     const pageData = useMemo(() => paginate(filtered, page, pageSize), [filtered, page, pageSize]);
     const columns = useMemo(() => buildColumns(showVersionColumn), [showVersionColumn]);
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRoleSelect.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupRoleSelect.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import type { GroupRole } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+
+const NO_ROLE_VALUE = '__none__';
+
+function isRoleOptionDisabled(
+    role: GroupRole,
+    disabledOptionNames: Set<string> | undefined,
+    disableSystemRoles: 'all' | 'except-primary-owner' | undefined,
+): boolean {
+    if (disabledOptionNames?.has(role.name)) {
+        return true;
+    }
+    if (!role.system || !disableSystemRoles) {
+        return false;
+    }
+    if (disableSystemRoles === 'except-primary-owner' && role.name === PRIMARY_OWNER_ROLE) {
+        return false;
+    }
+    return true;
+}
+
+export function GroupRoleSelect({
+    id,
+    label,
+    roles,
+    value,
+    onChange,
+    disabled,
+    disabledOptionNames,
+    disableSystemRoles,
+    hint,
+}: Readonly<{
+    id: string;
+    label: string;
+    roles: GroupRole[];
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    disabledOptionNames?: Set<string>;
+    /** Classic add-members: Application/Integration/Cluster disable all system roles; API/API Product keep PRIMARY_OWNER selectable under its own rules. */
+    disableSystemRoles?: 'all' | 'except-primary-owner';
+    hint?: string;
+}>) {
+    return (
+        <div className="space-y-1.5">
+            <Label htmlFor={id} className="text-sm text-muted-foreground">
+                {label}
+            </Label>
+            <Select value={value || NO_ROLE_VALUE} onValueChange={v => onChange(v === NO_ROLE_VALUE ? '' : v)} disabled={disabled}>
+                <SelectTrigger id={id} className="w-full">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {roles.map(role => (
+                        <SelectItem
+                            key={role.name}
+                            value={role.name}
+                            disabled={isRoleOptionDisabled(role, disabledOptionNames, disableSystemRoles)}
+                        >
+                            {role.name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupScopedRoleSelects.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupScopedRoleSelects.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GroupRoleSelect } from './GroupRoleSelect';
+import type { GroupRole } from '../types/group';
+import type { MemberRoleLockFlags, MemberRoleSelections, RoleField } from '../utils/memberRoles';
+
+export function GroupScopedRoleSelects({
+    idPrefix = 'group-role',
+    roles,
+    values,
+    onChange,
+    locks,
+    disabled = false,
+    disabledOptionNames,
+}: Readonly<{
+    idPrefix?: string;
+    roles: {
+        api: GroupRole[];
+        apiProduct: GroupRole[];
+        application: GroupRole[];
+        integration: GroupRole[];
+        cluster: GroupRole[];
+        explorer: GroupRole[];
+    };
+    values: MemberRoleSelections;
+    onChange: (field: RoleField, value: string) => void;
+    locks: MemberRoleLockFlags;
+    disabled?: boolean;
+    disabledOptionNames?: {
+        api?: Set<string>;
+        apiProduct?: Set<string>;
+    };
+}>) {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <GroupRoleSelect
+                id={`${idPrefix}-api`}
+                label="API"
+                roles={roles.api}
+                value={values.apiRole}
+                onChange={value => onChange('apiRole', value)}
+                disabled={disabled || locks.api}
+                disabledOptionNames={disabledOptionNames?.api}
+                disableSystemRoles="except-primary-owner"
+            />
+            <GroupRoleSelect
+                id={`${idPrefix}-api-product`}
+                label="API product"
+                roles={roles.apiProduct}
+                value={values.apiProductRole}
+                onChange={value => onChange('apiProductRole', value)}
+                disabled={disabled || locks.apiProduct}
+                disabledOptionNames={disabledOptionNames?.apiProduct}
+                disableSystemRoles="except-primary-owner"
+            />
+            <GroupRoleSelect
+                id={`${idPrefix}-application`}
+                label="Application"
+                roles={roles.application}
+                value={values.applicationRole}
+                onChange={value => onChange('applicationRole', value)}
+                disabled={disabled || locks.application}
+                disableSystemRoles="all"
+            />
+            <GroupRoleSelect
+                id={`${idPrefix}-integration`}
+                label="Integration"
+                roles={roles.integration}
+                value={values.integrationRole}
+                onChange={value => onChange('integrationRole', value)}
+                disabled={disabled || locks.integration}
+                disableSystemRoles="all"
+            />
+            <GroupRoleSelect
+                id={`${idPrefix}-cluster`}
+                label="Cluster"
+                roles={roles.cluster}
+                value={values.clusterRole}
+                onChange={value => onChange('clusterRole', value)}
+                disabled={disabled || locks.cluster}
+                disableSystemRoles="all"
+            />
+            <GroupRoleSelect
+                id={`${idPrefix}-explorer`}
+                label="Explorer"
+                roles={roles.explorer}
+                value={values.explorerRole}
+                onChange={value => onChange('explorerRole', value)}
+                disabled={disabled || locks.explorer}
+                disableSystemRoles="all"
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupUserSearchPicker.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupUserSearchPicker.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge, Button, Checkbox, Input, Label, Skeleton } from '@gravitee/graphene-core';
+import { SearchIcon, XIcon } from '@gravitee/graphene-core/icons';
+
+import type { SearchableUser } from '../../../shared/types/userSearch';
+import { isSameUser } from '../../../shared/utils/userSearch';
+import { UserAvatar } from '../../users/components/UserAvatar';
+
+const SEARCH_INPUT_ID = 'group-add-members-search';
+
+export function GroupUserSearchPicker({
+    search,
+    onSearchChange,
+    debouncedQuery,
+    isFetching,
+    candidates,
+    selected,
+    onToggle,
+    invitationLimitReached,
+    groupMemberCapReached = false,
+    disabled = false,
+}: Readonly<{
+    search: string;
+    onSearchChange: (value: string) => void;
+    debouncedQuery: string;
+    isFetching: boolean;
+    candidates: SearchableUser[];
+    selected: SearchableUser[];
+    onToggle: (user: SearchableUser) => void;
+    invitationLimitReached: boolean;
+    /** True when existing members alone already hit max_invitation (not just the current selection). */
+    groupMemberCapReached?: boolean;
+    disabled?: boolean;
+}>) {
+    const searchDisabled = disabled || invitationLimitReached;
+
+    return (
+        <div className="space-y-2">
+            <Label htmlFor={SEARCH_INPUT_ID} className="text-sm font-medium">
+                Search users
+            </Label>
+            <div className="relative">
+                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                <Input
+                    id={SEARCH_INPUT_ID}
+                    className="pl-10"
+                    placeholder="Search by name or email…"
+                    value={search}
+                    onChange={e => onSearchChange(e.target.value)}
+                    disabled={searchDisabled}
+                />
+            </div>
+
+            {selected.length > 0 && (
+                <div className="flex flex-wrap gap-1.5" aria-label="Selected users">
+                    {selected.map(user => (
+                        <Badge key={user.id ?? user.reference} variant="secondary" className="gap-0.5 pr-1 font-normal">
+                            {user.displayName}
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                className="ml-0.5 shrink-0 hover:text-destructive"
+                                onClick={() => onToggle(user)}
+                                aria-label={`Remove ${user.displayName}`}
+                                disabled={disabled}
+                            >
+                                <XIcon className="size-3" aria-hidden />
+                            </Button>
+                        </Badge>
+                    ))}
+                </div>
+            )}
+
+            {invitationLimitReached ? (
+                <p className="px-1 py-2 text-sm text-muted-foreground">
+                    {groupMemberCapReached
+                        ? 'This group has reached its maximum number of members.'
+                        : 'Selection limit reached for this group.'}
+                </p>
+            ) : debouncedQuery.trim().length < 2 ? (
+                <p className="px-1 py-2 text-sm text-muted-foreground">Type at least 2 characters to search for users.</p>
+            ) : isFetching || search !== debouncedQuery ? (
+                <div className="space-y-2 p-1">
+                    <Skeleton className="h-10 rounded" />
+                    <Skeleton className="h-10 rounded" />
+                </div>
+            ) : candidates.length === 0 ? (
+                <p className="px-1 py-2 text-sm text-muted-foreground">No users found.</p>
+            ) : (
+                <div className="rounded-lg border">
+                    {candidates.map(user => {
+                        const isChecked = selected.some(u => isSameUser(u, user));
+                        const inputId = `add-member-${user.id ?? user.reference}`;
+                        return (
+                            <label
+                                key={user.id ?? user.reference}
+                                htmlFor={inputId}
+                                className={`flex items-center gap-3 border-b px-3 py-2.5 last:border-b-0 ${disabled ? 'opacity-50' : 'hover:bg-muted/50 cursor-pointer'}`}
+                            >
+                                <Checkbox id={inputId} checked={isChecked} onCheckedChange={() => onToggle(user)} disabled={disabled} />
+                                <UserAvatar name={user.displayName} />
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-medium truncate">{user.displayName}</p>
+                                    {user.email ? <p className="text-xs text-muted-foreground truncate">{user.email}</p> : null}
+                                </div>
+                            </label>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.spec.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { GroupsRequireGroupSetting } from './GroupsRequireGroupSetting';
+import { useConsoleSettings, useSetConsoleSettings, type ConsoleSettings } from '../../../shared/console-settings';
+import { notify } from '../../../shared/notify';
+import { saveOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+
+jest.mock('../../../shared/console-settings', () => ({
+    ...jest.requireActual('../../../shared/console-settings'),
+    useConsoleSettings: jest.fn(),
+    useSetConsoleSettings: jest.fn(),
+}));
+jest.mock('../../../shared/services/orgConsoleSettings');
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+const mockUseConsoleSettings = jest.mocked(useConsoleSettings);
+const mockUseSetConsoleSettings = jest.mocked(useSetConsoleSettings);
+const mockSaveOrgConsoleSettings = jest.mocked(saveOrgConsoleSettings);
+const mockUseHasPermission = jest.mocked(useHasPermission);
+
+describe('GroupsRequireGroupSetting', () => {
+    const setConsoleSettings = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseSetConsoleSettings.mockReturnValue(setConsoleSettings);
+        mockUseHasPermission.mockReturnValue(true);
+    });
+
+    it('reflects the currently-loaded setting and disables Save until changed', () => {
+        mockUseConsoleSettings.mockReturnValue({ userGroup: { required: { enabled: true } } });
+        render(<GroupsRequireGroupSetting />);
+
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+    });
+
+    it('defaults to off when the setting is missing entirely', () => {
+        mockUseConsoleSettings.mockReturnValue(null);
+        render(<GroupsRequireGroupSetting />);
+        expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('keeps Save disabled without organization-settings-u even after flipping the toggle', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseConsoleSettings.mockReturnValue({ userGroup: { required: { enabled: false } } });
+        render(<GroupsRequireGroupSetting />);
+
+        expect(screen.getByRole('switch')).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+    });
+
+    it('enables Save once the toggle is flipped, and preserves other settings fields on save', async () => {
+        mockUseConsoleSettings.mockReturnValue({
+            userGroup: { required: { enabled: false } },
+            authentication: { localLogin: { enabled: true } },
+        } as ConsoleSettings & { authentication: { localLogin: { enabled: boolean } } });
+        mockSaveOrgConsoleSettings.mockResolvedValue({ userGroup: { required: { enabled: true } } });
+        render(<GroupsRequireGroupSetting />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', false);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+            expect(mockSaveOrgConsoleSettings).toHaveBeenCalledWith({
+                userGroup: { required: { enabled: true } },
+                authentication: { localLogin: { enabled: true } },
+            }),
+        );
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Successfully updated groups settings.'));
+        expect(setConsoleSettings).toHaveBeenCalledWith({ userGroup: { required: { enabled: true } } });
+    });
+
+    it('shows an error toast when saving fails', async () => {
+        mockUseConsoleSettings.mockReturnValue({ userGroup: { required: { enabled: false } } });
+        mockSaveOrgConsoleSettings.mockRejectedValue(new Error('failed'));
+        render(<GroupsRequireGroupSetting />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(expect.any(Error), 'Error occurred while saving groups settings.'));
+        expect(setConsoleSettings).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupsRequireGroupSetting.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Switch } from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import { isUserGroupRequired, useConsoleSettings, useSetConsoleSettings, type ConsoleSettings } from '../../../shared/console-settings';
+import { notify } from '../../../shared/notify';
+import { saveOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+import { ORGANIZATION_SETTINGS_UPDATE_PERMISSION } from '../utils/groupPermissions';
+
+export function GroupsRequireGroupSetting() {
+    const settings = useConsoleSettings();
+    const setConsoleSettings = useSetConsoleSettings();
+    const canUpdateOrgSettings = useHasPermission({ anyOf: [ORGANIZATION_SETTINGS_UPDATE_PERMISSION] });
+
+    const [enabled, setEnabled] = useState(() => isUserGroupRequired(settings));
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        setEnabled(isUserGroupRequired(settings));
+    }, [settings]);
+
+    const hasChanged = enabled !== isUserGroupRequired(settings);
+
+    async function handleSave() {
+        setIsSaving(true);
+        try {
+            const payload: ConsoleSettings = {
+                ...settings,
+                userGroup: { ...settings?.userGroup, required: { ...settings?.userGroup?.required, enabled } },
+            };
+            const saved = await saveOrgConsoleSettings(payload);
+            setConsoleSettings(saved);
+            notify.success('Successfully updated groups settings.');
+        } catch (error) {
+            notify.error(error, 'Error occurred while saving groups settings.');
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+            <div className="flex items-center gap-3">
+                <Switch
+                    id="require-user-group"
+                    checked={enabled}
+                    onCheckedChange={setEnabled}
+                    disabled={isSaving || !canUpdateOrgSettings}
+                />
+                <div className="space-y-0.5">
+                    <label htmlFor="require-user-group" className="text-sm font-medium cursor-pointer">
+                        Requires an application to have at least one group added in order to create or update it.
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                        Use this setting if you want to enforce group ownership of applications.
+                    </p>
+                </div>
+            </div>
+            <Button type="button" size="sm" onClick={handleSave} disabled={!hasChanged || isSaving || !canUpdateOrgSettings}>
+                {isSaving ? 'Saving…' : 'Save'}
+            </Button>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.spec.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useGroupAddMembersForm } from './useGroupAddMembersForm';
+import { searchUsers } from '../../../shared/services/userSearch';
+import { GROUP_SEARCH_DEBOUNCE_MS } from '../utils/paginationConstants';
+
+jest.mock('../../../shared/services/userSearch', () => ({
+    searchUsers: jest.fn(),
+}));
+
+const mockSearchUsers = jest.mocked(searchUsers);
+
+describe('useGroupAddMembersForm', () => {
+    let queryClient: QueryClient;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: { retry: false },
+            },
+        });
+        mockSearchUsers.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        queryClient.clear();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    function wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+
+    function renderForm(open: boolean) {
+        return renderHook(
+            ({ isOpen }) =>
+                useGroupAddMembersForm({
+                    open: isOpen,
+                    groupRoles: undefined,
+                    members: [],
+                    lockApiRole: false,
+                    lockApiProductRole: false,
+                    lockApplicationRole: false,
+                    canOverrideLocks: true,
+                    maxInvitation: null,
+                    apiPrimaryOwnerMode: 'GROUP',
+                    apiProductPrimaryOwnerMode: 'GROUP',
+                    onSubmit: jest.fn(),
+                }),
+            { initialProps: { isOpen: open }, wrapper },
+        );
+    }
+
+    it('collapses rapid search input into one request for the final query', async () => {
+        const { result } = renderForm(true);
+
+        act(() => result.current.setSearch('an'));
+        act(() => {
+            jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS - 1);
+        });
+        act(() => result.current.setSearch('anna'));
+        act(() => {
+            jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS - 1);
+        });
+        expect(mockSearchUsers).not.toHaveBeenCalled();
+
+        await act(async () => {
+            jest.advanceTimersByTime(1);
+            await Promise.resolve();
+        });
+
+        expect(mockSearchUsers).toHaveBeenCalledTimes(1);
+        expect(mockSearchUsers).toHaveBeenCalledWith('anna');
+    });
+
+    it('does not debounce or query while the sheet is closed', async () => {
+        const { result } = renderForm(false);
+
+        act(() => {
+            result.current.setSearch('anna');
+            jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS);
+        });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.debouncedQuery).toBe('');
+        expect(mockSearchUsers).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+
+import { searchUsers } from '../../../shared/services/userSearch';
+import type { SearchableUser } from '../../../shared/types/userSearch';
+import type { GroupMember, GroupMembershipPayload } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+import { buildMembershipRoles, getMemberRoleLockFlags, type RoleField } from '../utils/memberRoles';
+import { GROUP_SEARCH_DEBOUNCE_MS } from '../utils/paginationConstants';
+import { groupKeys } from '../utils/queryKeys';
+import { nextSearchableUserSelection } from '../utils/searchableUsers';
+
+const PRIMARY_OWNER_MODE_USER = 'USER';
+
+/** Fail closed: until the mode is known and is not USER, PRIMARY_OWNER must stay unavailable. */
+function isPrimaryOwnerUnavailable(mode: string | undefined): boolean {
+    return mode === undefined || mode.toUpperCase() === PRIMARY_OWNER_MODE_USER;
+}
+
+const DEFAULT_USER_ROLES: Record<RoleField, string> = {
+    apiRole: 'USER',
+    apiProductRole: 'USER',
+    applicationRole: 'USER',
+    integrationRole: 'USER',
+    clusterRole: 'USER',
+    explorerRole: 'USER',
+};
+
+export function useGroupAddMembersForm({
+    open,
+    groupRoles,
+    members,
+    lockApiRole,
+    lockApiProductRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    maxInvitation,
+    apiPrimaryOwnerMode,
+    apiProductPrimaryOwnerMode,
+    onSubmit,
+}: {
+    open: boolean;
+    groupRoles: Record<string, string> | undefined;
+    members: GroupMember[];
+    lockApiRole: boolean;
+    lockApiProductRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    maxInvitation: number | null;
+    apiPrimaryOwnerMode: string | undefined;
+    apiProductPrimaryOwnerMode: string | undefined;
+    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+}) {
+    const [search, setSearch] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
+    const [selected, setSelected] = useState<SearchableUser[]>([]);
+    const [roleValues, setRoleValues] = useState(DEFAULT_USER_ROLES);
+
+    useEffect(() => {
+        if (!open) return;
+        setSearch('');
+        setDebouncedQuery('');
+        setSelected([]);
+        setRoleValues({
+            apiRole: groupRoles?.API ?? 'USER',
+            apiProductRole: groupRoles?.API_PRODUCT ?? 'USER',
+            applicationRole: groupRoles?.APPLICATION ?? 'USER',
+            integrationRole: 'USER',
+            clusterRole: 'USER',
+            explorerRole: 'USER',
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on the open transition only
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        const timer = setTimeout(() => setDebouncedQuery(search), GROUP_SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(timer);
+    }, [open, search]);
+
+    const roleLocks = getMemberRoleLockFlags({ lockApiRole, lockApiProductRole, lockApplicationRole }, canOverrideLocks);
+    const groupMemberCapReached = typeof maxInvitation === 'number' && maxInvitation <= members.length;
+    const invitationLimitReached = typeof maxInvitation === 'number' && maxInvitation <= members.length + selected.length;
+
+    const { data: results, isFetching } = useQuery({
+        queryKey: groupKeys.userSearch(debouncedQuery),
+        queryFn: () => searchUsers(debouncedQuery),
+        enabled: open && debouncedQuery.trim().length >= 2,
+        staleTime: 30_000,
+    });
+
+    const existingMemberIds = useMemo(() => new Set(members.map(m => m.id)), [members]);
+    const candidates = useMemo(
+        () => (results ?? []).filter(u => !existingMemberIds.has(u.id ?? u.reference)),
+        [results, existingMemberIds],
+    );
+
+    const apiPrimaryOwnerDisabled =
+        isPrimaryOwnerUnavailable(apiPrimaryOwnerMode) || members.some(m => m.roles?.API === PRIMARY_OWNER_ROLE);
+    const apiProductPrimaryOwnerDisabled =
+        isPrimaryOwnerUnavailable(apiProductPrimaryOwnerMode) || members.some(m => m.roles?.API_PRODUCT === PRIMARY_OWNER_ROLE);
+
+    const primaryOwnerSelected = roleValues.apiRole === PRIMARY_OWNER_ROLE || roleValues.apiProductRole === PRIMARY_OWNER_ROLE;
+
+    return {
+        search,
+        setSearch,
+        selected,
+        roleValues,
+        roleLocks,
+        groupMemberCapReached,
+        invitationLimitReached,
+        primaryOwnerSelected,
+        debouncedQuery,
+        isFetching,
+        candidates,
+        disabledOptionNames: {
+            api: apiPrimaryOwnerDisabled ? new Set([PRIMARY_OWNER_ROLE]) : undefined,
+            apiProduct: apiProductPrimaryOwnerDisabled ? new Set([PRIMARY_OWNER_ROLE]) : undefined,
+        },
+        handleRoleChange: (field: RoleField, value: string) => {
+            setRoleValues(prev => ({ ...prev, [field]: value }));
+            if (field === 'apiRole' || field === 'apiProductRole') {
+                setSelected([]);
+            }
+        },
+        handleToggle: (user: SearchableUser) => setSelected(prev => nextSearchableUserSelection(prev, user, primaryOwnerSelected)),
+        handleSubmit: () => {
+            const roles = buildMembershipRoles(roleValues);
+            onSubmit(
+                selected.map(user => ({
+                    ...(user.id ? { id: user.id } : {}),
+                    reference: user.reference,
+                    roles,
+                })),
+            );
+        },
+        canSubmit: selected.length > 0,
+        submitLabel: selected.length > 1 ? `Add ${selected.length} members` : 'Add member',
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
@@ -17,7 +17,7 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
-import { getGroup, listGroupMembers, listGroupMemberships } from '../services/groups';
+import { getEnvironmentSettings, getGroup, listGroupMembers, listGroupMemberships } from '../services/groups';
 import type { GroupMembershipType } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
@@ -48,6 +48,17 @@ function useGroupMemberships(groupId: string | undefined, type: GroupMembershipT
         queryKey: groupKeys.memberships(env?.id ?? '', groupId ?? '', type),
         queryFn: () => listGroupMemberships(env!.id, groupId!, type),
         enabled: Boolean(env && groupId),
+    });
+}
+
+export function useEnvironmentSettings({ enabled = true }: { enabled?: boolean } = {}) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.settings(env?.id ?? ''),
+        queryFn: () => getEnvironmentSettings(env!.id),
+        enabled: Boolean(env) && enabled,
+        staleTime: 5 * 60_000,
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { useAddGroupMembers } from './useGroupMutations';
+import { notify } from '../../../shared/notify';
+import type { GroupMembershipPayload } from '../types/group';
+
+type MemberSheetState = 'closed' | 'search';
+
+export function useGroupMemberActions(groupId: string | undefined) {
+    const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
+
+    const addMembersMutation = useAddGroupMembers();
+
+    function closeMemberSheet() {
+        setMemberSheet('closed');
+    }
+
+    async function handleAddMembers(memberships: GroupMembershipPayload[]) {
+        if (!groupId) return;
+        try {
+            await addMembersMutation.mutateAsync({ groupId, memberships });
+            notify.success(memberships.length > 1 ? `${memberships.length} members added successfully` : 'Member added successfully');
+            closeMemberSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to add members');
+        }
+    }
+
+    return {
+        memberSheet,
+        setMemberSheet,
+        closeMemberSheet,
+        addMembersMutation,
+        handleAddMembers,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -17,8 +17,8 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createGroup, deleteGroup, updateGroup } from '../services/groups';
-import type { Group, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import { addGroupMembers, createGroup, deleteGroup, updateGroup } from '../services/groups';
+import type { Group, GroupMembershipPayload, NewGroupPayload, UpdateGroupPayload } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
 function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
@@ -52,4 +52,10 @@ export function useUpdateGroup() {
 
 export function useDeleteGroup() {
     return useGroupMutation<string, void>(deleteGroup);
+}
+
+export function useAddGroupMembers() {
+    return useGroupMutation<{ groupId: string; memberships: GroupMembershipPayload[] }, void>((envId, { groupId, memberships }) =>
+        addGroupMembers(envId, groupId, memberships),
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupRoles.ts
@@ -16,27 +16,39 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { listGroupApiProductRoles, listGroupApiRoles, listGroupApplicationRoles } from '../services/groups';
+import { listGroupRolesByScope, type GroupRoleScope } from '../services/groups';
 import type { GroupRole } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
-function useGroupRolesQuery(queryKey: readonly unknown[], queryFn: () => Promise<GroupRole[]>, enabled: boolean) {
-    return useQuery({
+function useGroupRolesQuery(queryKey: readonly unknown[], scope: GroupRoleScope, enabled: boolean) {
+    return useQuery<GroupRole[]>({
         queryKey,
-        queryFn,
+        queryFn: () => listGroupRolesByScope(scope),
         staleTime: 5 * 60_000,
         enabled,
     });
 }
 
 export function useGroupApiRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.apiRoles(), listGroupApiRoles, enabled);
+    return useGroupRolesQuery(groupKeys.apiRoles(), 'API', enabled);
 }
 
 export function useGroupApplicationRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.applicationRoles(), listGroupApplicationRoles, enabled);
+    return useGroupRolesQuery(groupKeys.applicationRoles(), 'APPLICATION', enabled);
 }
 
 export function useGroupApiProductRoles({ enabled = true }: { enabled?: boolean } = {}) {
-    return useGroupRolesQuery(groupKeys.apiProductRoles(), listGroupApiProductRoles, enabled);
+    return useGroupRolesQuery(groupKeys.apiProductRoles(), 'API_PRODUCT', enabled);
+}
+
+export function useGroupIntegrationRoles({ enabled = true }: { enabled?: boolean } = {}) {
+    return useGroupRolesQuery(groupKeys.integrationRoles(), 'INTEGRATION', enabled);
+}
+
+export function useGroupClusterRoles({ enabled = true }: { enabled?: boolean } = {}) {
+    return useGroupRolesQuery(groupKeys.clusterRoles(), 'CLUSTER', enabled);
+}
+
+export function useGroupExplorerRoles({ enabled = true }: { enabled?: boolean } = {}) {
+    return useGroupRolesQuery(groupKeys.explorerRoles(), 'EXPLORER', enabled);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -19,6 +19,7 @@ import type {
     Group,
     GroupMember,
     GroupMembershipItem,
+    GroupMembershipPayload,
     GroupMembershipType,
     GroupRole,
     GroupsPagedResponse,
@@ -83,18 +84,26 @@ export async function deleteGroup(environmentId: string, groupId: string): Promi
     });
 }
 
-async function listGroupRolesByScope(scope: 'API' | 'APPLICATION' | 'API_PRODUCT'): Promise<GroupRole[]> {
+export type GroupRoleScope = 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'EXPLORER';
+
+export async function listGroupRolesByScope(scope: GroupRoleScope): Promise<GroupRole[]> {
     return apimFetchJsonOrg<GroupRole[]>(`/configuration/rolescopes/${scope}/roles`);
 }
 
-export async function listGroupApiRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('API');
+/** Subset of GET /environments/{envId}/portal needed to gate PRIMARY_OWNER in add-members.
+ *  Classic loads the same unguarded `/portal` resource (any authenticated user), not `/settings`. */
+export interface EnvironmentPrimaryOwnerSettings {
+    api?: { primaryOwnerMode?: string };
+    apiProduct?: { primaryOwnerMode?: string };
 }
 
-export async function listGroupApplicationRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('APPLICATION');
+export async function getEnvironmentSettings(environmentId: string): Promise<EnvironmentPrimaryOwnerSettings> {
+    return apimFetchJsonV1Env<EnvironmentPrimaryOwnerSettings>(environmentId, '/portal');
 }
 
-export async function listGroupApiProductRoles(): Promise<GroupRole[]> {
-    return listGroupRolesByScope('API_PRODUCT');
+export async function addGroupMembers(environmentId: string, groupId: string, memberships: GroupMembershipPayload[]): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/members`, {
+        method: 'POST',
+        body: JSON.stringify(memberships),
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -101,6 +101,8 @@ export interface GroupRole {
     default?: boolean;
 }
 
+export const PRIMARY_OWNER_ROLE = 'PRIMARY_OWNER';
+
 /** v1 `GroupMemberEntity` (GET .../configuration/groups/{id}/members...). */
 export interface GroupMember {
     id: string;
@@ -118,4 +120,17 @@ export interface GroupMembershipItem {
     id: string;
     name: string;
     version?: string;
+}
+
+export type GroupMemberRoleScope = 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'EXPLORER' | 'GROUP';
+
+export interface GroupMembershipRole {
+    scope: GroupMemberRoleScope;
+    name: string;
+}
+
+export interface GroupMembershipPayload {
+    id?: string;
+    reference?: string;
+    roles: GroupMembershipRole[];
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/clientPagination.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/clientPagination.ts
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+
+export function paginate<T>(items: readonly T[], page: number, pageSize: number): T[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+export function totalPagesFor(totalCount: number, pageSize: number): number {
+    return pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/groupPermissions.ts
@@ -16,11 +16,13 @@
 
 import type { Group } from '../types/group';
 
-/** Mirrors classic settings-routing.module.ts groups route guard + groups.component.ts permission checks. */
 export const ENVIRONMENT_GROUP_READ_PERMISSION = 'environment-group-r' as const;
 export const ENVIRONMENT_GROUP_CREATE_PERMISSION = 'environment-group-c' as const;
 export const ENVIRONMENT_GROUP_UPDATE_PERMISSION = 'environment-group-u' as const;
 export const ENVIRONMENT_GROUP_DELETE_PERMISSION = 'environment-group-d' as const;
+
+export const ORGANIZATION_SETTINGS_READ_PERMISSION = 'organization-settings-r' as const;
+export const ORGANIZATION_SETTINGS_UPDATE_PERMISSION = 'organization-settings-u' as const;
 
 /**
  * Mirrors classic Console's `apiPrimaryOwner || apiProductPrimaryOwner` badge/delete-guard condition
@@ -29,4 +31,8 @@ export const ENVIRONMENT_GROUP_DELETE_PERMISSION = 'environment-group-d' as cons
  */
 export function isPrimaryOwnerGroup(group: Pick<Group, 'primary_owner' | 'apiPrimaryOwner' | 'apiProductPrimaryOwner'>): boolean {
     return Boolean(group.primary_owner || group.apiPrimaryOwner || group.apiProductPrimaryOwner);
+}
+
+export function isRoleLocked(locked: boolean, canOverrideLocks: boolean): boolean {
+    return locked && !canOverrideLocks;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/memberRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/memberRoles.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isRoleLocked } from './groupPermissions';
+import type { GroupMembershipRole } from '../types/group';
+
+export type MemberRoleSelections = {
+    apiRole: string;
+    apiProductRole: string;
+    applicationRole: string;
+    integrationRole: string;
+    clusterRole: string;
+    explorerRole: string;
+};
+
+export type RoleField = keyof MemberRoleSelections;
+
+export type MemberRoleLockFlags = {
+    api: boolean;
+    apiProduct: boolean;
+    application: boolean;
+    integration: boolean;
+    cluster: boolean;
+    explorer: boolean;
+};
+
+export function getMemberRoleLockFlags(
+    locks: {
+        lockApiRole: boolean;
+        lockApiProductRole: boolean;
+        lockApplicationRole: boolean;
+    },
+    canOverrideLocks: boolean,
+): MemberRoleLockFlags {
+    return {
+        api: isRoleLocked(locks.lockApiRole, canOverrideLocks),
+        apiProduct: isRoleLocked(locks.lockApiProductRole, canOverrideLocks),
+        application: isRoleLocked(locks.lockApplicationRole, canOverrideLocks),
+        integration: !canOverrideLocks,
+        cluster: !canOverrideLocks,
+        explorer: !canOverrideLocks,
+    };
+}
+
+export function buildMembershipRoles(selections: MemberRoleSelections): GroupMembershipRole[] {
+    const roles: GroupMembershipRole[] = [];
+    if (selections.apiRole) roles.push({ scope: 'API', name: selections.apiRole });
+    if (selections.apiProductRole) roles.push({ scope: 'API_PRODUCT', name: selections.apiProductRole });
+    if (selections.applicationRole) roles.push({ scope: 'APPLICATION', name: selections.applicationRole });
+    if (selections.integrationRole) roles.push({ scope: 'INTEGRATION', name: selections.integrationRole });
+    if (selections.clusterRole) roles.push({ scope: 'CLUSTER', name: selections.clusterRole });
+    if (selections.explorerRole) roles.push({ scope: 'EXPLORER', name: selections.explorerRole });
+    return roles;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -23,8 +23,15 @@ export const groupKeys = {
     members: (envId: string, groupId: string) => [...groupKeys.all, 'members', envId, groupId] as const,
     memberships: (envId: string, groupId: string, type: GroupMembershipType) =>
         [...groupKeys.all, 'memberships', envId, groupId, type] as const,
-    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT') => [...groupKeys.all, 'roles', scope] as const,
+    roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'EXPLORER') => ['org-roles', scope] as const,
     apiRoles: () => groupKeys.roles('API'),
     applicationRoles: () => groupKeys.roles('APPLICATION'),
     apiProductRoles: () => groupKeys.roles('API_PRODUCT'),
+    integrationRoles: () => groupKeys.roles('INTEGRATION'),
+    clusterRoles: () => groupKeys.roles('CLUSTER'),
+    explorerRoles: () => groupKeys.roles('EXPLORER'),
+    /** Org-scoped user search — not under `all`, so group mutations do not invalidate it. */
+    userSearch: (query: string) => ['org-user-search', query] as const,
+    /** Env portal config (primaryOwnerMode) — not under `all` and not group-scoped. */
+    settings: (envId: string) => ['environment-portal', envId] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/searchableUsers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/searchableUsers.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { nextSearchableUserSelection, toggleSearchableUser } from './searchableUsers';
+import type { SearchableUser } from '../../../shared/types/userSearch';
+
+const ANNA: SearchableUser = { id: '1', reference: 'anna', displayName: 'Anna' };
+const JONAS: SearchableUser = { id: '2', reference: 'jonas', displayName: 'Jonas' };
+
+describe('searchableUsers', () => {
+    it('toggles a user in and out of the selection', () => {
+        expect(toggleSearchableUser([], ANNA)).toEqual([ANNA]);
+        expect(toggleSearchableUser([ANNA, JONAS], ANNA)).toEqual([JONAS]);
+    });
+
+    it('keeps at most one user when exclusive and replaces the current selection', () => {
+        expect(nextSearchableUserSelection([ANNA], JONAS, true)).toEqual([JONAS]);
+        expect(nextSearchableUserSelection([ANNA], ANNA, true)).toEqual([]);
+    });
+
+    it('delegates to toggle when exclusive is false', () => {
+        expect(nextSearchableUserSelection([ANNA], JONAS, false)).toEqual([ANNA, JONAS]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/searchableUsers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/searchableUsers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SearchableUser } from '../../../shared/types/userSearch';
+import { isSameUser } from '../../../shared/utils/userSearch';
+
+export function toggleSearchableUser(selected: SearchableUser[], user: SearchableUser): SearchableUser[] {
+    const isAlreadySelected = selected.some(u => isSameUser(u, user));
+    if (isAlreadySelected) {
+        return selected.filter(u => !isSameUser(u, user));
+    }
+    return [...selected, user];
+}
+
+/** When exclusive, at most one user can be selected (primary-owner add-members). */
+export function nextSearchableUserSelection(selected: SearchableUser[], user: SearchableUser, exclusive: boolean): SearchableUser[] {
+    if (exclusive) {
+        return selected.some(u => isSameUser(u, user)) ? [] : [user];
+    }
+    return toggleSearchableUser(selected, user);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
@@ -65,11 +65,11 @@ import type {
     ApplicationTransferOwnershipPayload,
     ApplicationUiMember,
     EditState,
-    SearchableUser,
 } from '../features/applications/types/applicationMembers.types';
 import { toApplicationMemberEntity } from '../features/applications/utils/applicationMemberMapper';
 import { applicationDetailKeys, applicationMemberKeys } from '../features/applications/utils/queryKeys';
 import { notify } from '../shared/notify';
+import type { SearchableUser } from '../shared/types/userSearch';
 
 class AddMembersMutationError extends Error {
     public readonly succeededCount: number;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -19,15 +19,23 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { GroupDetailPage } from './GroupDetailPage';
 import {
+    useEnvironmentSettings,
     useGroupApis,
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
-import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
-import type { Group, GroupMembershipItem } from '../features/groups/types/group';
+import { useAddGroupMembers, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupExplorerRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
+import type { Group, GroupMembershipItem, GroupMembershipPayload } from '../features/groups/types/group';
 import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
@@ -53,6 +61,18 @@ jest.mock('../features/groups/components/GroupMembershipTable', () => ({
         <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
     ),
 }));
+// GroupAddMembersSheet has its own spec covering its internals (search, role selects, selection);
+// here we only need to verify the page wires it to the add-members mutation.
+jest.mock('../features/groups/components/GroupAddMembersSheet', () => ({
+    GroupAddMembersSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (m: GroupMembershipPayload[]) => void }) =>
+        open ? (
+            <div data-testid="add-members-sheet">
+                <button type="button" onClick={() => onSubmit([{ id: 'user-1', roles: [{ scope: 'API', name: 'USER' }] }])}>
+                    Submit add members
+                </button>
+            </div>
+        ) : null,
+}));
 
 // Radix Switch (rendered inside the real GroupSheet, mounted unconditionally so Edit can open it) measures
 // its thumb via ResizeObserver, which jsdom lacks.
@@ -67,16 +87,21 @@ beforeAll(() => {
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseGroupDetail = jest.mocked(useGroupDetail);
 const mockUseGroupMembers = jest.mocked(useGroupMembers);
+const mockUseEnvironmentSettings = jest.mocked(useEnvironmentSettings);
 const mockUseGroupApis = jest.mocked(useGroupApis);
 const mockUseGroupApplications = jest.mocked(useGroupApplications);
 const mockUseGroupApiProducts = jest.mocked(useGroupApiProducts);
 const mockUseGroupApiRoles = jest.mocked(useGroupApiRoles);
 const mockUseGroupApplicationRoles = jest.mocked(useGroupApplicationRoles);
 const mockUseGroupApiProductRoles = jest.mocked(useGroupApiProductRoles);
+const mockUseGroupIntegrationRoles = jest.mocked(useGroupIntegrationRoles);
+const mockUseGroupClusterRoles = jest.mocked(useGroupClusterRoles);
+const mockUseGroupExplorerRoles = jest.mocked(useGroupExplorerRoles);
 const mockUseUpdateGroup = jest.mocked(useUpdateGroup);
 const mockUseDeleteGroup = jest.mocked(useDeleteGroup);
+const mockUseAddGroupMembers = jest.mocked(useAddGroupMembers);
 
-const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }] };
+const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }], system_invitation: true };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeMutation(mutateAsync = jest.fn()): any {
@@ -105,6 +130,7 @@ describe('GroupDetailPage', () => {
             isLoading: false,
             isError: false,
         } as ReturnType<typeof useGroupMembers>);
+        mockUseEnvironmentSettings.mockReturnValue({ data: undefined } as ReturnType<typeof useEnvironmentSettings>);
         mockUseGroupApis.mockReturnValue({
             data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }],
             isLoading: false,
@@ -127,8 +153,15 @@ describe('GroupDetailPage', () => {
             data: [{ name: 'USER', scope: 'API_PRODUCT', default: true }],
             isLoading: false,
         } as ReturnType<typeof useGroupApiProductRoles>);
+        mockUseGroupIntegrationRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupIntegrationRoles>);
+        mockUseGroupClusterRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupClusterRoles>);
+        mockUseGroupExplorerRoles.mockReturnValue({
+            data: [],
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGroupExplorerRoles>);
         mockUseUpdateGroup.mockReturnValue(makeMutation());
         mockUseDeleteGroup.mockReturnValue(makeMutation());
+        mockUseAddGroupMembers.mockReturnValue(makeMutation());
     });
 
     afterEach(() => {
@@ -169,24 +202,45 @@ describe('GroupDetailPage', () => {
             expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: false });
             expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: false });
             expect(mockUseGroupApiProductRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: false });
         });
 
-        it('fetches role catalogs once the user opens the Edit sheet', () => {
+        it('fetches only default-group role catalogs once the user opens the Edit sheet', () => {
             renderPage();
             fireEvent.click(screen.getByRole('button', { name: 'Edit group' }));
 
             expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: true });
             expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: true });
             expect(mockUseGroupApiProductRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: false });
         });
 
-        it('skips fetching role catalogs when the user cannot edit, since the sheet can never open', () => {
+        it('fetches all six role catalogs once the Add members sheet is open', () => {
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+
+            expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupApiProductRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: true });
+        });
+
+        it('skips fetching role catalogs when the user cannot edit or add members, since no sheet can open', () => {
             mockUseHasPermission.mockReturnValue(false);
             renderPage();
 
             expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: false });
             expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: false });
             expect(mockUseGroupApiProductRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: false });
         });
     });
 
@@ -367,6 +421,132 @@ describe('GroupDetailPage', () => {
             expect(screen.queryByText('Auto APIs')).not.toBeNull();
             expect(screen.queryByText('Auto API Products')).not.toBeNull();
             expect(screen.queryByText('Auto Applications')).not.toBeNull();
+        });
+    });
+
+    describe('Add members', () => {
+        it('hides Add members without permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+            expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: false });
+        });
+
+        it('hides Add members when the group does not allow adding users via search, even with update permission', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, system_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+            expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: false });
+        });
+
+        it('opens the Add members sheet, submits, and shows a success toast', async () => {
+            const addMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(addMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+            expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() =>
+                expect(addMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    memberships: [{ id: 'user-1', roles: [{ scope: 'API', name: 'USER' }] }],
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Member added successfully');
+            await waitFor(() => expect(screen.queryByTestId('add-members-sheet')).toBeNull());
+        });
+
+        it('shows an error toast and keeps the sheet open when adding members fails', async () => {
+            const error = new Error('failed');
+            mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+            fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to add members'));
+            expect(screen.queryByTestId('add-members-sheet')).not.toBeNull();
+        });
+    });
+
+    describe('self-service group admin (manageable)', () => {
+        it('shows Add members via manageable + system_invitation even without environment-group-u', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: true, system_invitation: true },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
+            expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: true });
+        });
+
+        it('hides Add members when manageable but system invitation is disabled', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: true, system_invitation: false, email_invitation: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('hides Add members when not manageable and lacking environment-group-u', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, manageable: false },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+    });
+
+    describe('member limit', () => {
+        it('shows an info banner and hides Add members once the group has reached max_invitation', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, max_invitation: 1 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            mockUseGroupMembers.mockReturnValue({
+                data: [{ id: 'member-1', displayName: 'Anna Schmidt', roles: {} }],
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupMembers>);
+            renderPage();
+
+            expect(
+                screen.getByText('The number of members in this group has reached maximum allowed. Adding users has been disabled.'),
+            ).not.toBeNull();
+            expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
+        });
+
+        it('does not show the banner below the limit', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, max_invitation: 5 },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            expect(screen.queryByText(/reached maximum allowed/)).toBeNull();
+            expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -15,11 +15,12 @@
  */
 
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, PencilIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import { Alert, AlertDescription, Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, InfoIcon, PencilIcon, PlusIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { GroupAddMembersSheet } from '../features/groups/components/GroupAddMembersSheet';
 import { GroupAssociationSection } from '../features/groups/components/GroupAssociationSection';
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
 import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
@@ -27,14 +28,23 @@ import { GroupSettingsSection } from '../features/groups/components/GroupSetting
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
 import { SectionError } from '../features/groups/components/SectionError';
 import {
+    useEnvironmentSettings,
     useGroupApis,
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
+import { useGroupMemberActions } from '../features/groups/hooks/useGroupMemberActions';
 import { useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
-import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
+import {
+    useGroupApiProductRoles,
+    useGroupApiRoles,
+    useGroupApplicationRoles,
+    useGroupClusterRoles,
+    useGroupExplorerRoles,
+    useGroupIntegrationRoles,
+} from '../features/groups/hooks/useGroupRoles';
 import { buildEventRules, buildRolesMap, hasEventRule, parseMaxInvitation } from '../features/groups/utils/groupPayload';
 import { ENVIRONMENT_GROUP_DELETE_PERMISSION, ENVIRONMENT_GROUP_UPDATE_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { notify } from '../shared/notify';
@@ -53,11 +63,28 @@ export function GroupDetailPage() {
     const { data: apis = [], isLoading: apisLoading, isError: apisError } = useGroupApis(groupId);
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
-    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: canEdit && editOpen });
+
+    const { memberSheet, setMemberSheet, closeMemberSheet, addMembersMutation, handleAddMembers } = useGroupMemberActions(groupId);
+
+    // Edit Group only needs API / application / API product catalogs. Add members needs all six.
+    const addMemberRolesNeeded = memberSheet !== 'closed';
+    const defaultGroupRolesNeeded = editOpen || addMemberRolesNeeded;
+    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: defaultGroupRolesNeeded });
     const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles({
-        enabled: canEdit && editOpen,
+        enabled: defaultGroupRolesNeeded,
     });
-    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles({ enabled: canEdit && editOpen });
+    const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles({
+        enabled: defaultGroupRolesNeeded,
+    });
+    const { data: integrationRoles = [] } = useGroupIntegrationRoles({ enabled: addMemberRolesNeeded });
+    const { data: clusterRoles = [] } = useGroupClusterRoles({ enabled: addMemberRolesNeeded });
+    const { data: explorerRoles = [] } = useGroupExplorerRoles({ enabled: addMemberRolesNeeded });
+
+    const maxInvitationsLimitReached = typeof group?.max_invitation === 'number' && group.max_invitation <= members.length;
+    const canAddMembers =
+        group !== undefined && Boolean(group.system_invitation) && (canEdit || Boolean(group.manageable)) && !maxInvitationsLimitReached;
+    // Portal settings only matter for add-members PRIMARY_OWNER gating; skip when the user cannot open the sheet.
+    const { data: environmentSettings } = useEnvironmentSettings({ enabled: canAddMembers });
 
     const updateMutation = useUpdateGroup();
     const deleteMutation = useDeleteGroup();
@@ -203,14 +230,30 @@ export function GroupDetailPage() {
                 <GroupSettingsSection group={group} />
 
                 <section className="space-y-4 rounded-xl border bg-card p-5">
-                    <div>
-                        <h2 className="text-base font-semibold">Members</h2>
-                        <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <h2 className="text-base font-semibold">Members</h2>
+                            <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
+                        </div>
+                        {canAddMembers && (
+                            <Button type="button" className="shrink-0 gap-1.5" onClick={() => setMemberSheet('search')}>
+                                <PlusIcon className="size-4" aria-hidden />
+                                Add members
+                            </Button>
+                        )}
                     </div>
+                    {maxInvitationsLimitReached && (
+                        <Alert variant="default">
+                            <InfoIcon className="size-4" aria-hidden />
+                            <AlertDescription>
+                                The number of members in this group has reached maximum allowed. Adding users has been disabled.
+                            </AlertDescription>
+                        </Alert>
+                    )}
                     {membersError ? (
                         <SectionError message="Failed to load members. Please refresh and try again." />
                     ) : (
-                        <GroupMembersTable members={members} loading={membersLoading} />
+                        <GroupMembersTable members={members} loading={membersLoading} canAddMembers={canAddMembers} />
                     )}
                 </section>
 
@@ -268,6 +311,29 @@ export function GroupDetailPage() {
                 onClose={() => setDeleteOpen(false)}
                 onConfirm={handleDelete}
                 isDeleting={deleteMutation.isPending}
+            />
+
+            <GroupAddMembersSheet
+                open={memberSheet === 'search'}
+                groupName={group.name}
+                groupRoles={group.roles}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                apiProductRoles={apiProductRoles}
+                integrationRoles={integrationRoles}
+                clusterRoles={clusterRoles}
+                explorerRoles={explorerRoles}
+                lockApiRole={Boolean(group.lock_api_role)}
+                lockApiProductRole={Boolean(group.lock_api_product_role)}
+                lockApplicationRole={Boolean(group.lock_application_role)}
+                canOverrideLocks={canEdit}
+                maxInvitation={group.max_invitation ?? null}
+                apiPrimaryOwnerMode={environmentSettings?.api?.primaryOwnerMode}
+                apiProductPrimaryOwnerMode={environmentSettings?.apiProduct?.primaryOwnerMode}
+                onClose={closeMemberSheet}
+                onSubmit={handleAddMembers}
+                isSaving={addMembersMutation.isPending}
             />
         </>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.spec.tsx
@@ -88,6 +88,12 @@ jest.mock('../features/groups/components/GroupsTable', () => ({
         ),
 }));
 
+// Has its own dedicated spec (mocking the ConsoleSettingsProvider context it reads/writes); stubbing it
+// here avoids needing that context just to render this page's own wiring.
+jest.mock('../features/groups/components/GroupsRequireGroupSetting', () => ({
+    GroupsRequireGroupSetting: () => <div data-testid="require-group-setting" />,
+}));
+
 // Radix Switch (rendered inside the real GroupSheet) measures its thumb via ResizeObserver, which jsdom lacks.
 beforeAll(() => {
     global.ResizeObserver = class ResizeObserver {
@@ -169,6 +175,17 @@ describe('GroupsPage', () => {
             mockUseHasPermission.mockReturnValue(false);
             renderPage();
             expect(screen.queryByRole('button', { name: /Create Group/i })).toBeNull();
+        });
+
+        it('shows the require-group org setting when the user can read organization settings', () => {
+            renderPage();
+            expect(screen.queryByTestId('require-group-setting')).not.toBeNull();
+        });
+
+        it('hides the require-group org setting without organization-settings-r', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+            expect(screen.queryByTestId('require-group-setting')).toBeNull();
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupsPage.tsx
@@ -22,6 +22,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import { GroupsRequireGroupSetting } from '../features/groups/components/GroupsRequireGroupSetting';
 import { GroupsTable } from '../features/groups/components/GroupsTable';
 import { useCreateGroup, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
 import { useGroupApiProductRoles, useGroupApiRoles, useGroupApplicationRoles } from '../features/groups/hooks/useGroupRoles';
@@ -32,6 +33,7 @@ import {
     ENVIRONMENT_GROUP_CREATE_PERMISSION,
     ENVIRONMENT_GROUP_DELETE_PERMISSION,
     ENVIRONMENT_GROUP_UPDATE_PERMISSION,
+    ORGANIZATION_SETTINGS_READ_PERMISSION,
 } from '../features/groups/utils/groupPermissions';
 import { DEFAULT_GROUP_LIST_PAGE_SIZE, GROUP_SEARCH_DEBOUNCE_MS } from '../features/groups/utils/paginationConstants';
 import { notify } from '../shared/notify';
@@ -43,6 +45,7 @@ export function GroupsPage() {
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_DELETE_PERMISSION] });
+    const canReadOrgSettings = useHasPermission({ anyOf: [ORGANIZATION_SETTINGS_READ_PERMISSION] });
 
     const [search, setSearch] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -200,6 +203,8 @@ export function GroupsPage() {
                     </Button>
                 ) : null}
             </div>
+
+            {canReadOrgSettings && <GroupsRequireGroupSetting />}
 
             <GroupsTable
                 groups={groups}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
@@ -23,6 +23,10 @@ const LOAD_ERROR_MESSAGE = 'Management API unreachable or error occurs, please c
 interface ConsoleSettingsContextValue {
     settings: ConsoleSettings | null;
     isReady: boolean;
+    /** Updates the cached settings after a successful save elsewhere (e.g. GroupsPage's userGroupRequired
+     *  toggle) — mirrors classic's `merge(this.constants.org.settings, consoleSettings)`, keeping every
+     *  reader of `useConsoleSettings()` in sync for the rest of the session without a page reload. */
+    setSettings: (settings: ConsoleSettings) => void;
 }
 
 const ConsoleSettingsContext = createContext<ConsoleSettingsContextValue | null>(null);
@@ -66,7 +70,7 @@ export function ConsoleSettingsProvider({ children }: ConsoleSettingsProviderPro
         };
     }, []);
 
-    const value = useMemo(() => ({ settings, isReady }), [settings, isReady]);
+    const value = useMemo(() => ({ settings, isReady, setSettings }), [settings, isReady]);
 
     if (isLoading) {
         return (
@@ -101,4 +105,8 @@ export function useConsoleSettings(): ConsoleSettings | null {
 
 export function useConsoleSettingsReady(): boolean {
     return useConsoleSettingsContext().isReady;
+}
+
+export function useSetConsoleSettings(): (settings: ConsoleSettings) => void {
+    return useConsoleSettingsContext().setSettings;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
@@ -20,3 +20,16 @@ import type { ConsoleSettings } from '../console-settings';
 export async function fetchOrgConsoleSettings(): Promise<ConsoleSettings> {
     return apimFetchJsonOrg<ConsoleSettings>('/console');
 }
+
+/**
+ * POST /organizations/{orgId}/console (Angular ConsoleSettingsService.save()). The backend replaces the
+ * whole settings document, so callers must pass the complete object (spread the currently-loaded settings
+ * and override only the field being changed) — sending a partial object would wipe out every other console
+ * setting (authentication providers, CORS, etc.), not just merge the one field.
+ */
+export async function saveOrgConsoleSettings(settings: ConsoleSettings): Promise<ConsoleSettings> {
+    return apimFetchJsonOrg<ConsoleSettings>('/console', {
+        method: 'POST',
+        body: JSON.stringify(settings),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/userSearch.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/userSearch.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+
+import { apimFetchJsonOrg } from '../api/apimClient';
+import type { SearchableUser } from '../types/userSearch';
+
+export async function searchUsers(query: string): Promise<SearchableUser[]> {
+    return apimFetchJsonOrg<SearchableUser[]>(`/search/users?q=${encodeURIComponent(query)}`);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/types/userSearch.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/types/userSearch.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+
+export interface SearchableUser {
+    id?: string | null;
+    reference: string;
+    displayName: string;
+    email?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/userSearch.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/userSearch.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSameUser } from './userSearch';
+import type { SearchableUser } from '../types/userSearch';
+
+const ANNA: SearchableUser = { id: '1', reference: 'anna', displayName: 'Anna' };
+const ANNA_NO_ID: SearchableUser = { id: null, reference: 'anna', displayName: 'Anna' };
+const JONAS: SearchableUser = { id: '2', reference: 'jonas', displayName: 'Jonas' };
+
+describe('isSameUser', () => {
+    it('matches by id when both sides have one', () => {
+        expect(isSameUser(ANNA, { ...ANNA, reference: 'other' })).toBe(true);
+        expect(isSameUser(ANNA, JONAS)).toBe(false);
+    });
+
+    it('falls back to reference when either id is missing', () => {
+        expect(isSameUser(ANNA_NO_ID, { id: undefined, reference: 'anna', displayName: 'Anna' })).toBe(true);
+        expect(isSameUser(ANNA_NO_ID, JONAS)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/userSearch.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/userSearch.ts
@@ -13,6 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type { ConsoleSettings } from './types';
-export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
-export { isUserGroupRequired } from './isUserGroupRequired';
+
+import type { SearchableUser } from '../types/userSearch';
+
+function hasId(id: string | null | undefined): id is string {
+    return id !== null && id !== undefined;
+}
+
+export function isSameUser(userA: SearchableUser, userB: SearchableUser): boolean {
+    if (!hasId(userA.id) || !hasId(userB.id)) {
+        return userA.reference === userB.reference;
+    }
+    return userA.id === userB.id;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-106

## Description

Adds **user-search add members** to the Gamma group detail page (classic Console parity for “Add Member to Group”).

Admins can open **Add members**, search platform users, assign default roles across API / API Product / Application / Integration / Cluster / **Explorer**, and add one or more users in bulk.

### What to review

**Group detail — Members**

- New **Add members** button opens `GroupAddMembersSheet`
- Gating: `environment-group-u` **or** `manageable`, plus `system_invitation`; hidden when `max_invitation` is reached
- Info banner when the max-members limit is hit
- Empty-state copy nudges toward **Add members** when the user can add
- Email invitation is out of scope here; it lands in #19165

**Add members sheet**

- User search (≥ 2 chars, 300ms debounce), multi-select, existing members excluded
- Search is disabled while the sheet is closed (`enabled: open && …`)
- Default role selects with lock enforcement (`lock_*` + override via env update permission)
- Six scopes, including **EXPLORER** (classic `roleService.list('EXPLORER')` parity)
- Edit group fetches only API / application / API product catalogs; Integration / Cluster / Explorer load only when Add members is open
- `PRIMARY_OWNER` fail-closed until portal settings load; disabled for a scope that already has one
- Bulk submit via `POST …/configuration/groups/{id}/members`
- Success / error toasts; sheet stays open on failure; form locked while saving

**Shared user search**

- Org-scoped `/search/users`, `SearchableUser`, and `isSameUser` live in `shared/` — not on the group or application service

**Org settings — require a group on applications** (also in this PR)

- `GroupsRequireGroupSetting.tsx` on the groups list: org-level “application must have a group” toggle (classic parity)
- `saveOrgConsoleSettings` (`POST /organizations/{orgId}/console`) — full document, not a partial merge
- `setSettings` / `useSetConsoleSettings` on the shared `ConsoleSettingsProvider` so the rest of the session sees the save without a reload
- Toggle and Save gated on `organization-settings-u` (read-only org-settings users cannot save)