### PR TITLE
chore: bump xslt policy to 3.1.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -172,7 +172,7 @@
     <gravitee-policy-xml-json.version>2.0.1</gravitee-policy-xml-json.version>
     <gravitee-policy-xml-threat-protection.version>1.5.1</gravitee-policy-xml-threat-protection.version>
     <gravitee-policy-xml-validation.version>1.2.1</gravitee-policy-xml-validation.version>
-    <gravitee-policy-xslt.version>3.1.1</gravitee-policy-xslt.version>
+    <gravitee-policy-xslt.version>3.1.2</gravitee-policy-xslt.version>
     <gravitee-policy-wssecurity-authentication.version>2.0.2</gravitee-policy-wssecurity-authentication.version>
     <gravitee-policy-http-redirect.version>1.0.2</gravitee-policy-http-redirect.version>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14931
https://gravitee.atlassian.net/browse/APIM-14731

## Description

Picks up gravitee-io/gravitee-policy-xslt#109 — an XSLT parameter whose expression resolves to no value is now left unbound instead of being passed to Saxon as null, which it rejects. Previously the transformation failed and the request returned 500 with nothing logged.

This changes behavior: a parameter whose expression resolves to no value previously failed the request with a 500; it is now left unbound and the transformation proceeds using the stylesheet's declared default. Configurations that were failing will start succeeding.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

