### PR TITLE
fix(audit): resolve api product audit names and raise user search limit (AIAM-207)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/audit/AuditMetadataQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/audit/AuditMetadataQueryServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.infra.adapter.UserAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -29,6 +30,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Group;
@@ -51,6 +53,7 @@ public class AuditMetadataQueryServiceImpl implements AuditMetadataQueryService 
     private final PageRepository pageRepository;
     private final PlanRepository planRepository;
     private final UserRepository userRepository;
+    private final ApiProductsRepository apiProductRepository;
 
     public AuditMetadataQueryServiceImpl(
         @Lazy ApiRepository apiRepository,
@@ -59,7 +62,8 @@ public class AuditMetadataQueryServiceImpl implements AuditMetadataQueryService 
         @Lazy MetadataRepository metadataRepository,
         @Lazy PageRepository pageRepository,
         @Lazy PlanRepository planRepository,
-        @Lazy UserRepository userRepository
+        @Lazy UserRepository userRepository,
+        @Lazy ApiProductsRepository apiProductRepository
     ) {
         this.apiRepository = apiRepository;
         this.applicationRepository = applicationRepository;
@@ -68,6 +72,7 @@ public class AuditMetadataQueryServiceImpl implements AuditMetadataQueryService 
         this.pageRepository = pageRepository;
         this.planRepository = planRepository;
         this.userRepository = userRepository;
+        this.apiProductRepository = apiProductRepository;
     }
 
     @Override
@@ -113,6 +118,8 @@ public class AuditMetadataQueryServiceImpl implements AuditMetadataQueryService 
                     return pageRepository.findById(propertyValue).map(Page::getName).orElse(propertyValue);
                 case PLAN:
                     return planRepository.findById(propertyValue).map(Plan::getName).orElse(propertyValue);
+                case API_PRODUCT:
+                    return apiProductRepository.findById(propertyValue).map(ApiProduct::getName).orElse(propertyValue);
                 case USER:
                     return userRepository
                         .findById(propertyValue)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/audit/AuditMetadataQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/audit/AuditMetadataQueryServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -29,6 +30,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.Metadata;
@@ -74,6 +76,9 @@ class AuditMetadataQueryServiceImplTest {
     @Mock
     UserRepository userRepository;
 
+    @Mock
+    ApiProductsRepository apiProductRepository;
+
     AuditMetadataQueryServiceImpl service;
 
     @BeforeEach
@@ -87,7 +92,8 @@ class AuditMetadataQueryServiceImplTest {
             metadataRepository,
             pageRepository,
             planRepository,
-            userRepository
+            userRepository,
+            apiProductRepository
         );
     }
 
@@ -527,6 +533,44 @@ class AuditMetadataQueryServiceImplTest {
 
                 // Then
                 Assertions.assertThat(result).isEqualTo(PLAN_ID);
+            }
+        }
+
+        @Nested
+        class ApiProductProperty {
+
+            public static final String API_PRODUCT_ID = "product-id";
+
+            @Test
+            @SneakyThrows
+            void should_return_api_product_name() {
+                when(apiProductRepository.findById(API_PRODUCT_ID)).thenReturn(
+                    Optional.of(ApiProduct.builder().id(API_PRODUCT_ID).name("Finance Team").build())
+                );
+
+                var result = service.fetchPropertyMetadata(AUDIT, AuditProperties.API_PRODUCT.name(), API_PRODUCT_ID);
+
+                Assertions.assertThat(result).isEqualTo("Finance Team");
+            }
+
+            @Test
+            @SneakyThrows
+            void should_return_api_product_id_when_no_product_is_found() {
+                when(apiProductRepository.findById(any())).thenReturn(Optional.empty());
+
+                var result = service.fetchPropertyMetadata(AUDIT, AuditProperties.API_PRODUCT.name(), API_PRODUCT_ID);
+
+                Assertions.assertThat(result).isEqualTo(API_PRODUCT_ID);
+            }
+
+            @Test
+            @SneakyThrows
+            void should_return_api_product_id_when_technical_exception_occurs() {
+                when(apiProductRepository.findById(any())).thenThrow(new TechnicalException());
+
+                var result = service.fetchPropertyMetadata(AUDIT, AuditProperties.API_PRODUCT.name(), API_PRODUCT_ID);
+
+                Assertions.assertThat(result).isEqualTo(API_PRODUCT_ID);
             }
         }
 


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/AIAM-207
## Summary

Companion to gravitee-io/gravitee-gamma-module-aim#651.

- Resolve **API Product** names in audit property metadata (so AI Workspace audit targets show workspace names).

## Test plan

- [x] `AuditMetadataQueryServiceImplTest` — API_PRODUCT name resolution
- [ ] Open AI Workspace → Audit Logs: Target value shows workspace name, not raw id