### PR TITLE
feat(distribution): init JDBC migrations distribution module with Liquibase changesets

### DIFF
--- a/.run/Rest API - JDBC.run.xml
+++ b/.run/Rest API - JDBC.run.xml
@@ -12,7 +12,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
     <module name="gravitee-apim-rest-api-standalone-container" />
-    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000 " />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution -Dvertx.options.maxEventLoopExecuteTime=1000000000000" />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
@@ -48,7 +48,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-apim/es-index-mappings</publish-folder-path>
+        <publish-folder-path>graviteeio-apim/resources</publish-folder-path>
     </properties>
 
     <dependencies>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/README.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/README.md
@@ -1,0 +1,137 @@
+# APIM — JDBC schema migrations
+
+This module packages every Liquibase changeset APIM and its bundled Gamma modules apply to a JDBC
+management database, so that installations running with `management.jdbc.liquibase=false` can apply
+them themselves instead of opening each installed plugin. It ships as this file's own README inside
+the published archive, which is what a customer reads.
+
+Applies to the JDBC backend only.
+
+You need a Liquibase CLI. Nothing else: the changesets in the archive are the ones the application
+runs, and the CLI ships the JDBC driver for every database APIM supports except MySQL, whose licence
+keeps it out. The archive filename carries the APIM version it was built from.
+
+## Read this first
+
+**Always pass the prefix parameters, even when your installation uses no prefix.** Almost every
+changeset names its tables through a parameter — `${gravitee_prefix}api_products` rather than
+`api_products`. Omitting the parameter leaves the placeholder unresolved, which changes the checksum
+of every changeset, and Liquibase then reports well over a hundred failures of this shape:
+
+```
+Validation Failed:
+     141 changesets check sum
+          liquibase/changelogs/v1_15_0/schema.yml::1.15.0::GraviteeSource Team
+              was: 9:89bae981dae8df68c63aa03c4aa12792 but is now: 9:8259b78599409dec370ffa0c10c4395f
+```
+
+Nothing is corrupted and no version is incompatible: a parameter is missing. Pass
+`-Dgravitee_prefix=` with an empty value if you have no prefix.
+
+## What is in the archive, and what to run it against
+
+One entry point per component. List them:
+
+```
+find . -name master.yml
+```
+
+```
+./liquibase/master.yml       APIM itself
+./liquibase/aim/master.yml   the "aim" Gamma module
+```
+
+`liquibase/master.yml` is always APIM. Every other entry point is a Gamma module, and the directory
+name is the module id. Only modules that own a schema appear — a module absent from this list has
+nothing to migrate.
+
+**Each entry point is a separate run.** Modules keep their migration history in their own tracking
+tables, independently of APIM and of each other, so running APIM's changelog does not migrate the
+modules. Derive the arguments from the id:
+
+| | Changelog | Tracking tables | Parameters |
+|---|---|---|---|
+| APIM | `liquibase/master.yml` | `<prefix>databasechangelog` and `<prefix>databasechangeloglock` | `gravitee_prefix`, `gravitee_rate_limit_prefix` |
+| module `<id>` | `liquibase/<id>/master.yml` | `<prefix><id>_databasechangelog` and `<prefix><id>_databasechangeloglock` | `<id>_prefix` |
+
+`<prefix>` is `management.jdbc.prefix` from your `gravitee.yml`, empty unless you configured one.
+`gravitee_rate_limit_prefix` is `ratelimit.jdbc.prefix`.
+
+**The tracking table names carry the prefix too.** The application derives them from
+`management.jdbc.prefix`, so a run that leaves them at Liquibase's default opens a different table
+from the one the application writes to, finds it empty, and replays every changeset against an
+already-migrated database.
+
+Set these once and every command below can be pasted as it is:
+
+```
+URL=<jdbc url>     # e.g. jdbc:postgresql://localhost:5432/gravitee
+USER=<user>
+PASSWORD=<password>
+PREFIX=            # management.jdbc.prefix, leave empty if you configured none
+RL_PREFIX=         # ratelimit.jdbc.prefix
+```
+
+## Reviewing what an upgrade would do
+
+`update-sql` writes the pending statements to a file without applying them. Run it from the
+directory you unzipped the archive into.
+
+APIM:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/master.yml --url="$URL" --username="$USER" --password="$PASSWORD" --database-changelog-table-name="${PREFIX}databasechangelog" --database-changelog-lock-table-name="${PREFIX}databasechangeloglock" --output-file=apim.sql update-sql "-Dgravitee_prefix=$PREFIX" "-Dgravitee_rate_limit_prefix=$RL_PREFIX"
+```
+
+Then one run per module — here `aim`:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/aim/master.yml --url="$URL" --username="$USER" --password="$PASSWORD" --database-changelog-table-name="${PREFIX}aim_databasechangelog" --database-changelog-lock-table-name="${PREFIX}aim_databasechangeloglock" --output-file=aim.sql update-sql "-Daim_prefix=$PREFIX"
+```
+
+Or generate every file in one pass:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/master.yml --url="$URL" --username="$USER" --password="$PASSWORD" --database-changelog-table-name="${PREFIX}databasechangelog" --database-changelog-lock-table-name="${PREFIX}databasechangeloglock" --output-file=apim.sql update-sql "-Dgravitee_prefix=$PREFIX" "-Dgravitee_rate_limit_prefix=$RL_PREFIX"
+for module in $(find liquibase -mindepth 2 -name master.yml | cut -d/ -f2); do
+  liquibase --search-path=. --changelog-file="liquibase/$module/master.yml" --url="$URL" --username="$USER" --password="$PASSWORD" --database-changelog-table-name="${PREFIX}${module}_databasechangelog" --database-changelog-lock-table-name="${PREFIX}${module}_databasechangeloglock" --output-file="$module.sql" update-sql "-D${module}_prefix=$PREFIX"
+done
+```
+
+The generated files carry their own `INSERT INTO ... databasechangelog` statements. Applying one
+therefore leaves the database in the state the application expects, and it will start without
+replaying anything.
+
+`update-sql` does not change your schema, but it does take the Liquibase lock, so it writes to the
+lock table and creates it if absent. It is not a read-only operation.
+
+## Applying
+
+Replace `update-sql` with `update` to apply.
+
+## Three things that will bite you
+
+**Do not move the files inside `liquibase/`.** Liquibase identifies a changeset by *(id, author,
+filename)*, and `filename` is the changelog path as resolved — it is stored in the tracking table.
+The paths in the archive are the ones the application records when it migrates itself. Re-rooting
+them makes your run record different filenames, and the application then considers nothing applied
+and replays everything against an already-migrated database. No error is reported at the time of
+your run.
+
+**The archive describes one combination.** It carries one APIM version and the module versions
+bundled with it. If you upgraded a module on its own, use the changelogs of the version you actually
+run — they are inside that plugin's own archive, under `liquibase/<id>/`.
+
+**MySQL and MariaDB need `--classpath`.** On MySQL, because the CLI carries no driver for it. And on
+both, when the server runs with `sql_require_primary_key=ON`: Liquibase creates its tracking table
+without a primary key, and the server rejects it with error 3750 before any changeset runs. The
+application never hits this, because it registers a generator that adds the key. Take that same jar
+out of the plugin you already have installed:
+
+```
+unzip -j plugins/gravitee-apim-repository-jdbc-*.zip 'gravitee-apim-repository-jdbc-*.jar' -d .
+```
+
+then add `--classpath=<that jar>` to the commands above, prefixed by your MySQL driver and a colon if
+you need one. It only matters for the run that creates the tracking table: once the table exists with
+its key, later runs need nothing.

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.distribution</groupId>
+        <artifactId>gravitee-apim-distribution</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-distribution-jdbc-migrations</artifactId>
+    <packaging>pom</packaging>
+    <name>Gravitee.io APIM - Distribution - JDBC Migrations</name>
+    <description>Liquibase changesets of APIM and of the bundled Gamma modules, in one archive. JDBC only.</description>
+
+    <properties>
+        <!--
+            The umbrella turns deployment off for the assembly poms; this module is an exception, like
+            es-index-mappings — the archive it produces is the deliverable, and it is meant to reach the download
+            website so that installations running with management.jdbc.liquibase=false have somewhere to get the
+            changesets from.
+        -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/jdbc-migrations</publish-folder-path>
+
+    </properties>
+
+    <!--
+        Published so that an installation running with management.jdbc.liquibase=false has one place to get every
+        changelog it needs, instead of opening each installed plugin.
+
+        The dependencies are the ordinary plugin zips, the same ones the standalone distribution bundles, at the
+        same versions. Each carries its changelogs at its root under liquibase/, and unpack-dependencies keeps only
+        that. A component with no schema contributes nothing and needs no declaration of its own — which is what
+        keeps these lists stable while modules adopt JDBC one at a time.
+
+        The trees are disjoint by construction: APIM owns liquibase/master.yml and liquibase/changelogs/, each
+        module owns liquibase/<module id>/. A module taking liquibase/changelogs/ for itself would silently
+        overwrite APIM's files here; that path is reserved.
+
+        Only the open-source repository plugin is declared here. The Gamma modules are enterprise artefacts,
+        resolvable from the private Artifactory only, so they live in the bundle-default profile as they do in the
+        standalone distribution — see the rule at gravitee-apim-distribution-standalone/pom.xml:47-50. Declaring
+        them here would break any build without credentials, job-community-build-backend first.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-jdbc</artifactId>
+            <version>${apim.server.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Both directories accumulate: nothing here overwrites a file that no longer has a source. Bump a
+                module version and rebuild without clean, and the previous jar stays in plugin-jars, its changelogs
+                stay in migrations, and the archive ships changesets that no master.yml references. The build stays
+                green, and the assertions below stay green too, because the files they expect do exist.
+
+                The markers directory has to go with them. unpack-dependencies records what it has already
+                extracted, so leaving the markers behind while deleting plugin-jars would make the unpack a no-op
+                and produce an empty archive instead of a mixed one.
+
+                Declared first: within a phase, plugins run in the order they appear here.
+
+                The configuration sits on the execution, not on the plugin: plugin-level configuration also reaches
+                default-clean, and excludeDefaultDirectories there stops `mvn clean` from removing target/ at all.
+            -->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>reset-collection-directories</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/plugin-jars</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>${project.build.directory}/${project.artifactId}</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>${project.build.directory}/reservation-check</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>${project.build.directory}/dependency-maven-plugin-markers</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                The changelogs live inside each plugin's jar, which lives inside the plugin zip, so collecting them
+                takes two stages. Maven does the first, Ant the second.
+
+                Only the jar at the root of each zip is taken — deliberately "*.jar" and not "**/*.jar". The jars
+                under lib/ include liquibase-core, whose own Java package is also called liquibase: unpacking it
+                would pour 1426 class files into an archive meant for a DBA, and the changelog assertion below would
+                still pass. Keeping lib/ out is what makes that impossible rather than merely filtered.
+            -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-plugin-jars</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>*.jar</includes>
+                            <outputDirectory>${project.build.directory}/plugin-jars</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>collect-changelogs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!--
+                                    Every jar expands into the same directory and Ant overwrites, so the paths
+                                    reserved for APIM above are an invariant nothing enforced: a module shipping
+                                    liquibase/master.yml would replace APIM's, and the assertion below would still
+                                    pass because a file of that name exists. Extract the reserved paths from the
+                                    module jars alone first, and fail if that finds anything.
+                                -->
+                                <unzip dest="${project.build.directory}/reservation-check">
+                                    <fileset dir="${project.build.directory}/plugin-jars" includes="*.jar" excludes="gravitee-apim-repository-jdbc-*.jar" erroronmissingdir="false" />
+                                    <patternset>
+                                        <include name="liquibase/master.yml" />
+                                        <include name="liquibase/changelogs/**" />
+                                    </patternset>
+                                </unzip>
+                                <fail message="A module ships files under a path reserved for APIM (liquibase/master.yml or liquibase/changelogs/). Collecting them into one tree would silently overwrite APIM's own changelogs.">
+                                    <condition>
+                                        <resourcecount when="greater" count="0">
+                                            <fileset dir="${project.build.directory}/reservation-check" includes="**/*.yml" erroronmissingdir="false" />
+                                        </resourcecount>
+                                    </condition>
+                                </fail>
+
+                                <unzip dest="${project.build.directory}/${project.artifactId}">
+                                    <fileset dir="${project.build.directory}/plugin-jars" includes="*.jar" erroronmissingdir="false" />
+                                    <patternset>
+                                        <include name="liquibase/**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                An empty collection is a silent failure: the assembly happily produces a valid, empty zip. That
+                happens if the include pattern stops matching, or if a component stops shipping its changelogs at
+                the zip root. APIM's own changelog is always expected, so assert it and fail loudly instead.
+
+                This assertion covers the repository plugin only, which is the one dependency whose absence would be
+                unmissable anyway. The modules are asserted in the bundle-default profile, where they are declared.
+            -->
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>changelogs-were-collected</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.build.directory}/${project.artifactId}/liquibase/master.yml</file>
+                                    </files>
+                                </requireFilesExist>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <!--
+        Same activation as the standalone distribution's own bundle-default: the property, not the profile id, so
+        that -Dbundle reaches it from the parent reactor.
+
+        The assembly lives here too, not only the module dependencies. The archive is APIM plus the bundled
+        modules; an APIM-only zip built without -Dbundle would be a valid, incomplete archive that nothing
+        distinguishes from the real one, and whose README tells the reader that a module absent from the listing
+        "has nothing to migrate". Without the profile the collection above still runs, so a build without
+        credentials still exercises it, but no zip comes out.
+
+        The enforcer execution asserts the modules known to own a schema, one entry each. A module adopting JDBC
+        has to be added to both lists, which is the point.
+    -->
+    <profiles>
+        <profile>
+            <id>bundle-default</id>
+            <activation>
+                <property>
+                    <name>bundle</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-aim</artifactId>
+                    <version>${gravitee-gamma-module-aim.version}</version>
+                    <type>zip</type>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-authz</artifactId>
+                    <version>${gravitee-gamma-module-authz.version}</version>
+                    <type>zip</type>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-edge</artifactId>
+                    <version>${gravitee-gamma-module-edge.version}</version>
+                    <type>zip</type>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-esm</artifactId>
+                    <version>${gravitee-gamma-module-esm.version}</version>
+                    <type>zip</type>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>module-changelogs-were-collected</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireFilesExist>
+                                            <files>
+                                                <file>${project.build.directory}/${project.artifactId}/liquibase/aim/master.yml</file>
+                                            </files>
+                                        </requireFilesExist>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>make-migrations-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <appendAssemblyId>false</appendAssemblyId>
+                                    <finalName>${project.artifactId}-${apim.server.version}</finalName>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/migrations-assembly.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
@@ -42,8 +42,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-apim/jdbc-migrations</publish-folder-path>
-
+        <publish-folder-path>graviteeio-apim/resources</publish-folder-path>
     </properties>
 
     <!--

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/src/main/assembly/migrations-assembly.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/src/main/assembly/migrations-assembly.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>migrations</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!--
+		The changesets alone are not usable: they name their tables through parameters, and nothing in them says
+		which tracking tables to write to. The README carries the coordinates, and tells the reader to discover the
+		components to run rather than listing them — the archive contents are the list, so it cannot drift as
+		modules adopt JDBC.
+	-->
+	<files>
+		<file>
+			<source>README.md</source>
+			<outputDirectory>/</outputDirectory>
+		</file>
+	</files>
+
+	<!-- Filled by dependency:unpack-dependencies, which keeps only liquibase/** from each plugin zip. -->
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/${project.artifactId}</directory>
+			<outputDirectory>/</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -101,6 +101,8 @@
 
         <!-- Build plugins the distribution drives itself -->
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
 
         <!-- ===== Bundled plugin version catalog (moved from the root pom) ===== -->
@@ -320,6 +322,29 @@
     </repositories>
 
     <build>
+        <!--
+            gravitee-parent manages assembly and enforcer, and nothing else this tree drives. Left
+            unmanaged, these three resolve from Maven's super-POM, so their versions come from the
+            executor image rather than from here: the same reactor would unpack with 3.8.1 in
+            standalone, which pins it locally, and with whatever the super-POM offers elsewhere. On
+            Maven 3.8.x that means antrun 1.3, which has no target parameter at all.
+        -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven-antrun-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!--
                 The license header check runs with gravitee-parent's configuration now, which knows
@@ -424,6 +449,7 @@
     <modules>
         <module>gravitee-apim-distribution-standalone</module>
         <module>gravitee-apim-distribution-es-index-mappings</module>
+        <module>gravitee-apim-distribution-jdbc-migrations</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/FOUND-183

**Description**

Adds `gravitee-apim-distribution-jdbc-migrations`, a distribution module that publishes every Liquibase changeset APIM and its bundled Gamma modules apply to a JDBC management database, as one versioned archive on the download website.

Installations running with `management.jdbc.liquibase=false` — controlled upgrades, DBA-driven processes, restricted database credentials — currently have no supported way to apply the pending schema changes themselves. The changesets exist only inside each plugin's jar, inside its zip, and nothing documents how to invoke them. That is already true for APIM alone; Gamma modules turn one undocumented procedure into one per installed module, each with its own tracking tables and prefix parameter.

The archive collects them all:

```
gravitee-apim-jdbc-migrations-<version>.zip
├── README.md
└── liquibase/
    ├── master.yml          APIM
    ├── changelogs/v*/
    └── aim/                one directory per module that owns a schema
