### PR TITLE
fix(rest-api): apply categoryId filter to portal catalog search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
 
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
@@ -106,7 +107,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
         @BeanParam PaginationParam paginationParam
     ) {
         if ("catalog".equalsIgnoreCase(type)) {
-            return searchPortalCatalog(query, include, paginationParam);
+            return searchPortalCatalog(query, include, categoryId, paginationParam);
         }
         if (!"api".equalsIgnoreCase(type)) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new ErrorResponse()).build();
@@ -143,7 +144,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
         return Response.ok(responseBody).build();
     }
 
-    private Response searchPortalCatalog(String query, Set<String> include, PaginationParam paginationParam) {
+    private Response searchPortalCatalog(String query, Set<String> include, String categoryId, PaginationParam paginationParam) {
         Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> coreIncludes = parseIncludes(include);
         var executionContext = getExecutionContext();
         var output = getVisiblePortalCatalogItemsUseCase.execute(
@@ -153,7 +154,8 @@ public class PortalNavigationItemsResource extends AbstractResource {
                 PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull()),
                 new PageableImpl(paginationParam.getPage(), paginationParam.getSize()),
                 Optional.ofNullable(query),
-                coreIncludes
+                coreIncludes,
+                Optional.ofNullable(categoryId).map(PortalCategoryId::of)
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -66,6 +67,9 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
     @Autowired
     private ApiProductQueryServiceInMemory apiProductQueryService;
 
+    @Autowired
+    private ApiQueryServiceInMemory apiQueryService;
+
     @Override
     protected String contextPath() {
         return "portal-navigation-items";
@@ -85,6 +89,7 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
         portalNavigationItemsQueryService.reset();
         apiPortalSearchQueryService.reset();
         apiProductQueryService.reset();
+        apiQueryService.reset();
     }
 
     @Test
@@ -532,6 +537,106 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
                 assertThat(apiProduct).containsEntry("navigationItemId", navigationItemId.json());
                 assertThat(apiProduct).containsEntry("apis", List.of());
             });
+    }
+
+    @Test
+    void should_filter_catalog_api_items_by_known_category_id() {
+        var itemInCategory = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Auth API").value())
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
+        var itemOutsideCategory = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Other API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(2)
+            .apiId("api-uuid-2")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Other API").value())
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(itemInCategory, itemOutsideCategory));
+        var apis = List.of(
+            Api.builder().id("api-uuid-1").name("Auth API").environmentId(ENV_ID).build(),
+            Api.builder().id("api-uuid-2").name("Other API").environmentId(ENV_ID).build()
+        );
+        apiPortalSearchQueryService.initWith(apis);
+        apiQueryService.initWith(apis);
+
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("categoryId", CATEGORY_ID_1).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data).hasSize(1);
+        assertThat(data.getFirst()).containsEntry("id", itemInCategory.getId().toString());
+    }
+
+    @Test
+    void should_exclude_api_products_from_catalog_search_when_category_id_is_present() {
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .segment(PortalNavigationItem.slugify("Auth API").value())
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
+        var apiProductId = UUID.randomUUID();
+        var apiProductItem = PortalNavigationFixtures.apiProduct(
+            PortalNavigationFixtures.randomNavigationId(),
+            "Payments Product",
+            PortalArea.TOP_NAVBAR,
+            apiProductId
+        );
+        apiProductItem.setEnvironmentId(ENV_ID);
+        portalNavigationItemsQueryService.initWith(List.of(apiItem, apiProductItem));
+        var apis = List.of(Api.builder().id("api-uuid-1").name("Auth API").environmentId(ENV_ID).build());
+        apiPortalSearchQueryService.initWith(apis);
+        apiQueryService.initWith(apis);
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(apiProductId.toString())
+                    .environmentId(ENV_ID)
+                    .name("Payments Product")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build()
+            )
+        );
+
+        Response response = target("/_search")
+            .queryParam("type", "catalog")
+            .queryParam("include", "api_product")
+            .queryParam("categoryId", CATEGORY_ID_1)
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data).hasSize(1);
+        assertThat(data.getFirst()).containsEntry("id", apiItem.getId().toString());
+        assertThat(result.get("apiProducts")).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
@@ -75,6 +76,7 @@ public class GetVisiblePortalCatalogItemsUseCase {
     private final CheckTypoToleranceDomainService checkTypoToleranceDomainService;
 
     public Output execute(Input input) {
+        String categoryId = input.categoryId().map(PortalCategoryId::toString).orElse(null);
         List<PortalNavigationItem> navigationItems = portalNavigationItemsQueryService.search(
             PortalNavigationItemQueryCriteria.builder().environmentId(input.environmentId()).build()
         );
@@ -84,8 +86,8 @@ public class GetVisiblePortalCatalogItemsUseCase {
         List<PortalNavigationApi> accessibleApis = input
             .viewerContext()
             .userId()
-            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId))
-            .orElseGet(() -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId()));
+            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId, categoryId))
+            .orElseGet(() -> apiVisibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryId));
         Set<PortalNavigationItemId> accessibleApiNavigationItemIds = accessibleApis
             .stream()
             .map(PortalNavigationItem::getId)
