### PR TITLE
feat(gateway): add http.pathHandling to normalize or reject non-canonical request paths

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugEvent.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugEvent.ts
@@ -47,6 +47,9 @@ interface DebugEventPayload {
   preprocessorStep: {
     attributes?: Record<string, boolean | number | string>;
     headers?: Record<string, string[]>;
+    // The path the policies actually ran on. It overrides the submitted one when the gateway
+    // resolved it, so the timeline shows the request the gateway handled rather than the one typed.
+    path?: string;
   };
   backendResponse: {
     statusCode?: number;

--- a/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugResponse.ts
+++ b/gravitee-apim-console-webui/src/management/api/debug-mode/models/DebugResponse.ts
@@ -100,14 +100,20 @@ export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugRespon
     { ...requestInputDebugStep, id: 'request-output' },
   );
 
-  // Then, compute response initial attributes and headers -> either from the last REQUEST debug step or the request initial attributes
+  // Then, compute response initial attributes and headers -> either from the last REQUEST debug step or the request initial attributes.
+  // Both branches list what a response step may inherit, deliberately. Spreading the whole
+  // preprocessor step here would carry its `path` onto the backend response, where the inspector
+  // renders it as an HTTP property a response policy added — a change that never happened.
   const responsePreprocessorStep: DebugEvent['payload']['preprocessorStep'] =
     requestPolicyDebugSteps.length > 0
       ? {
           attributes: requestPolicyDebugSteps[requestPolicyDebugSteps.length - 1].output.attributes,
           headers: requestPolicyDebugSteps[requestPolicyDebugSteps.length - 1].output.headers,
         }
-      : event.payload.preprocessorStep;
+      : {
+          attributes: event.payload.preprocessorStep?.attributes,
+          headers: event.payload.preprocessorStep?.headers,
+        };
 
   // Finally, create the hydrated debug steps for the RESPONSE with initial request data + attributes
   const responsePolicyDebugSteps =

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/debug/PreprocessorStep.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/debug/PreprocessorStep.java
@@ -28,6 +28,15 @@ public class PreprocessorStep implements Serializable {
     @JsonProperty("headers")
     private Map<String, List<String>> headers;
 
+    /**
+     * The path the gateway is about to run the policies on, once everything it does before them has
+     * been applied. It differs from the path submitted in the debug request whenever the gateway
+     * resolved it — see {@code http.pathHandling} — and reporting only the submitted one would show
+     * a request that never existed.
+     */
+    @JsonProperty("path")
+    private String path;
+
     public Map<String, Serializable> getAttributes() {
         return attributes;
     }
@@ -42,5 +51,13 @@ public class PreprocessorStep implements Serializable {
 
     public void setHeaders(Map<String, List<String>> headers) {
         this.headers = headers;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
@@ -51,4 +51,24 @@ public class RequestConfiguration {
     ) {
         return new RequestClientAuthConfiguration(headerName);
     }
+
+    @Bean
+    public RequestPathConfiguration httpRequestPathConfiguration(@Value("${http.pathHandling:RAW}") String pathHandling) {
+        RequestPathHandling handling;
+        try {
+            handling = RequestPathHandling.valueOf(pathHandling.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                "Unknown value [{}] for http.pathHandling, falling back to {}. Expected one of {}.",
+                pathHandling,
+                RequestPathHandling.RAW,
+                java.util.Arrays.toString(RequestPathHandling.values())
+            );
+            handling = RequestPathHandling.RAW;
+        }
+        if (handling != RequestPathHandling.RAW) {
+            log.info("Request path handling is set to {}: dot segments are resolved before the listener is resolved.", handling);
+        }
+        return new RequestPathConfiguration(handling);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.env;
 
+import java.util.Arrays;
+import java.util.Locale;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -56,19 +58,33 @@ public class RequestConfiguration {
     public RequestPathConfiguration httpRequestPathConfiguration(@Value("${http.pathHandling:RAW}") String pathHandling) {
         RequestPathHandling handling;
         try {
-            handling = RequestPathHandling.valueOf(pathHandling.trim().toUpperCase());
+            // Locale.ROOT, and not the JVM default: in Turkish 🇹🇷 (and Azerbaijani) a lowercase "i"
+            // uppercases to "İ", so "normalize" becomes "NORMALİZE", valueOf throws, and the catch
+            // below quietly turns a security control off because of where the server happens to be.
+            // "raw" and "reject" carry no "i" and would have kept working, which is exactly the kind
+            // of bug that survives every test suite that does not set a locale.
+            handling = RequestPathHandling.valueOf(pathHandling.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             log.warn(
                 "Unknown value [{}] for http.pathHandling, falling back to {}. Expected one of {}.",
                 pathHandling,
                 RequestPathHandling.RAW,
-                java.util.Arrays.toString(RequestPathHandling.values())
+                Arrays.toString(RequestPathHandling.values())
             );
             handling = RequestPathHandling.RAW;
         }
-        if (handling != RequestPathHandling.RAW) {
-            log.info("Request path handling is set to {}: dot segments are resolved before the listener is resolved.", handling);
-        }
+        // Logged in every mode, including the default. An operator who mistyped the value above gets
+        // a warning they may not be watching for; this line is what lets them confirm, positively,
+        // which mode the gateway actually came up in.
+        log.info("Request path handling is set to {}: {}", handling, describe(handling));
         return new RequestPathConfiguration(handling);
+    }
+
+    private static String describe(final RequestPathHandling handling) {
+        return switch (handling) {
+            case RAW -> "the request path is used exactly as received";
+            case REJECT -> "a path that is not already in its normalized form is answered 400, and nothing is rewritten";
+            case NORMALIZE -> "dot segments are resolved before the listener is resolved";
+        };
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.env;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@RequiredArgsConstructor
+public class RequestPathConfiguration {
+
+    private final RequestPathHandling handling;
+
+    public boolean isEnabled() {
+        return handling != RequestPathHandling.RAW;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathHandling.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestPathHandling.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.env;
+
+/**
+ * How the gateway treats dot segments in an incoming request path, before the listener context path
+ * is resolved and therefore before any plan is enforced.
+ *
+ * <p>The distinction matters because the gateway both decides on that path and forwards it upstream.
+ * Left untouched, a request can be authorized as one API and, once a conforming upstream applies
+ * RFC 3986 §5.2.4, delivered to another one's backend.
+ *
+ * @author GraviteeSource Team
+ */
+public enum RequestPathHandling {
+    /**
+     * Byte-preserving pass-through: the path is used, and forwarded, exactly as it arrived. This is
+     * the historical behaviour and remains the default, so that request signing and encoded slashes
+     * keep working without any change.
+     */
+    RAW,
+
+    /**
+     * Answers {@code 400} when the normalized path differs from the one received. Nothing is
+     * rewritten and no routing decision changes, which makes it the safest way to close the gap on
+     * an existing platform.
+     */
+    REJECT,
+
+    /**
+     * Resolves the dot segments and uses the result for listener resolution, plan enforcement, flow
+     * selection and the upstream URI. The request is not blocked, it is simply read for what it
+     * means: {@code /alpha/api/../../beta/api} is a call to {@code beta}, so {@code beta}'s plan
+     * applies.
+     */
+    NORMALIZE,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/RequestConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/RequestConfigurationTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.env;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Level;
@@ -22,9 +23,12 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import java.util.List;
+import java.util.Locale;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
@@ -106,5 +110,70 @@ class RequestConfigurationTest {
             .element(0)
             .extracting(ILoggingEvent::getMessage, ILoggingEvent::getLevel)
             .containsExactly("Http request timeout cannot be unset. Setting it to default value: 30_000 ms", Level.WARN);
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class Reading_the_path_handling_mode {
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(strings = { "RAW", "REJECT", "NORMALIZE", "normalize", "  NORMALIZE  ", "NoRmAlIzE" })
+        void should_accept_a_known_value_whatever_its_case_or_padding(String configured) {
+            final RequestPathConfiguration result = cut.httpRequestPathConfiguration(configured);
+
+            assertThat(result.getHandling()).isEqualTo(RequestPathHandling.valueOf(configured.trim().toUpperCase(Locale.ROOT)));
+            assertThat(warnings()).isEmpty();
+        }
+
+        @ParameterizedTest(name = "[{index}] \"{0}\"")
+        @ValueSource(strings = { "NORMALISE", "REJEKT", "", "  ", "true" })
+        void should_fall_back_to_raw_on_an_unknown_value_and_say_so(String configured) {
+            // A security control that degrades has to be loud about it: the operator believes they
+            // enabled something. We do not refuse to start — the sibling timeout bean above sets the
+            // house rule — but the warning is the only signal they will get.
+            final RequestPathConfiguration result = cut.httpRequestPathConfiguration(configured);
+
+            assertThat(result.getHandling()).isEqualTo(RequestPathHandling.RAW);
+            assertThat(warnings())
+                .singleElement()
+                .satisfies(warning -> assertThat(warning).contains("http.pathHandling"));
+        }
+
+        @Test
+        void should_survive_a_jvm_whose_default_locale_uppercases_i_to_a_dotted_capital() {
+            // Turkish: "normalize".toUpperCase() is "NORMALİZE", valueOf throws, and the control
+            // silently turns itself off. RAW and REJECT carry no "i", so only the safe modes would
+            // have kept working — the failure is invisible until someone deploys in Istanbul.
+            final Locale previous = Locale.getDefault();
+            try {
+                Locale.setDefault(Locale.forLanguageTag("tr"));
+
+                assertThat(cut.httpRequestPathConfiguration("normalize").getHandling()).isEqualTo(RequestPathHandling.NORMALIZE);
+            } finally {
+                Locale.setDefault(previous);
+            }
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(strings = { "RAW", "REJECT", "NORMALIZE" })
+        void should_state_the_active_mode_at_startup_including_the_default(String configured) {
+            // The operator's only positive confirmation of which mode came up, and the counterpart
+            // of the warning above: without it, a mistyped value looks exactly like a correct RAW.
+            cut.httpRequestPathConfiguration(configured);
+
+            assertThat(listAppender.list)
+                .filteredOn(event -> event.getLevel() == Level.INFO)
+                .singleElement()
+                .extracting(ILoggingEvent::getFormattedMessage, as(InstanceOfAssertFactories.STRING))
+                .contains(configured);
+        }
+
+        private List<String> warnings() {
+            return listAppender.list
+                .stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
@@ -30,12 +30,25 @@ import io.vertx.core.http.HttpServerRequest;
  */
 public class VertxHttp2ServerRequest extends VertxHttpServerRequest {
 
+    /**
+     * @deprecated kept so that anything built against it keeps compiling and keeps working. Prefer
+     *     the {@link VertxHttpServerRequestOptions} form.
+     */
+    @Deprecated
     public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        this(httpServerRequest, idGenerator, null);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
+    /**
+     * @deprecated see {@link #VertxHttp2ServerRequest(HttpServerRequest, IdGenerator)}.
+     */
+    @Deprecated
     public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        super(httpServerRequest, idGenerator, path);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
+    }
+
+    public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
+        super(httpServerRequest, idGenerator, options);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
@@ -39,14 +39,6 @@ public class VertxHttp2ServerRequest extends VertxHttpServerRequest {
         this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
-    /**
-     * @deprecated see {@link #VertxHttp2ServerRequest(HttpServerRequest, IdGenerator)}.
-     */
-    @Deprecated
-    public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
-    }
-
     public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
         super(httpServerRequest, idGenerator, options);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
@@ -31,7 +31,11 @@ import io.vertx.core.http.HttpServerRequest;
 public class VertxHttp2ServerRequest extends VertxHttpServerRequest {
 
     public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        super(httpServerRequest, idGenerator);
+        this(httpServerRequest, idGenerator, null);
+    }
+
+    public VertxHttp2ServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
+        super(httpServerRequest, idGenerator, path);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -58,20 +58,28 @@ public class VertxHttpServerRequest implements Request {
 
     private Handler<Long> timeoutHandler;
 
+    /**
+     * @deprecated kept so that anything built against it keeps compiling and keeps working. Prefer
+     *     {@link #VertxHttpServerRequest(HttpServerRequest, IdGenerator, VertxHttpServerRequestOptions)},
+     *     which absorbs new fields without moving this signature.
+     */
+    @Deprecated
     public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        this(httpServerRequest, idGenerator, null);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
     /**
-     * @param path the path this request reports, so that everything derived from it — starting with
-     *     the {@code pathInfo} a contextualized request computes — matches the path the gateway
-     *     resolved rather than the one received. {@code null} reports the native path, which is the
-     *     historical behaviour. {@link #uri()} reports the untouched native value either way.
+     * @deprecated see {@link #VertxHttpServerRequest(HttpServerRequest, IdGenerator)}.
      */
+    @Deprecated
     public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        this.path = path;
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
+    }
+
+    public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
+        this.path = options.getPath();
         this.serverRequest = httpServerRequest;
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = options.getTimestamp() != null ? options.getTimestamp() : System.currentTimeMillis();
         this.id = idGenerator.randomString();
         this.headers = new VertxHttpHeaders(httpServerRequest.headers());
         this.metrics = Metrics.on(timestamp).build();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -46,6 +46,7 @@ public class VertxHttpServerRequest implements Request {
     private final long timestamp;
 
     protected final HttpServerRequest serverRequest;
+    private String path;
 
     private MultiValueMap<String, String> queryParameters = null;
 
@@ -58,6 +59,17 @@ public class VertxHttpServerRequest implements Request {
     private Handler<Long> timeoutHandler;
 
     public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
+        this(httpServerRequest, idGenerator, null);
+    }
+
+    /**
+     * @param path the path this request reports, so that everything derived from it — starting with
+     *     the {@code pathInfo} a contextualized request computes — matches the path the gateway
+     *     resolved rather than the one received. {@code null} reports the native path, which is the
+     *     historical behaviour. {@link #uri()} reports the untouched native value either way.
+     */
+    public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
+        this.path = path;
         this.serverRequest = httpServerRequest;
         this.timestamp = System.currentTimeMillis();
         this.id = idGenerator.randomString();
@@ -89,7 +101,10 @@ public class VertxHttpServerRequest implements Request {
 
     @Override
     public String path() {
-        return serverRequest.path();
+        if (path == null) {
+            path = serverRequest.path();
+        }
+        return path;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -68,14 +68,6 @@ public class VertxHttpServerRequest implements Request {
         this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
-    /**
-     * @deprecated see {@link #VertxHttpServerRequest(HttpServerRequest, IdGenerator)}.
-     */
-    @Deprecated
-    public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
-    }
-
     public VertxHttpServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
         this.path = options.getPath();
         this.serverRequest = httpServerRequest;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptions.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.vertx;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * What the dispatcher knows about a request before the wrapper for it exists.
+ *
+ * <p>It is a single constructor parameter on purpose. Every field the dispatcher needs to seed used
+ * to be one more positional argument, on this class and on each of its subtypes, and each addition
+ * moved a {@code public} constructor and the {@code protected} factory method that calls it. That
+ * is not theoretical: it silently disabled an override in the debug service, which kept compiling
+ * while no longer overriding anything. A builder cannot do that — a new field moves no signature,
+ * so a subclass or a plugin that extends the construction path keeps working untouched.
+ *
+ * <p>All fields are optional. A {@code null} means "the wrapper decides", which is the behaviour
+ * that existed before the dispatcher had anything to say.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Builder
+public class VertxHttpServerRequestOptions {
+
+    /**
+     * The path the request reports, so that everything derived from it — starting with the
+     * {@code pathInfo} a contextualized request computes — matches the path the gateway resolved
+     * rather than the one received. {@code null} reports the native path, which is the historical
+     * behaviour. {@code uri()} reports the untouched native value either way.
+     */
+    private final String path;
+
+    /**
+     * When the gateway started handling this request, in milliseconds since the epoch, taken before
+     * any work is done on it. {@code null} stamps the clock at construction, which excludes
+     * everything the dispatcher did beforehand from every latency the gateway reports.
+     */
+    private final Long timestamp;
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
@@ -27,7 +27,11 @@ import io.vertx.core.http.HttpServerRequest;
 public class VertxGrpcServerRequest extends VertxHttp2ServerRequest {
 
     public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        super(httpServerRequest, idGenerator);
+        this(httpServerRequest, idGenerator, null);
+    }
+
+    public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
+        super(httpServerRequest, idGenerator, path);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
@@ -36,14 +36,6 @@ public class VertxGrpcServerRequest extends VertxHttp2ServerRequest {
         this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
-    /**
-     * @deprecated see {@link #VertxGrpcServerRequest(HttpServerRequest, IdGenerator)}.
-     */
-    @Deprecated
-    public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
-    }
-
     public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
         super(httpServerRequest, idGenerator, options);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.http.vertx.grpc;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.vertx.core.http.HttpServerRequest;
 
 /**
@@ -26,12 +27,25 @@ import io.vertx.core.http.HttpServerRequest;
  */
 public class VertxGrpcServerRequest extends VertxHttp2ServerRequest {
 
+    /**
+     * @deprecated kept so that anything built against it keeps compiling and keeps working. Prefer
+     *     the {@link VertxHttpServerRequestOptions} form.
+     */
+    @Deprecated
     public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        this(httpServerRequest, idGenerator, null);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
+    /**
+     * @deprecated see {@link #VertxGrpcServerRequest(HttpServerRequest, IdGenerator)}.
+     */
+    @Deprecated
     public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        super(httpServerRequest, idGenerator, path);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
+    }
+
+    public VertxGrpcServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
+        super(httpServerRequest, idGenerator, options);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
@@ -31,7 +31,11 @@ public class VertxWebSocketServerRequest extends VertxHttpServerRequest {
     private final VertxWebSocket vertxWebSocket;
 
     public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        super(httpServerRequest, idGenerator);
+        this(httpServerRequest, idGenerator, null);
+    }
+
+    public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
+        super(httpServerRequest, idGenerator, path);
         this.vertxWebSocket = new VertxWebSocket(httpServerRequest);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
@@ -40,14 +40,6 @@ public class VertxWebSocketServerRequest extends VertxHttpServerRequest {
         this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
-    /**
-     * @deprecated see {@link #VertxWebSocketServerRequest(HttpServerRequest, IdGenerator)}.
-     */
-    @Deprecated
-    public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
-    }
-
     public VertxWebSocketServerRequest(
         HttpServerRequest httpServerRequest,
         IdGenerator idGenerator,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.ws.WebSocket;
 import io.gravitee.gateway.http.vertx.VertxHttpServerRequest;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.vertx.core.http.HttpServerRequest;
 
 /**
@@ -30,12 +31,29 @@ public class VertxWebSocketServerRequest extends VertxHttpServerRequest {
 
     private final VertxWebSocket vertxWebSocket;
 
+    /**
+     * @deprecated kept so that anything built against it keeps compiling and keeps working. Prefer
+     *     the {@link VertxHttpServerRequestOptions} form.
+     */
+    @Deprecated
     public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
-        this(httpServerRequest, idGenerator, null);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
     }
 
+    /**
+     * @deprecated see {@link #VertxWebSocketServerRequest(HttpServerRequest, IdGenerator)}.
+     */
+    @Deprecated
     public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator, String path) {
-        super(httpServerRequest, idGenerator, path);
+        this(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
+    }
+
+    public VertxWebSocketServerRequest(
+        HttpServerRequest httpServerRequest,
+        IdGenerator idGenerator,
+        VertxHttpServerRequestOptions options
+    ) {
+        super(httpServerRequest, idGenerator, options);
         this.vertxWebSocket = new VertxWebSocket(httpServerRequest);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
@@ -37,6 +37,7 @@ import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.net.SocketAddress;
 import javax.net.ssl.SSLSession;
+import lombok.Builder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -57,7 +58,8 @@ public class VertxHttpServerRequest extends AbstractRequest {
     public VertxHttpServerRequest(final HttpServerRequest nativeRequest, IdGenerator idGenerator, VertxHttpServerRequestOptions options) {
         this.nativeRequest = nativeRequest;
         this.originalHost = this.nativeRequest.host();
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = options.timestamp() != null ? options.timestamp() : System.currentTimeMillis();
+        this.path = options.path();
         this.id = idGenerator.randomString();
         this.headers = new VertxHttpHeaders(nativeRequest.headers().getDelegate());
         this.bufferFlow = new BufferFlow(nativeRequest.toFlowable().map(Buffer::buffer), this::isStreaming);
@@ -254,9 +256,31 @@ public class VertxHttpServerRequest extends AbstractRequest {
         chunks(Flowable.empty());
     }
 
-    public record VertxHttpServerRequestOptions(String clientAuthHeaderName) {
+    /**
+     * What the dispatcher knows about a request before this wrapper exists.
+     *
+     * <p>Build it rather than calling the canonical constructor: a record's canonical constructor is
+     * positional, so adding a component to it moves a signature — the very thing this type exists to
+     * avoid. Through the builder a new field costs no call site anything.
+     *
+     * @param clientAuthHeaderName header the client certificate is extracted from, when a front
+     *     proxy terminates TLS.
+     * @param path the path the request reports, so that everything derived from it — starting with
+     *     the {@code pathInfo} a contextualized request computes — matches the path the gateway
+     *     resolved rather than the one received. {@code null} reports the native path, which is the
+     *     historical behaviour. {@code uri()} reports the untouched native value either way.
+     * @param timestamp when the gateway started handling this request, in milliseconds since the
+     *     epoch, taken before any work is done on it. {@code null} stamps the clock at construction,
+     *     which excludes everything the dispatcher did beforehand from every latency it reports.
+     */
+    @Builder
+    public record VertxHttpServerRequestOptions(String clientAuthHeaderName, String path, Long timestamp) {
         public VertxHttpServerRequestOptions() {
-            this(null);
+            this(null, null, null);
+        }
+
+        public VertxHttpServerRequestOptions(String clientAuthHeaderName) {
+            this(clientAuthHeaderName, null, null);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptionsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptionsTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import io.gravitee.common.http.IdGenerator;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * What the dispatcher hands the wrapper at construction, and what the wrapper does with it.
+ *
+ * <p>Two things are pinned here, and both are behaviours a reader would otherwise have to infer
+ * from the dispatcher: the wrapper reports the path it was given rather than the native one, and it
+ * dates itself from the instant the dispatcher started handling the request rather than from its
+ * own construction.
+ *
+ * <p>That second point cannot be asserted end to end. The gateway dates requests in milliseconds,
+ * and everything the dispatcher does before building the wrapper takes tens of nanoseconds, so a
+ * reported metric looks identical either way. What is testable — and what actually matters — is
+ * that the wrapper honours the instant it is handed instead of taking its own reading.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class VertxHttpServerRequestOptionsTest {
+
+    private static final String NATIVE_PATH = "/alpha/api/public/../admin";
+    private static final String RESOLVED_PATH = "/alpha/api/admin";
+
+    @Mock
+    HttpServerRequest serverRequest;
+
+    @Mock
+    IdGenerator idGenerator;
+
+    @BeforeEach
+    void init() {
+        lenient().when(serverRequest.path()).thenReturn(NATIVE_PATH);
+        lenient().when(serverRequest.uri()).thenReturn(NATIVE_PATH);
+        lenient().when(serverRequest.method()).thenReturn(HttpMethod.GET);
+        lenient().when(serverRequest.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(idGenerator.randomString()).thenReturn("request-id");
+    }
+
+    @Nested
+    class The_path {
+
+        @Test
+        void should_be_the_one_the_acceptor_matched_when_the_dispatcher_supplies_it() {
+            var request = new VertxHttpServerRequest(
+                serverRequest,
+                idGenerator,
+                VertxHttpServerRequestOptions.builder().path(RESOLVED_PATH).build()
+            );
+
+            assertThat(request.path()).isEqualTo(RESOLVED_PATH);
+        }
+
+        @Test
+        void should_keep_reporting_the_untouched_uri_whatever_the_path_becomes() {
+            var request = new VertxHttpServerRequest(
+                serverRequest,
+                idGenerator,
+                VertxHttpServerRequestOptions.builder().path(RESOLVED_PATH).build()
+            );
+
+            // The received bytes stay available, which is what an operator correlates with the
+            // logs of whatever sits in front of the gateway.
+            assertThat(request.uri()).isEqualTo(NATIVE_PATH);
+        }
+
+        @Test
+        void should_fall_back_to_the_native_path_when_nothing_is_supplied() {
+            var request = new VertxHttpServerRequest(serverRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
+
+            assertThat(request.path()).isEqualTo(NATIVE_PATH);
+        }
+    }
+
+    @Nested
+    class The_timestamp {
+
+        @Test
+        void should_be_the_instant_the_dispatcher_started_handling_the_request() {
+            // A value far enough in the past that no clock reading could produce it by accident,
+            // which is the whole point: the wrapper must not take its own.
+            final long receivedAt = System.currentTimeMillis() - 60_000;
+
+            var request = new VertxHttpServerRequest(
+                serverRequest,
+                idGenerator,
+                VertxHttpServerRequestOptions.builder().timestamp(receivedAt).build()
+            );
+
+            assertThat(request.timestamp()).isEqualTo(receivedAt);
+        }
+
+        @Test
+        void should_reach_the_metrics_so_that_every_latency_derives_from_it() {
+            final long receivedAt = System.currentTimeMillis() - 60_000;
+
+            var request = new VertxHttpServerRequest(
+                serverRequest,
+                idGenerator,
+                VertxHttpServerRequestOptions.builder().timestamp(receivedAt).build()
+            );
+
+            // This is the link that makes the decision worth anything: whatever the dispatcher did
+            // before the wrapper existed now falls inside the window the metrics measure.
+            assertThat(request.metrics().timestamp()).isEqualTo(Instant.ofEpochMilli(receivedAt));
+        }
+
+        @Test
+        void should_stamp_the_clock_itself_when_nothing_is_supplied() {
+            final long before = System.currentTimeMillis();
+
+            var request = new VertxHttpServerRequest(serverRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
+
+            // The historical behaviour, kept so that every existing caller of the deprecated
+            // constructors keeps working exactly as it did.
+            assertThat(request.timestamp()).isBetween(before, System.currentTimeMillis());
+        }
+    }
+
+    @Nested
+    class The_deprecated_constructors {
+
+        @Test
+        void should_still_report_the_native_path() {
+            var request = new VertxHttpServerRequest(serverRequest, idGenerator);
+
+            assertThat(request.path()).isEqualTo(NATIVE_PATH);
+        }
+
+        @Test
+        void should_still_honour_a_supplied_path() {
+            var request = new VertxHttpServerRequest(serverRequest, idGenerator, RESOLVED_PATH);
+
+            assertThat(request.path()).isEqualTo(RESOLVED_PATH);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptionsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequestOptionsTest.java
@@ -150,20 +150,17 @@ class VertxHttpServerRequestOptionsTest {
     }
 
     @Nested
-    class The_deprecated_constructors {
+    class The_deprecated_constructor {
 
+        /**
+         * The two-argument form is the only one this branch inherited, so it is the only one a
+         * plugin can have been compiled against and the only one worth keeping alive.
+         */
         @Test
         void should_still_report_the_native_path() {
             var request = new VertxHttpServerRequest(serverRequest, idGenerator);
 
             assertThat(request.path()).isEqualTo(NATIVE_PATH);
-        }
-
-        @Test
-        void should_still_honour_a_supplied_path() {
-            var request = new VertxHttpServerRequest(serverRequest, idGenerator, RESOLVED_PATH);
-
-            assertThat(request.path()).isEqualTo(RESOLVED_PATH);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
@@ -127,5 +127,17 @@
         </dependency>
 
         <!-- Test dependencies -->
+
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -20,6 +20,7 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ExecutionMode;
@@ -28,6 +29,8 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
@@ -47,6 +50,7 @@ import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.http.vertx.ClientCloseClassifier;
 import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathNormalizer;
 import io.gravitee.gateway.reactive.reactor.processor.DefaultPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
@@ -97,6 +101,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     private final TracingContext gatewayTracingContext;
     private final RequestTimeoutConfiguration requestTimeoutConfiguration;
     private final RequestClientAuthConfiguration requestClientAuthConfiguration;
+    private final RequestPathConfiguration requestPathConfiguration;
     private final Vertx vertx;
     private final ComponentProvider globalComponentProvider;
     private final TracingHook tracingHook;
@@ -114,6 +119,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         TracingContext gatewayTracingContext,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         boolean warningsEnabled
     ) {
@@ -128,6 +134,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         this.gatewayTracingContext = gatewayTracingContext;
         this.requestTimeoutConfiguration = requestTimeoutConfiguration;
         this.requestClientAuthConfiguration = requestClientAuthConfiguration;
+        this.requestPathConfiguration = requestPathConfiguration;
         this.vertx = vertx;
         this.tracingHook = new TracingHook("Processor chain");
         this.warningsEnabled = warningsEnabled;
@@ -144,9 +151,18 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      */
     @Override
     public Completable dispatch(HttpServerRequest httpServerRequest, String serverId) {
-        log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), httpServerRequest.path());
+        final String rawPath = httpServerRequest.path();
+        log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), rawPath);
 
-        final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), httpServerRequest.path(), serverId);
+        final String normalizedPath = requestPathConfiguration.isEnabled() ? RequestPathNormalizer.normalize(rawPath) : rawPath;
+
+        // A malformed percent sequence has no normalized form at all, so there is nothing to decide
+        // on and it is refused whatever the mode.
+        if (normalizedPath == null || (normalizedPath != rawPath && requestPathConfiguration.getHandling() == RequestPathHandling.REJECT)) {
+            return handleRejectedPath(httpServerRequest, serverId);
+        }
+
+        final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), normalizedPath, serverId);
         Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         if (httpAcceptor == null || httpAcceptor.reactor() == null) {
             log.debug(
@@ -196,6 +212,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         } else if (httpAcceptor.reactor() instanceof ApiReactor<?> apiReactor) {
             log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
+            if (normalizedPath != rawPath) {
+                // Seed the lazily initialized path so that pathInfo, the flow selectors and the
+                // upstream URI are all derived from the value the acceptor actually matched.
+                // uri() and parameters() keep reading the untouched native request.
+                mutableCtx.request().path(normalizedPath);
+            }
             mutableCtx.request().contextPath(httpAcceptor.path());
             markTracingRoute(vertxContext, httpAcceptor.path());
             TracingContext tracingContext = apiReactor.tracingContext();
@@ -256,7 +278,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         }
         // V3 execution mode.
         log.debug("Request routed to V3 handler on path [{}]", httpAcceptor.path());
-        return handleV3Request(httpServerRequest, httpAcceptor, vertxContext);
+        return handleV3Request(httpServerRequest, httpAcceptor, vertxContext, normalizedPath == rawPath ? null : normalizedPath);
     }
 
     /**
@@ -326,6 +348,24 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         return context;
     }
 
+    /**
+     * Refuses the request before any API is selected, through a processor chain rather than on the
+     * raw response, so that it is measured and reported like any other request the gateway answers
+     * on its own.
+     */
+    private Completable handleRejectedPath(final HttpServerRequest httpServerRequest, final String serverId) {
+        final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId);
+        ctx.request().contextPath("/");
+        final ProcessorChain processorChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
+        return HookHelper.hook(
+            () -> processorChain.execute(ctx, ExecutionPhase.RESPONSE),
+            processorChain.getId(),
+            List.of(),
+            ctx,
+            ExecutionPhase.RESPONSE
+        );
+    }
+
     private Completable handleNotFound(final MutableExecutionContext ctx, final List<ProcessorHook> notFoundProcessorHook) {
         ctx.request().contextPath("/");
         ProcessorChain processorChain = notFoundProcessorChainFactory.processorChain();
@@ -341,12 +381,15 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     private Completable handleV3Request(
         final HttpServerRequest httpServerRequest,
         final HttpAcceptor handlerEntrypoint,
-        final Context vertxContext
+        final Context vertxContext,
+        final String normalizedPath
     ) {
         final ReactorHandler reactorHandler = handlerEntrypoint.reactor();
         markTracingRoute(vertxContext, handlerEntrypoint.path());
 
-        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(httpServerRequest, idGenerator);
+        // The normalized path is handed over at construction: pathInfo, and therefore the upstream
+        // URI, must derive from the path the acceptor matched rather than from the one received.
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(httpServerRequest, idGenerator, normalizedPath);
 
         // Prepare invocation execution context.
         SimpleExecutionContext simpleExecutionContext = createV3ExecutionContext(httpServerRequest, request);
@@ -432,23 +475,31 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         gatewayConfiguration.zone().ifPresent(metrics::setZone);
     }
 
+    /**
+     * The single extension point for building the v3 request: subclasses that decorate it must
+     * override this signature, since it is the one {@link #handleV3Request} calls. A convenience
+     * overload without {@code path} would compile in a subclass and never be invoked.
+     *
+     * @param path the path the acceptor matched, or {@code null} to report the one received
+     */
     protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
         HttpServerRequest httpServerRequest,
-        IdGenerator idGenerator
+        IdGenerator idGenerator,
+        String path
     ) {
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest request;
 
         if (isV3WebSocket(httpServerRequest)) {
-            request = new VertxWebSocketServerRequest(httpServerRequest.getDelegate(), idGenerator);
+            request = new VertxWebSocketServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
         } else {
             if (httpServerRequest.version() == HttpVersion.HTTP_2) {
                 if (MediaType.APPLICATION_GRPC.equals(httpServerRequest.getHeader(HttpHeaders.CONTENT_TYPE))) {
-                    request = new VertxGrpcServerRequest(httpServerRequest.getDelegate(), idGenerator);
+                    request = new VertxGrpcServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
                 } else {
-                    request = new VertxHttp2ServerRequest(httpServerRequest.getDelegate(), idGenerator);
+                    request = new VertxHttp2ServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
                 }
             } else {
-                request = new io.gravitee.gateway.http.vertx.VertxHttpServerRequest(httpServerRequest.getDelegate(), idGenerator);
+                request = new io.gravitee.gateway.http.vertx.VertxHttpServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -302,13 +302,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         }
         // V3 execution mode.
         log.debug("Request routed to V3 handler on path [{}]", httpAcceptor.path());
-        return handleV3Request(
-                httpServerRequest,
-                httpAcceptor,
-                vertxContext,
-                pathWasNormalized ? normalizedPath : null,
-                receivedAt
-            );
+        return handleV3Request(httpServerRequest, httpAcceptor, vertxContext, pathWasNormalized ? normalizedPath : null, receivedAt);
     }
 
     /**
@@ -357,7 +351,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         return path.length() > 1 && path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
     }
 
-    private MutableExecutionContext prepareExecutionContext(
+    /**
+     * Visible to subclasses so that a dispatcher serving a single kind of traffic can build the same
+     * context this one builds, rather than a lookalike. The debug dispatcher needs it to answer a
+     * rejected path without losing the debug session — see {@code DebugHttpRequestDispatcher}.
+     */
+    protected MutableExecutionContext prepareExecutionContext(
         final HttpServerRequest httpServerRequest,
         String serverId,
         final String path,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -91,6 +91,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     public static final String ATTR_ENTRYPOINT = ContextAttributes.ATTR_PREFIX + "entrypoint";
     // Key checked by gravitee-node's RouteGetter (OTel span naming) before falling back to the raw request URI.
     private static final String TRACING_ROUTE_CONTEXT_KEY = "VertxRoute";
+
     private final GatewayConfiguration gatewayConfiguration;
     private final HttpAcceptorResolver httpAcceptorResolver;
     private final IdGenerator idGenerator;
@@ -170,6 +171,13 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             return handleRejectedPath(httpServerRequest, serverId);
         }
 
+        final boolean pathWasNormalized = normalizedPath != rawPath;
+        if (pathWasNormalized) {
+            // Both forms, deliberately: the point of this line is to answer "what did the client
+            // actually send" once the gateway has started deciding on something else.
+            log.debug("Path normalized from [{}] to [{}]", rawPath, normalizedPath);
+        }
+
         final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), normalizedPath, serverId);
         Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         if (httpAcceptor == null || httpAcceptor.reactor() == null) {
@@ -220,11 +228,15 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         } else if (httpAcceptor.reactor() instanceof ApiReactor<?> apiReactor) {
             log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
-            if (normalizedPath != rawPath) {
+            if (pathWasNormalized) {
                 // Seed the lazily initialized path so that pathInfo, the flow selectors and the
                 // upstream URI are all derived from the value the acceptor actually matched.
                 // uri() and parameters() keep reading the untouched native request.
                 mutableCtx.request().path(normalizedPath);
+                // Nothing to record here: MetricsProcessor already reports both forms, since it
+                // builds uri from request.uri(), which keeps reading the native request, and
+                // pathInfo from the value seeded above. Received and routed are both accounted
+                // for without a custom metric.
             }
             mutableCtx.request().contextPath(httpAcceptor.path());
             markTracingRoute(vertxContext, httpAcceptor.path());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -20,7 +20,6 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ExecutionMode;
@@ -165,33 +164,45 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         // pays for the resolution when there is something to resolve.
         final boolean needsNormalization = requestPathConfiguration.isEnabled() && RequestPathNormalizer.needsNormalization(rawPath);
 
-        if (needsNormalization && requestPathConfiguration.getHandling() == RequestPathHandling.REJECT) {
-            return handleRejectedPath(httpServerRequest, serverId, receivedAt);
-        }
-
-        final String normalizedPath = needsNormalization ? RequestPathNormalizer.normalize(rawPath) : rawPath;
-
-        // No normalized form at all: the path carries a malformed percent sequence.
-        if (normalizedPath == null) {
-            return handleRejectedPath(httpServerRequest, serverId, receivedAt);
-        }
-
-        final boolean pathWasNormalized = normalizedPath != rawPath;
-        if (pathWasNormalized) {
+        final String normalizedPath;
+        if (needsNormalization) {
+            if (requestPathConfiguration.getHandling() == RequestPathHandling.REJECT) {
+                return handleRejectedPath(httpServerRequest, serverId, receivedAt);
+            }
+            normalizedPath = RequestPathNormalizer.normalize(rawPath);
+            // No normalized form at all: the path carries a malformed percent sequence. Inside this
+            // branch on purpose. Under RAW nothing is inspected, and a null path — which the Vert.x
+            // API declares and an HTTP/2 request without a :path pseudo-header actually produces —
+            // must keep reaching the acceptor exactly as it did before this setting existed.
+            if (normalizedPath == null) {
+                return handleRejectedPath(httpServerRequest, serverId, receivedAt);
+            }
             // Both forms, deliberately: the point of this line is to answer "what did the client
             // actually send" once the gateway has started deciding on something else.
             log.debug("Path normalized from [{}] to [{}]", rawPath, normalizedPath);
+        } else {
+            normalizedPath = rawPath;
         }
+
+        // Exactly needsNormalization: the normalizer answers the same instance if and only if there
+        // was nothing to resolve, and the property test holds the two methods to that. Reusing the
+        // flag rather than comparing references makes that coupling explicit at the call site.
+        final boolean pathWasNormalized = needsNormalization;
 
         final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), normalizedPath, serverId);
         Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         if (httpAcceptor == null || httpAcceptor.reactor() == null) {
-            log.debug(
-                "No acceptor found for host {} and path {}, handling as not found",
-                httpServerRequest.host(),
-                httpServerRequest.path()
+            log.debug("No acceptor found for host {} and path {}, handling as not found", httpServerRequest.host(), normalizedPath);
+            // The resolved path, like the API branch below. The lookup that just failed was made on
+            // it, so an operator investigating a 404 has to see it — reporting the received path
+            // would send them looking for a context path the gateway never tried. Nothing is lost:
+            // uri() still carries the bytes the client sent.
+            MutableExecutionContext mutableCtx = prepareExecutionContext(
+                httpServerRequest,
+                serverId,
+                pathWasNormalized ? normalizedPath : null,
+                receivedAt
             );
-            MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
             mutableCtx.tracer(
                 new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, gatewayTracingContext.opentelemetryTracer())
             );
@@ -390,20 +401,90 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      * Refuses the request before any API is selected, through a processor chain rather than on the
      * raw response, so that it is measured and reported like any other request the gateway answers
      * on its own.
+     *
+     * <p>The platform pre-processor chain runs first, exactly as it does for a not-found. It is not
+     * decoration: {@code XForwardProcessor} is what rewrites the remote address from
+     * {@code X-Forwarded-For}, and without it a gateway behind an ingress reports every rejection
+     * with the load balancer's address instead of the prober's — which would defeat the reason
+     * {@code handlers.rejected.analytics.enabled} defaults to on. The same chain carries the
+     * connection drain and the W3C trace context.
+     *
+     * <p>A subclass needing to do something around a rejection hooks into
+     * {@link #afterRejectedPath(Completable, MutableExecutionContext)} rather than restating this
+     * flow. That is not a preference: while the debug dispatcher carried its own copy, this method
+     * gained the pre-processor chain and the whole tracing block in a single review round, and the
+     * copy silently kept neither.
      */
     private Completable handleRejectedPath(final HttpServerRequest httpServerRequest, final String serverId, final long receivedAt) {
         // Nothing is rewritten here, so the path stays the one received — which is what the report
         // has to carry for an operator to see what was actually sent.
         final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
         ctx.request().contextPath("/");
-        final ProcessorChain processorChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
-        return HookHelper.hook(
-            () -> processorChain.execute(ctx, ExecutionPhase.RESPONSE),
-            processorChain.getId(),
-            List.of(),
+
+        final Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        ctx.tracer(new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, gatewayTracingContext.opentelemetryTracer()));
+        // No route was resolved and none will be, so the span is bucketed like a not-found rather
+        // than under the unbounded raw request URI a prober chose.
+        markTracingRoute(vertxContext, "/");
+
+        final List<ProcessorHook> processHooks = gatewayTracingContext.isVerbose() ? List.of(tracingHook) : List.of();
+        final ProcessorChain preProcessorChain = platformProcessorChainFactory.preProcessorChain();
+        final ProcessorChain rejectedChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
+
+        final Completable rejected = HookHelper.hook(
+            () -> preProcessorChain.execute(ctx, ExecutionPhase.REQUEST),
+            preProcessorChain.getId(),
+            processHooks,
             ctx,
-            ExecutionPhase.RESPONSE
+            ExecutionPhase.REQUEST
+        ).andThen(
+            HookHelper.hook(
+                () -> rejectedChain.execute(ctx, ExecutionPhase.RESPONSE),
+                rejectedChain.getId(),
+                processHooks,
+                ctx,
+                ExecutionPhase.RESPONSE
+            )
         );
+
+        if (!gatewayTracingContext.isEnabled()) {
+            return afterRejectedPath(rejected, ctx);
+        }
+        return afterRejectedPath(
+            rejected
+                .doOnSubscribe(disposable -> {
+                    final Span rootSpan = ctx
+                        .getTracer()
+                        .startRootSpanFrom(new ObservableHttpServerRequest(httpServerRequest.getDelegate()));
+                    ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN, rootSpan);
+                })
+                .doOnError(throwable -> ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ERROR, throwable))
+                .doFinally(() -> {
+                    final Span rootSpan = ctx.getInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN);
+                    final Throwable throwable = ctx.getInternalAttribute(ATTR_INTERNAL_TRACING_ERROR);
+                    ctx
+                        .getTracer()
+                        .endWithResponseAndError(
+                            rootSpan,
+                            new ObservableHttpServerResponse(httpServerRequest.getDelegate().response()),
+                            throwable
+                        );
+                }),
+            ctx
+        );
+    }
+
+    /**
+     * The extension point for a dispatcher that must do something once a rejection has been handled.
+     *
+     * <p>It receives the rejection and the context it ran on, so a subclass can wrap the former
+     * without rebuilding the latter — which is the whole point, since the context is precisely what
+     * a second copy of this flow had to recreate, and what made that copy drift.
+     *
+     * <p>Answers the rejection untouched by default.
+     */
+    protected Completable afterRejectedPath(final Completable rejection, final MutableExecutionContext ctx) {
+        return rejection;
     }
 
     private Completable handleNotFound(final MutableExecutionContext ctx, final List<ProcessorHook> notFoundProcessorHook) {
@@ -527,18 +608,6 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      *     {@link #createV3Request(HttpServerRequest, IdGenerator, VertxHttpServerRequestOptions)},
      *     which is the signature {@link #handleV3Request} invokes and which absorbs new fields
      *     without ever moving again.
-     */
-    @Deprecated
-    protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
-        HttpServerRequest httpServerRequest,
-        IdGenerator idGenerator,
-        String path
-    ) {
-        return createV3Request(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
-    }
-
-    /**
-     * @deprecated see {@link #createV3Request(HttpServerRequest, IdGenerator, String)}.
      */
     @Deprecated
     protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -20,7 +20,6 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ExecutionMode;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -154,11 +154,19 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         final String rawPath = httpServerRequest.path();
         log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), rawPath);
 
-        final String normalizedPath = requestPathConfiguration.isEnabled() ? RequestPathNormalizer.normalize(rawPath) : rawPath;
+        // One scan answers what both active modes ask. REJECT needs nothing more: a path that is
+        // not in the form it claims to be is refused without ever being rewritten. NORMALIZE only
+        // pays for the resolution when there is something to resolve.
+        final boolean needsNormalization = requestPathConfiguration.isEnabled() && RequestPathNormalizer.needsNormalization(rawPath);
 
-        // A malformed percent sequence has no normalized form at all, so there is nothing to decide
-        // on and it is refused whatever the mode.
-        if (normalizedPath == null || (normalizedPath != rawPath && requestPathConfiguration.getHandling() == RequestPathHandling.REJECT)) {
+        if (needsNormalization && requestPathConfiguration.getHandling() == RequestPathHandling.REJECT) {
+            return handleRejectedPath(httpServerRequest, serverId);
+        }
+
+        final String normalizedPath = needsNormalization ? RequestPathNormalizer.normalize(rawPath) : rawPath;
+
+        // No normalized form at all: the path carries a malformed percent sequence.
+        if (normalizedPath == null) {
             return handleRejectedPath(httpServerRequest, serverId);
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -34,6 +34,7 @@ import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.gravitee.gateway.http.vertx.grpc.VertxGrpcServerRequest;
 import io.gravitee.gateway.http.vertx.ws.VertxWebSocketServerRequest;
 import io.gravitee.gateway.opentelemetry.TracingContext;
@@ -152,6 +153,10 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      */
     @Override
     public Completable dispatch(HttpServerRequest httpServerRequest, String serverId) {
+        // Before anything else, so that whatever the dispatcher does with this request — the scan,
+        // the resolution, the acceptor lookup — falls inside the window every latency metric covers.
+        // Stamping it in the wrapper's constructor would start the clock once the work is done.
+        final long receivedAt = System.currentTimeMillis();
         final String rawPath = httpServerRequest.path();
         log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), rawPath);
 
@@ -161,14 +166,14 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         final boolean needsNormalization = requestPathConfiguration.isEnabled() && RequestPathNormalizer.needsNormalization(rawPath);
 
         if (needsNormalization && requestPathConfiguration.getHandling() == RequestPathHandling.REJECT) {
-            return handleRejectedPath(httpServerRequest, serverId);
+            return handleRejectedPath(httpServerRequest, serverId, receivedAt);
         }
 
         final String normalizedPath = needsNormalization ? RequestPathNormalizer.normalize(rawPath) : rawPath;
 
         // No normalized form at all: the path carries a malformed percent sequence.
         if (normalizedPath == null) {
-            return handleRejectedPath(httpServerRequest, serverId);
+            return handleRejectedPath(httpServerRequest, serverId, receivedAt);
         }
 
         final boolean pathWasNormalized = normalizedPath != rawPath;
@@ -186,7 +191,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
                 httpServerRequest.host(),
                 httpServerRequest.path()
             );
-            MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
+            MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
             mutableCtx.tracer(
                 new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, gatewayTracingContext.opentelemetryTracer())
             );
@@ -227,17 +232,16 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             }
         } else if (httpAcceptor.reactor() instanceof ApiReactor<?> apiReactor) {
             log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
-            MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
-            if (pathWasNormalized) {
-                // Seed the lazily initialized path so that pathInfo, the flow selectors and the
-                // upstream URI are all derived from the value the acceptor actually matched.
-                // uri() and parameters() keep reading the untouched native request.
-                mutableCtx.request().path(normalizedPath);
-                // Nothing to record here: MetricsProcessor already reports both forms, since it
-                // builds uri from request.uri(), which keeps reading the native request, and
-                // pathInfo from the value seeded above. Received and routed are both accounted
-                // for without a custom metric.
-            }
+            // The path is seeded at construction so that pathInfo, the flow selectors and the
+            // upstream URI all derive from the value the acceptor actually matched. uri() and
+            // parameters() keep reading the untouched native request, and MetricsProcessor reports
+            // both forms from those two — received and routed — with no custom metric needed.
+            MutableExecutionContext mutableCtx = prepareExecutionContext(
+                httpServerRequest,
+                serverId,
+                pathWasNormalized ? normalizedPath : null,
+                receivedAt
+            );
             mutableCtx.request().contextPath(httpAcceptor.path());
             markTracingRoute(vertxContext, httpAcceptor.path());
             TracingContext tracingContext = apiReactor.tracingContext();
@@ -298,7 +302,13 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         }
         // V3 execution mode.
         log.debug("Request routed to V3 handler on path [{}]", httpAcceptor.path());
-        return handleV3Request(httpServerRequest, httpAcceptor, vertxContext, normalizedPath == rawPath ? null : normalizedPath);
+        return handleV3Request(
+                httpServerRequest,
+                httpAcceptor,
+                vertxContext,
+                pathWasNormalized ? normalizedPath : null,
+                receivedAt
+            );
     }
 
     /**
@@ -347,11 +357,20 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         return path.length() > 1 && path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
     }
 
-    private MutableExecutionContext prepareExecutionContext(final HttpServerRequest httpServerRequest, String serverId) {
+    private MutableExecutionContext prepareExecutionContext(
+        final HttpServerRequest httpServerRequest,
+        String serverId,
+        final String path,
+        final long receivedAt
+    ) {
         VertxHttpServerRequest request = new VertxHttpServerRequest(
             httpServerRequest,
             idGenerator,
-            new VertxHttpServerRequest.VertxHttpServerRequestOptions(requestClientAuthConfiguration.getHeaderName())
+            VertxHttpServerRequest.VertxHttpServerRequestOptions.builder()
+                .clientAuthHeaderName(requestClientAuthConfiguration.getHeaderName())
+                .path(path)
+                .timestamp(receivedAt)
+                .build()
         );
 
         MutableExecutionContext ctx = createExecutionContext(request);
@@ -373,8 +392,10 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
      * raw response, so that it is measured and reported like any other request the gateway answers
      * on its own.
      */
-    private Completable handleRejectedPath(final HttpServerRequest httpServerRequest, final String serverId) {
-        final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId);
+    private Completable handleRejectedPath(final HttpServerRequest httpServerRequest, final String serverId, final long receivedAt) {
+        // Nothing is rewritten here, so the path stays the one received — which is what the report
+        // has to carry for an operator to see what was actually sent.
+        final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
         ctx.request().contextPath("/");
         final ProcessorChain processorChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
         return HookHelper.hook(
@@ -402,14 +423,20 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         final HttpServerRequest httpServerRequest,
         final HttpAcceptor handlerEntrypoint,
         final Context vertxContext,
-        final String normalizedPath
+        final String normalizedPath,
+        final long receivedAt
     ) {
         final ReactorHandler reactorHandler = handlerEntrypoint.reactor();
         markTracingRoute(vertxContext, handlerEntrypoint.path());
 
-        // The normalized path is handed over at construction: pathInfo, and therefore the upstream
-        // URI, must derive from the path the acceptor matched rather than from the one received.
-        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(httpServerRequest, idGenerator, normalizedPath);
+        // Both are handed over at construction: pathInfo, and therefore the upstream URI, must
+        // derive from the path the acceptor matched rather than from the one received; and the
+        // clock must have started before the dispatcher did any of that work.
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(
+            httpServerRequest,
+            idGenerator,
+            VertxHttpServerRequestOptions.builder().path(normalizedPath).timestamp(receivedAt).build()
+        );
 
         // Prepare invocation execution context.
         SimpleExecutionContext simpleExecutionContext = createV3ExecutionContext(httpServerRequest, request);
@@ -496,30 +523,57 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     }
 
     /**
-     * The single extension point for building the v3 request: subclasses that decorate it must
-     * override this signature, since it is the one {@link #handleV3Request} calls. A convenience
-     * overload without {@code path} would compile in a subclass and never be invoked.
-     *
-     * @param path the path the acceptor matched, or {@code null} to report the one received
+     * @deprecated kept so that anything overriding it keeps compiling — but it is no longer called,
+     *     so an override here decorates nothing. Move to
+     *     {@link #createV3Request(HttpServerRequest, IdGenerator, VertxHttpServerRequestOptions)},
+     *     which is the signature {@link #handleV3Request} invokes and which absorbs new fields
+     *     without ever moving again.
      */
+    @Deprecated
     protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
         HttpServerRequest httpServerRequest,
         IdGenerator idGenerator,
         String path
     ) {
+        return createV3Request(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().path(path).build());
+    }
+
+    /**
+     * @deprecated see {@link #createV3Request(HttpServerRequest, IdGenerator, String)}.
+     */
+    @Deprecated
+    protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
+        HttpServerRequest httpServerRequest,
+        IdGenerator idGenerator
+    ) {
+        return createV3Request(httpServerRequest, idGenerator, VertxHttpServerRequestOptions.builder().build());
+    }
+
+    /**
+     * The extension point for building the v3 request: this is the signature
+     * {@link #handleV3Request} calls, and the only one worth overriding to decorate it.
+     *
+     * <p>It takes a single options parameter on purpose, so that a field added later moves nothing
+     * and leaves every subclass and plugin overriding it untouched.
+     */
+    protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
+        HttpServerRequest httpServerRequest,
+        IdGenerator idGenerator,
+        VertxHttpServerRequestOptions options
+    ) {
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest request;
 
         if (isV3WebSocket(httpServerRequest)) {
-            request = new VertxWebSocketServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
+            request = new VertxWebSocketServerRequest(httpServerRequest.getDelegate(), idGenerator, options);
         } else {
             if (httpServerRequest.version() == HttpVersion.HTTP_2) {
                 if (MediaType.APPLICATION_GRPC.equals(httpServerRequest.getHeader(HttpHeaders.CONTENT_TYPE))) {
-                    request = new VertxGrpcServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
+                    request = new VertxGrpcServerRequest(httpServerRequest.getDelegate(), idGenerator, options);
                 } else {
-                    request = new VertxHttp2ServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
+                    request = new VertxHttp2ServerRequest(httpServerRequest.getDelegate(), idGenerator, options);
                 }
             } else {
-                request = new io.gravitee.gateway.http.vertx.VertxHttpServerRequest(httpServerRequest.getDelegate(), idGenerator, path);
+                request = new io.gravitee.gateway.http.vertx.VertxHttpServerRequest(httpServerRequest.getDelegate(), idGenerator, options);
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -39,13 +39,29 @@ package io.gravitee.gateway.reactive.reactor.path;
  *       stack.
  *   <li>A malformed percent sequence has no normalized form. {@link #normalize(String)} answers
  *       {@code null} for it rather than throwing, leaving the caller to reject the request.
+ *   <li>A dot segment carrying path parameters, {@code ..;x}, is treated as a dot segment. RFC 3986
+ *       says it is an ordinary segment; the Servlet specification says a container strips
+ *       {@code ;params} first, which makes it a dot segment. Tomcat, Jetty and Spring follow the
+ *       latter. The gateway takes the most permissive reading any receiver could, because being
+ *       stricter than the receiver costs a refused request while being laxer re-opens the very
+ *       bypass this class closes. See {@link #stripDotSegmentParameters(StringBuilder)}.
  * </ul>
+ *
+ * <p><b>What the modes assume of the receiver.</b> The rules above describe a receiver that decodes
+ * percent sequences once, per RFC 3986 §2.3, and treats only {@code /} as a separator. Reserved
+ * characters are deliberately left encoded, so {@code /a/..%2f../b} and {@code /a/%252e%252e/b} are
+ * canonical here and are neither resolved nor refused. A receiver configured to decode {@code %2F}
+ * into a separator (nginx with a URI in {@code proxy_pass}, Apache with {@code AllowEncodedSlashes
+ * On}) or to accept {@code \} as one resolves paths this class does not, and neither mode protects
+ * against that. {@code REJECT} refuses paths that are not canonical; it is not traversal hardening
+ * for an arbitrary receiver.
  *
  * @author GraviteeSource Team
  */
 public final class RequestPathNormalizer {
 
     private static final char SEGMENT_SEPARATOR = '/';
+    private static final char PARAM_SEPARATOR = ';';
     private static final String ROOT = "/";
 
     private RequestPathNormalizer() {}
@@ -123,9 +139,10 @@ public final class RequestPathNormalizer {
     }
 
     /**
-     * @return whether the segment starting at {@code start} is exactly {@code .} or {@code ..}.
-     *     Encoded spellings are not looked for here: they are already caught by the unreserved
-     *     decoding rule, whatever their position.
+     * @return whether the segment starting at {@code start} is a dot segment. Encoded spellings are
+     *     not looked for here: they are already caught by the unreserved decoding rule, whatever
+     *     their position. A path-parameter suffix does not disqualify one — see
+     *     {@link #stripDotSegmentParameters(StringBuilder)}.
      */
     private static boolean isDotSegment(final String path, final int start, final int length) {
         if (start >= length || path.charAt(start) != '.') {
@@ -135,15 +152,78 @@ public final class RequestPathNormalizer {
         if (end < length && path.charAt(end) == '.') {
             end++;
         }
-        return end == length || path.charAt(end) == SEGMENT_SEPARATOR;
+        return end == length || path.charAt(end) == SEGMENT_SEPARATOR || path.charAt(end) == PARAM_SEPARATOR;
     }
 
     /**
-     * @return the octet the two characters spell, or {@code -1} when they are not hexadecimal
+     * Drops the path-parameter suffix of any segment whose content is exactly {@code .} or
+     * {@code ..}, so that {@link #removeDotSegments(CharSequence)} sees the dot segment the receiver
+     * downstream is going to see.
+     *
+     * <p><b>Why this is not RFC 3986.</b> The specification is clear that a segment may carry
+     * parameters after a {@code ;} (§3.3) and that {@code remove_dot_segments} matches only the
+     * exact strings {@code .} and {@code ..} (§5.2.4). By that reading {@code ..;x} is an ordinary
+     * segment and this method is wrong. The Servlet specification is equally clear that a container
+     * strips {@code ;params} from every segment <em>before</em> resolving anything, which is what
+     * Tomcat, Jetty and Spring do. By that reading {@code ..;x} is a dot segment.
+     *
+     * <p>Both are right, and that disagreement is the whole bug this class exists to close. A
+     * gateway cannot know what sits behind it, so it decides on the most permissive reading any
+     * plausible receiver could take. Being stricter than a receiver costs an over-refused request;
+     * being laxer authorises one resource and lets another be served, which is the escalation that
+     * started this.
+     *
+     * <p>Only segments that are <em>entirely</em> dots before the {@code ;} are touched, so an
+     * ordinary {@code /orders;v=2} or a session id on a real segment is left alone.
+     */
+    private static void stripDotSegmentParameters(final StringBuilder path) {
+        int segmentStart = 0;
+        while (segmentStart <= path.length()) {
+            int segmentEnd = segmentStart;
+            while (segmentEnd < path.length() && path.charAt(segmentEnd) != SEGMENT_SEPARATOR) {
+                segmentEnd++;
+            }
+            int afterDots = segmentStart;
+            while (afterDots < segmentEnd && path.charAt(afterDots) == '.') {
+                afterDots++;
+            }
+            final int dots = afterDots - segmentStart;
+            if ((dots == 1 || dots == 2) && afterDots < segmentEnd && path.charAt(afterDots) == PARAM_SEPARATOR) {
+                path.delete(afterDots, segmentEnd);
+                segmentEnd = afterDots;
+            }
+            segmentStart = segmentEnd + 1;
+        }
+    }
+
+    /**
+     * @return the value of a single <b>ASCII</b> hexadecimal digit, or {@code -1}.
+     *     <p>Deliberately not {@link Character#digit(char, int)}, which is Unicode-aware:
+     *     {@code Character.digit('٢', 16)} answers 2, so {@code %٢e} would decode to a dot that no
+     *     receiver on earth resolves, and the gateway would route somewhere the raw path never
+     *     named. A percent sequence is ASCII by definition (RFC 3986 §2.1).
+     */
+    private static int hexDigit(final char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'A' && c <= 'F') {
+            return c - 'A' + 10;
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - 'a' + 10;
+        }
+        return -1;
+    }
+
+    /**
+     * @return the octet the two characters spell, or {@code -1} when they are not hexadecimal.
+     *     Shared by both implementations on purpose: when they each had their own reading of what a
+     *     hexadecimal digit is, they disagreed on {@code %+41}.
      */
     private static int hexValue(final char high, final char low) {
-        final int h = Character.digit(high, 16);
-        final int l = Character.digit(low, 16);
+        final int h = hexDigit(high);
+        final int l = hexDigit(low);
         return h < 0 || l < 0 ? -1 : (h << 4) + l;
     }
 
@@ -191,6 +271,9 @@ public final class RequestPathNormalizer {
         if (firstPercent != -1) {
             decodeUnreservedChars(buffer, firstPercent);
         }
+        // After decoding, so that %2e%2e; is stripped too — otherwise this method would itself
+        // produce the ..; shape that a servlet receiver resolves and this one would not.
+        stripDotSegmentParameters(buffer);
         return removeDotSegments(buffer);
     }
 
@@ -295,15 +378,9 @@ public final class RequestPathNormalizer {
             throw new IllegalArgumentException("Invalid position for escape character: " + start);
         }
 
-        final String escapeSequence = path.substring(start + 1, start + 3);
-        final int unescaped;
-        try {
-            unescaped = Integer.parseInt(escapeSequence, 16);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence, e);
-        }
+        final int unescaped = hexValue(path.charAt(start + 1), path.charAt(start + 2));
         if (unescaped < 0) {
-            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence);
+            throw new IllegalArgumentException("Invalid escape sequence: %" + path.substring(start + 1, start + 3));
         }
 
         if (isUnreserved(unescaped)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -39,14 +39,43 @@ package io.gravitee.gateway.reactive.reactor.path;
  *       stack.
  *   <li>A malformed percent sequence has no normalized form. {@link #normalize(String)} answers
  *       {@code null} for it rather than throwing, leaving the caller to reject the request.
+ *   <li>A dot segment carrying path parameters, {@code ..;x}, is treated as a dot segment. RFC 3986
+ *       says it is an ordinary segment; the Servlet specification says a container strips
+ *       {@code ;params} first, which makes it a dot segment. Tomcat, Jetty and Spring follow the
+ *       latter. The gateway takes the most permissive reading any receiver could, because being
+ *       stricter than the receiver costs a refused request while being laxer re-opens the very
+ *       bypass this class closes. See {@link #stripDotSegmentParameters(StringBuilder)}.
  * </ul>
+ *
+ * <p><b>What the modes assume of the receiver.</b> The rules above describe a receiver that decodes
+ * percent sequences once, per RFC 3986 §2.3, and treats only {@code /} as a separator. Reserved
+ * characters are deliberately left encoded, so {@code /a/..%2f../b} and {@code /a/%252e%252e/b} are
+ * canonical here and are neither resolved nor refused. A receiver configured to decode {@code %2F}
+ * into a separator (nginx with a URI in {@code proxy_pass}, Apache with {@code AllowEncodedSlashes
+ * On}) or to accept {@code \} as one resolves paths this class does not, and neither mode protects
+ * against that. {@code REJECT} refuses paths that are not canonical; it is not traversal hardening
+ * for an arbitrary receiver.
+ *
+ * <p><b>And the Servlet reading above is applied to dot segments only.</b> {@code /a/admin;x/b} is
+ * canonical here and forwarded byte for byte, while a container strips {@code ;x} and serves
+ * {@code /a/admin/b} — so a policy matching on {@code /admin/**} sees one path and the backend
+ * another. That is deliberate, and the asymmetry with {@code ..;x} is the whole point: a dot segment
+ * carrying parameters is never legitimate, so treating it as a dot segment refuses and rewrites
+ * nothing anyone sends. An ordinary segment carrying parameters <em>is</em> legitimate — matrix
+ * parameters, {@code ;jsessionid} — so refusing them under {@code REJECT} would turn away well
+ * formed traffic, and stripping them under {@code NORMALIZE} would forward a path the client did
+ * not ask for, which toward a receiver that keeps them means serving a different resource rather
+ * than merely a stricter one. Closing that gap is a decision about matrix parameters, not about
+ * traversal, and it is not taken here.
  *
  * @author GraviteeSource Team
  */
 public final class RequestPathNormalizer {
 
     private static final char SEGMENT_SEPARATOR = '/';
+    private static final char PARAM_SEPARATOR = ';';
     private static final String ROOT = "/";
+    private static final String ASTERISK_FORM = "*";
 
     private RequestPathNormalizer() {}
 
@@ -58,7 +87,11 @@ public final class RequestPathNormalizer {
      * claims to be, and is refused without ever being rewritten. {@code NORMALIZE} uses it as its
      * fast path, so an ordinary request pays one scan instead of a full resolution.
      *
-     * <p>A path needs normalizing when any of these holds:
+     * <p>A request target that is not in origin-form — {@code null}, or the asterisk-form of
+     * {@code OPTIONS *} — never needs normalizing and is answered {@code false} before anything
+     * else. There are no segments to resolve there, and no receiver could read them differently.
+     *
+     * <p>Otherwise a path needs normalizing when any of these holds:
      *
      * <ul>
      *   <li>it is empty, or does not start with {@code /} — {@link #normalize(String)} forces both
@@ -87,7 +120,11 @@ public final class RequestPathNormalizer {
      * @return {@code true} when normalizing would change the path, or when it cannot be normalized
      */
     public static boolean needsNormalization(final String path) {
-        if (path == null || path.isEmpty() || path.charAt(0) != SEGMENT_SEPARATOR) {
+        if (isNotOriginForm(path)) {
+            return false;
+        }
+        // Not null by here: isNotOriginForm answered for that case above.
+        if (path.isEmpty() || path.charAt(0) != SEGMENT_SEPARATOR) {
             return true;
         }
 
@@ -123,9 +160,34 @@ public final class RequestPathNormalizer {
     }
 
     /**
-     * @return whether the segment starting at {@code start} is exactly {@code .} or {@code ..}.
-     *     Encoded spellings are not looked for here: they are already caught by the unreserved
-     *     decoding rule, whatever their position.
+     * @return whether this request target is one of the forms that is not a path at all, and that
+     *     neither mode has any business inspecting.
+     *     <p>Two targets qualify, and only two. The asterisk-form of {@code OPTIONS *}, which RFC
+     *     9110 §7.1 allows and which proxies and health probes do send: it has no segments to
+     *     resolve, nothing to compare against a context path, and no receiver that could read it
+     *     differently from us. Left to the general scan it would be answered 400 under
+     *     {@code REJECT} — a legal request refused — and rewritten to {@code /*} under
+     *     {@code NORMALIZE}, then routed to whatever sits on the root context path. And
+     *     {@code null}, which is what an HTTP/2 stream carrying no {@code :path} pseudo-header
+     *     produces.
+     *     <p>Authority-form is <b>not</b> exempted, despite arriving on the same kind of request. A
+     *     {@code CONNECT} over HTTP/2 has no {@code :path} and is therefore covered by the
+     *     {@code null} case above, but over HTTP/1 it reaches {@code path()} as {@code host:443},
+     *     fails the leading-slash test and is answered 400 under {@code REJECT}. That is left as is
+     *     on purpose: a gateway is not a forward proxy, and the request had nowhere to go.
+     */
+    private static boolean isNotOriginForm(final String path) {
+        // Null belongs here too: the Vert.x API declares path() nullable, and an HTTP/2 stream
+        // without a :path pseudo-header — a CONNECT — produces exactly that. Such a request reached
+        // the acceptor before this class existed, and must keep doing so in every mode.
+        return path == null || ASTERISK_FORM.equals(path);
+    }
+
+    /**
+     * @return whether the segment starting at {@code start} is a dot segment. Encoded spellings are
+     *     not looked for here: they are already caught by the unreserved decoding rule, whatever
+     *     their position. A path-parameter suffix does not disqualify one — see
+     *     {@link #stripDotSegmentParameters(StringBuilder)}.
      */
     private static boolean isDotSegment(final String path, final int start, final int length) {
         if (start >= length || path.charAt(start) != '.') {
@@ -135,15 +197,78 @@ public final class RequestPathNormalizer {
         if (end < length && path.charAt(end) == '.') {
             end++;
         }
-        return end == length || path.charAt(end) == SEGMENT_SEPARATOR;
+        return end == length || path.charAt(end) == SEGMENT_SEPARATOR || path.charAt(end) == PARAM_SEPARATOR;
     }
 
     /**
-     * @return the octet the two characters spell, or {@code -1} when they are not hexadecimal
+     * Drops the path-parameter suffix of any segment whose content is exactly {@code .} or
+     * {@code ..}, so that {@link #removeDotSegments(CharSequence)} sees the dot segment the receiver
+     * downstream is going to see.
+     *
+     * <p><b>Why this is not RFC 3986.</b> The specification is clear that a segment may carry
+     * parameters after a {@code ;} (§3.3) and that {@code remove_dot_segments} matches only the
+     * exact strings {@code .} and {@code ..} (§5.2.4). By that reading {@code ..;x} is an ordinary
+     * segment and this method is wrong. The Servlet specification is equally clear that a container
+     * strips {@code ;params} from every segment <em>before</em> resolving anything, which is what
+     * Tomcat, Jetty and Spring do. By that reading {@code ..;x} is a dot segment.
+     *
+     * <p>Both are right, and that disagreement is the whole bug this class exists to close. A
+     * gateway cannot know what sits behind it, so it decides on the most permissive reading any
+     * plausible receiver could take. Being stricter than a receiver costs an over-refused request;
+     * being laxer authorises one resource and lets another be served, which is the escalation that
+     * started this.
+     *
+     * <p>Only segments that are <em>entirely</em> dots before the {@code ;} are touched, so an
+     * ordinary {@code /orders;v=2} or a session id on a real segment is left alone.
+     */
+    private static void stripDotSegmentParameters(final StringBuilder path) {
+        int segmentStart = 0;
+        while (segmentStart <= path.length()) {
+            int segmentEnd = segmentStart;
+            while (segmentEnd < path.length() && path.charAt(segmentEnd) != SEGMENT_SEPARATOR) {
+                segmentEnd++;
+            }
+            int afterDots = segmentStart;
+            while (afterDots < segmentEnd && path.charAt(afterDots) == '.') {
+                afterDots++;
+            }
+            final int dots = afterDots - segmentStart;
+            if ((dots == 1 || dots == 2) && afterDots < segmentEnd && path.charAt(afterDots) == PARAM_SEPARATOR) {
+                path.delete(afterDots, segmentEnd);
+                segmentEnd = afterDots;
+            }
+            segmentStart = segmentEnd + 1;
+        }
+    }
+
+    /**
+     * @return the value of a single <b>ASCII</b> hexadecimal digit, or {@code -1}.
+     *     <p>Deliberately not {@link Character#digit(char, int)}, which is Unicode-aware:
+     *     {@code Character.digit('٢', 16)} answers 2, so {@code %٢e} would decode to a dot that no
+     *     receiver on earth resolves, and the gateway would route somewhere the raw path never
+     *     named. A percent sequence is ASCII by definition (RFC 3986 §2.1).
+     */
+    private static int hexDigit(final char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'A' && c <= 'F') {
+            return c - 'A' + 10;
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - 'a' + 10;
+        }
+        return -1;
+    }
+
+    /**
+     * @return the octet the two characters spell, or {@code -1} when they are not hexadecimal.
+     *     Shared by both implementations on purpose: when they each had their own reading of what a
+     *     hexadecimal digit is, they disagreed on {@code %+41}.
      */
     private static int hexValue(final char high, final char low) {
-        final int h = Character.digit(high, 16);
-        final int l = Character.digit(low, 16);
+        final int h = hexDigit(high);
+        final int l = hexDigit(low);
         return h < 0 || l < 0 ? -1 : (h << 4) + l;
     }
 
@@ -152,10 +277,15 @@ public final class RequestPathNormalizer {
      * @return the normalized path, the very same instance when there is nothing to resolve so
      *     callers can rely on {@code ==}, or {@code null} when the path carries a malformed percent
      *     sequence and therefore cannot be normalized at all.
+     *     <p>A target that is not in origin-form is answered unchanged, {@code null} included — see
+     *     {@link #needsNormalization(String)}. A {@code null} answer therefore means "malformed"
+     *     only for a path that was not {@code null} to begin with, which is why callers pair this
+     *     method with the scan rather than calling it alone.
      */
     public static String normalize(final String path) {
-        if (path == null) {
-            return null;
+        if (isNotOriginForm(path)) {
+            // Answered unchanged rather than turned into "/*": see isNotOriginForm.
+            return path;
         }
         if (path.isEmpty()) {
             return ROOT;
@@ -191,50 +321,56 @@ public final class RequestPathNormalizer {
         if (firstPercent != -1) {
             decodeUnreservedChars(buffer, firstPercent);
         }
+        // After decoding, so that %2e%2e; is stripped too — otherwise this method would itself
+        // produce the ..; shape that a servlet receiver resolves and this one would not.
+        stripDotSegmentParameters(buffer);
         return removeDotSegments(buffer);
     }
 
     /**
      * RFC 3986 §5.2.4, plus the merging of duplicate slashes inherited from Vert.x.
      */
-    private static String removeDotSegments(CharSequence path) {
+    private static String removeDotSegments(final CharSequence path) {
         final StringBuilder out = new StringBuilder(path.length());
+        // The input buffer of §5.2.4, kept apart from the parameter so the path the caller handed us
+        // stays readable while the algorithm rewrites its own working copy.
+        CharSequence remaining = path;
         int i = 0;
 
-        while (i < path.length()) {
-            if (matches(path, i, "./")) {
+        while (i < remaining.length()) {
+            if (matches(remaining, i, "./")) {
                 i += 2;
-            } else if (matches(path, i, "../")) {
+            } else if (matches(remaining, i, "../")) {
                 i += 3;
-            } else if (matches(path, i, "/./")) {
+            } else if (matches(remaining, i, "/./")) {
                 // Preserve the trailing slash.
                 i += 2;
-            } else if (matches(path, i, "/.", true)) {
-                path = ROOT;
+            } else if (matches(remaining, i, "/.", true)) {
+                remaining = ROOT;
                 i = 0;
-            } else if (matches(path, i, "/../")) {
+            } else if (matches(remaining, i, "/../")) {
                 i += 3;
                 removeLastSegment(out);
-            } else if (matches(path, i, "/..", true)) {
-                path = ROOT;
+            } else if (matches(remaining, i, "/..", true)) {
+                remaining = ROOT;
                 i = 0;
                 removeLastSegment(out);
-            } else if (matches(path, i, ".", true) || matches(path, i, "..", true)) {
+            } else if (matches(remaining, i, ".", true) || matches(remaining, i, "..", true)) {
                 break;
             } else {
-                if (path.charAt(i) == SEGMENT_SEPARATOR) {
+                if (remaining.charAt(i) == SEGMENT_SEPARATOR) {
                     i++;
                     // Not standard, but every hop around us collapses "//" into "/".
                     if (out.length() == 0 || out.charAt(out.length() - 1) != SEGMENT_SEPARATOR) {
                         out.append(SEGMENT_SEPARATOR);
                     }
                 }
-                final int nextSlash = indexOfSlash(path, i);
+                final int nextSlash = indexOfSlash(remaining, i);
                 if (nextSlash != -1) {
-                    out.append(path, i, nextSlash);
+                    out.append(remaining, i, nextSlash);
                     i = nextSlash;
                 } else {
-                    out.append(path, i, path.length());
+                    out.append(remaining, i, remaining.length());
                     break;
                 }
             }
@@ -275,12 +411,24 @@ public final class RequestPathNormalizer {
         return -1;
     }
 
-    private static void decodeUnreservedChars(final StringBuilder path, int start) {
-        while (start < path.length()) {
-            if (path.charAt(start) == '%') {
-                decodeUnreserved(path, start);
+    /**
+     * Decodes in place, which is quadratic in the worst case: every decoded escape deletes two
+     * characters from the middle of the buffer and shifts the suffix behind them.
+     *
+     * <p>Kept that way deliberately. The input is a request line, which Vert.x caps at
+     * {@code maxInitialLineLength} — 4096 bytes by default — so the worst case an attacker can reach
+     * is a full line of {@code %41}, measured at around 60 µs. A single-pass rewrite would be faster
+     * on paper and would also be a rewrite of vendored resolution logic on the one code path where a
+     * mistake is a security defect, which is a poor trade at this size. Revisit if that cap is ever
+     * raised.
+     */
+    private static void decodeUnreservedChars(final StringBuilder path, final int start) {
+        int cursor = start;
+        while (cursor < path.length()) {
+            if (path.charAt(cursor) == '%') {
+                decodeUnreserved(path, cursor);
             }
-            start++;
+            cursor++;
         }
     }
 
@@ -295,15 +443,9 @@ public final class RequestPathNormalizer {
             throw new IllegalArgumentException("Invalid position for escape character: " + start);
         }
 
-        final String escapeSequence = path.substring(start + 1, start + 3);
-        final int unescaped;
-        try {
-            unescaped = Integer.parseInt(escapeSequence, 16);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence, e);
-        }
+        final int unescaped = hexValue(path.charAt(start + 1), path.charAt(start + 2));
         if (unescaped < 0) {
-            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence);
+            throw new IllegalArgumentException("Invalid escape sequence: %" + path.substring(start + 1, start + 3));
         }
 
         if (isUnreserved(unescaped)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -51,6 +51,103 @@ public final class RequestPathNormalizer {
     private RequestPathNormalizer() {}
 
     /**
+     * Answers, in a single pass and without allocating, whether normalizing this path would change
+     * anything. It is the cheap question that both modes actually ask.
+     *
+     * <p>{@code REJECT} needs nothing else: a path that needs normalizing is not in the form it
+     * claims to be, and is refused without ever being rewritten. {@code NORMALIZE} uses it as its
+     * fast path, so an ordinary request pays one scan instead of a full resolution.
+     *
+     * <p>A path needs normalizing when any of these holds:
+     *
+     * <ul>
+     *   <li>it is empty, or does not start with {@code /} — {@link #normalize(String)} forces both
+     *   <li>it contains two consecutive separators, which are merged
+     *   <li>one of its segments is exactly {@code .} or {@code ..}
+     *   <li>it carries a percent sequence that decodes to an <b>unreserved</b> character, which is
+     *       decoded. This is what catches {@code %2e} and its variants wherever they sit, so the
+     *       segment test above only has to look at plain dots
+     *   <li>it carries a percent sequence that is truncated or not hexadecimal, which has no
+     *       normalized form at all
+     * </ul>
+     *
+     * <p>And, deliberately, a path does <b>not</b> need normalizing merely because it contains a
+     * dot inside a segment, {@code /v1/orders/12345.json}, or a percent sequence that decodes to a
+     * <b>reserved</b> character, {@code /a/b%2Fc}. Both are extremely common and both are already
+     * canonical; treating them as suspect would send the most ordinary traffic down the slow path,
+     * and would make {@code REJECT} refuse requests that are perfectly well formed.
+     *
+     * <p><b>This method and {@link #normalize(String)} must agree.</b> Two implementations of the
+     * same rules drift the moment one is touched alone, and the drift is silent: a false negative
+     * here is a path that is quietly left unnormalized. That agreement is not maintained by review
+     * but asserted, over a generated corpus, by the property {@code needsNormalization(p) ==
+     * !p.equals(normalize(p))} in {@code RequestPathNormalizerTest}.
+     *
+     * @param path the raw request path
+     * @return {@code true} when normalizing would change the path, or when it cannot be normalized
+     */
+    public static boolean needsNormalization(final String path) {
+        if (path == null || path.isEmpty() || path.charAt(0) != SEGMENT_SEPARATOR) {
+            return true;
+        }
+
+        final int length = path.length();
+        int i = 0;
+
+        while (i < length) {
+            final char c = path.charAt(i);
+
+            if (c == SEGMENT_SEPARATOR) {
+                final int segmentStart = i + 1;
+                if (segmentStart < length && path.charAt(segmentStart) == SEGMENT_SEPARATOR) {
+                    return true;
+                }
+                if (isDotSegment(path, segmentStart, length)) {
+                    return true;
+                }
+                i = segmentStart;
+            } else if (c == '%') {
+                if (i + 2 >= length) {
+                    return true;
+                }
+                final int decoded = hexValue(path.charAt(i + 1), path.charAt(i + 2));
+                if (decoded < 0 || isUnreserved(decoded)) {
+                    return true;
+                }
+                i += 3;
+            } else {
+                i++;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return whether the segment starting at {@code start} is exactly {@code .} or {@code ..}.
+     *     Encoded spellings are not looked for here: they are already caught by the unreserved
+     *     decoding rule, whatever their position.
+     */
+    private static boolean isDotSegment(final String path, final int start, final int length) {
+        if (start >= length || path.charAt(start) != '.') {
+            return false;
+        }
+        int end = start + 1;
+        if (end < length && path.charAt(end) == '.') {
+            end++;
+        }
+        return end == length || path.charAt(end) == SEGMENT_SEPARATOR;
+    }
+
+    /**
+     * @return the octet the two characters spell, or {@code -1} when they are not hexadecimal
+     */
+    private static int hexValue(final char high, final char low) {
+        final int h = Character.digit(high, 16);
+        final int l = Character.digit(low, 16);
+        return h < 0 || l < 0 ? -1 : (h << 4) + l;
+    }
+
+    /**
      * @param path the raw request path
      * @return the normalized path, the very same instance when there is nothing to resolve so
      *     callers can rely on {@code ==}, or {@code null} when the path carries a malformed percent

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+/**
+ * Normalizes a request path following RFC 3986, so that the gateway decides on the same path a
+ * conforming receiver will resolve.
+ *
+ * <p>Derived from Eclipse Vert.x, {@code io.vertx.core.internal.net.RFC3986} in Vert.x 5 and
+ * {@code io.vertx.core.http.impl.HttpUtils} in Vert.x 4, originally written by Paulo Lopes.
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation, dual-licensed under EPL-2.0 and
+ * Apache-2.0, and reused here under Apache-2.0.
+ *
+ * <p>It is carried in this codebase rather than called through Vert.x because no public entry point
+ * exists: the class sits in {@code impl} on Vert.x 4 and in {@code internal} on Vert.x 5, and it
+ * moved between the two. Vendoring keeps one behaviour across every branch we maintain.
+ *
+ * <p>Three behaviours are worth stating, because they go beyond resolving dot segments:
+ *
+ * <ul>
+ *   <li>Percent-encoded <b>unreserved</b> characters are decoded, as RFC 3986 §6.2.2.2 requires.
+ *       That is what makes {@code %2e%2e} a dot segment, and it also turns {@code %41} into
+ *       {@code A}. Reserved characters are untouched, so {@code %2F} never becomes a separator.
+ *   <li>Duplicate slashes are merged, and a path is forced to start with a slash. Neither is in the
+ *       specification; both come from Vert.x and are kept so the behaviour matches the rest of the
+ *       stack.
+ *   <li>A malformed percent sequence has no normalized form. {@link #normalize(String)} answers
+ *       {@code null} for it rather than throwing, leaving the caller to reject the request.
+ * </ul>
+ *
+ * @author GraviteeSource Team
+ */
+public final class RequestPathNormalizer {
+
+    private static final char SEGMENT_SEPARATOR = '/';
+    private static final String ROOT = "/";
+
+    private RequestPathNormalizer() {}
+
+    /**
+     * @param path the raw request path
+     * @return the normalized path, the very same instance when there is nothing to resolve so
+     *     callers can rely on {@code ==}, or {@code null} when the path carries a malformed percent
+     *     sequence and therefore cannot be normalized at all.
+     */
+    public static String normalize(final String path) {
+        if (path == null) {
+            return null;
+        }
+        if (path.isEmpty()) {
+            return ROOT;
+        }
+
+        final int firstPercent = path.indexOf('%');
+        if (firstPercent == -1 && path.indexOf('.') == -1 && path.indexOf("//") == -1 && path.charAt(0) == SEGMENT_SEPARATOR) {
+            return path;
+        }
+
+        try {
+            final String normalized = normalizeSlow(path, firstPercent);
+            return normalized.equals(path) ? path : normalized;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String normalizeSlow(final String path, int firstPercent) {
+        final StringBuilder buffer;
+
+        if (path.charAt(0) != SEGMENT_SEPARATOR) {
+            buffer = new StringBuilder(path.length() + 1);
+            buffer.append(SEGMENT_SEPARATOR);
+            if (firstPercent != -1) {
+                firstPercent++;
+            }
+        } else {
+            buffer = new StringBuilder(path.length());
+        }
+        buffer.append(path);
+
+        if (firstPercent != -1) {
+            decodeUnreservedChars(buffer, firstPercent);
+        }
+        return removeDotSegments(buffer);
+    }
+
+    /**
+     * RFC 3986 §5.2.4, plus the merging of duplicate slashes inherited from Vert.x.
+     */
+    private static String removeDotSegments(CharSequence path) {
+        final StringBuilder out = new StringBuilder(path.length());
+        int i = 0;
+
+        while (i < path.length()) {
+            if (matches(path, i, "./")) {
+                i += 2;
+            } else if (matches(path, i, "../")) {
+                i += 3;
+            } else if (matches(path, i, "/./")) {
+                // Preserve the trailing slash.
+                i += 2;
+            } else if (matches(path, i, "/.", true)) {
+                path = ROOT;
+                i = 0;
+            } else if (matches(path, i, "/../")) {
+                i += 3;
+                removeLastSegment(out);
+            } else if (matches(path, i, "/..", true)) {
+                path = ROOT;
+                i = 0;
+                removeLastSegment(out);
+            } else if (matches(path, i, ".", true) || matches(path, i, "..", true)) {
+                break;
+            } else {
+                if (path.charAt(i) == SEGMENT_SEPARATOR) {
+                    i++;
+                    // Not standard, but every hop around us collapses "//" into "/".
+                    if (out.length() == 0 || out.charAt(out.length() - 1) != SEGMENT_SEPARATOR) {
+                        out.append(SEGMENT_SEPARATOR);
+                    }
+                }
+                final int nextSlash = indexOfSlash(path, i);
+                if (nextSlash != -1) {
+                    out.append(path, i, nextSlash);
+                    i = nextSlash;
+                } else {
+                    out.append(path, i, path.length());
+                    break;
+                }
+            }
+        }
+        return out.toString();
+    }
+
+    private static void removeLastSegment(final StringBuilder out) {
+        final int lastSlash = out.lastIndexOf(ROOT);
+        out.setLength(lastSlash == -1 ? 0 : lastSlash);
+    }
+
+    private static boolean matches(final CharSequence path, final int start, final String expected) {
+        return matches(path, start, expected, false);
+    }
+
+    private static boolean matches(final CharSequence path, final int start, final String expected, final boolean exact) {
+        if (exact && path.length() - start != expected.length()) {
+            return false;
+        }
+        if (path.length() - start < expected.length()) {
+            return false;
+        }
+        for (int i = 0; i < expected.length(); i++) {
+            if (path.charAt(start + i) != expected.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int indexOfSlash(final CharSequence path, final int start) {
+        for (int i = start; i < path.length(); i++) {
+            if (path.charAt(i) == SEGMENT_SEPARATOR) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void decodeUnreservedChars(final StringBuilder path, int start) {
+        while (start < path.length()) {
+            if (path.charAt(start) == '%') {
+                decodeUnreserved(path, start);
+            }
+            start++;
+        }
+    }
+
+    /**
+     * Decodes one escape sequence when it spells an unreserved character, RFC 3986 §2.3. Anything
+     * reserved is left encoded, which is what keeps {@code %2F} from becoming a separator.
+     *
+     * @throws IllegalArgumentException when the sequence is truncated or not hexadecimal
+     */
+    private static void decodeUnreserved(final StringBuilder path, final int start) {
+        if (start + 3 > path.length()) {
+            throw new IllegalArgumentException("Invalid position for escape character: " + start);
+        }
+
+        final String escapeSequence = path.substring(start + 1, start + 3);
+        final int unescaped;
+        try {
+            unescaped = Integer.parseInt(escapeSequence, 16);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence, e);
+        }
+        if (unescaped < 0) {
+            throw new IllegalArgumentException("Invalid escape sequence: %" + escapeSequence);
+        }
+
+        if (isUnreserved(unescaped)) {
+            path.setCharAt(start, (char) unescaped);
+            path.delete(start + 1, start + 3);
+        }
+    }
+
+    private static boolean isUnreserved(final int octet) {
+        return (
+            (octet >= 0x41 && octet <= 0x5A) || // A-Z
+            (octet >= 0x61 && octet <= 0x7A) || // a-z
+            (octet >= 0x30 && octet <= 0x39) || // 0-9
+            octet == 0x2D || // -
+            octet == 0x2E || // .
+            octet == 0x5F || // _
+            octet == 0x7E // ~
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizer.java
@@ -280,44 +280,47 @@ public final class RequestPathNormalizer {
     /**
      * RFC 3986 §5.2.4, plus the merging of duplicate slashes inherited from Vert.x.
      */
-    private static String removeDotSegments(CharSequence path) {
+    private static String removeDotSegments(final CharSequence path) {
         final StringBuilder out = new StringBuilder(path.length());
+        // The input buffer of §5.2.4, kept apart from the parameter so the path the caller handed us
+        // stays readable while the algorithm rewrites its own working copy.
+        CharSequence remaining = path;
         int i = 0;
 
-        while (i < path.length()) {
-            if (matches(path, i, "./")) {
+        while (i < remaining.length()) {
+            if (matches(remaining, i, "./")) {
                 i += 2;
-            } else if (matches(path, i, "../")) {
+            } else if (matches(remaining, i, "../")) {
                 i += 3;
-            } else if (matches(path, i, "/./")) {
+            } else if (matches(remaining, i, "/./")) {
                 // Preserve the trailing slash.
                 i += 2;
-            } else if (matches(path, i, "/.", true)) {
-                path = ROOT;
+            } else if (matches(remaining, i, "/.", true)) {
+                remaining = ROOT;
                 i = 0;
-            } else if (matches(path, i, "/../")) {
+            } else if (matches(remaining, i, "/../")) {
                 i += 3;
                 removeLastSegment(out);
-            } else if (matches(path, i, "/..", true)) {
-                path = ROOT;
+            } else if (matches(remaining, i, "/..", true)) {
+                remaining = ROOT;
                 i = 0;
                 removeLastSegment(out);
-            } else if (matches(path, i, ".", true) || matches(path, i, "..", true)) {
+            } else if (matches(remaining, i, ".", true) || matches(remaining, i, "..", true)) {
                 break;
             } else {
-                if (path.charAt(i) == SEGMENT_SEPARATOR) {
+                if (remaining.charAt(i) == SEGMENT_SEPARATOR) {
                     i++;
                     // Not standard, but every hop around us collapses "//" into "/".
                     if (out.length() == 0 || out.charAt(out.length() - 1) != SEGMENT_SEPARATOR) {
                         out.append(SEGMENT_SEPARATOR);
                     }
                 }
-                final int nextSlash = indexOfSlash(path, i);
+                final int nextSlash = indexOfSlash(remaining, i);
                 if (nextSlash != -1) {
-                    out.append(path, i, nextSlash);
+                    out.append(remaining, i, nextSlash);
                     i = nextSlash;
                 } else {
-                    out.append(path, i, path.length());
+                    out.append(remaining, i, remaining.length());
                     break;
                 }
             }
@@ -358,12 +361,24 @@ public final class RequestPathNormalizer {
         return -1;
     }
 
-    private static void decodeUnreservedChars(final StringBuilder path, int start) {
-        while (start < path.length()) {
-            if (path.charAt(start) == '%') {
-                decodeUnreserved(path, start);
+    /**
+     * Decodes in place, which is quadratic in the worst case: every decoded escape deletes two
+     * characters from the middle of the buffer and shifts the suffix behind them.
+     *
+     * <p>Kept that way deliberately. The input is a request line, which Vert.x caps at
+     * {@code maxInitialLineLength} — 4096 bytes by default — so the worst case an attacker can reach
+     * is a full line of {@code %41}, measured at around 60 µs. A single-pass rewrite would be faster
+     * on paper and would also be a rewrite of vendored resolution logic on the one code path where a
+     * mistake is a security defect, which is a poor trade at this size. Revisit if that cap is ever
+     * raised.
+     */
+    private static void decodeUnreservedChars(final StringBuilder path, final int start) {
+        int cursor = start;
+        while (cursor < path.length()) {
+            if (path.charAt(cursor) == '%') {
+                decodeUnreserved(path, cursor);
             }
-            start++;
+            cursor++;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
@@ -35,10 +35,14 @@ import io.gravitee.gateway.env.RequestPathHandling;
  * <p><b>Why this exists next to the dispatcher rather than inside it.</b> {@code
  * DefaultHttpRequestDispatcher.dispatch} runs on every request the gateway serves, and deliberately
  * inlines this decision so it can reuse the single scan it already pays for and allocate nothing.
- * Calling this method there would scan the path a second time. The duplication is intentional and
- * bounded, and it is pinned by {@code RequestPathRejectionTest}, which walks the same table of modes
- * and paths the dispatcher tests use — two readings of one rule drift silently, and this one would
- * drift open.
+ * Calling this method there would scan the path a second time.
+ *
+ * <p>The duplication is therefore intentional, and it is guarded by {@code
+ * DefaultHttpRequestDispatcherTest.The_rejection_decision}, which drives the <b>dispatcher</b> over
+ * a table of modes and paths and asserts that it refused exactly the ones this method announces.
+ * Two readings of one rule drift the moment one is touched alone, and this drift fails open. Note
+ * what that guard is not: asserting this method against the normalizer it is built from restates its
+ * own body and passes whatever the dispatcher does.
  *
  * @author GraviteeSource Team
  */

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
+
+/**
+ * Answers whether the gateway will refuse to route on a path, for a caller that needs to know it
+ * before the request is dispatched.
+ *
+ * <p>There are two ways a request is refused, and only stating both keeps a caller correct:
+ *
+ * <ul>
+ *   <li>{@link RequestPathHandling#REJECT} meeting a path that is not already in its normalized
+ *       form — the mode's whole purpose;
+ *   <li>a path that has <b>no</b> normalized form at all, because it carries a malformed percent
+ *       sequence. That one is refused under {@link RequestPathHandling#NORMALIZE} too: the gateway
+ *       cannot know which octets the client meant, so there is nothing to decide on.
+ * </ul>
+ *
+ * <p><b>Why this exists next to the dispatcher rather than inside it.</b> {@code
+ * DefaultHttpRequestDispatcher.dispatch} runs on every request the gateway serves, and deliberately
+ * inlines this decision so it can reuse the single scan it already pays for and allocate nothing.
+ * Calling this method there would scan the path a second time. The duplication is intentional and
+ * bounded, and it is pinned by {@code RequestPathRejectionTest}, which walks the same table of modes
+ * and paths the dispatcher tests use — two readings of one rule drift silently, and this one would
+ * drift open.
+ *
+ * @author GraviteeSource Team
+ */
+public final class RequestPathRejection {
+
+    private RequestPathRejection() {}
+
+    /**
+     * @return {@code true} when dispatching this path would answer 400 instead of routing it.
+     */
+    public static boolean applies(final RequestPathConfiguration configuration, final String path) {
+        if (!configuration.isEnabled() || !RequestPathNormalizer.needsNormalization(path)) {
+            return false;
+        }
+        if (configuration.getHandling() == RequestPathHandling.REJECT) {
+            return true;
+        }
+        return RequestPathNormalizer.normalize(path) == null;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactory.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.reactor.processor.metrics.MetricsProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.notfound.NotFoundProcessor;
+import io.gravitee.gateway.reactive.reactor.processor.rejected.RejectedPathProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.reporter.ReporterProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.responsetime.ResponseTimeProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
@@ -43,6 +44,7 @@ public class NotFoundProcessorChainFactory {
     private final GatewayConfiguration gatewayConfiguration;
     private final List<ProcessorHook> processorHooks = new ArrayList<>();
     private ProcessorChain processorChain;
+    private ProcessorChain rejectedPathProcessorChain;
 
     public NotFoundProcessorChainFactory(
         final TransactionPreProcessorFactory transactionHandlerFactory,
@@ -63,6 +65,25 @@ public class NotFoundProcessorChainFactory {
             initProcessorChain();
         }
         return processorChain;
+    }
+
+    /**
+     * The same chain as {@link #processorChain()}, answering 400 instead of 404. A request refused
+     * on its path is refused before any API is selected, exactly like an unmatched context path, so
+     * it needs the same treatment to be counted and reported at all.
+     */
+    public ProcessorChain rejectedPathProcessorChain() {
+        if (rejectedPathProcessorChain == null) {
+            List<Processor> processorList = new ArrayList<>();
+            processorList.add(transactionHandlerFactory.create());
+            processorList.add(new MetricsProcessor(gatewayConfiguration, notFoundAnalyticsEnabled));
+            processorList.add(new RejectedPathProcessor(environment));
+            processorList.add(new ResponseTimeProcessor());
+            processorList.add(new ReporterProcessor(reporterService));
+            rejectedPathProcessorChain = new ProcessorChain("rejected-path", processorList);
+            rejectedPathProcessorChain.addHooks(processorHooks);
+        }
+        return rejectedPathProcessorChain;
     }
 
     void initProcessorChain() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactory.java
@@ -41,6 +41,7 @@ public class NotFoundProcessorChainFactory {
     private final Environment environment;
     private final ReporterService reporterService;
     private final boolean notFoundAnalyticsEnabled;
+    private final boolean rejectedAnalyticsEnabled;
     private final GatewayConfiguration gatewayConfiguration;
     private final List<ProcessorHook> processorHooks = new ArrayList<>();
     private ProcessorChain processorChain;
@@ -51,12 +52,14 @@ public class NotFoundProcessorChainFactory {
         final Environment environment,
         final ReporterService reporterService,
         boolean notFoundAnalyticsEnabled,
+        boolean rejectedAnalyticsEnabled,
         GatewayConfiguration gatewayConfiguration
     ) {
         this.transactionHandlerFactory = transactionHandlerFactory;
         this.environment = environment;
         this.reporterService = reporterService;
         this.notFoundAnalyticsEnabled = notFoundAnalyticsEnabled;
+        this.rejectedAnalyticsEnabled = rejectedAnalyticsEnabled;
         this.gatewayConfiguration = gatewayConfiguration;
     }
 
@@ -71,12 +74,17 @@ public class NotFoundProcessorChainFactory {
      * The same chain as {@link #processorChain()}, answering 400 instead of 404. A request refused
      * on its path is refused before any API is selected, exactly like an unmatched context path, so
      * it needs the same treatment to be counted and reported at all.
+     *
+     * <p>Its reporting is on by default, where the not-found chain's is off. An unmatched context
+     * path is ordinary internet noise and reporting all of it would drown an operator; a path the
+     * gateway refused to route on is rare and diagnostic, and staying silent about it would defeat
+     * the point of refusing.
      */
     public ProcessorChain rejectedPathProcessorChain() {
         if (rejectedPathProcessorChain == null) {
             List<Processor> processorList = new ArrayList<>();
             processorList.add(transactionHandlerFactory.create());
-            processorList.add(new MetricsProcessor(gatewayConfiguration, notFoundAnalyticsEnabled));
+            processorList.add(new MetricsProcessor(gatewayConfiguration, rejectedAnalyticsEnabled));
             processorList.add(new RejectedPathProcessor(environment));
             processorList.add(new ResponseTimeProcessor());
             processorList.add(new ReporterProcessor(reporterService));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/rejected/RejectedPathProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/rejected/RejectedPathProcessor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.processor.rejected;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.core.Completable;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+
+/**
+ * Answers 400 for a request whose path the gateway refused to route on, and makes sure it is
+ * reported.
+ *
+ * <p>A rejection happens before any API is selected, so nothing downstream would ever account for
+ * it. Left to answer on the raw response, the request would leave no trace at all — which is the
+ * wrong outcome for a control whose value is telling an operator that someone is probing the
+ * platform. Running through a processor chain is what gives it a metric and a report, the way an
+ * unmatched context path already gets one.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+public class RejectedPathProcessor implements Processor {
+
+    private static final String ID = "processor-rejected-path";
+    private static final String UNKNOWN_SERVICE = "1";
+    private static final String DEFAULT_MESSAGE = "The request path is not in its normalized form.";
+
+    private final Environment environment;
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Completable execute(final HttpExecutionContextInternal ctx) {
+        return Completable.defer(() -> {
+            ctx.withLogger(log).warn("Rejecting request {}, returning BAD_REQUEST (400)", ctx.request().path());
+
+            final Metrics metrics = ctx.metrics();
+            metrics.setApiId(UNKNOWN_SERVICE);
+            metrics.setApplicationId(UNKNOWN_SERVICE);
+
+            ctx.response().status(HttpStatusCode.BAD_REQUEST_400);
+
+            final String message = environment.getProperty("http.errors[400].message", DEFAULT_MESSAGE);
+            ctx.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()));
+            ctx
+                .response()
+                .headers()
+                .set(HttpHeaderNames.CONTENT_TYPE, environment.getProperty("http.errors[400].contentType", MediaType.TEXT_PLAIN));
+            ctx.response().body(Buffer.buffer(message));
+            return ctx.response().end(ctx);
+        });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/rejected/RejectedPathProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/rejected/RejectedPathProcessor.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.grpc.Status;
 import io.reactivex.rxjava3.core.Completable;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -66,12 +67,26 @@ public class RejectedPathProcessor implements Processor {
             ctx.response().status(HttpStatusCode.BAD_REQUEST_400);
 
             final String message = environment.getProperty("http.errors[400].message", DEFAULT_MESSAGE);
-            ctx.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()));
+
+            // A gRPC caller reads the status from the trailers, not from the HTTP code: without
+            // these it sees UNKNOWN and has no idea why it was refused. Same treatment as an
+            // unmatched context path, which is the closest thing this rejection resembles.
+            final MediaType mediaType = MediaType.parseMediaType(ctx.request().headers().get(HttpHeaderNames.CONTENT_TYPE));
+            if (MediaType.MEDIA_APPLICATION_GRPC.equals(mediaType)) {
+                ctx.response().headers().set("grpc-status", String.valueOf(Status.INVALID_ARGUMENT.getCode().value()));
+                ctx.response().headers().set("grpc-message", message);
+            }
+
+            final Buffer body = Buffer.buffer(message);
+            // Counted on the encoded body, not on the string: a localised http.errors[400].message
+            // holding any non-ASCII character has more bytes than it has characters, and a short
+            // Content-Length truncates the response.
+            ctx.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(body.length()));
             ctx
                 .response()
                 .headers()
                 .set(HttpHeaderNames.CONTENT_TYPE, environment.getProperty("http.errors[400].contentType", MediaType.TEXT_PLAIN));
-            ctx.response().body(Buffer.buffer(message));
+            ctx.response().body(body);
             return ctx.response().end(ctx);
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -255,6 +255,7 @@ public class ReactorConfiguration {
         ReporterService reporterService,
         @Value("${handlers.notfound.analytics.enabled:false}") boolean notFoundAnalyticsEnabled,
         @Deprecated @Value("${handlers.notfound.log.enabled:false}") boolean notFoundLogEnabled,
+        @Value("${handlers.rejected.analytics.enabled:true}") boolean rejectedAnalyticsEnabled,
         GatewayConfiguration gatewayConfiguration
     ) {
         return new NotFoundProcessorChainFactory(
@@ -262,6 +263,7 @@ public class ReactorConfiguration {
             environment,
             reporterService,
             notFoundAnalyticsEnabled || notFoundLogEnabled,
+            rejectedAnalyticsEnabled,
             gatewayConfiguration
         );
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -25,6 +25,7 @@ import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.core.connection.ConnectionDrainManager;
@@ -164,6 +165,7 @@ public class ReactorConfiguration {
         NotFoundProcessorChainFactory notFoundProcessorChainFactory,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         TracingContext tracingContext,
         @Value("${reporters.warnings.enabled:true}") boolean warningsEnabled
@@ -180,6 +182,7 @@ public class ReactorConfiguration {
             tracingContext,
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            requestPathConfiguration,
             vertx,
             warningsEnabled
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -41,6 +41,8 @@ import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.processor.provider.ProcessorProviderChain;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
@@ -219,6 +221,7 @@ class DefaultHttpRequestDispatcherTest {
             tracingContext,
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            new RequestPathConfiguration(RequestPathHandling.RAW),
             vertx,
             true
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +50,7 @@ import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.http.vertx.ClientCloseClassifier;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathRejection;
 import io.gravitee.gateway.reactive.reactor.processor.DefaultPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
@@ -81,10 +83,17 @@ import io.vertx.rxjava3.core.http.HttpServerResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -240,6 +249,88 @@ class DefaultHttpRequestDispatcherTest {
         lenient().when(httpServerConnection.channel()).thenReturn(channel);
         lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
         lenient().when(attribute.get()).thenReturn(System.currentTimeMillis());
+    }
+
+    /**
+     * Which paths the dispatcher refuses, checked against an oracle rather than against itself.
+     *
+     * <p>{@code dispatch} decides inline whether a path is refused, inside the single scan it
+     * already pays for. {@link RequestPathRejection#applies} states the same rule a second time,
+     * written independently and living in the test tree because nothing in production calls it.
+     * This drives the <b>dispatcher</b> over a table of modes and paths and asserts it refused
+     * exactly what the oracle announces.
+     *
+     * <p>The independence is the whole point. An oracle derived from the production code — asserting
+     * the predicate against the normalizer it is built from, as an earlier version of this did —
+     * passes whatever the dispatcher does. This table is what caught {@code OPTIONS *} and the null
+     * target being refused when they should be dispatched.
+     */
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class The_rejection_decision {
+
+        /**
+         * One table, walked by both readings. Every path that is refused under some mode, and a few
+         * that never are, so a predicate stuck on {@code true} fails too.
+         */
+        static Stream<Arguments> modesAndPaths() {
+            final String[] paths = {
+                "/alpha/api/echo",
+                "/alpha/api/../../beta/api/echo",
+                "/alpha/api/%2e%2e/%2e%2e/beta",
+                "/alpha/api/..;/..;/beta",
+                "/alpha/api/%zz",
+                "/alpha/api/%+41",
+                "/alpha//api/echo",
+                "/",
+                // Request targets that are not origin-form paths. They must be dispatched, not
+                // refused, whatever the mode: OPTIONS * is legal and a null target is what an
+                // HTTP/2 stream without a :path pseudo-header produces.
+                "*",
+                null,
+            };
+            return Stream.of(RequestPathHandling.values()).flatMap(mode -> Stream.of(paths).map(path -> Arguments.of(mode, path)));
+        }
+
+        @ParameterizedTest(name = "{0} on {1}")
+        @MethodSource("modesAndPaths")
+        void should_be_the_one_the_predicate_announces(RequestPathHandling mode, String path) {
+            // Given a dispatcher in that mode, and nothing to route to — the acceptor is irrelevant
+            // here, since the decision under test is taken before it is consulted.
+            final RequestPathConfiguration configuration = new RequestPathConfiguration(mode);
+            when(rxRequest.path()).thenReturn(path);
+            lenient().when(httpAcceptorResolver.resolve(any(), any(), any())).thenReturn(null);
+            lenient().when(notFoundProcessorChainFactory.processorChain()).thenReturn(new ProcessorChain("not-found", List.of()));
+            lenient()
+                .when(notFoundProcessorChainFactory.rejectedPathProcessorChain())
+                .thenReturn(new ProcessorChain("rejected", List.of()));
+
+            // When the request is dispatched.
+            dispatcherWith(configuration).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS);
+
+            // Then the rejected chain was reached exactly when the predicate said it would be.
+            final boolean predicted = RequestPathRejection.applies(configuration, path);
+            verify(notFoundProcessorChainFactory, times(predicted ? 1 : 0)).rejectedPathProcessorChain();
+        }
+
+        private DefaultHttpRequestDispatcher dispatcherWith(final RequestPathConfiguration configuration) {
+            return new DefaultHttpRequestDispatcher(
+                gatewayConfiguration,
+                httpAcceptorResolver,
+                idGenerator,
+                globalComponentProvider,
+                new RequestProcessorChainFactory(),
+                responseProcessorChainFactory,
+                platformProcessorChainFactory,
+                notFoundProcessorChainFactory,
+                tracingContext,
+                requestTimeoutConfiguration,
+                requestClientAuthConfiguration,
+                configuration,
+                vertx,
+                true
+            );
+        }
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +50,7 @@ import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.http.vertx.ClientCloseClassifier;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathRejection;
 import io.gravitee.gateway.reactive.reactor.processor.DefaultPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
@@ -81,10 +83,17 @@ import io.vertx.rxjava3.core.http.HttpServerResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -240,6 +249,84 @@ class DefaultHttpRequestDispatcherTest {
         lenient().when(httpServerConnection.channel()).thenReturn(channel);
         lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
         lenient().when(attribute.get()).thenReturn(System.currentTimeMillis());
+    }
+
+    /**
+     * The drift guard between the two readings of one rule.
+     *
+     * <p>{@code dispatch} decides inline whether a path is refused, because it reuses the single
+     * scan it already pays for and allocates nothing. {@link RequestPathRejection#applies} states
+     * the same rule again for callers that need the answer before dispatching — the debug
+     * dispatcher. Two implementations of one rule drift the moment one is touched alone, and the
+     * drift here fails open: a caller believes a request will be routed when it will not, or the
+     * reverse.
+     *
+     * <p>What makes this a guard rather than a restatement is that it drives the <b>dispatcher</b>
+     * and compares what it did against what the predicate said it would do. Asserting the predicate
+     * against the normalizer it is built from, which is what this class used to do, passes by
+     * construction.
+     */
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class The_rejection_decision {
+
+        /**
+         * One table, walked by both readings. Every path that is refused under some mode, and a few
+         * that never are, so a predicate stuck on {@code true} fails too.
+         */
+        static Stream<Arguments> modesAndPaths() {
+            final String[] paths = {
+                "/alpha/api/echo",
+                "/alpha/api/../../beta/api/echo",
+                "/alpha/api/%2e%2e/%2e%2e/beta",
+                "/alpha/api/..;/..;/beta",
+                "/alpha/api/%zz",
+                "/alpha/api/%+41",
+                "/alpha//api/echo",
+                "/",
+            };
+            return Stream.of(RequestPathHandling.values()).flatMap(mode -> Stream.of(paths).map(path -> Arguments.of(mode, path)));
+        }
+
+        @ParameterizedTest(name = "{0} on {1}")
+        @MethodSource("modesAndPaths")
+        void should_be_the_one_the_predicate_announces(RequestPathHandling mode, String path) {
+            // Given a dispatcher in that mode, and nothing to route to — the acceptor is irrelevant
+            // here, since the decision under test is taken before it is consulted.
+            final RequestPathConfiguration configuration = new RequestPathConfiguration(mode);
+            when(rxRequest.path()).thenReturn(path);
+            lenient().when(httpAcceptorResolver.resolve(any(), any(), any())).thenReturn(null);
+            lenient().when(notFoundProcessorChainFactory.processorChain()).thenReturn(new ProcessorChain("not-found", List.of()));
+            lenient()
+                .when(notFoundProcessorChainFactory.rejectedPathProcessorChain())
+                .thenReturn(new ProcessorChain("rejected", List.of()));
+
+            // When the request is dispatched.
+            dispatcherWith(configuration).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS);
+
+            // Then the rejected chain was reached exactly when the predicate said it would be.
+            final boolean predicted = RequestPathRejection.applies(configuration, path);
+            verify(notFoundProcessorChainFactory, times(predicted ? 1 : 0)).rejectedPathProcessorChain();
+        }
+
+        private DefaultHttpRequestDispatcher dispatcherWith(final RequestPathConfiguration configuration) {
+            return new DefaultHttpRequestDispatcher(
+                gatewayConfiguration,
+                httpAcceptorResolver,
+                idGenerator,
+                globalComponentProvider,
+                new RequestProcessorChainFactory(),
+                responseProcessorChainFactory,
+                platformProcessorChainFactory,
+                notFoundProcessorChainFactory,
+                tracingContext,
+                requestTimeoutConfiguration,
+                requestClientAuthConfiguration,
+                configuration,
+                vertx,
+                true
+            );
+        }
     }
 
     @Nested

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerPropertyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerPropertyTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Holds {@link RequestPathNormalizer#needsNormalization(String)} and
+ * {@link RequestPathNormalizer#normalize(String)} to the same rules.
+ *
+ * <p>The two answer the same question by different means: one decides in a single scan, the other
+ * by rewriting. That is the point — the scan is what makes {@code REJECT} cheap and gives
+ * {@code NORMALIZE} its fast path — and it is also the risk, because two implementations of one
+ * rule drift as soon as one is touched alone. The drift would be silent and would fail open: a scan
+ * that wrongly answers "nothing to do" leaves a path unnormalized and routed on as received.
+ *
+ * <p>So the agreement is asserted rather than reviewed, over paths assembled from a vocabulary of
+ * segment kinds rather than from a hand-written list, which is what makes the coverage broader than
+ * anyone's imagination of the edge cases. The seed is fixed, so a failure is reproducible and names
+ * the exact path.
+ *
+ * <p>No property-testing library is used: none is available in this repository, and pulling one in
+ * for a single invariant is not worth the dependency. What is lost is shrinking — a failing case is
+ * reported as generated rather than reduced — which these paths are short enough to survive.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RequestPathNormalizerPropertyTest {
+
+    private static final long SEED = 20260814L;
+    private static final int GENERATED_PATHS = 20_000;
+    private static final int MAX_SEGMENTS = 6;
+
+    /**
+     * Every kind of segment worth combining, including the ones that must <em>not</em> trigger a
+     * normalization — an ordinary segment carrying a dot, and a reserved character left encoded.
+     */
+    private static final String[] SEGMENT_KINDS = {
+        "orders",
+        "12345.json",
+        "a.b.c",
+        ".hidden",
+        "..config",
+        ".",
+        "..",
+        "%2e",
+        "%2E",
+        "%2e%2e",
+        ".%2e",
+        "%41",
+        "%7e",
+        "%2d",
+        "%2F",
+        "%3F",
+        "%23",
+        "a%20b",
+        "%zz",
+        "%2",
+        "%",
+        "",
+    };
+
+    @Test
+    void should_agree_with_normalize_on_every_generated_path() {
+        final List<String> disagreements = new ArrayList<>();
+        int needing = 0;
+        int canonical = 0;
+
+        for (final String path : generatePaths()) {
+            final String normalized = RequestPathNormalizer.normalize(path);
+            final boolean wouldChange = normalized == null || !normalized.equals(path);
+
+            if (wouldChange) {
+                needing++;
+            } else {
+                canonical++;
+            }
+            if (RequestPathNormalizer.needsNormalization(path) != wouldChange) {
+                disagreements.add(path + "  -> normalize=" + normalized + ", needsNormalization=" + !wouldChange);
+            }
+        }
+
+        assertThat(disagreements).as("needsNormalization(p) must equal !p.equals(normalize(p)) for every path").isEmpty();
+
+        // A corpus that landed on one side only would make the assertion above pass without ever
+        // exercising it. Both branches have to be walked for the property to mean anything.
+        assertThat(needing).as("paths needing normalization in the corpus").isGreaterThan(1_000);
+        assertThat(canonical).as("already canonical paths in the corpus").isGreaterThan(1_000);
+    }
+
+    /**
+     * The generated corpus is broad but blind; these are the shapes the decision was written for,
+     * named one by one so a regression on them is reported as itself rather than counted.
+     */
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "/",
+            "/v1/orders/list",
+            "/v1/orders/12345.json",
+            "/a/b%2Fc",
+            "/alpha/api/../../beta/api/echo",
+            "/alpha/api/%2e%2e/%2e%2e/beta/api/echo",
+            "/a//b",
+            "/a/./b",
+            "/a/b/..",
+            "/../../x",
+            "/a%",
+            "/a%zz",
+            "relative/path",
+            "",
+        }
+    )
+    void should_agree_with_normalize_on_the_paths_that_matter_most(final String path) {
+        final String normalized = RequestPathNormalizer.normalize(path);
+        final boolean wouldChange = normalized == null || !normalized.equals(path);
+
+        assertThat(RequestPathNormalizer.needsNormalization(path)).as("normalized [%s]", normalized).isEqualTo(wouldChange);
+    }
+
+    /**
+     * Stated separately from the equivalence, because this is the reason the scan exists: these are
+     * the paths a gateway sees all day, and they must cost one pass and nothing more.
+     */
+    @ParameterizedTest
+    @ValueSource(
+        strings = { "/v1/orders/list", "/v1/orders/12345.json", "/a/b%2Fc", "/api/v2/customers/8f3a/orders/2026/08/13/items/447/details" }
+    )
+    void should_leave_the_ordinary_shapes_alone(final String path) {
+        assertThat(RequestPathNormalizer.needsNormalization(path)).isFalse();
+    }
+
+    private static List<String> generatePaths() {
+        final Random random = new Random(SEED);
+        final List<String> paths = new ArrayList<>(GENERATED_PATHS);
+
+        for (int i = 0; i < GENERATED_PATHS; i++) {
+            final StringBuilder path = new StringBuilder();
+            // One path in ten has no leading slash, which is a case of its own.
+            if (random.nextInt(10) != 0) {
+                path.append('/');
+            }
+            final int segments = 1 + random.nextInt(MAX_SEGMENTS);
+            for (int s = 0; s < segments; s++) {
+                if (s > 0) {
+                    path.append('/');
+                }
+                path.append(SEGMENT_KINDS[random.nextInt(SEGMENT_KINDS.length)]);
+            }
+            // One path in five ends on a separator.
+            if (random.nextInt(5) == 0) {
+                path.append('/');
+            }
+            paths.add(path.toString());
+        }
+        return paths;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerPropertyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerPropertyTest.java
@@ -81,6 +81,21 @@ class RequestPathNormalizerPropertyTest {
         "%2",
         "%",
         "",
+        // The shapes the threat model names. They were absent while the vocabulary was written from
+        // what the implementation handles rather than from what an attacker sends, which is why the
+        // %+41 disagreement between the two hex readings survived 20 000 generated paths.
+        "%252e",
+        "%c0%ae",
+        "%00",
+        "%5c",
+        "%+41",
+        "%-41",
+        "..;",
+        ".;",
+        "..;jsessionid=1",
+        "orders;v=2",
+        "..%2f",
+        "%٢e",
     };
 
     @Test
@@ -109,6 +124,24 @@ class RequestPathNormalizerPropertyTest {
         // exercising it. Both branches have to be walked for the property to mean anything.
         assertThat(needing).as("paths needing normalization in the corpus").isGreaterThan(1_000);
         assertThat(canonical).as("already canonical paths in the corpus").isGreaterThan(1_000);
+    }
+
+    @Test
+    void should_produce_a_path_that_never_needs_normalizing_again() {
+        // The agreement property alone is not enough, and this is the gap it leaves: a normalize
+        // that left a ".." segment behind would satisfy it perfectly, as long as the scan agreed
+        // that the result still needed work. That is the same fail-open shape the property exists to
+        // prevent, so the output has to be asserted canonical in its own right.
+        final List<String> notFixedPoints = new ArrayList<>();
+
+        for (final String path : generatePaths()) {
+            final String normalized = RequestPathNormalizer.normalize(path);
+            if (normalized != null && RequestPathNormalizer.needsNormalization(normalized)) {
+                notFixedPoints.add(path + "  -> " + normalized + ", which still needs normalizing");
+            }
+        }
+
+        assertThat(notFixedPoints).as("normalize must be idempotent: its output is already canonical").isEmpty();
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
@@ -119,6 +119,71 @@ class RequestPathNormalizerTest {
     }
 
     @Nested
+    class Dot_segments_carrying_path_parameters {
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/..;/..;/beta/api/secret, /beta/api/secret",
+                "/alpha/..;jsessionid=1/beta, /beta",
+                "/alpha/.;/beta, /alpha/beta",
+                "/alpha/..;/..;/beta, /beta",
+            }
+        )
+        void should_resolve_them_the_way_a_servlet_container_will(String path, String expected) {
+            // Given a receiver that strips ;params before resolving — Tomcat, Jetty, Spring.
+            // When the gateway normalizes.
+            // Then it lands on the same resource the receiver would, rather than authorizing one
+            // and letting the other be served. This is the escalation, in one line.
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @Test
+        void should_flag_them_so_that_reject_refuses_them_too() {
+            assertThat(RequestPathNormalizer.needsNormalization("/alpha/api/..;/..;/beta/api/secret")).isTrue();
+        }
+
+        @Test
+        void should_never_emit_the_shape_it_refuses_to_resolve() {
+            // The dangerous one: %2e%2e; decodes to ..; and, before the strip, normalize produced a
+            // traversal a servlet receiver resolves from an input that contained none literally.
+            final String normalized = RequestPathNormalizer.normalize("/alpha/%2e%2e;/beta");
+
+            assertThat(normalized).isEqualTo("/beta").doesNotContain("..");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/orders;v=2", "/a/report.csv;charset=utf8", "/a/..b;x/c", "/a/b..;x/c" })
+        void should_leave_ordinary_segments_alone(String path) {
+            // Only a segment that is entirely dots before the ';' is a dot segment. Anything else
+            // keeps its parameters, or REJECT would start refusing perfectly well formed traffic.
+            assertThat(RequestPathNormalizer.normalize(path)).isSameAs(path);
+        }
+    }
+
+    @Nested
+    class Reading_percent_sequences {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/a%+41b", "/a%-41b", "/a%4+1b" })
+        void should_refuse_a_sign_wherever_a_hexadecimal_digit_is_expected(String path) {
+            // Integer.parseInt accepts a leading sign, Character.digit does not. While the two
+            // implementations each had their own reading, %+41 was flagged by one and ignored by
+            // the other — the single disagreement a brute force over the input space could find.
+            assertThat(RequestPathNormalizer.normalize(path)).isNull();
+            assertThat(RequestPathNormalizer.needsNormalization(path)).isTrue();
+        }
+
+        @Test
+        void should_refuse_a_non_ascii_digit_rather_than_reading_it_as_a_number() {
+            // Character.digit is Unicode-aware: it reads the Arabic-Indic '٢' as 2, which turned
+            // %٢e%٢e into a dot segment the gateway resolved and no receiver ever would — routing
+            // to an API the raw path never named.
+            assertThat(RequestPathNormalizer.normalize("/alpha/%٢e%٢e/beta")).isNull();
+        }
+    }
+
+    @Nested
     class Beyond_the_specification {
 
         @ParameterizedTest

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RequestPathNormalizerTest {
+
+    @Nested
+    class Resolving_dot_segments {
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/../../beta/api/echo, /beta/api/echo",
+                "/alpha/api/../beta, /alpha/beta",
+                "/a/./b, /a/b",
+                "/a/b/./, /a/b/",
+                "/./a, /a",
+            }
+        )
+        void should_resolve_plain_dot_segments(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/%2e%2e/%2e%2e/beta/api/echo, /beta/api/echo",
+                "/alpha/api/%2E%2E/%2E%2E/beta/api/echo, /beta/api/echo",
+                "/alpha/api/.%2e/%2e./beta/api/echo, /beta/api/echo",
+                "/a/%2e/b, /a/b",
+            }
+        )
+        void should_resolve_percent_encoded_dot_segments(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/a/../b/../c, /c",
+                "/alpha/api/../../beta/api/../../gamma/api/echo, /gamma/api/echo",
+                "/a/%2e%2e/b/../c, /c",
+                "/a/b/../../c/d/../e, /c/e",
+            }
+        )
+        void should_resolve_a_chain_of_dot_segments(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @Test
+        void should_leave_a_directory_behind_when_the_path_ends_on_a_dot_segment() {
+            assertThat(RequestPathNormalizer.normalize("/a/b/..")).isEqualTo("/a/");
+        }
+
+        @Test
+        void should_discard_the_steps_that_would_climb_above_the_root() {
+            // RFC 3986 §5.2.4 drops them rather than failing.
+            assertThat(RequestPathNormalizer.normalize("/../../x")).isEqualTo("/x");
+        }
+    }
+
+    @Nested
+    class Decoding_percent_encoding {
+
+        @ParameterizedTest
+        @CsvSource({ "/a/%41%42, /a/AB", "/a/%7Etilde, /a/~tilde", "/a/%2Ddash, /a/-dash", "/a/%30%39, /a/09" })
+        void should_decode_unreserved_characters(String path, String expected) {
+            // RFC 3986 §6.2.2.2 makes them equivalent to their plain form. It is the same rule
+            // that turns %2e into a dot, so it cannot be applied to the dot alone.
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/a/b%2Fc", "/a/b%3Fc", "/a/b%23c", "/a/b%3Bc" })
+        void should_leave_reserved_characters_encoded(String path) {
+            // This is what keeps %2F from becoming a separator, and object keys intact.
+            assertThat(RequestPathNormalizer.normalize(path)).isSameAs(path);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/a%", "/a%2", "/a%zz", "/a/%2e%2", "/a/%g0" })
+        void should_answer_null_on_a_malformed_percent_sequence(String path) {
+            // No normalized form exists, so the caller has nothing to decide on and rejects.
+            assertThat(RequestPathNormalizer.normalize(path)).isNull();
+        }
+
+        @Test
+        void should_not_resolve_a_double_encoded_dot_segment() {
+            // %252e decodes to %2e, not to a dot: one pass only, by design.
+            assertThat(RequestPathNormalizer.normalize("/a/b%252e%252e/c")).isSameAs("/a/b%252e%252e/c");
+        }
+    }
+
+    @Nested
+    class Beyond_the_specification {
+
+        @ParameterizedTest
+        @CsvSource({ "/a//b, /a/b", "/a///b, /a/b", "//a/b, /a/b" })
+        void should_merge_duplicate_slashes(String path, String expected) {
+            // Not in RFC 3986. Inherited from Vert.x and kept so the gateway agrees with the
+            // rest of the stack, nginx included.
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource({ "relative/path, /relative/path", "a, /a" })
+        void should_force_a_leading_slash(String path, String expected) {
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class Leaving_the_rest_untouched {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/alpha/api/echo", "/file.txt", "/a/b.c/d", "/v1/orders/12345.json", "/" })
+        void should_return_the_very_same_instance_when_there_is_nothing_to_resolve(String path) {
+            assertThat(RequestPathNormalizer.normalize(path)).isSameAs(path);
+        }
+
+        @Test
+        void should_tolerate_a_null_path() {
+            assertThat(RequestPathNormalizer.normalize(null)).isNull();
+        }
+
+        @Test
+        void should_answer_the_root_for_an_empty_path() {
+            assertThat(RequestPathNormalizer.normalize("")).isEqualTo("/");
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathNormalizerTest.java
@@ -119,6 +119,101 @@ class RequestPathNormalizerTest {
     }
 
     @Nested
+    class Request_targets_that_are_not_paths {
+
+        @Test
+        void should_leave_the_asterisk_form_alone() {
+            // OPTIONS * is legal (RFC 9110 §7.1) and is what proxies and health probes send. Run
+            // through the general scan it would be answered 400 under REJECT — a legal request
+            // refused — and rewritten to "/*" under NORMALIZE, then routed to whatever sits on the
+            // root context path.
+            assertThat(RequestPathNormalizer.needsNormalization("*")).isFalse();
+            assertThat(RequestPathNormalizer.normalize("*")).isEqualTo("*");
+        }
+
+        @Test
+        void should_leave_a_null_target_alone() {
+            // path() is nullable in the Vert.x API, and an HTTP/2 stream with no :path pseudo-header
+            // produces exactly that. Such a request reached the acceptor before this class existed.
+            assertThat(RequestPathNormalizer.needsNormalization(null)).isFalse();
+            assertThat(RequestPathNormalizer.normalize(null)).isNull();
+        }
+
+        @Test
+        void should_still_force_a_leading_slash_on_an_ordinary_relative_path() {
+            // The exemption above is for the two forms that are not paths, not for anything that
+            // merely fails to start with a slash.
+            assertThat(RequestPathNormalizer.needsNormalization("relative/path")).isTrue();
+            assertThat(RequestPathNormalizer.normalize("relative/path")).isEqualTo("/relative/path");
+        }
+    }
+
+    @Nested
+    class Dot_segments_carrying_path_parameters {
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "/alpha/api/..;/..;/beta/api/secret, /beta/api/secret",
+                "/alpha/..;jsessionid=1/beta, /beta",
+                "/alpha/.;/beta, /alpha/beta",
+                "/alpha/..;/..;/beta, /beta",
+            }
+        )
+        void should_resolve_them_the_way_a_servlet_container_will(String path, String expected) {
+            // Given a receiver that strips ;params before resolving — Tomcat, Jetty, Spring.
+            // When the gateway normalizes.
+            // Then it lands on the same resource the receiver would, rather than authorizing one
+            // and letting the other be served. This is the escalation, in one line.
+            assertThat(RequestPathNormalizer.normalize(path)).isEqualTo(expected);
+        }
+
+        @Test
+        void should_flag_them_so_that_reject_refuses_them_too() {
+            assertThat(RequestPathNormalizer.needsNormalization("/alpha/api/..;/..;/beta/api/secret")).isTrue();
+        }
+
+        @Test
+        void should_never_emit_the_shape_it_refuses_to_resolve() {
+            // The dangerous one: %2e%2e; decodes to ..; and, before the strip, normalize produced a
+            // traversal a servlet receiver resolves from an input that contained none literally.
+            final String normalized = RequestPathNormalizer.normalize("/alpha/%2e%2e;/beta");
+
+            assertThat(normalized).isEqualTo("/beta").doesNotContain("..");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/orders;v=2", "/a/report.csv;charset=utf8", "/a/..b;x/c", "/a/b..;x/c" })
+        void should_leave_ordinary_segments_alone(String path) {
+            // Only a segment that is entirely dots before the ';' is a dot segment. Anything else
+            // keeps its parameters, or REJECT would start refusing perfectly well formed traffic.
+            assertThat(RequestPathNormalizer.normalize(path)).isSameAs(path);
+        }
+    }
+
+    @Nested
+    class Reading_percent_sequences {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "/a%+41b", "/a%-41b", "/a%4+1b" })
+        void should_refuse_a_sign_wherever_a_hexadecimal_digit_is_expected(String path) {
+            // Integer.parseInt accepts a leading sign, Character.digit does not. While the two
+            // implementations each had their own reading, %+41 was flagged by one and ignored by
+            // the other — the single disagreement a brute force over the input space could find.
+            assertThat(RequestPathNormalizer.normalize(path)).isNull();
+            assertThat(RequestPathNormalizer.needsNormalization(path)).isTrue();
+        }
+
+        @Test
+        void should_refuse_a_non_ascii_digit_rather_than_reading_it_as_a_number() {
+            // Character.digit is Unicode-aware: it reads the Arabic-Indic '٢' as 2, which turned
+            // %٢e%٢e into a dot segment the gateway resolved and no receiver ever would — routing
+            // to an API the raw path never named.
+            assertThat(RequestPathNormalizer.normalize("/alpha/%٢e%٢e/beta")).isNull();
+        }
+    }
+
+    @Nested
     class Beyond_the_specification {
 
         @ParameterizedTest

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejection.java
@@ -19,10 +19,9 @@ import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestPathHandling;
 
 /**
- * Answers whether the gateway will refuse to route on a path, for a caller that needs to know it
- * before the request is dispatched.
+ * States, for the tests alone, which paths the gateway refuses to route on.
  *
- * <p>There are two ways a request is refused, and only stating both keeps a caller correct:
+ * <p>Two ways a request is refused, and only stating both makes the oracle correct:
  *
  * <ul>
  *   <li>{@link RequestPathHandling#REJECT} meeting a path that is not already in its normalized
@@ -32,13 +31,20 @@ import io.gravitee.gateway.env.RequestPathHandling;
  *       cannot know which octets the client meant, so there is nothing to decide on.
  * </ul>
  *
- * <p><b>Why this exists next to the dispatcher rather than inside it.</b> {@code
- * DefaultHttpRequestDispatcher.dispatch} runs on every request the gateway serves, and deliberately
- * inlines this decision so it can reuse the single scan it already pays for and allocate nothing.
- * Calling this method there would scan the path a second time. The duplication is intentional and
- * bounded, and it is pinned by {@code RequestPathRejectionTest}, which walks the same table of modes
- * and paths the dispatcher tests use — two readings of one rule drift silently, and this one would
- * drift open.
+ * <p><b>This is a test oracle, not production code, and it lives here for that reason.</b> The rule
+ * is written once in production, inlined in {@code DefaultHttpRequestDispatcher.dispatch} so that it
+ * reuses the single scan that method already pays for and allocates nothing. This class restates the
+ * same rule independently, and {@code DefaultHttpRequestDispatcherTest.The_rejection_decision} drives
+ * the <b>dispatcher</b> over a table of modes and paths, asserting it refused exactly what is
+ * announced here.
+ *
+ * <p>Two independent readings compared against each other is what gives that test its value. One
+ * restating the other would pass whatever the dispatcher did — which is what an earlier version of
+ * this guard actually did, by asserting this class against the normalizer it is built from.
+ *
+ * <p>It was briefly production code, called by the debug dispatcher to predict a rejection before
+ * delegating. That dispatcher now hooks into the rejection instead of predicting it, so no caller
+ * remains. Promote it back the day one appears — with the caller, not in anticipation.
  *
  * @author GraviteeSource Team
  */

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejectionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejectionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The predicate exists so a caller can know, before dispatching, that the gateway will answer 400.
+ * It restates a decision {@code DefaultHttpRequestDispatcher.dispatch} makes inline for speed, and
+ * this class is what keeps the two readings from drifting apart — a drift that would fail open, by
+ * letting a caller believe a request will be routed when it will not.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RequestPathRejectionTest {
+
+    private static final String CANONICAL = "/alpha/api/echo";
+    private static final String WITH_DOT_SEGMENTS = "/alpha/api/../../beta/api/echo";
+    private static final String WITH_ENCODED_DOT_SEGMENTS = "/alpha/api/%2e%2e/%2e%2e/beta/api/echo";
+    private static final String MALFORMED_PERCENT = "/alpha/api/%zz";
+
+    private static RequestPathConfiguration configured(final RequestPathHandling handling) {
+        return new RequestPathConfiguration(handling);
+    }
+
+    @Nested
+    class Under_raw {
+
+        @ParameterizedTest
+        @ValueSource(strings = { CANONICAL, WITH_DOT_SEGMENTS, WITH_ENCODED_DOT_SEGMENTS, MALFORMED_PERCENT })
+        void should_never_reject_since_the_gateway_decides_nothing_about_the_path(final String path) {
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.RAW), path)).isFalse();
+        }
+    }
+
+    @Nested
+    class Under_reject {
+
+        @ParameterizedTest
+        @ValueSource(strings = { WITH_DOT_SEGMENTS, WITH_ENCODED_DOT_SEGMENTS, MALFORMED_PERCENT })
+        void should_reject_a_path_that_is_not_already_in_its_normalized_form(final String path) {
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.REJECT), path)).isTrue();
+        }
+
+        @Test
+        void should_let_a_canonical_path_through() {
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.REJECT), CANONICAL)).isFalse();
+        }
+    }
+
+    @Nested
+    class Under_normalize {
+
+        @ParameterizedTest
+        @ValueSource(strings = { CANONICAL, WITH_DOT_SEGMENTS, WITH_ENCODED_DOT_SEGMENTS })
+        void should_let_through_anything_that_has_a_normalized_form(final String path) {
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.NORMALIZE), path)).isFalse();
+        }
+
+        @Test
+        void should_still_reject_a_path_that_has_no_normalized_form_at_all() {
+            // The one case a caller reading only the mode would miss: there is nothing to resolve,
+            // so NORMALIZE has no more to offer than REJECT and the request is refused either way.
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.NORMALIZE), MALFORMED_PERCENT)).isTrue();
+        }
+    }
+
+    @Nested
+    class Against_the_normalizer {
+
+        @ParameterizedTest
+        @ValueSource(strings = { CANONICAL, WITH_DOT_SEGMENTS, WITH_ENCODED_DOT_SEGMENTS, MALFORMED_PERCENT })
+        void should_agree_with_what_normalization_can_produce(final String path) {
+            // Restating the rule from the other side: a rejection under NORMALIZE happens if and
+            // only if the normalizer cannot produce a path. If someone changes one and not the
+            // other, this is what fails.
+            boolean rejected = RequestPathRejection.applies(configured(RequestPathHandling.NORMALIZE), path);
+            boolean hasNoNormalizedForm = RequestPathNormalizer.needsNormalization(path) && RequestPathNormalizer.normalize(path) == null;
+
+            assertThat(rejected).isEqualTo(hasNoNormalizedForm);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejectionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/RequestPathRejectionTest.java
@@ -89,18 +89,22 @@ class RequestPathRejectionTest {
     }
 
     @Nested
-    class Against_the_normalizer {
+    class Dot_segments_carrying_path_parameters {
 
-        @ParameterizedTest
-        @ValueSource(strings = { CANONICAL, WITH_DOT_SEGMENTS, WITH_ENCODED_DOT_SEGMENTS, MALFORMED_PERCENT })
-        void should_agree_with_what_normalization_can_produce(final String path) {
-            // Restating the rule from the other side: a rejection under NORMALIZE happens if and
-            // only if the normalizer cannot produce a path. If someone changes one and not the
-            // other, this is what fails.
-            boolean rejected = RequestPathRejection.applies(configured(RequestPathHandling.NORMALIZE), path);
-            boolean hasNoNormalizedForm = RequestPathNormalizer.needsNormalization(path) && RequestPathNormalizer.normalize(path) == null;
+        @Test
+        void should_be_refused_like_any_other_dot_segment() {
+            // A servlet container strips the ;params before resolving, so this is a traversal to
+            // every receiver that matters — and REJECT exists to refuse traversals.
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.REJECT), "/alpha/api/..;/..;/beta")).isTrue();
+        }
 
-            assertThat(rejected).isEqualTo(hasNoNormalizedForm);
+        @Test
+        void should_be_resolvable_rather_than_refused_under_normalize() {
+            assertThat(RequestPathRejection.applies(configured(RequestPathHandling.NORMALIZE), "/alpha/api/..;/..;/beta")).isFalse();
         }
     }
 }
+// The drift this predicate exists to prevent — between it and the copy inlined in
+// DefaultHttpRequestDispatcher.dispatch — is guarded by DefaultHttpRequestDispatcherTest, which
+// drives the dispatcher itself. Asserting the predicate against RequestPathNormalizer here would
+// only restate the predicate's own body.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.path.benchmark;
+
+import io.gravitee.gateway.env.RequestPathHandling;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathNormalizer;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * What each value of {@code http.pathHandling} costs per request.
+ *
+ * <p>The measured method mirrors the decision {@code DefaultHttpRequestDispatcher} takes on every
+ * request, before the acceptor is resolved: under {@code RAW} the path is handed over untouched,
+ * under {@code REJECT} it is normalized and compared, under {@code NORMALIZE} the normalized value
+ * is the one carried forward. Everything after that decision — acceptor resolution, plans, flows —
+ * is identical in all three and is deliberately out of the measurement.
+ *
+ * <p>Each mode is crossed with the shapes of path a gateway actually receives, because the cost is
+ * driven by the shape far more than by the mode: an ordinary path exits on the first scan, only a
+ * path carrying dot segments pays for the resolution.
+ *
+ * @author GraviteeSource Team
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+public class RequestPathHandlingBenchmark {
+
+    private static final Map<String, String> PATHS = Map.of(
+        "ordinary",
+        "/v1/orders/list",
+        "ordinary_deep",
+        "/api/v2/customers/8f3a/orders/2026/08/13/items/447/details",
+        "ordinary_with_dot",
+        "/v1/orders/12345.json",
+        "dot_segments",
+        "/alpha/api/../../beta/api/echo",
+        "encoded_dot_segments",
+        "/alpha/api/%2e%2e/%2e%2e/beta/api/echo"
+    );
+
+    @Param({ "RAW", "REJECT", "NORMALIZE" })
+    public String mode;
+
+    @Param({ "ordinary", "ordinary_deep", "ordinary_with_dot", "dot_segments", "encoded_dot_segments" })
+    public String shape;
+
+    private RequestPathHandling handling;
+    private String rawPath;
+
+    // Run directly from the IDE.
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(RequestPathHandlingBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        handling = RequestPathHandling.valueOf(mode);
+        rawPath = PATHS.get(shape);
+    }
+
+    /**
+     * @return the path the dispatcher carries forward, or {@code null} when the request is rejected.
+     */
+    @Benchmark
+    public String path_handling_decision() {
+        if (handling == RequestPathHandling.RAW) {
+            return rawPath;
+        }
+        final String normalized = RequestPathNormalizer.normalize(rawPath);
+        if (normalized != rawPath && handling == RequestPathHandling.REJECT) {
+            return null;
+        }
+        return normalized;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingBenchmark.java
@@ -68,6 +68,8 @@ public class RequestPathHandlingBenchmark {
         "/v1/orders/list",
         "ordinary_deep",
         "/api/v2/customers/8f3a/orders/2026/08/13/items/447/details",
+        "ordinary_uuids",
+        "/v1/customers/3f2504e0-4f89-11d3-9a0c-0305e82c3301/orders/7c9e6679-7425-40de-944b-e07fc1f90ae7/items/0f8fad5b-d9cb-469f-a165-70867728950e",
         "ordinary_with_dot",
         "/v1/orders/12345.json",
         "ordinary_encoded",
@@ -81,7 +83,9 @@ public class RequestPathHandlingBenchmark {
     @Param({ "RAW", "REJECT", "NORMALIZE" })
     public String mode;
 
-    @Param({ "ordinary", "ordinary_deep", "ordinary_with_dot", "ordinary_encoded", "dot_segments", "encoded_dot_segments" })
+    @Param(
+        { "ordinary", "ordinary_deep", "ordinary_uuids", "ordinary_with_dot", "ordinary_encoded", "dot_segments", "encoded_dot_segments" }
+    )
     public String shape;
 
     private RequestPathHandling handling;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingCorpusBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/path/benchmark/RequestPathHandlingCorpusBenchmark.java
@@ -17,7 +17,7 @@ package io.gravitee.gateway.reactive.reactor.path.benchmark;
 
 import io.gravitee.gateway.env.RequestPathHandling;
 import io.gravitee.gateway.reactive.reactor.path.RequestPathNormalizer;
-import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -36,22 +36,14 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
- * What each value of {@code http.pathHandling} costs per request, by shape of path.
+ * What {@code http.pathHandling} costs on a traffic profile rather than on a single path.
  *
- * <p>The measured method mirrors the decision {@code DefaultHttpRequestDispatcher} takes on every
- * request, before the acceptor is resolved: under {@code RAW} the path is handed over untouched,
- * under {@code REJECT} it is normalized and compared, under {@code NORMALIZE} the normalized value
- * is the one carried forward. Everything after that decision — acceptor resolution, plans, flows —
- * is identical in all three and is deliberately out of the measurement.
+ * <p>A benchmark that hands the same string over and over lets the branch predictor learn it and
+ * reports a number no production gateway will ever see. This one cycles a thousand distinct paths,
+ * mixed at 95% ordinary and 5% carrying dot segments, which is generous towards the attack: real
+ * traffic carrying five percent of traversals would be an incident in itself.
  *
- * <p>{@code RAW} is the baseline: it never calls the normalizer, so its numbers are the cost of the
- * feature switched off, and the floor of this harness.
- *
- * <p>Throughput, in operations per second, is what translates into capacity for an operator, and it
- * is the only figure reported: for a deterministic single-threaded call, average time is its
- * inverse and measuring both would double the run for nothing. A single constant string per shape
- * is easy on the branch predictor, which is why {@link RequestPathHandlingCorpusBenchmark} exists
- * next to this one.
+ * <p>This is the figure to quote when someone asks what the setting costs.
  *
  * @author GraviteeSource Team
  */
@@ -61,42 +53,52 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Fork(value = 2)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-public class RequestPathHandlingBenchmark {
+public class RequestPathHandlingCorpusBenchmark {
 
-    private static final Map<String, String> PATHS = Map.of(
-        "ordinary",
-        "/v1/orders/list",
-        "ordinary_deep",
-        "/api/v2/customers/8f3a/orders/2026/08/13/items/447/details",
-        "ordinary_with_dot",
-        "/v1/orders/12345.json",
-        "ordinary_encoded",
-        "/v1/orders/a%20b/details",
-        "dot_segments",
-        "/alpha/api/../../beta/api/echo",
-        "encoded_dot_segments",
-        "/alpha/api/%2e%2e/%2e%2e/beta/api/echo"
-    );
+    private static final int CORPUS_SIZE = 1_000;
+    private static final int TRAVERSAL_PERCENTAGE = 5;
+    private static final long SEED = 20260814L;
 
     @Param({ "RAW", "REJECT", "NORMALIZE" })
     public String mode;
 
-    @Param({ "ordinary", "ordinary_deep", "ordinary_with_dot", "ordinary_encoded", "dot_segments", "encoded_dot_segments" })
-    public String shape;
-
     private RequestPathHandling handling;
-    private String rawPath;
+    private String[] corpus;
+    private int cursor;
 
     // Run directly from the IDE.
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(RequestPathHandlingBenchmark.class.getSimpleName()).build();
+        Options opt = new OptionsBuilder().include(RequestPathHandlingCorpusBenchmark.class.getSimpleName()).build();
         new Runner(opt).run();
     }
 
     @Setup
     public void setup() {
         handling = RequestPathHandling.valueOf(mode);
-        rawPath = PATHS.get(shape);
+        corpus = buildCorpus();
+        cursor = 0;
+    }
+
+    /**
+     * Fixed seed: the corpus is the same on every run, so two runs remain comparable.
+     */
+    private String[] buildCorpus() {
+        final Random random = new Random(SEED);
+        final String[] paths = new String[CORPUS_SIZE];
+
+        for (int i = 0; i < CORPUS_SIZE; i++) {
+            final String customer = Integer.toHexString(random.nextInt(0xFFFF));
+            final int order = random.nextInt(100_000);
+
+            if (random.nextInt(100) < TRAVERSAL_PERCENTAGE) {
+                paths[i] = random.nextBoolean()
+                    ? "/v1/customers/" + customer + "/../../../admin/orders/" + order
+                    : "/v1/customers/" + customer + "/%2e%2e/%2e%2e/admin/orders/" + order;
+            } else {
+                paths[i] = "/v1/customers/" + customer + "/orders/" + order + "/details";
+            }
+        }
+        return paths;
     }
 
     /**
@@ -104,6 +106,16 @@ public class RequestPathHandlingBenchmark {
      */
     @Benchmark
     public String path_handling_decision() {
+        // Wrapped by hand rather than with a modulo: RAW runs at over a billion operations a
+        // second, so a monotonic counter overflows int within a single iteration and the modulo of
+        // a negative is negative.
+        int next = cursor + 1;
+        if (next == CORPUS_SIZE) {
+            next = 0;
+        }
+        cursor = next;
+        final String rawPath = corpus[next];
+
         if (handling == RequestPathHandling.RAW) {
             return rawPath;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactoryTest.java
@@ -97,6 +97,7 @@ class NotFoundProcessorChainFactoryTest {
             new StandardEnvironment(),
             reporterService,
             false,
+            true,
             gatewayConfiguration
         );
         List<Processor> processors = notFoundProcessorChainFactory.buildProcessorChain();
@@ -120,6 +121,7 @@ class NotFoundProcessorChainFactoryTest {
             transactionPreProcessorFactory,
             new StandardEnvironment(),
             reporterService,
+            true,
             true,
             gatewayConfiguration
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -56,6 +56,7 @@ import io.gravitee.gateway.reactive.debug.DebugReactorEventListener;
 import io.gravitee.gateway.reactive.debug.handlers.api.v4.DebugV4ApiReactorHandlerFactory;
 import io.gravitee.gateway.reactive.debug.policy.condition.DebugExpressionLanguageConditionFilter;
 import io.gravitee.gateway.reactive.debug.reactor.DebugHttpRequestDispatcher;
+import io.gravitee.gateway.reactive.debug.reactor.processor.DebugCompletionProcessor;
 import io.gravitee.gateway.reactive.debug.reactor.processor.DebugPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.handlers.api.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.reactive.handlers.api.processor.ApiProcessorChainFactory;
@@ -323,6 +324,7 @@ public class DebugConfiguration {
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
         RequestPathConfiguration requestPathConfiguration,
+        DebugCompletionProcessor debugCompletionProcessor,
         Vertx vertx,
         @Value("${reporters.warnings.enabled:true}") boolean warningsEnabled
     ) {
@@ -338,6 +340,7 @@ public class DebugConfiguration {
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
             requestPathConfiguration,
+            debugCompletionProcessor,
             vertx,
             warningsEnabled
         );
@@ -348,6 +351,16 @@ public class DebugConfiguration {
         @Qualifier("debugReactorHandlerRegistry") ReactorHandlerRegistry debugReactorHandlerRegistry
     ) {
         return new DefaultHttpAcceptorResolver(debugReactorHandlerRegistry);
+    }
+
+    /**
+     * The same processor the platform post-chain builds, exposed on its own so the dispatcher can
+     * run it directly on a request that was refused before any reactor could handle it. It holds no
+     * state, so the two instances are interchangeable.
+     */
+    @Bean
+    public DebugCompletionProcessor debugCompletionProcessor(EventRepository eventRepository, ObjectMapper objectMapper) {
+        return new DebugCompletionProcessor(eventRepository, objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -34,6 +34,7 @@ import io.gravitee.gateway.debug.vertx.VertxDebugService;
 import io.gravitee.gateway.dictionary.DictionaryManager;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.flow.FlowPolicyResolverFactory;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
@@ -321,6 +322,7 @@ public class DebugConfiguration {
         NotFoundProcessorChainFactory notFoundProcessorChainFactory,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         @Value("${reporters.warnings.enabled:true}") boolean warningsEnabled
     ) {
@@ -335,6 +337,7 @@ public class DebugConfiguration {
             notFoundProcessorChainFactory,
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            requestPathConfiguration,
             vertx,
             warningsEnabled
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.api.Invoker;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.debug.core.invoker.InvokerDebugDecorator;
 import io.gravitee.gateway.debug.definition.DebugApiV2;
+import io.gravitee.gateway.debug.definition.ReactableDebugApi;
 import io.gravitee.gateway.debug.reactor.handler.http.ContextualizedDebugHttpServerRequest;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
 import io.gravitee.gateway.handlers.api.ApiReactorHandler;
@@ -45,6 +46,19 @@ public class DebugApiReactorHandler extends ApiReactorHandler {
         TracingContext tracingContext
     ) {
         super(configuration, api, accessPointManager, eventManager, httpAcceptorFactory, tracingContext);
+    }
+
+    /**
+     * The debug session this handler was deployed for.
+     *
+     * <p>Exposed because a caller holding only the {@code ReactorHandler} has no other way to reach
+     * it: {@code reactable} is protected and the interface declares no accessor. The dispatcher
+     * needs it to close the session of a request it refused before any reactor could run — and an
+     * API in V3 execution mode is served by this class rather than by an {@code ApiReactor}, so
+     * matching on that interface alone silently leaves this engine out.
+     */
+    public ReactableDebugApi<?> debugApi() {
+        return (ReactableDebugApi<?>) reactable;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
@@ -43,15 +43,24 @@ public class DebugExecutionContext implements MutableExecutionContext {
     private final Map<String, Serializable> initialAttributes;
     private final InvokerResponse invokerResponse = new InvokerResponse();
     private final HttpHeaders initialHeaders;
+    private final String initialPath;
 
     public DebugExecutionContext(ExecutionContext context) {
         this.context = (MutableExecutionContext) context;
         this.initialAttributes = AttributeHelper.filterAndSerializeAttributes(context.getAttributes());
         this.initialHeaders = HttpHeaders.create(request().headers());
+        // Read here rather than at completion, like the attributes and headers above: this is the
+        // state the policies are about to see. Reading it once they have run would report a path a
+        // policy rewrote as if the gateway had produced it.
+        this.initialPath = request().pathInfo();
     }
 
     public Map<String, Serializable> getInitialAttributes() {
         return initialAttributes;
+    }
+
+    public String getInitialPath() {
+        return initialPath;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
@@ -134,6 +134,7 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         final PreprocessorStep preprocessorStep = new PreprocessorStep();
         preprocessorStep.setAttributes(debugContext.getInitialAttributes());
         preprocessorStep.setHeaders(convertHeaders(debugContext.getInitialHeaders()));
+        preprocessorStep.setPath(debugContext.getInitialPath());
         return preprocessorStep;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxHttpServerRequestDebugDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxHttpServerRequestDebugDecorator.java
@@ -18,13 +18,26 @@ package io.gravitee.gateway.debug.vertx;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.http.vertx.VertxHttpServerRequest;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 
 public class VertxHttpServerRequestDebugDecorator extends VertxHttpServerRequest {
 
     private final VertxHttpServerRequest delegate;
 
+    /**
+     * Rebuilds itself from the native request, so anything the dispatcher decided about the delegate
+     * has to be carried across explicitly — otherwise this decorator silently reverts it.
+     *
+     * <p>That is not hypothetical: the path is resolved before the listener is chosen, and until the
+     * options below were passed on, a debug session running in V3 execution mode reported the path
+     * as received while the request it described had been routed on the resolved one.
+     */
     public VertxHttpServerRequestDebugDecorator(VertxHttpServerRequest delegate, IdGenerator idGenerator) {
-        super(delegate.getNativeServerRequest(), idGenerator);
+        super(
+            delegate.getNativeServerRequest(),
+            idGenerator,
+            VertxHttpServerRequestOptions.builder().path(delegate.path()).timestamp(delegate.timestamp()).build()
+        );
         this.delegate = delegate;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
@@ -136,9 +136,6 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
         // names the session to close. The raw path still matches: the acceptor compares prefixes and
         // the debug context path the daemon prepends sits ahead of whatever the user typed.
         final ReactableDebugApi<?> debugApi = resolveDebugApi(httpServerRequest, serverId);
-        if (debugApi != null) {
-            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, debugApi);
-        }
 
         final ProcessorChain rejectedChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
         final Completable reject = rejectedChain.execute(ctx, ExecutionPhase.RESPONSE);
@@ -148,7 +145,21 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
             log.warn("Rejected debug request on path {} could not be matched to a debug API", httpServerRequest.path());
             return reject;
         }
-        return reject.andThen(Completable.defer(() -> debugCompletionProcessor.execute((HttpExecutionContextInternal) ctx)));
+
+        // doFinally rather than andThen, and for one reason: the session must be closed on failure
+        // and on cancellation too. Ending the response throws when the client has already gone, and
+        // the debug verticle disposes this chain when the connection closes — either would otherwise
+        // leave the event in DEBUGGING and the console spinning, which is the dead end this exists
+        // to close.
+        return reject.doFinally(() -> {
+            // Set here rather than before the rejected chain: two of its processors read this same
+            // attribute to decide whether to report, and finding it set would make them follow the
+            // API's own analytics configuration instead of handlers.rejected.analytics.enabled.
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, debugApi);
+            debugCompletionProcessor
+                .execute((HttpExecutionContextInternal) ctx)
+                .subscribe(() -> {}, throwable -> log.error("Failed to close the debug session for a rejected path", throwable));
+        });
     }
 
     private ReactableDebugApi<?> resolveDebugApi(final HttpServerRequest httpServerRequest, final String serverId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.debug.reactor;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.debug.vertx.VertxHttpServerRequestDebugDecorator;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
 import io.gravitee.gateway.env.RequestPathConfiguration;
@@ -86,9 +87,9 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
     protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
         final HttpServerRequest httpServerRequest,
         final IdGenerator idGenerator,
-        final String path
+        final VertxHttpServerRequestOptions options
     ) {
-        io.gravitee.gateway.http.vertx.VertxHttpServerRequest v3Request = super.createV3Request(httpServerRequest, idGenerator, path);
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest v3Request = super.createV3Request(httpServerRequest, idGenerator, options);
         return new VertxHttpServerRequestDebugDecorator(v3Request, idGenerator);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.debug.reactor;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.debug.definition.ReactableDebugApi;
+import io.gravitee.gateway.debug.handlers.api.DebugApiReactorHandler;
 import io.gravitee.gateway.debug.vertx.VertxHttpServerRequestDebugDecorator;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
@@ -38,7 +39,6 @@ import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactive.reactor.DefaultHttpRequestDispatcher;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
-import io.gravitee.gateway.reactive.reactor.path.RequestPathRejection;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
@@ -121,42 +121,59 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
      * failing to match an acceptor means something is wrong well upstream of this decision.
      */
     @Override
-    public Completable dispatch(final HttpServerRequest httpServerRequest, final String serverId) {
-        if (!RequestPathRejection.applies(requestPathConfiguration, httpServerRequest.path())) {
-            return super.dispatch(httpServerRequest, serverId);
-        }
-        return dispatchRejected(httpServerRequest, serverId, System.currentTimeMillis());
-    }
-
-    private Completable dispatchRejected(final HttpServerRequest httpServerRequest, final String serverId, final long receivedAt) {
-        final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
-        ctx.request().contextPath("/");
-
-        // Resolving here decides nothing about routing — the request is refused either way. It only
-        // names the session to close. The raw path still matches: the acceptor compares prefixes and
-        // the debug context path the daemon prepends sits ahead of whatever the user typed.
-        final ReactableDebugApi<?> debugApi = resolveDebugApi(httpServerRequest, serverId);
-        if (debugApi != null) {
-            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, debugApi);
-        }
-
-        final ProcessorChain rejectedChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
-        final Completable reject = rejectedChain.execute(ctx, ExecutionPhase.RESPONSE);
+    protected Completable afterRejectedPath(final Completable rejection, final MutableExecutionContext ctx) {
+        // Resolving here decides nothing about routing — the request has already been refused. It
+        // only names the session to close. The raw path still matches: the acceptor compares
+        // prefixes and the debug context path the daemon prepends sits ahead of whatever was typed.
+        final ReactableDebugApi<?> debugApi = resolveDebugApi(ctx);
 
         if (debugApi == null) {
             // Nothing identifies the session, so there is nothing to close. Answering is still right.
-            log.warn("Rejected debug request on path {} could not be matched to a debug API", httpServerRequest.path());
-            return reject;
+            ctx.withLogger(log).warn("Rejected debug request on path {} could not be matched to a debug API", ctx.request().path());
+            return rejection;
         }
-        return reject.andThen(Completable.defer(() -> debugCompletionProcessor.execute((HttpExecutionContextInternal) ctx)));
+
+        // doFinally rather than andThen, and for one reason: the session must be closed on failure
+        // and on cancellation too. Ending the response throws when the client has already gone, and
+        // the debug verticle disposes this chain when the connection closes — either would otherwise
+        // leave the event in DEBUGGING and the console spinning, which is the dead end this exists
+        // to close.
+        return rejection.doFinally(() -> {
+            // Set here rather than before the rejected chain: two of its processors read this same
+            // attribute to decide whether to report, and finding it set would make them follow the
+            // API's own analytics configuration instead of handlers.rejected.analytics.enabled.
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, debugApi);
+            debugCompletionProcessor
+                .execute((HttpExecutionContextInternal) ctx)
+                .subscribe(
+                    () -> {},
+                    throwable -> ctx.withLogger(log).error("Failed to close the debug session for a rejected path", throwable)
+                );
+        });
     }
 
-    private ReactableDebugApi<?> resolveDebugApi(final HttpServerRequest httpServerRequest, final String serverId) {
-        final HttpAcceptor acceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), httpServerRequest.path(), serverId);
-        if (acceptor != null && acceptor.reactor() instanceof ApiReactor<?> apiReactor) {
-            return apiReactor.api() instanceof ReactableDebugApi<?> reactableDebugApi ? reactableDebugApi : null;
+    /**
+     * Both engines, deliberately. A v4 definition — and a v2 one under emulation — is deployed
+     * behind an {@link ApiReactor}, but a v2 definition whose execution mode is {@code V3} is served
+     * by a {@link DebugApiReactorHandler}, which is a plain {@code ReactorHandler} and never an
+     * {@code ApiReactor}. Matching the interface alone left that engine with the endless spinner
+     * this class exists to remove, and said so in a warning claiming no debug API had matched —
+     * while the acceptor had matched perfectly well.
+     */
+    private ReactableDebugApi<?> resolveDebugApi(final MutableExecutionContext ctx) {
+        final HttpAcceptor acceptor = httpAcceptorResolver.resolve(
+            ctx.request().host(),
+            ctx.request().path(),
+            ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SERVER_ID)
+        );
+        if (acceptor == null) {
+            return null;
         }
-        return null;
+        return switch (acceptor.reactor()) {
+            case ApiReactor<?> apiReactor when apiReactor.api() instanceof ReactableDebugApi<?> api -> api;
+            case DebugApiReactorHandler handler -> handler.debugApi();
+            case null, default -> null;
+        };
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
@@ -17,33 +17,51 @@ package io.gravitee.gateway.reactive.debug.reactor;
 
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.debug.definition.ReactableDebugApi;
 import io.gravitee.gateway.debug.vertx.VertxHttpServerRequestDebugDecorator;
-import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
 import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.gateway.http.vertx.VertxHttpServerRequestOptions;
 import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.debug.reactor.context.DebugExecutionContext;
+import io.gravitee.gateway.reactive.debug.reactor.processor.DebugCompletionProcessor;
 import io.gravitee.gateway.reactive.debug.reactor.processor.DebugPlatformProcessorChainFactory;
 import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
+import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactive.reactor.DefaultHttpRequestDispatcher;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.path.RequestPathRejection;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
+import io.gravitee.gateway.reactor.handler.HttpAcceptor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
+import io.reactivex.rxjava3.core.Completable;
 import io.vertx.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
+import lombok.CustomLog;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
+
+    private final HttpAcceptorResolver httpAcceptorResolver;
+    private final NotFoundProcessorChainFactory notFoundProcessorChainFactory;
+    private final RequestPathConfiguration requestPathConfiguration;
+    private final DebugCompletionProcessor debugCompletionProcessor;
 
     public DebugHttpRequestDispatcher(
         GatewayConfiguration gatewayConfiguration,
@@ -57,6 +75,7 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
         RequestPathConfiguration requestPathConfiguration,
+        DebugCompletionProcessor debugCompletionProcessor,
         Vertx vertx,
         boolean warningsEnabled
     ) {
@@ -76,6 +95,68 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
             vertx,
             warningsEnabled
         );
+        this.httpAcceptorResolver = httpAcceptorResolver;
+        this.notFoundProcessorChainFactory = notFoundProcessorChainFactory;
+        this.requestPathConfiguration = requestPathConfiguration;
+        this.debugCompletionProcessor = debugCompletionProcessor;
+    }
+
+    /**
+     * Answers a rejected path without abandoning the debug session it belongs to.
+     *
+     * <p>The gateway refuses a path <em>before</em> the acceptor is resolved — that is the point of
+     * the mode, since the routing decision itself is what must not be made on an unresolved path.
+     * The consequence is that the dispatcher never learns the request was a debug one: the platform
+     * post-processor chain is skipped, {@link DebugCompletionProcessor} never runs, and the debug
+     * event is left in {@code DEBUGGING} while the console waits for a result that will never come.
+     * The user sees an endless spinner, with nothing in the logs to explain it.
+     *
+     * <p>This port serves debug traffic and nothing else, so it is the one place where that can be
+     * noticed without weakening the production path. The request is refused exactly as it would be
+     * upstream — the same chain, the same 400 — and the completion processor is then run on the same
+     * context, which reports a session with no policy step and the response the gateway gave.
+     *
+     * <p>Note this holds for the not-found branch too, which has always had the same dead end. It is
+     * left alone deliberately: a debug request carries a context path the daemon built itself, so
+     * failing to match an acceptor means something is wrong well upstream of this decision.
+     */
+    @Override
+    public Completable dispatch(final HttpServerRequest httpServerRequest, final String serverId) {
+        if (!RequestPathRejection.applies(requestPathConfiguration, httpServerRequest.path())) {
+            return super.dispatch(httpServerRequest, serverId);
+        }
+        return dispatchRejected(httpServerRequest, serverId, System.currentTimeMillis());
+    }
+
+    private Completable dispatchRejected(final HttpServerRequest httpServerRequest, final String serverId, final long receivedAt) {
+        final MutableExecutionContext ctx = prepareExecutionContext(httpServerRequest, serverId, null, receivedAt);
+        ctx.request().contextPath("/");
+
+        // Resolving here decides nothing about routing — the request is refused either way. It only
+        // names the session to close. The raw path still matches: the acceptor compares prefixes and
+        // the debug context path the daemon prepends sits ahead of whatever the user typed.
+        final ReactableDebugApi<?> debugApi = resolveDebugApi(httpServerRequest, serverId);
+        if (debugApi != null) {
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, debugApi);
+        }
+
+        final ProcessorChain rejectedChain = notFoundProcessorChainFactory.rejectedPathProcessorChain();
+        final Completable reject = rejectedChain.execute(ctx, ExecutionPhase.RESPONSE);
+
+        if (debugApi == null) {
+            // Nothing identifies the session, so there is nothing to close. Answering is still right.
+            log.warn("Rejected debug request on path {} could not be matched to a debug API", httpServerRequest.path());
+            return reject;
+        }
+        return reject.andThen(Completable.defer(() -> debugCompletionProcessor.execute((HttpExecutionContextInternal) ctx)));
+    }
+
+    private ReactableDebugApi<?> resolveDebugApi(final HttpServerRequest httpServerRequest, final String serverId) {
+        final HttpAcceptor acceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), httpServerRequest.path(), serverId);
+        if (acceptor != null && acceptor.reactor() instanceof ApiReactor<?> apiReactor) {
+            return apiReactor.api() instanceof ReactableDebugApi<?> reactableDebugApi ? reactableDebugApi : null;
+        }
+        return null;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcher.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.debug.vertx.VertxHttpServerRequestDebugDecorator;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
@@ -54,6 +55,7 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
         NotFoundProcessorChainFactory notFoundProcessorChainFactory,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
         RequestClientAuthConfiguration requestClientAuthConfiguration,
+        RequestPathConfiguration requestPathConfiguration,
         Vertx vertx,
         boolean warningsEnabled
     ) {
@@ -69,6 +71,7 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
             TracingContext.noop(),
             requestTimeoutConfiguration,
             requestClientAuthConfiguration,
+            requestPathConfiguration,
             vertx,
             warningsEnabled
         );
@@ -82,9 +85,10 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
     @Override
     protected io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(
         final HttpServerRequest httpServerRequest,
-        final IdGenerator idGenerator
+        final IdGenerator idGenerator,
+        final String path
     ) {
-        io.gravitee.gateway.http.vertx.VertxHttpServerRequest v3Request = super.createV3Request(httpServerRequest, idGenerator);
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest v3Request = super.createV3Request(httpServerRequest, idGenerator, path);
         return new VertxHttpServerRequestDebugDecorator(v3Request, idGenerator);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/context/DebugExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/context/DebugExecutionContext.java
@@ -45,11 +45,27 @@ public class DebugExecutionContext extends DefaultExecutionContext {
     private final Map<String, Serializable> initialAttributes;
     private final InvokerResponse invokerResponse = new InvokerResponse();
     private final HttpHeaders initialHeaders;
+    private String initialPath;
 
     public DebugExecutionContext(final MutableRequest request, final MutableResponse response) {
         super(request, response);
         this.initialAttributes = AttributeHelper.filterAndSerializeAttributes(getAttributes());
         this.initialHeaders = HttpHeaders.create(request().headers());
+    }
+
+    /**
+     * Records the path the policies are about to run on.
+     *
+     * <p>Unlike the attributes and headers above, this cannot be read at construction: {@code
+     * pathInfo} is derived from the context path, and the dispatcher only assigns that once the
+     * acceptor has matched — which happens after this context exists. It must equally not be read at
+     * completion, since by then a policy may have rewritten the path, and reporting that value here
+     * would credit the gateway with a change a policy made.
+     *
+     * <p>Called from {@code DebugInitProcessor}, which sits between the two.
+     */
+    public void captureInitialPath() {
+        this.initialPath = request().pathInfo();
     }
 
     public Completable prePolicyExecution(final String id, final ExecutionPhase executionPhase) {
@@ -116,6 +132,10 @@ public class DebugExecutionContext extends DefaultExecutionContext {
 
     public HttpHeaders getInitialHeaders() {
         return initialHeaders;
+    }
+
+    public String getInitialPath() {
+        return initialPath;
     }
 
     public PolicyStep<?> getCurrentDebugStep() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
@@ -145,6 +145,7 @@ public class DebugCompletionProcessor implements Processor {
         final PreprocessorStep preprocessorStep = new PreprocessorStep();
         preprocessorStep.setAttributes(debugContext.getInitialAttributes());
         preprocessorStep.setHeaders(debugContext.getInitialHeaders().toListValuesMap());
+        preprocessorStep.setPath(debugContext.getInitialPath());
         return preprocessorStep;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugCompletionProcessor.java
@@ -27,6 +27,7 @@ import io.gravitee.gateway.debug.definition.DebugApiV4;
 import io.gravitee.gateway.debug.definition.ReactableDebugApi;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.debug.policy.steps.PolicyStep;
@@ -121,14 +122,20 @@ public class DebugCompletionProcessor implements Processor {
     }
 
     private ReactableDebugApi<?> getDebugApi(HttpExecutionContextInternal ctx) {
-        ReactableDebugApi<?> debugApi;
-        try {
-            debugApi = (ReactableDebugApi<?>) ctx.getComponent(Api.class);
-        } catch (NoSuchBeanDefinitionException e) {
-            debugApi = (ReactableDebugApi<?>) ctx.getComponent(io.gravitee.gateway.reactive.handlers.api.v4.Api.class);
+        // The API-scoped component provider is only installed once a reactor starts handling the
+        // request. A request refused on its path never gets that far, so the context still carries
+        // the global provider — which has no Api bean at all — and the dispatcher's own attribute is
+        // the only place the API can be read from.
+        final Object reactableApi = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API);
+        if (reactableApi instanceof ReactableDebugApi<?> debugApi) {
+            return debugApi;
         }
 
-        return debugApi;
+        try {
+            return (ReactableDebugApi<?>) ctx.getComponent(Api.class);
+        } catch (NoSuchBeanDefinitionException e) {
+            return (ReactableDebugApi<?>) ctx.getComponent(io.gravitee.gateway.reactive.handlers.api.v4.Api.class);
+        }
     }
 
     private DebugMetrics createMetrics(Metrics metrics) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugInitProcessor.java
@@ -19,6 +19,7 @@ import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.gateway.reactive.debug.reactor.context.DebugExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
 import lombok.CustomLog;
 
@@ -45,6 +46,12 @@ public class DebugInitProcessor implements Processor {
             ctx.withLogger(log).debug("Original URL: {}", originalUrl);
 
             ctx.setAttribute(ContextAttributes.ATTR_REQUEST_ORIGINAL_URL, originalUrl);
+
+            // The acceptor has matched by now, so the path the policies will run on is finally
+            // readable — and none of them has run yet. This is the only window where both hold.
+            if (ctx instanceof DebugExecutionContext debugContext) {
+                debugContext.captureInitialPath();
+            }
         });
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessorTest.java
@@ -166,6 +166,44 @@ class DebugEventCompletionProcessorTest {
         assertThat(updatedEvent.getPayload()).isEqualTo("PAYLOAD_CONTENT");
     }
 
+    /**
+     * The console spreads the preprocessor step over the request submitted in the form, so this is
+     * the only channel through which it can learn that the gateway resolved the path before the
+     * policies ran. Without it the timeline shows a request that never reached a single policy.
+     */
+    @Test
+    void should_report_the_path_the_policies_ran_on_in_the_preprocessor_step() throws TechnicalException, JsonProcessingException {
+        // Given a request whose path the gateway resolved before the API was selected.
+        when(debugApi.getEventId()).thenReturn("event-id");
+        when(debugExecutionContext.getComponent(io.gravitee.gateway.handlers.api.definition.Api.class)).thenReturn(debugApi);
+        when(debugExecutionContext.request()).thenReturn(request);
+        when(debugExecutionContext.getDebugSteps()).thenReturn(List.of());
+        // Built before the stubbing below: these helpers create mocks of their own, and Mockito
+        // cannot open a stubbing while another one is still being defined.
+        VertxHttpServerResponseDebugDecorator debugResponse = getDebugResponse();
+        InvokerResponse invokerResponse = getInvokerResponse();
+        when(debugExecutionContext.response()).thenReturn(debugResponse);
+        when(debugExecutionContext.getInvokerResponse()).thenReturn(invokerResponse);
+        when(debugExecutionContext.getInitialPath()).thenReturn("/b");
+
+        Event event = new Event();
+        event.setId("event-id");
+        event.setProperties(new HashMap<>());
+        event.setType(EventType.DEBUG_API);
+        when(eventRepository.findById("event-id")).thenReturn(Optional.of(event));
+        when(objectMapper.writeValueAsString(any())).thenReturn("PAYLOAD_CONTENT");
+
+        // When the debug session completes.
+        cut.handle(debugExecutionContext);
+
+        // Then the payload handed to the console carries the executed path.
+        ArgumentCaptor<io.gravitee.definition.model.debug.DebugApiV2> captor = ArgumentCaptor.forClass(
+            io.gravitee.definition.model.debug.DebugApiV2.class
+        );
+        verify(objectMapper).writeValueAsString(captor.capture());
+        assertThat(captor.getValue().getPreprocessorStep().getPath()).isEqualTo("/b");
+    }
+
     @ParameterizedTest
     @EnumSource(ResponseType.class)
     void shouldSetEventInErrorWhenEventUpdateThrows(ResponseType responseType) throws TechnicalException, JsonProcessingException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.debug.reactor;
+
+import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API;
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.IdGenerator;
+import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.debug.definition.ReactableDebugApi;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.env.RequestClientAuthConfiguration;
+import io.gravitee.gateway.env.RequestPathConfiguration;
+import io.gravitee.gateway.env.RequestPathHandling;
+import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
+import io.gravitee.gateway.reactive.debug.reactor.context.DebugExecutionContext;
+import io.gravitee.gateway.reactive.debug.reactor.processor.DebugCompletionProcessor;
+import io.gravitee.gateway.reactive.debug.reactor.processor.DebugPlatformProcessorChainFactory;
+import io.gravitee.gateway.reactive.reactor.ApiReactor;
+import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
+import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
+import io.gravitee.gateway.reactor.handler.HttpAcceptor;
+import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
+import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
+import io.netty.channel.Channel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.HttpServerConnection;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.http.HttpConnection;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.core.http.HttpServerResponse;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * What happens to a debug session whose path the gateway refuses to route on.
+ *
+ * <p>The refusal is decided before the acceptor is resolved, so nothing downstream ever learns the
+ * request was a debug one. Left alone, the debug event stays in {@code DEBUGGING} and the console
+ * waits forever. What is pinned here is that the dispatcher answers the request <em>and</em> closes
+ * the session, and that it does not interfere when there is nothing to refuse.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DebugHttpRequestDispatcherTest {
+
+    private static final String HOST = "gravitee.io";
+    private static final String CANONICAL_PATH = "/event-id-proxyv4/b";
+    private static final String PATH_WITH_DOT_SEGMENTS = "/event-id-proxyv4/a/../b";
+    private static final String SERVER_ID = null;
+
+    @Spy
+    private final Vertx vertx = Vertx.vertx();
+
+    @Mock
+    private HttpServerRequest rxRequest;
+
+    @Mock
+    private HttpServerResponse rxResponse;
+
+    @Mock
+    private io.vertx.core.http.HttpServerRequest request;
+
+    @Mock
+    private io.vertx.core.http.HttpServerResponse response;
+
+    @Mock
+    private HttpAcceptorResolver httpAcceptorResolver;
+
+    @Mock
+    private NotFoundProcessorChainFactory notFoundProcessorChainFactory;
+
+    @Mock
+    private DebugPlatformProcessorChainFactory platformProcessorChainFactory;
+
+    @Mock
+    private DebugCompletionProcessor debugCompletionProcessor;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private IdGenerator idGenerator;
+
+    @Mock
+    private ComponentProvider globalComponentProvider;
+
+    @Mock
+    private ResponseProcessorChainFactory responseProcessorChainFactory;
+
+    @Mock
+    private RequestTimeoutConfiguration requestTimeoutConfiguration;
+
+    @Mock
+    private RequestClientAuthConfiguration requestClientAuthConfiguration;
+
+    @Mock
+    private ReactableDebugApi<?> debugApi;
+
+    @BeforeEach
+    void init() {
+        lenient().when(rxRequest.host()).thenReturn(HOST);
+        lenient().when(rxRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        lenient().when(rxRequest.method()).thenReturn(HttpMethod.GET);
+        lenient().when(rxRequest.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxRequest.toFlowable()).thenReturn(Flowable.empty());
+        lenient().when(rxRequest.response()).thenReturn(rxResponse);
+        lenient().when(rxRequest.getDelegate()).thenReturn(request);
+
+        lenient().when(request.host()).thenReturn(HOST);
+        lenient().when(request.method()).thenReturn(HttpMethod.GET);
+        lenient().when(request.headers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(request.response()).thenReturn(response);
+
+        lenient().when(rxResponse.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxResponse.trailers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxResponse.getDelegate()).thenReturn(response);
+
+        lenient().when(response.headers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(response.trailers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(response.end()).thenReturn(Future.succeededFuture());
+
+        lenient().when(requestTimeoutConfiguration.getRequestTimeout()).thenReturn(0L);
+        lenient().when(requestTimeoutConfiguration.getRequestTimeoutGraceDelay()).thenReturn(10L);
+        lenient().when(notFoundProcessorChainFactory.rejectedPathProcessorChain()).thenReturn(new ProcessorChain("rejected", List.of()));
+        lenient().when(notFoundProcessorChainFactory.processorChain()).thenReturn(new ProcessorChain("not-found", List.of()));
+        lenient().when(platformProcessorChainFactory.preProcessorChain()).thenReturn(new ProcessorChain("pre", List.of()));
+        lenient().when(platformProcessorChainFactory.postProcessorChain()).thenReturn(new ProcessorChain("post", List.of()));
+        lenient().when(debugCompletionProcessor.execute(any())).thenReturn(Completable.complete());
+
+        mockConnectionCreationTimestamp();
+    }
+
+    private void mockConnectionCreationTimestamp() {
+        HttpConnection httpConnection = mock(HttpConnection.class);
+        HttpServerConnection httpServerConnection = mock(HttpServerConnection.class);
+        Channel channel = mock(Channel.class);
+        Attribute attribute = mock(Attribute.class);
+
+        lenient().when(rxRequest.connection()).thenReturn(httpConnection);
+        lenient().when(httpConnection.getDelegate()).thenReturn(httpServerConnection);
+        lenient().when(httpServerConnection.channel()).thenReturn(channel);
+        lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
+        lenient().when(attribute.get()).thenReturn(System.currentTimeMillis());
+    }
+
+    private DebugHttpRequestDispatcher dispatcher(final RequestPathHandling handling) {
+        return new DebugHttpRequestDispatcher(
+            gatewayConfiguration,
+            httpAcceptorResolver,
+            idGenerator,
+            globalComponentProvider,
+            new RequestProcessorChainFactory(),
+            responseProcessorChainFactory,
+            platformProcessorChainFactory,
+            notFoundProcessorChainFactory,
+            requestTimeoutConfiguration,
+            requestClientAuthConfiguration,
+            new RequestPathConfiguration(handling),
+            debugCompletionProcessor,
+            vertx,
+            true
+        );
+    }
+
+    private void resolveDebugApi() {
+        ApiReactor<?> apiReactor = mock(ApiReactor.class);
+        HttpAcceptor acceptor = mock(HttpAcceptor.class);
+        lenient()
+            .when(apiReactor.api())
+            .thenAnswer(invocation -> debugApi);
+        lenient().when(acceptor.reactor()).thenReturn(apiReactor);
+        lenient().when(httpAcceptorResolver.resolve(HOST, PATH_WITH_DOT_SEGMENTS, SERVER_ID)).thenReturn(acceptor);
+    }
+
+    @Nested
+    class When_the_path_is_refused {
+
+        @Test
+        void should_close_the_debug_session_instead_of_leaving_the_console_waiting() {
+            // Given a debug request the gateway will refuse to route on.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            resolveDebugApi();
+
+            // When it is dispatched on the debug port.
+            dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            // Then the session is completed rather than abandoned mid-flight.
+            verify(debugCompletionProcessor).execute(any());
+        }
+
+        @Test
+        void should_hand_the_completion_the_api_it_could_not_otherwise_find() {
+            // Given the same request. The API-scoped component provider is never installed, because
+            // no reactor ever handles the request, so the attribute is the only channel left.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            resolveDebugApi();
+
+            // When it is dispatched.
+            dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            // Then the context carries the debug API, and it is a debug context so the completion
+            // processor can read the steps — empty here, since no policy ran.
+            ArgumentCaptor<HttpExecutionContextInternal> captor = ArgumentCaptor.forClass(HttpExecutionContextInternal.class);
+            verify(debugCompletionProcessor).execute(captor.capture());
+
+            assertThat(captor.getValue()).isInstanceOf(DebugExecutionContext.class);
+            assertThat((Object) captor.getValue().getInternalAttribute(ATTR_INTERNAL_REACTABLE_API)).isSameAs(debugApi);
+        }
+
+        @Test
+        void should_still_answer_when_no_debug_api_matches_the_path() {
+            // Given a refused path that matches no acceptor: there is no session to close, but the
+            // request must still be answered rather than hang.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            when(httpAcceptorResolver.resolve(HOST, PATH_WITH_DOT_SEGMENTS, SERVER_ID)).thenReturn(null);
+
+            dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            verify(debugCompletionProcessor, never()).execute(any());
+        }
+    }
+
+    @Nested
+    class When_there_is_nothing_to_refuse {
+
+        @Test
+        void should_not_interfere_with_a_canonical_path() {
+            // Given a path that needs no resolution, under the strictest mode.
+            when(rxRequest.path()).thenReturn(CANONICAL_PATH);
+            when(httpAcceptorResolver.resolve(HOST, CANONICAL_PATH, SERVER_ID)).thenReturn(null);
+
+            // When it is dispatched, the ordinary flow runs — here it finds no acceptor, which is
+            // the not-found branch and none of this class's business.
+            dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS);
+
+            // Then the rejection path was never taken.
+            verify(debugCompletionProcessor, never()).execute(any());
+            verify(notFoundProcessorChainFactory, never()).rejectedPathProcessorChain();
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
@@ -17,16 +17,20 @@ package io.gravitee.gateway.reactive.debug.reactor;
 
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API;
 import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+import static io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.debug.definition.DebugApiV2;
 import io.gravitee.gateway.debug.definition.ReactableDebugApi;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
@@ -41,9 +45,16 @@ import io.gravitee.gateway.reactive.debug.reactor.processor.DebugPlatformProcess
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
+import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
+import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.api.EventRepository;
+import io.gravitee.repository.management.model.ApiDebugStatus;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
 import io.netty.channel.Channel;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
@@ -58,7 +69,9 @@ import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.core.http.HttpConnection;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -70,6 +83,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.StandardEnvironment;
 
 /**
  * What happens to a debug session whose path the gateway refuses to route on.
@@ -89,6 +103,7 @@ class DebugHttpRequestDispatcherTest {
     private static final String CANONICAL_PATH = "/event-id-proxyv4/b";
     private static final String PATH_WITH_DOT_SEGMENTS = "/event-id-proxyv4/a/../b";
     private static final String SERVER_ID = null;
+    private static final String EVENT_ID = "event-id";
 
     @Spy
     private final Vertx vertx = Vertx.vertx();
@@ -137,6 +152,15 @@ class DebugHttpRequestDispatcherTest {
 
     @Mock
     private ReactableDebugApi<?> debugApi;
+
+    @Mock
+    private ReporterService reporterService;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private Node node;
 
     @BeforeEach
     void init() {
@@ -259,6 +283,93 @@ class DebugHttpRequestDispatcherTest {
             dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
 
             verify(debugCompletionProcessor, never()).execute(any());
+        }
+    }
+
+    /**
+     * The wiring tests above replace the rejected chain with an empty one and the completion
+     * processor with a mock, so they pin that the dispatcher calls the right things. They would pass
+     * unchanged if the response never carried a 400, or if the debug event were never moved out of
+     * {@code DEBUGGING} — which is the entire behaviour this class exists to deliver. This runs the
+     * real chain and the real processor, and asks the two questions a user would.
+     */
+    @Nested
+    class End_to_end_on_the_debug_port {
+
+        @Test
+        void should_answer_400_and_move_the_event_out_of_debugging() throws Exception {
+            // Given a real rejected chain and a real completion processor over a stored debug event.
+            // A real debug API rather than a mock: the completion processor converts the definition
+            // into the payload, so a hollow stub only proves that the failure branch is reachable.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            resolveRealDebugApi();
+
+            final Event stored = new Event();
+            stored.setId(EVENT_ID);
+            stored.setProperties(new HashMap<>());
+            stored.setType(EventType.DEBUG_API);
+            when(eventRepository.findById(EVENT_ID)).thenReturn(Optional.of(stored));
+
+            // The real chain logs contextually, which resolves a Node through the component provider,
+            // and actually writes the body — neither is needed while the chain is stubbed empty.
+            lenient().when(globalComponentProvider.getComponent(Node.class)).thenReturn(node);
+            lenient().when(rxResponse.rxSend(any(Flowable.class))).thenReturn(Completable.complete());
+
+            final DebugHttpRequestDispatcher dispatcher = dispatcherWithRealChain();
+
+            // When a path the gateway refuses to route on arrives on the debug port.
+            dispatcher.dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            // Then the caller got a 400...
+            verify(rxResponse).setStatusCode(400);
+
+            // ...and the session was closed, so the console stops waiting.
+            final ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            verify(eventRepository, timeout(5_000)).update(captor.capture());
+            assertThat(captor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.SUCCESS.name());
+        }
+
+        private void resolveRealDebugApi() {
+            final io.gravitee.definition.model.debug.DebugApiV2 definition = new io.gravitee.definition.model.debug.DebugApiV2();
+            definition.setId("api-id");
+            definition.setName("alpha");
+            definition.setVersion("1.0");
+            final DebugApiV2 realDebugApi = new DebugApiV2(EVENT_ID, definition);
+
+            final ApiReactor<?> apiReactor = mock(ApiReactor.class);
+            final HttpAcceptor acceptor = mock(HttpAcceptor.class);
+            lenient()
+                .when(apiReactor.api())
+                .thenAnswer(invocation -> realDebugApi);
+            lenient().when(acceptor.reactor()).thenReturn(apiReactor);
+            lenient().when(httpAcceptorResolver.resolve(HOST, PATH_WITH_DOT_SEGMENTS, SERVER_ID)).thenReturn(acceptor);
+        }
+
+        private DebugHttpRequestDispatcher dispatcherWithRealChain() {
+            final NotFoundProcessorChainFactory realChainFactory = new NotFoundProcessorChainFactory(
+                new TransactionPreProcessorFactory(null, null),
+                new StandardEnvironment(),
+                reporterService,
+                false,
+                true,
+                gatewayConfiguration
+            );
+            return new DebugHttpRequestDispatcher(
+                gatewayConfiguration,
+                httpAcceptorResolver,
+                idGenerator,
+                globalComponentProvider,
+                new RequestProcessorChainFactory(),
+                responseProcessorChainFactory,
+                platformProcessorChainFactory,
+                realChainFactory,
+                requestTimeoutConfiguration,
+                requestClientAuthConfiguration,
+                new RequestPathConfiguration(RequestPathHandling.REJECT),
+                new DebugCompletionProcessor(eventRepository, new ObjectMapper()),
+                vertx,
+                true
+            );
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/DebugHttpRequestDispatcherTest.java
@@ -17,17 +17,22 @@ package io.gravitee.gateway.reactive.debug.reactor;
 
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API;
 import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+import static io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.debug.definition.DebugApiV2;
 import io.gravitee.gateway.debug.definition.ReactableDebugApi;
+import io.gravitee.gateway.debug.handlers.api.DebugApiReactorHandler;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestClientAuthConfiguration;
 import io.gravitee.gateway.env.RequestPathConfiguration;
@@ -41,9 +46,16 @@ import io.gravitee.gateway.reactive.debug.reactor.processor.DebugPlatformProcess
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactive.reactor.handler.HttpAcceptorResolver;
 import io.gravitee.gateway.reactive.reactor.processor.NotFoundProcessorChainFactory;
+import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
+import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.api.EventRepository;
+import io.gravitee.repository.management.model.ApiDebugStatus;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
 import io.netty.channel.Channel;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
@@ -58,7 +70,9 @@ import io.vertx.rxjava3.core.MultiMap;
 import io.vertx.rxjava3.core.http.HttpConnection;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -70,6 +84,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.StandardEnvironment;
 
 /**
  * What happens to a debug session whose path the gateway refuses to route on.
@@ -89,6 +104,7 @@ class DebugHttpRequestDispatcherTest {
     private static final String CANONICAL_PATH = "/event-id-proxyv4/b";
     private static final String PATH_WITH_DOT_SEGMENTS = "/event-id-proxyv4/a/../b";
     private static final String SERVER_ID = null;
+    private static final String EVENT_ID = "event-id";
 
     @Spy
     private final Vertx vertx = Vertx.vertx();
@@ -138,6 +154,15 @@ class DebugHttpRequestDispatcherTest {
     @Mock
     private ReactableDebugApi<?> debugApi;
 
+    @Mock
+    private ReporterService reporterService;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private Node node;
+
     @BeforeEach
     void init() {
         lenient().when(rxRequest.host()).thenReturn(HOST);
@@ -168,6 +193,10 @@ class DebugHttpRequestDispatcherTest {
         lenient().when(platformProcessorChainFactory.preProcessorChain()).thenReturn(new ProcessorChain("pre", List.of()));
         lenient().when(platformProcessorChainFactory.postProcessorChain()).thenReturn(new ProcessorChain("post", List.of()));
         lenient().when(debugCompletionProcessor.execute(any())).thenReturn(Completable.complete());
+
+        // Contextual logging resolves a Node through the component provider, and the rejection path
+        // logs on the branch where no debug API matched.
+        lenient().when(globalComponentProvider.getComponent(Node.class)).thenReturn(node);
 
         mockConnectionCreationTimestamp();
     }
@@ -250,6 +279,29 @@ class DebugHttpRequestDispatcherTest {
         }
 
         @Test
+        void should_close_the_session_of_an_api_running_in_v3_execution_mode() {
+            // Given a V2 API whose executionMode is V3. It is not deployed behind an ApiReactor:
+            // ApiReactorHandlerFactory branches into getApiReactorHandler, which the debug service
+            // overrides to DebugApiReactorHandler — a ReactorHandler, never an ApiReactor.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            final DebugApiReactorHandler handler = mock(DebugApiReactorHandler.class);
+            final HttpAcceptor acceptor = mock(HttpAcceptor.class);
+            lenient()
+                .when(handler.debugApi())
+                .thenAnswer(invocation -> debugApi);
+            lenient().when(acceptor.reactor()).thenReturn(handler);
+            lenient().when(httpAcceptorResolver.resolve(HOST, PATH_WITH_DOT_SEGMENTS, SERVER_ID)).thenReturn(acceptor);
+
+            // When the request is refused on its path.
+            dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            // Then the session is closed for this engine too. Matching only ApiReactor left the
+            // console spinning on exactly the dead end this override exists to remove, and the only
+            // clue was a warning saying no debug API matched — while the acceptor had matched.
+            verify(debugCompletionProcessor).execute(any());
+        }
+
+        @Test
         void should_still_answer_when_no_debug_api_matches_the_path() {
             // Given a refused path that matches no acceptor: there is no session to close, but the
             // request must still be answered rather than hang.
@@ -259,6 +311,91 @@ class DebugHttpRequestDispatcherTest {
             dispatcher(RequestPathHandling.REJECT).dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
 
             verify(debugCompletionProcessor, never()).execute(any());
+        }
+    }
+
+    /**
+     * The wiring tests above replace the rejected chain with an empty one and the completion
+     * processor with a mock, so they pin that the dispatcher calls the right things. They would pass
+     * unchanged if the response never carried a 400, or if the debug event were never moved out of
+     * {@code DEBUGGING} — which is the entire behaviour this class exists to deliver. This runs the
+     * real chain and the real processor, and asks the two questions a user would.
+     */
+    @Nested
+    class End_to_end_on_the_debug_port {
+
+        @Test
+        void should_answer_400_and_move_the_event_out_of_debugging() throws Exception {
+            // Given a real rejected chain and a real completion processor over a stored debug event.
+            // A real debug API rather than a mock: the completion processor converts the definition
+            // into the payload, so a hollow stub only proves that the failure branch is reachable.
+            when(rxRequest.path()).thenReturn(PATH_WITH_DOT_SEGMENTS);
+            resolveRealDebugApi();
+
+            final Event stored = new Event();
+            stored.setId(EVENT_ID);
+            stored.setProperties(new HashMap<>());
+            stored.setType(EventType.DEBUG_API);
+            when(eventRepository.findById(EVENT_ID)).thenReturn(Optional.of(stored));
+
+            // The real chain actually writes the body, which the stubbed-empty chain never does.
+            lenient().when(rxResponse.rxSend(any(Flowable.class))).thenReturn(Completable.complete());
+
+            final DebugHttpRequestDispatcher dispatcher = dispatcherWithRealChain();
+
+            // When a path the gateway refuses to route on arrives on the debug port.
+            dispatcher.dispatch(rxRequest, SERVER_ID).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+            // Then the caller got a 400...
+            verify(rxResponse).setStatusCode(400);
+
+            // ...and the session was closed, so the console stops waiting.
+            final ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            verify(eventRepository, timeout(5_000)).update(captor.capture());
+            assertThat(captor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.SUCCESS.name());
+        }
+
+        private void resolveRealDebugApi() {
+            final io.gravitee.definition.model.debug.DebugApiV2 definition = new io.gravitee.definition.model.debug.DebugApiV2();
+            definition.setId("api-id");
+            definition.setName("alpha");
+            definition.setVersion("1.0");
+            final DebugApiV2 realDebugApi = new DebugApiV2(EVENT_ID, definition);
+
+            final ApiReactor<?> apiReactor = mock(ApiReactor.class);
+            final HttpAcceptor acceptor = mock(HttpAcceptor.class);
+            lenient()
+                .when(apiReactor.api())
+                .thenAnswer(invocation -> realDebugApi);
+            lenient().when(acceptor.reactor()).thenReturn(apiReactor);
+            lenient().when(httpAcceptorResolver.resolve(HOST, PATH_WITH_DOT_SEGMENTS, SERVER_ID)).thenReturn(acceptor);
+        }
+
+        private DebugHttpRequestDispatcher dispatcherWithRealChain() {
+            final NotFoundProcessorChainFactory realChainFactory = new NotFoundProcessorChainFactory(
+                new TransactionPreProcessorFactory(null, null),
+                new StandardEnvironment(),
+                reporterService,
+                false,
+                true,
+                gatewayConfiguration
+            );
+            return new DebugHttpRequestDispatcher(
+                gatewayConfiguration,
+                httpAcceptorResolver,
+                idGenerator,
+                globalComponentProvider,
+                new RequestProcessorChainFactory(),
+                responseProcessorChainFactory,
+                platformProcessorChainFactory,
+                realChainFactory,
+                requestTimeoutConfiguration,
+                requestClientAuthConfiguration,
+                new RequestPathConfiguration(RequestPathHandling.REJECT),
+                new DebugCompletionProcessor(eventRepository, new ObjectMapper()),
+                vertx,
+                true
+            );
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugReportedPathTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugReportedPathTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.debug.reactor.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.core.component.CustomComponentProvider;
+import io.gravitee.gateway.debug.core.invoker.InvokerResponse;
+import io.gravitee.gateway.debug.definition.DebugApiV2;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
+import io.gravitee.gateway.reactive.core.context.MutableResponse;
+import io.gravitee.gateway.reactive.debug.reactor.context.DebugExecutionContext;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EventRepository;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
+import io.reactivex.rxjava3.core.Single;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Which path a debug session reports to the console.
+ *
+ * <p>The console builds its timeline by spreading the preprocessor step over the request that was
+ * submitted in the form, so whatever the preprocessor step carries wins. Until the gateway put the
+ * executed path there, the panel could only ever echo what the user typed — and that is wrong the
+ * moment {@code http.pathHandling} resolves the path, because it shows a request that never reached
+ * a single policy.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DebugReportedPathTest {
+
+    private static final String SUBMITTED_PATH = "/a/../b";
+    private static final String EXECUTED_PATH = "/b";
+    private static final String EVENT_ID = "event-id";
+
+    @Mock
+    private MutableRequest mockRequest;
+
+    @Mock
+    private MutableResponse mockResponse;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void init() {
+        lenient().when(mockRequest.headers()).thenReturn(HttpHeaders.create());
+        lenient().when(mockResponse.headers()).thenReturn(HttpHeaders.create());
+        lenient().when(mockResponse.status()).thenReturn(200);
+        lenient().when(mockResponse.bodyOrEmpty()).thenReturn(Single.just(Buffer.buffer("{}")));
+    }
+
+    @Nested
+    class The_preprocessor_step {
+
+        @Test
+        void should_carry_the_path_the_policies_actually_ran_on() throws Exception {
+            // Given a context built before the acceptor matched, which is when the dispatcher builds
+            // it — pathInfo is still unreadable at that point.
+            DebugExecutionContext debugCtx = debugContext();
+            // And the acceptor having matched, which is what makes pathInfo resolvable.
+            when(mockRequest.pathInfo()).thenReturn(EXECUTED_PATH);
+            debugCtx.captureInitialPath();
+
+            // When the debug session completes.
+            String payload = completeAndCapturePayload(debugCtx);
+
+            // Then the console reads the resolved path, not the one that was typed.
+            assertThat(pathIn(payload)).isEqualTo(EXECUTED_PATH).isNotEqualTo(SUBMITTED_PATH);
+        }
+
+        @Test
+        void should_be_empty_when_the_request_was_answered_before_any_api_matched() throws Exception {
+            // Given a context that never reached the pre-processor chain — a path the gateway
+            // refused, for instance. There is no resolved path to report, and the console falls back
+            // to the submitted one, which is correct: nothing was resolved.
+            DebugExecutionContext debugCtx = debugContext();
+
+            String payload = completeAndCapturePayload(debugCtx);
+
+            assertThat(pathIn(payload)).isNull();
+        }
+
+        @Test
+        void should_be_read_before_the_policies_run_so_a_rewrite_does_not_backdate_it() throws Exception {
+            // Given a path captured at the start of the request...
+            DebugExecutionContext debugCtx = debugContext();
+            when(mockRequest.pathInfo()).thenReturn(EXECUTED_PATH);
+            debugCtx.captureInitialPath();
+            // ...that a policy then rewrites. Stubbed leniently on purpose: nothing must read it
+            // back, and a strict stub would fail for being unused — which is the property under
+            // test, but stated by Mockito rather than by the assertion.
+            lenient().when(mockRequest.pathInfo()).thenReturn("/rewritten-by-a-policy");
+
+            // When the debug session completes.
+            String payload = completeAndCapturePayload(debugCtx);
+
+            // Then the step still reports the state the policies were handed. Reporting the later
+            // value would credit the gateway with a rewrite a policy made, which is precisely the
+            // distinction the timeline exists to draw.
+            assertThat(pathIn(payload)).isEqualTo(EXECUTED_PATH);
+        }
+    }
+
+    private DebugExecutionContext debugContext() {
+        io.gravitee.definition.model.debug.DebugApiV2 definition = new io.gravitee.definition.model.debug.DebugApiV2();
+        definition.setId("id");
+        definition.setName("name");
+        definition.setVersion("version");
+
+        DebugApiV2 debugApi = new DebugApiV2(EVENT_ID, definition);
+        CustomComponentProvider componentProvider = new CustomComponentProvider();
+        componentProvider.add(Api.class, debugApi);
+        componentProvider.add(Node.class, node);
+
+        DebugExecutionContext debugCtx = new DebugExecutionContext(mockRequest, mockResponse);
+        debugCtx.componentProvider(componentProvider);
+
+        InvokerResponse invokerResponse = debugCtx.getInvokerResponse();
+        invokerResponse.setStatus(200);
+        invokerResponse.setHeaders(HttpHeaders.create());
+        return debugCtx;
+    }
+
+    private String completeAndCapturePayload(final DebugExecutionContext debugCtx) throws TechnicalException {
+        Event event = new Event();
+        event.setId(EVENT_ID);
+        event.setProperties(new HashMap<>());
+        event.setType(EventType.DEBUG_API);
+        when(eventRepository.findById(EVENT_ID)).thenReturn(Optional.of(event));
+
+        new DebugCompletionProcessor(eventRepository, objectMapper)
+            .execute(debugCtx)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).update(captor.capture());
+        return captor.getValue().getPayload();
+    }
+
+    private String pathIn(final String payload) throws Exception {
+        return objectMapper.readTree(payload).path("preprocessorStep").path("path").asText(null);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -92,7 +92,11 @@ secrets:
 #              so /alpha/api/../../beta/api is read as the call to beta that it is.
 #  Beyond dot segments, both REJECT and NORMALIZE also decode percent-encoded unreserved
 #  characters, merge duplicate slashes, and answer 400 on a malformed percent sequence.
-#  Encoded slashes are never decoded. RAW is the default for backward compatibility.
+#  Encoded slashes are never decoded, and segment parameters on an ordinary segment are left
+#  alone: /a/admin;x/b is canonical here and forwarded as sent, while a Servlet receiver strips
+#  the ;x and serves /a/admin/b. An allow or deny rule written against /admin/** therefore still
+#  needs its own guard against that spelling.
+#  RAW is the default for backward compatibility.
 #  pathHandling: RAW
 #  secured: false
 #  alpn: false
@@ -779,9 +783,9 @@ services:
 #    analytics:
 #      enabled: false
 #  rejected:
-#    Reporting of the requests refused by http.pathHandling: REJECT. Enabled by default, so that a
-#    platform being probed with traversal paths leaves a trace, and deliberately independent from
-#    the notfound flag above, which is disabled by default.
+#    # Reporting of the requests refused by http.pathHandling: REJECT. Enabled by default, so that
+#    # a platform being probed with traversal paths leaves a trace, and deliberately independent
+#    # from the notfound flag above, which is disabled by default.
 #    analytics:
 #      enabled: true
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -778,6 +778,12 @@ services:
 #  notfound:
 #    analytics:
 #      enabled: false
+#  rejected:
+#    Reporting of the requests refused by http.pathHandling: REJECT. Enabled by default, so that a
+#    platform being probed with traversal paths leaves a trace, and deliberately independent from
+#    the notfound flag above, which is disabled by default.
+#    analytics:
+#      enabled: true
 
 # Referenced properties
 ds:

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -84,6 +84,16 @@ secrets:
 #  The following is only used in v4 engine. It represents the maximum delay to let the response's platform flows execute properly in case of error during the previous phases.
 #  It's configures a timeout from the max between (requestTimeout - api elapsed time) and requestTimeoutGraceDelay.
 #  requestTimeoutGraceDelay: 30
+#  How dot segments in the request path are treated, before the listener context path is
+#  resolved and therefore before any plan is enforced.
+#    RAW       (default) the path is used, and forwarded, exactly as received.
+#    REJECT    answers 400 when the normalized path differs from the one received.
+#    NORMALIZE resolves the dot segments and routes, enforces and forwards on the result,
+#              so /alpha/api/../../beta/api is read as the call to beta that it is.
+#  Beyond dot segments, both REJECT and NORMALIZE also decode percent-encoded unreserved
+#  characters, merge duplicate slashes, and answer 400 on a malformed percent sequence.
+#  Encoded slashes are never decoded. RAW is the default for backward compatibility.
+#  pathHandling: RAW
 #  secured: false
 #  alpn: false
 #  ssl:

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/PathToHeaderPolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/PathToHeaderPolicy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.fakes.policies;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Reports, as response headers, what a policy sees of the request path.
+ *
+ * <p>Implements both the reactive and the legacy policy API so the same assertions can be made
+ * whichever engine executes the API. This is the only way to observe from the outside whether a
+ * policy reasons on the path the gateway resolved or on the one it received — the difference a
+ * path-scoped policy stands or falls on.
+ *
+ * @author GraviteeSource Team
+ */
+public class PathToHeaderPolicy implements Policy {
+
+    public static final String X_PATH = "X-Observed-Path";
+    public static final String X_PATH_INFO = "X-Observed-PathInfo";
+    public static final String X_URI = "X-Observed-Uri";
+
+    @OnRequest
+    public void onRequest(final Request request, final Response response, final PolicyChain policyChain) {
+        policyChain.doNext(request, response);
+    }
+
+    @OnResponse
+    public void onResponse(final Request request, final Response response, final PolicyChain policyChain) {
+        response.headers().add(X_PATH, request.path());
+        response.headers().add(X_PATH_INFO, request.pathInfo());
+        response.headers().add(X_URI, request.uri());
+        policyChain.doNext(request, response);
+    }
+
+    @Override
+    public String id() {
+        return "path-to-header";
+    }
+
+    @Override
+    public Completable onResponse(final HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() -> {
+            ctx.response().headers().add(X_PATH, ctx.request().path());
+            ctx.response().headers().add(X_PATH_INFO, ctx.request().pathInfo());
+            ctx.response().headers().add(X_URI, ctx.request().uri());
+        });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV2IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV2IntegrationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.ExecutionMode;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Settles which execution modes {@code http.pathHandling} actually reaches, for a V2 definition.
+ *
+ * <p>The dispatcher branches on the reactor, not on the definition version: a V2 definition running
+ * in V4 emulation is served by a reactor that implements {@code ApiReactor} exactly like a V4 one,
+ * and therefore goes down the same path. The legacy V3 engine does not, and the dispatcher falls
+ * back to the raw path for it on purpose, because its request wrapper cannot be rewritten.
+ *
+ * <p>The API here is deliberately alone on the gateway: a traversal out of its context path lands
+ * on no listener, so the status alone says whether the path was resolved before routing.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathHandlingV2IntegrationTest {
+
+    private static final String TRAVERSAL = "/alpha/api/../../elsewhere/resource";
+    private static final String REGULAR = "/alpha/api/echo";
+
+    abstract static class PathHandlingV2Test extends AbstractGatewayTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
+        protected void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus)
+            throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.GET, rawPath)
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .await()
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        protected String singleUpstreamRequestUrl() {
+            final List<LoggedRequest> upstreamRequests = wiremock.findAll(getRequestedFor(anyUrl()));
+            assertThat(upstreamRequests).hasSize(1);
+            return upstreamRequests.get(0).getUrl();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
+    class With_v4_emulation extends PathHandlingV2Test {
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+        }
+
+        @Test
+        void should_resolve_the_path_before_routing(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Resolved, the request points outside every context path on this gateway, so it is
+            // answered as not found instead of being carried to the backend.
+            assertStatus(httpClient, TRAVERSAL, 404);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
+    class With_the_legacy_v3_engine extends PathHandlingV2Test {
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+        }
+
+        @Test
+        void should_resolve_the_path_before_routing(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The setting is applied before the acceptor is resolved, which is upstream of any
+            // engine, so the legacy one is covered for routing exactly like the reactive one.
+            assertStatus(httpClient, TRAVERSAL, 404);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_send_upstream_the_path_it_resolved(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // A traversal that lands back inside this API's own context path. Routing is right in
+            // both engines; what this pins is the upstream URI, which the legacy engine derives
+            // from its own request wrapper rather than from the value seeded by the dispatcher.
+            assertStatus(httpClient, "/alpha/api/../../alpha/api/echo", 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV2IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV2IntegrationTest.java
@@ -57,10 +57,14 @@ class PathHandlingV2IntegrationTest {
 
     abstract static class PathHandlingV2Test extends AbstractGatewayTest {
 
+        /**
+         * Left to the nested classes rather than fixed here. When this base pinned the mode to
+         * {@code NORMALIZE}, no V2 definition was ever run under {@code REJECT} — and whether that
+         * mode answers before any API is selected, on every definition version, is precisely the
+         * question this file exists to settle.
+         */
         @Override
-        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
-            configurationBuilder.set("http.pathHandling", "NORMALIZE");
-        }
+        public abstract void configureGateway(GatewayConfigurationBuilder configurationBuilder);
 
         protected void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus)
             throws InterruptedException {
@@ -89,6 +93,11 @@ class PathHandlingV2IntegrationTest {
     @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
     class With_v4_emulation extends PathHandlingV2Test {
 
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
         @Test
         void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
             wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
@@ -114,6 +123,11 @@ class PathHandlingV2IntegrationTest {
     @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
     @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
     class With_the_legacy_v3_engine extends PathHandlingV2Test {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
 
         @Test
         void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
@@ -143,6 +157,62 @@ class PathHandlingV2IntegrationTest {
             assertStatus(httpClient, "/alpha/api/../../alpha/api/echo", 200);
 
             assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
+    class With_reject_under_v4_emulation extends PathHandlingV2Test {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "REJECT");
+        }
+
+        @Test
+        void should_refuse_before_any_api_is_selected(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+        }
+    }
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha.json")
+    class With_reject_on_the_legacy_v3_engine extends PathHandlingV2Test {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "REJECT");
+        }
+
+        @Test
+        void should_refuse_before_any_api_is_selected(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The refusal happens upstream of the acceptor, so it cannot depend on the engine. That
+            // is an argument until a test makes it an observation.
+            assertStatus(httpClient, TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
         }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
@@ -77,6 +77,16 @@ class PathHandlingV4IntegrationTest {
     private static final String DECODED_UNRESERVED = "/alpha/api/AB/~tilde";
 
     /**
+     * A traversal that climbs and comes back down inside {@code alpha}, so the request is served
+     * rather than refused. That is what makes the resolved path observable at the upstream: every
+     * other traversal here is answered 401 or 404 before anything is forwarded.
+     */
+    private static final String INTERNAL_TRAVERSAL = "/alpha/api/orders/../echo";
+
+    /** Path parameters on a dot segment. A servlet container strips them before resolving. */
+    private static final String PARAMETERISED_TRAVERSAL = "/alpha/api/orders/..;/echo";
+
+    /**
      * Base wiring shared by the three modes. Only {@link #configureGateway} differs between them,
      * which is the whole point of the comparison.
      */
@@ -279,6 +289,60 @@ class PathHandlingV4IntegrationTest {
             assertStatus(httpClient, "/alpha/api/../../elsewhere/resource", 404);
 
             assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_forward_the_resolved_path_upstream(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The headline behaviour of the mode, and the only case here where it is observable:
+            // every other traversal is refused before anything is forwarded, so the upstream sees
+            // nothing. This one climbs and comes back down inside alpha, so the request is served
+            // and the backend can be asked what it actually received.
+            assertStatus(httpClient, INTERNAL_TRAVERSAL, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo").doesNotContain("..");
+        }
+
+        @Test
+        void should_resolve_a_dot_segment_carrying_path_parameters(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // RFC 3986 calls "..;" an ordinary segment; a servlet container strips the parameters
+            // first and calls it a dot segment. The gateway takes the second reading, because the
+            // first one authorises one resource and lets another be served.
+            assertStatus(httpClient, PARAMETERISED_TRAVERSAL, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_reject_handling_on_parameterised_dot_segments extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "REJECT");
+        }
+
+        @Test
+        void should_refuse_them_like_any_other_dot_segment(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, PARAMETERISED_TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_still_serve_an_ordinary_segment_that_carries_parameters(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Only a segment that is entirely dots before the ';' is a dot segment. If this ever
+            // starts failing, REJECT has begun refusing perfectly well formed traffic.
+            assertStatus(httpClient, "/alpha/api/orders;v=2/echo", 200);
         }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
@@ -72,6 +72,10 @@ class PathHandlingV4IntegrationTest {
     private static final String ENCODED_TRAVERSAL = "/alpha/api/%2e%2e/%2e%2e/beta/api/echo";
     private static final String REGULAR = "/alpha/api/echo";
 
+    /** No dot segment in sight, only unreserved characters that §6.2.2.2 decodes anyway. */
+    private static final String ENCODED_UNRESERVED = "/alpha/api/%41%42/%7Etilde";
+    private static final String DECODED_UNRESERVED = "/alpha/api/AB/~tilde";
+
     /**
      * Base wiring shared by the three modes. Only {@link #configureGateway} differs between them,
      * which is the whole point of the comparison.
@@ -150,6 +154,17 @@ class PathHandlingV4IntegrationTest {
             assertStatus(httpClient, TRAVERSAL, 200);
 
             assertThat(singleUpstreamRequestUrl()).isEqualTo(TRAVERSAL);
+        }
+
+        @Test
+        void should_leave_percent_encoded_unreserved_characters_encoded(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The counterpart of the NORMALIZE case: under RAW the backend receives the bytes the
+            // client sent. This is the pair that shows what switching the default actually changes.
+            assertStatus(httpClient, ENCODED_UNRESERVED, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(ENCODED_UNRESERVED);
         }
     }
 
@@ -240,6 +255,18 @@ class PathHandlingV4IntegrationTest {
             assertStatus(httpClient, "/alpha/api/../../beta/api/../../beta/api/echo", 401);
 
             assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_deliver_percent_encoded_unreserved_characters_decoded(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The consequence of RFC 3986 §6.2.2.2 that surprises people: the rule that makes
+            // %2e%2e a dot segment is the same one that turns %41 into A, so a backend matching on
+            // the encoded spelling sees the decoded one. Asserted end to end rather than argued.
+            assertStatus(httpClient, ENCODED_UNRESERVED, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(DECODED_UNRESERVED);
         }
 
         @Test

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingV4IntegrationTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the three values of {@code http.pathHandling} against the same pair of APIs:
+ * {@code alpha} on {@code /alpha/api/} with no plan, {@code beta} on {@code /beta/api/} behind an
+ * api-key plan, both pointing at the same upstream host.
+ *
+ * <p>The request under test, {@code /alpha/api/../../beta/api/echo}, means one thing to the gateway
+ * when it reads the path as it arrived, and another to any receiver applying RFC 3986 §5.2.4. Each
+ * mode below is one answer to that disagreement.
+ *
+ * <p>V4 APIs only. The V3 handler keeps its historical behaviour whatever the setting, because its
+ * request wrapper exposes the native path and cannot be rewritten.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathHandlingV4IntegrationTest {
+
+    private static final String TRAVERSAL = "/alpha/api/../../beta/api/echo";
+    private static final String ENCODED_TRAVERSAL = "/alpha/api/%2e%2e/%2e%2e/beta/api/echo";
+    private static final String REGULAR = "/alpha/api/echo";
+
+    /**
+     * Base wiring shared by the three modes. Only {@link #configureGateway} differs between them,
+     * which is the whole point of the comparison.
+     */
+    abstract static class PathHandlingTest extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "api-key",
+                PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+            );
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+                configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+            }
+        }
+
+        protected void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus)
+            throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.GET, rawPath)
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .await()
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        protected String singleUpstreamRequestUrl() {
+            final List<LoggedRequest> upstreamRequests = wiremock.findAll(getRequestedFor(anyUrl()));
+            assertThat(upstreamRequests).hasSize(1);
+            return upstreamRequests.get(0).getUrl();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_raw_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+        }
+
+        @Test
+        void should_keep_the_bypass_because_nothing_is_resolved(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The historical behaviour, kept as the default so no deployment changes on upgrade.
+            assertStatus(httpClient, TRAVERSAL, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(TRAVERSAL);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_reject_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "REJECT");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(REGULAR);
+        }
+
+        @Test
+        void should_reject_dot_segments_before_any_api_is_selected(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_reject_encoded_dot_segments(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ENCODED_TRAVERSAL, 400);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+    class With_normalize_handling extends PathHandlingTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
+        @Test
+        void should_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, REGULAR, 200);
+
+            assertThat(singleUpstreamRequestUrl()).isEqualTo(REGULAR);
+        }
+
+        @Test
+        void should_enforce_the_plan_of_the_api_the_resolved_path_designates(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Resolved, the request is a call to beta, so beta's api-key plan applies and answers
+            // 401 for want of a key. The request is not blocked as malformed, it is simply read
+            // for what it means.
+            assertStatus(httpClient, TRAVERSAL, 401);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_enforce_that_plan_on_encoded_dot_segments_too(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ENCODED_TRAVERSAL, 401);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_resolve_a_chain_of_dot_segments(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Three hops rather than one: alpha, back out, beta, back out, beta again. Whatever the
+            // depth, what counts is where the chain lands, and beta's plan answers for it.
+            assertStatus(httpClient, "/alpha/api/../../beta/api/../../beta/api/echo", 401);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+
+        @Test
+        void should_answer_not_found_when_the_resolved_path_matches_no_api(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The other half of the defect: escaping the configured endpoint target no longer
+            // reaches a neighbour of that target, because the gateway now reads where the request
+            // actually points and finds no listener there.
+            assertStatus(httpClient, "/alpha/api/../../elsewhere/resource", 404);
+
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingWithResourceFilteringIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathHandlingWithResourceFilteringIntegrationTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.resourcefiltering.ResourceFilteringPolicy;
+import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a request actually meets when {@code http.pathHandling} and a policy that normalizes on its
+ * own are both in play.
+ *
+ * <p>The product carries two normalizers: the gateway's, applied before the listener is resolved,
+ * and the one inside {@code gravitee-policy-resource-filtering}, applied inside the API. They do
+ * not implement the same rules, and the policy's can be switched off — so a filter written against
+ * one interpretation can be evaded by a path the other resolves differently. That is the reported
+ * bug reproduced between two of our own components, and it is asserted here rather than reasoned
+ * about.
+ *
+ * <p>The API denies the {@code /admin/**} subtree. The request under test asks for it the long way
+ * round, through a dot segment, and each class below is one combination of the two switches.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathHandlingWithResourceFilteringIntegrationTest {
+
+    /** Denied outright by the policy, whatever else happens. */
+    private static final String ADMIN = "/alpha/api/admin/secret";
+
+    /** The same resource, spelled so that only a normalizer sees the {@code /admin} in it. */
+    private static final String ADMIN_THROUGH_A_DOT_SEGMENT = "/alpha/api/public/../admin/secret";
+
+    abstract static class ResourceFilteringTest extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "resource-filtering",
+                PolicyBuilder.build("resource-filtering", ResourceFilteringPolicy.class, ResourceFilteringPolicyConfiguration.class)
+            );
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        protected void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus)
+            throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.GET, rawPath)
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .await()
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        protected void assertBackendWasNotCalled() {
+            assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/pathtraversal/api-alpha-resource-filtering.json")
+    class With_raw_gateway_and_a_policy_that_does_not_normalize extends ResourceFilteringTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_deny_the_admin_subtree_asked_for_plainly(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ADMIN, 403);
+
+            assertBackendWasNotCalled();
+        }
+
+        @Test
+        void should_let_a_dot_segment_through_the_filter(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // Neither component resolves the path, so the filter never sees an /admin to deny and
+            // the request reaches the backend. This is the parser differential, between our own
+            // components, and it is the reason both switches exist.
+            assertStatus(httpClient, ADMIN_THROUGH_A_DOT_SEGMENT, 200);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/pathtraversal/api-alpha-resource-filtering.json")
+    class With_normalize_gateway_and_a_policy_that_does_not_normalize extends ResourceFilteringTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
+        @Test
+        void should_deny_the_admin_subtree_asked_for_plainly(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertStatus(httpClient, ADMIN, 403);
+
+            assertBackendWasNotCalled();
+        }
+
+        @Test
+        void should_close_the_hole_for_a_policy_whose_own_normalization_is_off(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The result worth having: the gateway resolved the path before the API was even
+            // selected, so the filter is handed /admin/secret and denies it — without the policy
+            // being reconfigured, and without it knowing anything about the setting.
+            assertStatus(httpClient, ADMIN_THROUGH_A_DOT_SEGMENT, 403);
+
+            assertBackendWasNotCalled();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/pathtraversal/api-alpha-resource-filtering-normalizing.json")
+    class With_raw_gateway_and_a_policy_that_normalizes extends ResourceFilteringTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_defend_itself_without_help_from_the_gateway(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            // The policy resolves the path itself before matching, so the filter holds even under
+            // RAW. Worth pinning: it is the only reason the older deployments are not exposed here.
+            assertStatus(httpClient, ADMIN_THROUGH_A_DOT_SEGMENT, 403);
+
+            assertBackendWasNotCalled();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathSeenByPolicyIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathSeenByPolicyIntegrationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.gateway.tests.fakes.policies.PathToHeaderPolicy.X_PATH;
+import static io.gravitee.gateway.tests.fakes.policies.PathToHeaderPolicy.X_PATH_INFO;
+import static io.gravitee.gateway.tests.fakes.policies.PathToHeaderPolicy.X_URI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.tests.fakes.policies.PathToHeaderPolicy;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a policy sees of the path, which is where the whole decision lands.
+ *
+ * <p>A policy attached to a path-scoped flow is only as sound as the path it reasons on. If it read
+ * the value as received while the gateway routed on the resolved one, a rule guarding
+ * {@code /admin} would be evaded by asking for {@code /public/../admin} — the reported traversal in
+ * miniature, inside a single API.
+ *
+ * <p>Each engine is exercised in both {@code RAW} and {@code NORMALIZE}. The {@code RAW} classes are
+ * the control: without them, these tests would show that a policy sees a resolved path without
+ * showing that the setting is what makes it so.
+ *
+ * <p>{@code uri()} is asserted alongside, because it must keep reporting the bytes as received
+ * whatever the mode — that is what a signature or a raw-path integration relies on.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathSeenByPolicyIntegrationTest {
+
+    private static final String TRAVERSAL = "/alpha/api/../../alpha/api/echo";
+    private static final String RESOLVED_PATH = "/alpha/api/echo";
+    private static final String RESOLVED_PATH_INFO = "/echo";
+    private static final String RAW_PATH_INFO = "/../../alpha/api/echo";
+
+    abstract static class PathSeenByPolicyTest extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put("path-to-header", PolicyBuilder.build("path-to-header", PathToHeaderPolicy.class));
+        }
+
+        protected HttpClientResponse call(final HttpClient httpClient, final String rawPath) throws InterruptedException {
+            return httpClient
+                .rxRequest(HttpMethod.GET, rawPath)
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors()
+                .values()
+                .get(0);
+        }
+    }
+
+    abstract static class OnAV4Definition extends PathSeenByPolicyTest {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/pathtraversal/api-alpha-path-policy.json")
+    class On_a_v4_definition_in_normalize extends OnAV4Definition {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
+        @Test
+        void should_expose_the_resolved_path_to_the_policy(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            final HttpClientResponse response = call(httpClient, TRAVERSAL);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.getHeader(X_PATH)).isEqualTo(RESOLVED_PATH);
+            assertThat(response.getHeader(X_PATH_INFO)).isEqualTo(RESOLVED_PATH_INFO);
+        }
+
+        @Test
+        void should_still_expose_the_uri_as_received(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertThat(call(httpClient, TRAVERSAL).getHeader(X_URI)).isEqualTo(TRAVERSAL);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/pathtraversal/api-alpha-path-policy.json")
+    class On_a_v4_definition_in_raw extends OnAV4Definition {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_expose_the_path_as_received_to_the_policy(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            final HttpClientResponse response = call(httpClient, TRAVERSAL);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.getHeader(X_PATH)).isEqualTo(TRAVERSAL);
+            assertThat(response.getHeader(X_PATH_INFO)).isEqualTo(RAW_PATH_INFO);
+        }
+    }
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha-path-policy.json")
+    class On_the_legacy_engine_in_normalize extends PathSeenByPolicyTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "NORMALIZE");
+        }
+
+        @Test
+        void should_expose_the_resolved_path_to_the_policy(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            final HttpClientResponse response = call(httpClient, TRAVERSAL);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.getHeader(X_PATH)).isEqualTo(RESOLVED_PATH);
+            assertThat(response.getHeader(X_PATH_INFO)).isEqualTo(RESOLVED_PATH_INFO);
+        }
+
+        @Test
+        void should_still_expose_the_uri_as_received(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            assertThat(call(httpClient, TRAVERSAL).getHeader(X_URI)).isEqualTo(TRAVERSAL);
+        }
+    }
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+    @DeployApi("/apis/http/pathtraversal/api-v2-alpha-path-policy.json")
+    class On_the_legacy_engine_in_raw extends PathSeenByPolicyTest {
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.set("http.pathHandling", "RAW");
+        }
+
+        @Test
+        void should_expose_the_path_as_received_to_the_policy(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            final HttpClientResponse response = call(httpClient, TRAVERSAL);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.getHeader(X_PATH)).isEqualTo(TRAVERSAL);
+            assertThat(response.getHeader(X_PATH_INFO)).isEqualTo(RAW_PATH_INFO);
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalOrganizationGuardV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalOrganizationGuardV4IntegrationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganization;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.groovy.GroovyInitializer;
+import io.gravitee.policy.groovy.GroovyPolicy;
+import io.gravitee.policy.groovy.configuration.GroovyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the mitigation available without a gateway change: a Groovy policy on an organization flow
+ * that rejects any request whose path carries dot segments.
+ *
+ * <p>An organization flow runs inside the API reactor but ahead of the security chain and of the
+ * backend call, so it closes the traversal for every API on the gateway at once, including APIs
+ * published later, and without touching a single API definition.
+ *
+ * <p>Its limit is worth stating precisely, and the last test pins it: the API has already been
+ * selected by the time the policy runs, so the guard can only <em>reject</em> the request. It cannot
+ * route it to the API the resolved path actually designates. Reaching that behaviour requires
+ * normalizing before listener resolution, which is a gateway-level change.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployOrganization(
+    organization = "/organizations/organization-reject-dot-segments.json",
+    apis = { "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" }
+)
+class PathTraversalOrganizationGuardV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("groovy", PolicyBuilder.build("groovy", GroovyPolicy.class, GroovyPolicyConfiguration.class, GroovyInitializer.class));
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+            configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+        }
+    }
+
+    @Test
+    void should_still_serve_a_regular_path(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/echo", 200);
+    }
+
+    @Test
+    void should_reject_dot_segments_before_the_backend_is_called(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reject_encoded_dot_segments_before_the_backend_is_called(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/%2e%2e/%2e%2e/beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reject_rather_than_route_to_the_api_the_resolved_path_designates(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Once resolved the path designates beta, whose plan would answer 401 without an api key.
+        // The guard answers 400 instead: it interrupts, it does not re-route. This is the gap that
+        // only front-door normalization closes.
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 400);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    private void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus) throws InterruptedException {
+        httpClient
+            .rxRequest(HttpMethod.GET, rawPath)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                return true;
+            })
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/PathTraversalV4IntegrationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the gateway's current handling of dot segments in a request path.
+ *
+ * <p>Two v4 HTTP proxy APIs share one upstream host, each on its own path prefix: {@code alpha} on
+ * {@code /alpha/api/} with no plan, so it is reachable without any credential, and {@code beta} on
+ * {@code /beta/api/} behind an api-key plan, so it must never be reached without a key.
+ *
+ * <p>The gateway resolves the listener context path against the request path exactly as it arrived,
+ * enforces the matched API's plan, then appends the remaining path to the endpoint target without
+ * resolving it. A conforming upstream applies RFC 3986 §5.2.4 and serves a different resource than
+ * the one the gateway authorized.
+ *
+ * <p><strong>These assertions describe the behaviour as it stands, not the behaviour we want.</strong>
+ * They exist so the change is visible the day the gateway starts normalizing: this class is expected
+ * to go red, and the expectations below then become 401 or 404 rather than 200.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json", "/apis/v4/http/pathtraversal/api-beta.json" })
+class PathTraversalV4IntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    /** Only beta carries a plan, so any bypass below is obtained with no credential at all. */
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass) && "beta".equals(api.getId())) {
+            configurePlans((Api) api.getDefinition(), Set.of("api-key"));
+        }
+    }
+
+    @Test
+    void should_serve_alpha_on_a_regular_path(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/alpha/api/echo", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/echo");
+    }
+
+    @Test
+    void should_reject_a_direct_call_to_beta_without_its_api_key(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        assertStatus(httpClient, "/beta/api/echo", 401);
+
+        assertThat(wiremock.findAll(getRequestedFor(anyUrl()))).isEmpty();
+    }
+
+    @Test
+    void should_reach_beta_backend_through_dot_segments_without_any_credential(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Same resource as the call above, spelled so that the raw path still starts with alpha's
+        // context path. Alpha is selected, alpha's absent plan lets it through, and the upstream
+        // resolves the segments back to beta.
+        assertStatus(httpClient, "/alpha/api/../../beta/api/echo", 200);
+
+        // The gateway resolved nothing: it emitted its own target's base path followed by the
+        // client-controlled remainder, which lands outside that base path once resolved.
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/../../beta/api/echo");
+    }
+
+    @Test
+    void should_reach_beta_backend_through_encoded_dot_segments(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Percent-encoded dots. Removing dot segments without first decoding the unreserved
+        // characters, as RFC 3986 §6.2.2.2 requires, would leave this variant open.
+        assertStatus(httpClient, "/alpha/api/%2e%2e/%2e%2e/beta/api/echo", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/%2e%2e/%2e%2e/beta/api/echo");
+    }
+
+    @Test
+    void should_forward_a_path_that_escapes_the_configured_endpoint_target(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        // Nothing to do with a second API: the emitted URI simply leaves the subtree of the target
+        // configured on alpha's endpoint, which is enough to reach any neighbour of that target.
+        assertStatus(httpClient, "/alpha/api/../../elsewhere/resource", 200);
+
+        assertThat(singleUpstreamRequestUrl()).isEqualTo("/alpha/api/../../elsewhere/resource");
+    }
+
+    private void assertStatus(final HttpClient httpClient, final String rawPath, final int expectedStatus) throws InterruptedException {
+        httpClient
+            .rxRequest(HttpMethod.GET, rawPath)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    /** The request line the gateway emitted upstream, verbatim. */
+    private String singleUpstreamRequestUrl() {
+        final List<LoggedRequest> upstreamRequests = wiremock.findAll(getRequestedFor(anyUrl()));
+        assertThat(upstreamRequests).hasSize(1);
+        return upstreamRequests.get(0).getUrl();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/RejectedPathReportingIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/RejectedPathReportingIntegrationTest.java
@@ -32,12 +32,14 @@ import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
 import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -59,7 +61,13 @@ class RejectedPathReportingIntegrationTest extends AbstractGatewayTest {
 
     private static final String TRAVERSAL = "/alpha/api/../../beta/api/echo";
 
-    private final List<Metrics> reported = new CopyOnWriteArrayList<>();
+    /**
+     * A subject rather than a list read straight after the call. {@code ReporterProcessor} is the
+     * last processor of the rejected chain and runs after the response has been ended, so the client
+     * can observe the 400 before anything has been reported — asserting on a collection at that
+     * moment passes or fails with the machine's load.
+     */
+    private final BehaviorSubject<Metrics> reported = BehaviorSubject.create();
 
     @Override
     public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
@@ -78,10 +86,9 @@ class RejectedPathReportingIntegrationTest extends AbstractGatewayTest {
 
     @BeforeEach
     void captureReports() {
-        reported.clear();
         getBean(FakeReporter.class).setReportableHandler(reportable -> {
             if (reportable instanceof Metrics metrics) {
-                reported.add(metrics);
+                reported.onNext(metrics);
             }
         });
     }
@@ -89,6 +96,8 @@ class RejectedPathReportingIntegrationTest extends AbstractGatewayTest {
     @Test
     void should_report_a_rejected_request(HttpClient httpClient) throws InterruptedException {
         wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        final TestObserver<Metrics> metrics = reported.firstOrError().test();
 
         httpClient
             .rxRequest(HttpMethod.GET, TRAVERSAL)
@@ -102,9 +111,14 @@ class RejectedPathReportingIntegrationTest extends AbstractGatewayTest {
             })
             .assertNoErrors();
 
-        assertThat(reported).as("a rejected request must produce a metric").hasSize(1);
-        assertThat(reported.get(0).getStatus()).isEqualTo(400);
-        // The operator needs to see what was actually asked for, not a sanitized version of it.
-        assertThat(reported.get(0).getUri()).isEqualTo(TRAVERSAL);
+        metrics
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(reportable -> {
+                assertThat(reportable.getStatus()).isEqualTo(400);
+                // The operator needs to see what was actually asked for, not a sanitized version.
+                assertThat(reportable.getUri()).isEqualTo(TRAVERSAL);
+                return true;
+            });
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/RejectedPathReportingIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/pathtraversal/RejectedPathReportingIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.pathtraversal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A rejected request has to leave a trace.
+ *
+ * <p>The value of a path rejection is largely in telling an operator that someone is probing the
+ * platform. Answering 400 and reporting nothing would close the hole while keeping the operator
+ * blind to the fact that it was ever attacked, which is the wrong half of the job.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DeployApi({ "/apis/v4/http/pathtraversal/api-alpha.json" })
+class RejectedPathReportingIntegrationTest extends AbstractGatewayTest {
+
+    private static final String TRAVERSAL = "/alpha/api/../../beta/api/echo";
+
+    private final List<Metrics> reported = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+        configurationBuilder.set("http.pathHandling", "REJECT");
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @BeforeEach
+    void captureReports() {
+        reported.clear();
+        getBean(FakeReporter.class).setReportableHandler(reportable -> {
+            if (reportable instanceof Metrics metrics) {
+                reported.add(metrics);
+            }
+        });
+    }
+
+    @Test
+    void should_report_a_rejected_request(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, TRAVERSAL)
+            .flatMap(HttpClientRequest::rxSend)
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return true;
+            })
+            .assertNoErrors();
+
+        assertThat(reported).as("a rejected request must produce a metric").hasSize(1);
+        assertThat(reported.get(0).getStatus()).isEqualTo(400);
+        // The operator needs to see what was actually asked for, not a sanitized version of it.
+        assertThat(reported.get(0).getUri()).isEqualTo(TRAVERSAL);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/pathtraversal/api-v2-alpha-path-policy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/pathtraversal/api-v2-alpha-path-policy.json
@@ -1,0 +1,39 @@
+{
+  "id": "v2-alpha-path-policy",
+  "name": "v2-alpha-path-policy",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/alpha/api",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/alpha/api",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "observe the path",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "pre": [],
+      "post": [
+        {
+          "name": "Path to header",
+          "enabled": true,
+          "policy": "path-to-header",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/pathtraversal/api-v2-alpha.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/pathtraversal/api-v2-alpha.json
@@ -1,0 +1,20 @@
+{
+  "id": "v2-alpha",
+  "name": "v2-alpha",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/alpha/api",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/alpha/api",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-path-policy.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-path-policy.json
@@ -1,0 +1,70 @@
+{
+  "id": "alpha-path-policy",
+  "name": "alpha-path-policy",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/alpha/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/alpha/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "observe the path",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [],
+      "response": [
+        {
+          "name": "Path to header",
+          "enabled": true,
+          "policy": "path-to-header",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-resource-filtering-normalizing.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-resource-filtering-normalizing.json
@@ -1,0 +1,77 @@
+{
+  "id": "alpha-resource-filtering-normalizing",
+  "name": "alpha-resource-filtering-normalizing",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/alpha/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/alpha/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "deny the admin subtree",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Resource filtering",
+          "enabled": true,
+          "policy": "resource-filtering",
+          "configuration": {
+            "normalizeRequestPath": true,
+            "blacklist": [
+              {
+                "pattern": "/admin/**"
+              }
+            ]
+          }
+        }
+      ],
+      "response": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-resource-filtering.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha-resource-filtering.json
@@ -1,0 +1,77 @@
+{
+  "id": "alpha-resource-filtering",
+  "name": "alpha-resource-filtering",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/alpha/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/alpha/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "deny the admin subtree",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Resource filtering",
+          "enabled": true,
+          "policy": "resource-filtering",
+          "configuration": {
+            "normalizeRequestPath": false,
+            "blacklist": [
+              {
+                "pattern": "/admin/**"
+              }
+            ]
+          }
+        }
+      ],
+      "response": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-alpha.json
@@ -1,0 +1,48 @@
+{
+  "id": "alpha",
+  "name": "alpha",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/alpha/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/alpha/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-beta.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/pathtraversal/api-beta.json
@@ -1,0 +1,48 @@
+{
+  "id": "beta",
+  "name": "beta",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/beta/api/"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/beta/api"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/organizations/organization-reject-dot-segments.json
+++ b/gravitee-apim-integration-tests/src/test/resources/organizations/organization-reject-dot-segments.json
@@ -1,0 +1,30 @@
+{
+  "id": "DEFAULT",
+  "hrids": ["default"],
+  "name": "Reject dot segments",
+  "description": "Platform flow rejecting any request whose path carries dot segments, encoded or not.",
+  "flowMode": "DEFAULT",
+  "flows": [
+    {
+      "name": "reject-dot-segments",
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "pre": [
+        {
+          "name": "Reject dot segments",
+          "description": "Interrupts the request before its plan is enforced and before the backend is invoked.",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "script": "import io.gravitee.policy.groovy.PolicyResult.State\nString path = request.path.toLowerCase()\nif (path.contains('..') || path.contains('%2e')) {\n    result.state = State.FAILURE\n    result.code = 400\n    result.error = 'Request path contains dot segments'\n}\n"
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    }
+  ]
+}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -200,6 +200,9 @@ data:
     http:
       requestTimeout: {{ include "gateway.httpRequestTimeout" . }}
       requestTimeoutGraceDelay: {{ include "gateway.httpRequestTimeoutGraceDelay" . }}
+      {{- if .Values.gateway.http.pathHandling }}
+      pathHandling: {{ .Values.gateway.http.pathHandling }}
+      {{- end }}
     {{- else }}
     http:
       port: {{ .Values.gateway.service.internalPort }}
@@ -215,6 +218,9 @@ data:
       maxInitialLineLength: {{ .Values.gateway.http.maxInitialLineLength }}
       maxFormAttributeSize: {{ .Values.gateway.http.maxFormAttributeSize }}
       alpn: {{ .Values.gateway.http.alpn | default "true" }}
+      {{- if .Values.gateway.http.pathHandling }}
+      pathHandling: {{ .Values.gateway.http.pathHandling }}
+      {{- end }}
       {{- if .Values.gateway.ssl.enabled }}
       secured: true
       ssl:

--- a/helm/tests/gateway/configmap_path_handling_test.yaml
+++ b/helm/tests/gateway/configmap_path_handling_test.yaml
@@ -1,13 +1,15 @@
 suite: Test Gateway configmap - path handling
 templates:
   - "gateway/gateway-configmap.yaml"
+# Patterns are written inline rather than with a block scalar. `pattern: |` keeps the trailing
+# newline, so `\n  pathHandling:` only matched a line whose colon was followed by end-of-line —
+# which a rendered key never is. The negative assertion below passed even when the key was present.
 tests:
   - it: Defaults to RAW, so upgrading a deployment does not move its traffic
     asserts:
       - matchRegex:
           path: data["gravitee.yml"]
-          pattern: |
-            \n  pathHandling: RAW
+          pattern: "\n  pathHandling: RAW\n"
 
   - it: Sets the mode on the single http server
     set:
@@ -17,8 +19,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["gravitee.yml"]
-          pattern: |
-            \n  pathHandling: NORMALIZE
+          pattern: "\n  pathHandling: NORMALIZE\n"
 
   # The setting is gateway wide rather than per listener, so it belongs to the http block that
   # sits beside the servers list, not to an entry inside it.
@@ -33,8 +34,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["gravitee.yml"]
-          pattern: |
-            \n  pathHandling: REJECT
+          pattern: "\n  pathHandling: REJECT\n"
 
   - it: Emits nothing when the value is cleared
     set:
@@ -44,5 +44,4 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["gravitee.yml"]
-          pattern: |
-            \n  pathHandling:
+          pattern: "pathHandling"

--- a/helm/tests/gateway/configmap_path_handling_test.yaml
+++ b/helm/tests/gateway/configmap_path_handling_test.yaml
@@ -1,0 +1,48 @@
+suite: Test Gateway configmap - path handling
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Defaults to RAW, so upgrading a deployment does not move its traffic
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \n  pathHandling: RAW
+
+  - it: Sets the mode on the single http server
+    set:
+      gateway:
+        http:
+          pathHandling: NORMALIZE
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \n  pathHandling: NORMALIZE
+
+  # The setting is gateway wide rather than per listener, so it belongs to the http block that
+  # sits beside the servers list, not to an entry inside it.
+  - it: Sets the mode alongside a servers list
+    set:
+      gateway:
+        http:
+          pathHandling: REJECT
+        servers:
+          - type: http
+            port: 8082
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \n  pathHandling: REJECT
+
+  - it: Emits nothing when the value is cleared
+    set:
+      gateway:
+        http:
+          pathHandling: null
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \n  pathHandling:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1206,6 +1206,16 @@ gateway:
     maxInitialLineLength: 4096
     maxFormAttributeSize: 2048
     alpn: "true"
+    # How dot segments in the request path are treated, before the listener context path is
+    # resolved and therefore before any plan is enforced. One value for the whole gateway:
+    # it cannot be set per server or per API.
+    #   RAW       (default) the path is used, and forwarded, exactly as received.
+    #   REJECT    answers 400 when the normalized path differs from the one received.
+    #   NORMALIZE resolves the dot segments and routes, enforces and forwards on the result.
+    # Beyond dot segments, REJECT and NORMALIZE also decode percent-encoded unreserved
+    # characters, merge duplicate slashes, and answer 400 on a malformed percent sequence.
+    # Encoded slashes are never decoded.
+    pathHandling: RAW
     requestTimeout: 30000
     requestTimeoutGraceDelay: 30
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1214,7 +1214,10 @@ gateway:
     #   NORMALIZE resolves the dot segments and routes, enforces and forwards on the result.
     # Beyond dot segments, REJECT and NORMALIZE also decode percent-encoded unreserved
     # characters, merge duplicate slashes, and answer 400 on a malformed percent sequence.
-    # Encoded slashes are never decoded.
+    # Encoded slashes are never decoded, and segment parameters on an ordinary segment are
+    # left alone: /a/admin;x/b is canonical here and forwarded as sent, while a Servlet
+    # receiver strips the ;x and serves /a/admin/b. An allow or deny rule written against
+    # /admin/** therefore still needs its own guard against that spelling.
     pathHandling: RAW
     requestTimeout: 30000
     requestTimeoutGraceDelay: 30


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14917

**Description**

The gateway resolves the listener context path against the request path exactly as it arrived, enforces the matched API's plan, then forwards that path upstream without resolving it. Any conforming receiver applies RFC 3986 §5.2.4 and serves a different resource than the one the gateway authorized.

Reproduced on a clean 4.11.6 stack with two v4 APIs sharing an upstream host — `alpha` on `/alpha/api/` with no plan, `beta` on `/beta/api/` behind an api-key plan:

| Request | Credential | Before |
| --- | --- | --- |
| `/beta/api/echo` | none | 401 |
| `/alpha/api/../../beta/api/echo` | **none** | **200, beta's backend served** |
| `/alpha/api/%2e%2e/%2e%2e/beta/api/echo` | **none** | **200, beta's backend served** |

This adds a single gateway-level setting, `http.pathHandling`, applied in `DefaultHttpRequestDispatcher.dispatch()` before the acceptor is resolved — the only point where the routing decision itself can be corrected rather than merely blocked.

| Mode | Behaviour |
| --- | --- |
| `RAW` | Today's behaviour, unchanged. **Default**, so this PR is not a breaking change. |
| `REJECT` | 400 when the path is not already canonical. Nothing is rewritten. |
| `NORMALIZE` | Routes, enforces and forwards on the resolved path. |

**Scope.** Both modes apply to every definition version. `REJECT` by construction, since it answers before the acceptor distinguishes them; `NORMALIZE` because the normalized path is seeded into the request wrapper of the reactive engine and the legacy one alike. Integration tests cover v4, v2 under emulation, and v2 on the legacy engine, in every mode.

**Algorithm.** Derived from Vert.x (`HttpUtils.normalizePath` on 4.x, `RFC3986.normalizePath` on 5.x), carried here with EPL-2.0 / Apache-2.0 attribution — both live in non-public packages and the class moved between the two versions, so there is no public API to delegate to on any branch we maintain. `java.net.URI` was measured and rejected: it leaves `%2e%2e` intact and throws on characters that legitimately appear in a request line.

**One deliberate departure from RFC 3986, and it is the security-relevant one.** A segment may carry parameters after a `;`, and §5.2.4 resolves only the exact strings `.` and `..` — so by the specification, `..;x` is an ordinary segment. The Servlet specification is equally clear that a container strips `;params` from every segment *before* resolving, which is what Tomcat, Jetty and Spring do. The gateway takes the second reading and treats `..;x` as a dot segment, because a gateway cannot know what sits behind it: being stricter than the receiver costs an over-refused request, while being laxer authorises one resource and lets another be served — the escalation this PR closes. **This is the only change that widens what `REJECT` refuses**, so a deployment switching to `REJECT` may now see 400s it did not see on an earlier build of this branch.

**Performance.** A `needsNormalization` pre-check answers in one pass, without allocating, whether normalizing would change anything — so `REJECT` never normalizes and `NORMALIZE` only pays when there is something to resolve. Measured with JMH on a 1000-path corpus at 95/5: **38.8 ns per request** under `NORMALIZE`, 32.0 under `REJECT`, against 0.76 for `RAW`. That is +0.004 % on a 1 ms request. The predicate and `normalize()` are held to each other by a property test over 20 000 generated paths, which also asserts that the normalizer's own output never needs normalizing again — the agreement property alone would be satisfied by a `normalize` that left a `..` behind.

**This PR carries more than the fix.** Four things landed alongside it, each for a reason found while building it, and each in its own commit:

- **The request clock now starts at the entry of `dispatch()`.** It used to be stamped in the wrapper's constructor, so everything the dispatcher did — including normalization — fell outside every latency the gateway reports.
- **Request wrappers are built from an options object** rather than from a growing constructor. Adding a field used to move a `public` constructor on five classes and the `protected` factory that calls them; that is what **silently disabled an override in the debug service**, which kept compiling while no longer overriding anything. All previous constructors are kept, deprecated and delegating.
- **The Helm chart exposes the setting**, in both branches of the gateway configmap, defaulting to `RAW`.
- **A rejected path no longer strands a debug session.** The refusal happens before the acceptor is resolved, so the dispatcher never learns the request was a debug one, the completion processor never runs, and the console spins forever on an event stuck in `DEBUGGING`. The debug port now answers the request through the same chain and then closes the session, showing an empty timeline under a red 400.

**A result worth reading before reviewing.** The product already contains a second normalizer, in `gravitee-policy-resource-filtering`, with different rules and its own on/off switch. An integration test pins what happens when both are in play, on an API that denies `/admin/**` with the policy's own normalization switched off:

- under `RAW`, `/alpha/api/public/../admin/secret` reaches the backend — the reported bug, reproduced **between two of our own components**
- under `NORMALIZE`, the same request is refused with a 403, because the gateway resolved the path before the API was even selected — the policy is not reconfigured and knows nothing about the setting

**Additional context**

ADR, with the full reasoning, the benchmark tables and the review trail: https://gravitee.atlassian.net/wiki/spaces/APIM1/pages/385515526

**What the modes do not protect against.** They assume a receiver that decodes percent sequences once, per RFC 3986 §2.3, and treats only `/` as a separator. Reserved characters are deliberately left encoded, so `/a/..%2f../b` and `/a/%252e%252e/b` are canonical here and are neither resolved nor refused. A receiver configured to decode `%2F` into a separator (nginx with a URI in `proxy_pass`, Apache with `AllowEncodedSlashes On`) or to accept `\` as one resolves paths this normalizer does not. `REJECT` refuses paths that are not canonical; it is not traversal hardening for an arbitrary receiver. This is stated in the class contract so nobody reads the setting as more than it is.

**Branch plan.** This targets `4.11.x` to stay closest to the reporting customer, and deliberately keeps the vendored normalizer. Two follow-ups are agreed: `4.12.x` consumes the class from a released `gravitee-common` and gets the options builder for both request types; `master` does the same and **makes `NORMALIZE` the default**, which is a breaking change to be announced as one. The extraction to `gravitee-common` waits until the review of this branch has settled, so the released class starts from the hardened version rather than needing the same fixes three times.

**Testing.** 369 unit tests in the gateway reactor, 151 in the debug service, 32 in the gateway env module, 42 integration tests on path handling, and four `helm-unittest` cases. Four of the assertions added by this branch were verified by mutation rather than trusted green: breaking either side of the rejection decision fails 6 of 24 cases; reverting the locale fix fails exactly the one test that covers it; re-rendering the Helm key fails the negative assertion; and the property generator now draws from the encodings the threat model names.

**Note for reviewers on JDK 25**: `PathTraversalOrganizationGuardV4IntegrationTest` cannot run locally on a JDK 25 toolchain — the Groovy policy it deploys rejects class file major version 69. All four of its cases fail there, including the one that only serves a regular path. CI runs on JDK 21 and is unaffected.

**Not in this PR**: the documentation, the 4.13 announcement, and surfacing `handlers.rejected.analytics.enabled` in the chart's `values.yaml`. All tracked in the ADR.
