### PR TITLE
fix: bump gravitee-endpoint-jms to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
-        <gravitee-endpoint-jms.version>2.0.0</gravitee-endpoint-jms.version>
+        <gravitee-endpoint-jms.version>2.0.1</gravitee-endpoint-jms.version>
         <gravitee-endpoint-kafka.version>6.1.5</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14945

**Description**

Bumps the bundled JMS endpoint plugin to 2.0.1, which delivers the two APIM-14945 fixes: automatic recovery of message consumption after a broker connection loss (the failure is now propagated to the message stream so push subscriptions re-subscribe on their own), and support for typed IBM MQ custom properties (round-trip-safe coercion, so properties like `XMSC_WMQ_CLIENT_RECONNECT_TIMEOUT` no longer fail with a `ClassCastException` and existing string values are never altered). See gravitee-io/gravitee-endpoint-jms#42.