@@ -106,13 +108,10 @@ public class GetVisiblePortalCatalogItemsUseCase {
             visibleApis,
             navigationItemsById
         );
-        List<PortalNavigationApiProduct> visibleApiProducts = findVisibleApiProducts(
-            navigationItems,
-            input,
-            navigationItemsById,
-            accessibleApiNavigationItemIds,
-            accessibleApiProductIds
-        );
+        // API products carry no category association, so a category-filtered catalog search never matches any of them.
+        List<PortalNavigationApiProduct> visibleApiProducts = input.categoryId().isPresent()
+            ? List.of()
+            : findVisibleApiProducts(navigationItems, input, navigationItemsById, accessibleApiNavigationItemIds, accessibleApiProductIds);
 
         Optional<String> query = input
             .query()
@@ -326,7 +325,8 @@ public class GetVisiblePortalCatalogItemsUseCase {
         PortalNavigationItemViewerContext viewerContext,
         Pageable pageable,
         Optional<String> query,
-        Set<PortalNavigationSearchInclude> includes
+        Set<PortalNavigationSearchInclude> includes,
+        Optional<PortalCategoryId> categoryId
     ) {}
 
     public record Output(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.domain_service.CheckTypoToleranceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalCatalogNavigationVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
@@ -60,6 +61,8 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
 
     private static final String ENV_ID = "env-id";
     private static final String ORG_ID = "org-id";
+    private static final String CATEGORY_ID_1 = "11111111-1111-1111-1111-111111111111";
+    private static final String UNKNOWN_CATEGORY_ID = "99999999-9999-9999-9999-999999999999";
 
     private GetVisiblePortalCatalogItemsUseCase useCase;
     private CountingPortalNavigationItemsQueryService navigationItemsQueryService;
@@ -320,11 +323,86 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
         assertThat(output.items().getContent()).isEmpty();
     }
 