```

**How it is built**

The changesets sit inside each plugin's jar, which sits inside the plugin zip, so collecting them takes two stages: `dependency:unpack-dependencies` takes the jar out of each zip, then `antrun` takes `liquibase/**` out of the jars.

The dependencies are the ordinary plugin zips, the same ones the standalone distribution bundles, at the same versions — so **no component had to change**. A module that owns no schema contributes nothing and needs no declaration of its own, which is what keeps the list stable while modules adopt JDBC one at a time.

Two details are load-bearing and commented in place:

- the extraction takes `*.jar`, not `**/*.jar`. The jars under `lib/` include `liquibase-core`, whose own Java package is also called `liquibase`; unpacking those would pour 1426 class files into an archive meant for a DBA. Keeping `lib/` out makes that impossible rather than filtered.
- the `liquibase/` prefix is preserved verbatim. Liquibase identifies a changeset by *(id, author, filename)*, and `filename` is the changelog path as resolved — the same path the application records in `databasechangelog`. Re-rooting the tree would make a manual run record different filenames, and the application would then replay every changeset against an already-migrated database, without reporting an error at the time of the run.

An enforcer rule asserts APIM's own changelog was collected. Without it, a broken include pattern would publish a valid, empty archive and the build would stay green.

**Verified locally**

On Postgres, using only the published archive — unzipped into a directory, and nothing else: no
plugin opened, no jar extracted, no classpath assembled — with a Liquibase installed from Homebrew
(4.33) while the application runs 4.27:

- **Preview.** `update-sql` produced the 4.12 → 4.13 delta: 14 changesets, exactly the 14 files of `v4_13_0`; 4 tables, 9 columns, 6 indexes, each matching the changelogs on master.
- **Apply.** `update` applied them, and the module's own changesets went only to `aim_databasechangelog`, never to APIM's tracking table.
- **Restart.** The application then started normally and replayed nothing — `Run: 0, Previously run: 223` for APIM, `Run: 0, Previously run: 2` for aim, both tracking tables unchanged.

The last point is the one that matters: the paths a manual run records match what the application expects, and checksums written by 4.33 are accepted by 4.27.

Also confirmed the release job picks the archive up with no CI change: the zip matches its `find . -path '*target/gravitee-apim*.zip'`, the module declares `publish-folder-path`, and the name regex resolves to `gravitee-apim-jdbc-migrations`. It lands in `graviteeio-apim/jdbc-migrations/gravitee-apim-jdbc-migrations/`.

**Additional context**

The README shipped in the archive is the module's own `README.md` — one file, so the repository and the archive cannot drift. It leads with the failure a user is most likely to hit: omitting `-Dgravitee_prefix=` leaves the placeholder unresolved, which changes every checksum and produces 141 validation errors that look like a corrupted archive or an incompatible version. Nothing in Liquibase's message points at a missing parameter.

It also tells the reader to discover the components to run (`find . -name master.yml`) rather than listing them, so it cannot go stale as modules adopt JDBC.

Compatibility-sensitive: this publishes Liquibase changelogs as a customer-facing artifact. It adds no changeset and changes none — the files are the ones already inside the plugins.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