+    @Test
+    void should_filter_catalog_apis_by_category_id() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiInCategory = apiItem(
+            "api-item-in-category-id",
+            "api-in-category-id",
+            folder.getId(),
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        var apiOutsideCategory = apiItem(
+            "api-item-outside-category-id",
+            "api-outside-category-id",
+            folder.getId(),
+            PortalVisibility.PUBLIC
+        );
+        navigationItemsQueryService.initWith(List.of(folder, apiInCategory, apiOutsideCategory));
+        initApis(
+            List.of(api("api-in-category-id", "In Category API", "1.0.0"), api("api-outside-category-id", "Outside Category API", "1.0.0"))
+        );
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10, Optional.of(CATEGORY_ID_1)));
+
+        assertThat(output.items().getContent()).containsExactly(apiInCategory);
+    }
+
+    @Test
+    void should_exclude_api_products_from_catalog_when_category_id_is_present() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiInCategory = apiItem(
+            "api-item-in-category-id",
+            "api-in-category-id",
+            folder.getId(),
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        var apiProductItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        navigationItemsQueryService.initWith(List.of(folder, apiInCategory, apiProductItem));
+        initApis(List.of(api("api-in-category-id", "In Category API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of())));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10, Optional.of(CATEGORY_ID_1)));
+
+        assertThat(output.items().getContent()).containsExactly(apiInCategory);
+        assertThat(output.includedApiProducts()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_catalog_results_when_category_id_does_not_match() {
+        var folder = folder("folder-id", "Catalog", null);
+        var apiInCategory = apiItem(
+            "api-item-in-category-id",
+            "api-in-category-id",
+            folder.getId(),
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        navigationItemsQueryService.initWith(List.of(folder, apiInCategory));
+        initApis(List.of(api("api-in-category-id", "In Category API", "1.0.0")));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10, Optional.of(UNKNOWN_CATEGORY_ID)));
+
+        assertThat(output.items().getContent()).isEmpty();
+    }
+
     private GetVisiblePortalCatalogItemsUseCase.Input input(
         Optional<String> query,
         Set<PortalNavigationSearchInclude> includes,
         int page,
         int size
+    ) {
+        return input(query, includes, page, size, Optional.empty());
+    }
+
+    private GetVisiblePortalCatalogItemsUseCase.Input input(
+        Optional<String> query,
+        Set<PortalNavigationSearchInclude> includes,
+        int page,
+        int size,
+        Optional<String> categoryId
     ) {
         return new GetVisiblePortalCatalogItemsUseCase.Input(
             ENV_ID,
@@ -332,7 +410,8 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
             PortalNavigationItemViewerContext.forPortal((String) null),
             new PageableImpl(page, size),
             query,
-            includes
+            includes,
+            categoryId.map(PortalCategoryId::of)
         );
     }
 
@@ -372,6 +451,16 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
     }
 
     private PortalNavigationApi apiItem(String id, String apiId, PortalNavigationItemId parentId, PortalVisibility visibility) {
+        return apiItem(id, apiId, parentId, visibility, List.of());
+    }
+
+    private PortalNavigationApi apiItem(
+        String id,
+        String apiId,
+        PortalNavigationItemId parentId,
+        PortalVisibility visibility,
+        List<PortalCategoryId> categoryIds
+    ) {
         return PortalNavigationApi.builder()
             .id(navigationItemId(id))
             .organizationId(ORG_ID)
@@ -384,6 +473,7 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
             .apiId(apiId)
             .published(true)
             .visibility(visibility)
+            .categoryIds(categoryIds)
             .build();
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-124

**Purpose**

Fix the portal catalog search (`_search?type=catalog`) silently ignoring the `categoryId` query parameter, so category-filtered browsing on the Portal catalog page actually narrows results.

**Summary of changes**

- `PortalNavigationItemsResource#searchPortalCatalog` now forwards `categoryId` into `GetVisiblePortalCatalogItemsUseCase.Input` (previously dropped entirely on the `type=catalog` branch, while the sibling `type=api` branch already forwarded it).
- `GetVisiblePortalCatalogItemsUseCase` filters APIs by category using the existing `PortalNavigationApiVisibilityDomainService#resolveVisibleItems`/`resolveVisiblePublicItems` overloads (already used by the `type=api` path since PORTAL-22).
- API products are excluded from category-filtered catalog results, since `PortalNavigationApiProduct`/`ApiProduct` carry no category association anywhere in the domain model.
- `Input.categoryId` is typed `Optional<PortalCategoryId>` (the domain value type), converted from the raw query-param string at the REST boundary.

**Out of scope**

- Adding category association for API products — no such concept exists in the domain model today; would be a separate feature.
- The Portal Next catalog category dropdown-search UI (PORTAL-8, already merged in #19162) — this PR is the backend fix it depends on.

**Testing**

- New unit tests in `GetVisiblePortalCatalogItemsUseCaseTest` and `PortalNavigationItemsResourceTest` covering: filtering APIs by category, excluding API products when a category filter is active, and empty results for a non-matching category id.
- Full module suites pass: `gravitee-apim-rest-api-service` and `gravitee-apim-rest-api-portal-rest`. 2 pre-existing unrelated failures observed elsewhere (`JsonSchemaServiceTest` — locale-dependent error message under a non-English JVM locale; `ApplicationLogsResourceTest` — pagination validation), confirmed unrelated to this change.
- Manually verified against a local Docker stack (`management_api` image rebuilt from this branch), using two pre-existing seeded APIs (`categories: news` and `categories: news, finance`):

  ```
  GET .../_search?type=catalog                          -> API 1, API 2   (unfiltered)
  GET .../_search?type=catalog&categoryId=<finance>      -> API 2 only
  GET .../_search?type=catalog&categoryId=<news>         -> API 1, API 2
  GET .../_search?type=catalog&categoryId=<unknown-uuid> -> []            (empty)
  ```

**Additional context**

Full curl transcript of the manual verification:

```
=== Gravitee APIM PORTAL-124 fix verification ===
Stack: local Docker (management_api rebuilt from fix/PORTAL-124-catalog-search-ignores-category-id)
Endpoint under test: GET /portal/environments/DEFAULT/portal-navigation-items/_search?type=catalog

Seed data (pre-existing in this environment):
  API 1 'PORTAL-29 Test API 1' -> categories: news
  API 2 'PORTAL-29 Test API 2' -> categories: news, finance

--- Scenario 1: no categoryId (baseline, unfiltered) ---
$ curl "http://localhost:8083/portal/environments/DEFAULT/portal-navigation-items/_search?type=catalog"
titles returned: ['PORTAL-29 Test API 1', 'PORTAL-29 Test API 2']

--- Scenario 2: categoryId=finance (119fc02f-8f20-4912-a99d-e0db374bca49) -> only API 2 should match ---
$ curl ".../_search?type=catalog&categoryId=119fc02f-8f20-4912-a99d-e0db374bca49"
titles returned: ['PORTAL-29 Test API 2']
total: 1

--- Scenario 3: categoryId=news (5b1cebcd-f75f-4924-9f2d-0cf4da069f55) -> both API 1 and API 2 should match ---
$ curl ".../_search?type=catalog&categoryId=5b1cebcd-f75f-4924-9f2d-0cf4da069f55"
titles returned: ['PORTAL-29 Test API 1', 'PORTAL-29 Test API 2']
total: 2

--- Scenario 4: categoryId=<unknown uuid> -> empty result ---
$ curl ".../_search?type=catalog&categoryId=00000000-0000-0000-0000-000000000000"
titles returned: []
total: 0

--- Scenario 5: type=api (sibling path, already worked before this fix) with categoryId=finance -> sanity check same semantics ---
titles returned: ['PORTAL-29 Test API 2']
```

Note: no API Product existed in this environment's seed data, so the "API products are excluded from category-filtered catalog results" behavior was not re-verified manually here — it is covered by `GetVisiblePortalCatalogItemsUseCaseTest.should_exclude_api_products_from_catalog_when_category_id_is_present` and `PortalNavigationItemsResourceTest.should_exclude_api_products_from_catalog_search_when_category_id_is_present`.
