### PR TITLE
feat(gamma): edit shared policy group metadata

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupBasicFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupBasicFields.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Field, FieldDescription, FieldLabel, Input, Textarea } from '@gravitee/graphene-core';
+
+import {
+    DESCRIPTION_MAX_LENGTH,
+    PREREQUISITE_MESSAGE_MAX_LENGTH,
+    PREREQUISITE_MESSAGE_PLACEHOLDER,
+    type SharedPolicyGroupBasicFormValues,
+} from '../utils/sharedPolicyGroupPayload';
+
+export function SharedPolicyGroupBasicFields({
+    idPrefix,
+    values,
+    disabled,
+    onChange,
+}: Readonly<{
+    idPrefix: string;
+    values: SharedPolicyGroupBasicFormValues;
+    disabled?: boolean;
+    onChange: <K extends keyof SharedPolicyGroupBasicFormValues>(key: K, value: SharedPolicyGroupBasicFormValues[K]) => void;
+}>) {
+    const nameId = `${idPrefix}-name`;
+    const descriptionId = `${idPrefix}-description`;
+    const prerequisiteId = `${idPrefix}-prerequisite-message`;
+
+    return (
+        <>
+            <h3 className="text-sm font-semibold">Basic information</h3>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={nameId} required>
+                    Name
+                </FieldLabel>
+                <Input
+                    id={nameId}
+                    value={values.name}
+                    onChange={e => onChange('name', e.target.value)}
+                    placeholder="e.g. Default authentication"
+                    maxLength={512}
+                    disabled={disabled}
+                    required
+                />
+            </Field>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={descriptionId}>Describe the purpose of this policy group</FieldLabel>
+                <FieldDescription>{DESCRIPTION_MAX_LENGTH} characters max.</FieldDescription>
+                <Textarea
+                    id={descriptionId}
+                    value={values.description}
+                    onChange={e => onChange('description', e.target.value)}
+                    placeholder="Describe what this policy group is used for"
+                    maxLength={DESCRIPTION_MAX_LENGTH}
+                    disabled={disabled}
+                />
+            </Field>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={prerequisiteId}>Prerequisite message</FieldLabel>
+                <FieldDescription>{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</FieldDescription>
+                <Textarea
+                    id={prerequisiteId}
+                    value={values.prerequisiteMessage}
+                    onChange={e => onChange('prerequisiteMessage', e.target.value)}
+                    placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
+                    maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
+                    disabled={disabled}
+                />
+            </Field>
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.spec.tsx
@@ -17,12 +17,23 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { SharedPolicyGroupCreateSheet } from './SharedPolicyGroupCreateSheet';
+import { installFormActionTestEnvironment } from '../../../shared/testing/formAction';
+
+let restoreTestEnvironment: () => void;
 
 function renderSheet(overrides: Partial<React.ComponentProps<typeof SharedPolicyGroupCreateSheet>> = {}) {
     return render(<SharedPolicyGroupCreateSheet open onClose={jest.fn()} onSubmit={jest.fn()} {...overrides} />);
 }
 
 describe('SharedPolicyGroupCreateSheet', () => {
+    beforeAll(() => {
+        restoreTestEnvironment = installFormActionTestEnvironment();
+    });
+
+    afterAll(() => {
+        restoreTestEnvironment();
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -45,7 +56,7 @@ describe('SharedPolicyGroupCreateSheet', () => {
         renderSheet();
         expect(screen.getByPlaceholderText('e.g. Default authentication')).not.toBeNull();
         expect(screen.getByPlaceholderText('Describe what this policy group is used for')).not.toBeNull();
-        expect(screen.getAllByText('300 characters max.')).toHaveLength(2);
+        expect(screen.getAllByText('1024 characters max.')).toHaveLength(2);
     });
 
     it('defaults to Proxy, offering only the phases valid for a Proxy API', () => {
@@ -94,16 +105,27 @@ describe('SharedPolicyGroupCreateSheet', () => {
         );
     });
 
-    it('prevents duplicate submissions while creation is pending', async () => {
-        const onSubmit = jest.fn();
-        const { rerender } = renderSheet({ onSubmit });
+    it('prevents duplicate submissions and closing while creation is pending', async () => {
+        let resolveSubmit: (() => void) | undefined;
+        const onSubmit = jest.fn(
+            () =>
+                new Promise<void>(resolve => {
+                    resolveSubmit = resolve;
+                }),
+        );
+        const onClose = jest.fn();
+        renderSheet({ onSubmit, onClose });
 
         fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My SPG' } });
         fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
-        rerender(<SharedPolicyGroupCreateSheet open onClose={jest.fn()} onSubmit={onSubmit} isSaving />);
-        fireEvent.click(screen.getByRole('button', { name: 'Creating…' }));
+        expect(await screen.findByRole('button', { name: 'Creating…' })).toHaveProperty('disabled', true);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
         expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+
+        resolveSubmit?.();
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', false));
     });
 
     it('calls onClose when Cancel is clicked', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
@@ -18,7 +18,6 @@ import {
     Button,
     Field,
     FieldLabel,
-    Input,
     ScrollArea,
     Separator,
     Sheet,
@@ -27,27 +26,21 @@ import {
     SheetFooter,
     SheetHeader,
     SheetTitle,
-    Textarea,
     ToggleGroup,
     ToggleGroupItem,
 } from '@gravitee/graphene-core';
-import { useState, type FormEvent } from 'react';
+import { useActionState, useState } from 'react';
 
+import { SharedPolicyGroupBasicFields } from './SharedPolicyGroupBasicFields';
+import { FormActionSubmitButton } from '../../../shared/components/FormActionSubmitButton';
 import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
 import { toReadableApiType, toReadableFlowPhase, type ApiType, type FlowPhase } from '../types/sharedPolicyGroup';
-import { PHASE_BY_API_TYPE } from '../utils/sharedPolicyGroupPayload';
+import { PHASE_BY_API_TYPE, type SharedPolicyGroupBasicFormValues } from '../utils/sharedPolicyGroupPayload';
 
 const CREATABLE_API_TYPES: readonly ApiType[] = ['PROXY', 'MESSAGE'];
 const DEFAULT_API_TYPE: ApiType = 'PROXY';
-const DESCRIPTION_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_PLACEHOLDER =
-    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
 
-export interface SharedPolicyGroupCreateFormValues {
-    name: string;
-    description: string;
-    prerequisiteMessage: string;
+export interface SharedPolicyGroupCreateFormValues extends SharedPolicyGroupBasicFormValues {
     apiType: ApiType;
     phase: FlowPhase;
 }
@@ -62,66 +55,6 @@ function buildEmptyForm(): SharedPolicyGroupCreateFormValues {
         apiType: DEFAULT_API_TYPE,
         phase: PHASE_BY_API_TYPE[DEFAULT_API_TYPE][0],
     };
-}
-
-function BasicInformationFields({
-    form,
-    disabled,
-    setField,
-}: Readonly<{
-    form: SharedPolicyGroupCreateFormValues;
-    disabled: boolean;
-    setField: SetFormField;
-}>) {
-    return (
-        <>
-            <h3 className="text-sm font-semibold">Basic information</h3>
-
-            <Field orientation="vertical" className="gap-1.5">
-                <FieldLabel htmlFor="spg-name">
-                    Name{' '}
-                    <span className="text-destructive" aria-hidden>
-                        *
-                    </span>
-                </FieldLabel>
-                <Input
-                    id="spg-name"
-                    value={form.name}
-                    onChange={e => setField('name', e.target.value)}
-                    placeholder="e.g. Default authentication"
-                    maxLength={512}
-                    disabled={disabled}
-                    required
-                />
-            </Field>
-
-            <Field orientation="vertical" className="gap-1.5">
-                <FieldLabel htmlFor="spg-description">Describe the purpose of this policy group</FieldLabel>
-                <p className="text-xs text-muted-foreground">{DESCRIPTION_MAX_LENGTH} characters max.</p>
-                <Textarea
-                    id="spg-description"
-                    value={form.description}
-                    onChange={e => setField('description', e.target.value)}
-                    placeholder="Describe what this policy group is used for"
-                    maxLength={DESCRIPTION_MAX_LENGTH}
-                    disabled={disabled}
-                />
-            </Field>
-
-            <Field orientation="vertical" className="gap-1.5">
-                <FieldLabel htmlFor="spg-prerequisite-message">Prerequisite message</FieldLabel>
-                <p className="text-xs text-muted-foreground">{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</p>
-                <Textarea
-                    id="spg-prerequisite-message"
-                    value={form.prerequisiteMessage}
-                    onChange={e => setField('prerequisiteMessage', e.target.value)}
-                    placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
-                    maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
-                    disabled={disabled}
-                />
-            </Field>
-        </>
-    );
 }
 
 function ScopeFields({
@@ -141,11 +74,8 @@ function ScopeFields({
             <h3 className="text-sm font-semibold">Scope</h3>
 
             <Field orientation="vertical" className="gap-1.5">
-                <FieldLabel id="spg-api-type-label">
-                    API Type{' '}
-                    <span className="text-destructive" aria-hidden>
-                        *
-                    </span>
+                <FieldLabel id="spg-api-type-label" required>
+                    API Type
                 </FieldLabel>
                 <ToggleGroup
                     type="single"
@@ -163,11 +93,8 @@ function ScopeFields({
             </Field>
 
             <Field orientation="vertical" className="gap-1.5">
-                <FieldLabel id="spg-phase-label">
-                    Phase{' '}
-                    <span className="text-destructive" aria-hidden>
-                        *
-                    </span>
+                <FieldLabel id="spg-phase-label" required>
+                    Phase
                 </FieldLabel>
                 <ToggleGroup
                     type="single"
@@ -191,24 +118,22 @@ interface SharedPolicyGroupCreateSheetProps {
     readonly open: boolean;
     readonly onClose: () => void;
     readonly onSubmit: (values: SharedPolicyGroupCreateFormValues) => Promise<void> | void;
-    readonly isSaving?: boolean;
 }
 
-export function SharedPolicyGroupCreateSheet({ open, onClose, onSubmit, isSaving = false }: SharedPolicyGroupCreateSheetProps) {
+export function SharedPolicyGroupCreateSheet({ open, onClose, onSubmit }: SharedPolicyGroupCreateSheetProps) {
     const [form, setForm] = useState<SharedPolicyGroupCreateFormValues>(buildEmptyForm);
 
     const setField: SetFormField = (key, value) => setForm(previous => ({ ...previous, [key]: value }));
     const isValid = form.name.trim() !== '';
-
-    function handleSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (isValid && !isSaving) {
-            void onSubmit({ ...form, name: form.name.trim() });
+    const [, submitSharedPolicyGroup, isSaving] = useActionState<null, FormData>(async () => {
+        if (isValid) {
+            await onSubmit({ ...form, name: form.name.trim() });
         }
-    }
+        return null;
+    }, null);
 
     return (
-        <Sheet open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isSaving && onClose()}>
             <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
                 <SheetHeader>
                     <SheetTitle>Add Shared Policy Group</SheetTitle>
@@ -217,10 +142,10 @@ export function SharedPolicyGroupCreateSheet({ open, onClose, onSubmit, isSaving
                     </SheetDescription>
                 </SheetHeader>
 
-                <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+                <form action={submitSharedPolicyGroup} className="flex min-h-0 flex-1 flex-col">
                     <ScrollArea className="min-h-0 flex-1">
                         <div className="flex flex-col gap-5 px-4 py-4">
-                            <BasicInformationFields form={form} disabled={isSaving} setField={setField} />
+                            <SharedPolicyGroupBasicFields idPrefix="spg" values={form} disabled={isSaving} onChange={setField} />
                             <ScopeFields
                                 form={form}
                                 disabled={isSaving}
@@ -236,9 +161,7 @@ export function SharedPolicyGroupCreateSheet({ open, onClose, onSubmit, isSaving
                         <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
                             Cancel
                         </Button>
-                        <Button type="submit" disabled={!isValid || isSaving}>
-                            {isSaving ? 'Creating…' : 'Create'}
-                        </Button>
+                        <FormActionSubmitButton disabled={!isValid} label="Create" pendingLabel="Creating…" />
                     </SheetFooter>
                 </form>
             </SheetContent>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.spec.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { SharedPolicyGroupEditSheet } from './SharedPolicyGroupEditSheet';
+import { installFormActionTestEnvironment } from '../../../shared/testing/formAction';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+let restoreTestEnvironment: () => void;
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth',
+    prerequisiteMessage: 'Needs cache',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    steps: [],
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof SharedPolicyGroupEditSheet>> = {}) {
+    return render(<SharedPolicyGroupEditSheet open sharedPolicyGroup={SPG} onClose={jest.fn()} onSubmit={jest.fn()} {...overrides} />);
+}
+
+describe('SharedPolicyGroupEditSheet', () => {
+    beforeAll(() => {
+        restoreTestEnvironment = installFormActionTestEnvironment();
+    });
+
+    afterAll(() => {
+        restoreTestEnvironment();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the edit title and pre-fills fields from the shared policy group', () => {
+        renderSheet();
+        expect(screen.queryByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
+        expect(screen.getByLabelText(/Name/i)).toHaveProperty('value', 'Auth Bundle');
+        expect(screen.getByLabelText('Describe the purpose of this policy group')).toHaveProperty('value', 'Reusable auth');
+        expect(screen.getByLabelText('Prerequisite message')).toHaveProperty('value', 'Needs cache');
+    });
+
+    it('shows API type and phase as read-only — matching classic Console edit dialog', () => {
+        renderSheet();
+        expect(screen.queryByText('Proxy')).not.toBeNull();
+        expect(screen.queryByText('Request')).not.toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Proxy' })).toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Request' })).toBeNull();
+    });
+
+    it('disables Save when the name is cleared', () => {
+        renderSheet();
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '   ' } });
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits the trimmed form values', async () => {
+        const onSubmit = jest.fn();
+        renderSheet({ onSubmit });
+
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  Updated Name  ' } });
+        fireEvent.change(screen.getByLabelText('Describe the purpose of this policy group'), { target: { value: 'New description' } });
+        fireEvent.change(screen.getByLabelText('Prerequisite message'), { target: { value: 'New prerequisite' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'Updated Name',
+                description: 'New description',
+                prerequisiteMessage: 'New prerequisite',
+            }),
+        );
+    });
+
+    it('prevents duplicate submissions and closing while the update is pending', async () => {
+        let resolveSubmit: (() => void) | undefined;
+        const onSubmit = jest.fn(
+            () =>
+                new Promise<void>(resolve => {
+                    resolveSubmit = resolve;
+                }),
+        );
+        const onClose = jest.fn();
+        renderSheet({ onSubmit, onClose });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(await screen.findByRole('button', { name: 'Saving…' })).toHaveProperty('disabled', true);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+
+        resolveSubmit?.();
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Saving…' })).toBeNull());
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = jest.fn();
+        renderSheet({ onClose });
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, ScrollArea, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { useActionState, useState } from 'react';
+
+import { SharedPolicyGroupBasicFields } from './SharedPolicyGroupBasicFields';
+import { FormActionSubmitButton } from '../../../shared/components/FormActionSubmitButton';
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import { toReadableApiType, toReadableFlowPhase, type SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import type { SharedPolicyGroupBasicFormValues } from '../utils/sharedPolicyGroupPayload';
+
+export type SharedPolicyGroupEditFormValues = SharedPolicyGroupBasicFormValues;
+
+function toFormValues(sharedPolicyGroup: SharedPolicyGroup): SharedPolicyGroupEditFormValues {
+    return {
+        name: sharedPolicyGroup.name,
+        description: sharedPolicyGroup.description ?? '',
+        prerequisiteMessage: sharedPolicyGroup.prerequisiteMessage ?? '',
+    };
+}
+
+export function SharedPolicyGroupEditSheet({
+    open,
+    sharedPolicyGroup,
+    onClose,
+    onSubmit,
+}: Readonly<{
+    open: boolean;
+    sharedPolicyGroup: SharedPolicyGroup;
+    onClose: () => void;
+    onSubmit: (values: SharedPolicyGroupEditFormValues) => Promise<void> | void;
+}>) {
+    const [form, setForm] = useState<SharedPolicyGroupEditFormValues>(() => toFormValues(sharedPolicyGroup));
+
+    function setField<K extends keyof SharedPolicyGroupEditFormValues>(key: K, value: SharedPolicyGroupEditFormValues[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    const isValid = form.name.trim() !== '';
+    const [, submitSharedPolicyGroup, isSaving] = useActionState<null, FormData>(async () => {
+        if (isValid) {
+            await onSubmit({ ...form, name: form.name.trim() });
+        }
+        return null;
+    }, null);
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isSaving && onClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>Edit Shared Policy Group</SheetTitle>
+                    <SheetDescription>Update the name, description, and prerequisite message for this policy group.</SheetDescription>
+                </SheetHeader>
+
+                <form action={submitSharedPolicyGroup} className="flex min-h-0 flex-1 flex-col">
+                    <ScrollArea className="min-h-0 flex-1">
+                        <div className="flex flex-col gap-5 px-4 py-4">
+                            <SharedPolicyGroupBasicFields idPrefix="spg-edit" values={form} disabled={isSaving} onChange={setField} />
+
+                            <dl className="grid grid-cols-2 gap-4 rounded-lg border bg-muted/30 p-3">
+                                <div className="space-y-1">
+                                    <dt className="text-xs font-medium text-muted-foreground">API type</dt>
+                                    <dd className="text-sm">{toReadableApiType(sharedPolicyGroup.apiType)}</dd>
+                                </div>
+                                <div className="space-y-1">
+                                    <dt className="text-xs font-medium text-muted-foreground">Phase</dt>
+                                    <dd className="text-sm">{toReadableFlowPhase(sharedPolicyGroup.phase)}</dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </ScrollArea>
+
+                    <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <FormActionSubmitButton disabled={!isValid} label="Save" pendingLabel="Saving…" />
+                    </SheetFooter>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
@@ -44,12 +44,14 @@ function renderTable(overrides: Partial<React.ComponentProps<typeof SharedPolicy
                 page={1}
                 pageSize={25}
                 sorting={[]}
+                canEdit={false}
                 canDelete={false}
                 onSearchChange={jest.fn()}
                 onPageChange={jest.fn()}
                 onPageSizeChange={jest.fn()}
                 onSortingChange={jest.fn()}
                 onView={jest.fn()}
+                onEdit={jest.fn()}
                 onDelete={jest.fn()}
                 {...overrides}
             />
@@ -126,17 +128,25 @@ describe('SharedPolicyGroupsTable', () => {
             return user;
         }
 
-        it('shows a View action because editing is not available on the detail page', async () => {
-            renderTable();
+        it('shows only View when the user cannot update metadata', async () => {
+            renderTable({ canEdit: false });
             await openRowMenu();
             expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
             expect(screen.queryByRole('menuitem', { name: 'Edit' })).toBeNull();
         });
 
-        it('shows View for a Kubernetes-origin row', async () => {
-            renderTable({ sharedPolicyGroups: [{ ...SPG, originContext: { origin: 'KUBERNETES' } }] });
+        it('shows View and Edit when the user can update', async () => {
+            renderTable({ canEdit: true });
             await openRowMenu();
             expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeNull();
+        });
+
+        it('shows only View — never Edit — for a Kubernetes-origin row, even with update permission', async () => {
+            renderTable({ canEdit: true, sharedPolicyGroups: [{ ...SPG, originContext: { origin: 'KUBERNETES' } }] });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).toBeNull();
         });
 
         it('hides Delete without delete permission', async () => {
@@ -174,6 +184,14 @@ describe('SharedPolicyGroupsTable', () => {
             const user = await openRowMenu();
             await user.click(await screen.findByRole('menuitem', { name: 'View' }));
             expect(onView).toHaveBeenCalledWith(SPG);
+        });
+
+        it('calls onEdit when Edit is clicked', async () => {
+            const onEdit = jest.fn();
+            renderTable({ canEdit: true, onEdit });
+            const user = await openRowMenu();
+            await user.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+            expect(onEdit).toHaveBeenCalledWith(SPG);
         });
 
         it('explains that Kubernetes-origin groups are externally managed', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
@@ -34,7 +34,7 @@ import {
     TooltipTrigger,
     type DataTableProps,
 } from '@gravitee/graphene-core';
-import { EyeIcon, KubernetesIcon, LayersIcon, MoreVerticalIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { EyeIcon, KubernetesIcon, LayersIcon, MoreVerticalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { Link } from 'react-router-dom';
 
 import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
@@ -45,12 +45,16 @@ import { toReadableApiType, toReadableFlowPhase, type SharedPolicyGroup } from '
 import { isKubernetesOrigin } from '../utils/sharedPolicyGroupPermissions';
 
 function buildColumns({
+    canEdit,
     canDelete,
     onView,
+    onEdit,
     onDelete,
 }: {
+    canEdit: boolean;
     canDelete: boolean;
     onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    onEdit: (sharedPolicyGroup: SharedPolicyGroup) => void;
     onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
 }): DataTableProps<SharedPolicyGroup>['columns'] {
     return [
@@ -116,10 +120,12 @@ function buildColumns({
             enableHiding: false,
             cell: ({ row }: ColCell<SharedPolicyGroup>) => {
                 const sharedPolicyGroup = row.original;
-                const showDelete = canDelete && !isKubernetesOrigin(sharedPolicyGroup);
+                const kubernetesOrigin = isKubernetesOrigin(sharedPolicyGroup);
+                const showEdit = canEdit && !kubernetesOrigin;
+                const showDelete = canDelete && !kubernetesOrigin;
                 return (
                     <div className="flex items-center justify-end gap-1">
-                        {isKubernetesOrigin(sharedPolicyGroup) && (
+                        {kubernetesOrigin && (
                             <TooltipProvider delayDuration={200}>
                                 <Tooltip>
                                     <TooltipTrigger asChild>
@@ -142,6 +148,12 @@ function buildColumns({
                                     <EyeIcon className="size-4 mr-2" aria-hidden />
                                     View
                                 </DropdownMenuItem>
+                                {showEdit && (
+                                    <DropdownMenuItem onSelect={() => onEdit(sharedPolicyGroup)}>
+                                        <PencilIcon className="size-4 mr-2" aria-hidden />
+                                        Edit
+                                    </DropdownMenuItem>
+                                )}
                                 {showDelete && (
                                     <>
                                         <DropdownMenuSeparator />
@@ -169,12 +181,14 @@ interface SharedPolicyGroupsTableProps {
     readonly page: number;
     readonly pageSize: number;
     readonly sorting: TableSortingState;
+    readonly canEdit: boolean;
     readonly canDelete: boolean;
     readonly onSearchChange: (value: string) => void;
     readonly onPageChange: (page: number) => void;
     readonly onPageSizeChange: (size: number) => void;
     readonly onSortingChange: (updater: TableSortingState | ((previous: TableSortingState) => TableSortingState)) => void;
     readonly onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    readonly onEdit: (sharedPolicyGroup: SharedPolicyGroup) => void;
     readonly onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
     readonly onCreateSharedPolicyGroup?: () => void;
 }
@@ -188,16 +202,18 @@ export function SharedPolicyGroupsTable({
     page,
     pageSize,
     sorting,
+    canEdit,
     canDelete,
     onSearchChange,
     onPageChange,
     onPageSizeChange,
     onSortingChange,
     onView,
+    onEdit,
     onDelete,
     onCreateSharedPolicyGroup,
 }: SharedPolicyGroupsTableProps) {
-    const columns = buildColumns({ canDelete, onView, onDelete });
+    const columns = buildColumns({ canEdit, canDelete, onView, onEdit, onDelete });
 
     if (isFirstUse) {
         return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
@@ -17,8 +17,8 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createSharedPolicyGroup, deleteSharedPolicyGroup } from '../services/sharedPolicyGroups';
-import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { createSharedPolicyGroup, deleteSharedPolicyGroup, updateSharedPolicyGroup } from '../services/sharedPolicyGroups';
+import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 import { sharedPolicyGroupKeys } from '../utils/queryKeys';
 
 function useSharedPolicyGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
@@ -42,6 +42,12 @@ function useSharedPolicyGroupMutation<TData, TResult>(mutationFn: (envId: string
 
 export function useCreateSharedPolicyGroup() {
     return useSharedPolicyGroupMutation<CreateSharedPolicyGroupPayload, SharedPolicyGroup>(createSharedPolicyGroup);
+}
+
+export function useUpdateSharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<{ id: string; payload: UpdateSharedPolicyGroupPayload }, SharedPolicyGroup>(
+        (envId, { id, payload }) => updateSharedPolicyGroup(envId, id, payload),
+    );
 }
 
 export function useDeleteSharedPolicyGroup() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.spec.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-import { createSharedPolicyGroup, deleteSharedPolicyGroup, getSharedPolicyGroup, listSharedPolicyGroupsPaged } from './sharedPolicyGroups';
+import {
+    createSharedPolicyGroup,
+    deleteSharedPolicyGroup,
+    getSharedPolicyGroup,
+    listSharedPolicyGroupsPaged,
+    updateSharedPolicyGroup,
+} from './sharedPolicyGroups';
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { CreateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
+import type { CreateSharedPolicyGroupPayload, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 
 jest.mock('../../../shared/api/apimClient', () => ({
     apimFetchJsonV2: jest.fn(),
@@ -56,6 +62,22 @@ describe('shared policy groups service', () => {
 
         expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/shared-policy-groups', {
             method: 'POST',
+            body: JSON.stringify(payload),
+        });
+    });
+
+    it('updates the encoded group resource with the serialized Management API v2 payload', async () => {
+        const payload: UpdateSharedPolicyGroupPayload = {
+            name: 'Authentication',
+            description: '',
+            prerequisiteMessage: '',
+            steps: [{ name: 'jwt' }],
+        };
+
+        await updateSharedPolicyGroup('env-1', 'group/1', payload);
+
+        expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/shared-policy-groups/group%2F1', {
+            method: 'PUT',
             body: JSON.stringify(payload),
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
@@ -15,7 +15,12 @@
  */
 
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, SharedPolicyGroupsPagedResponse } from '../types/sharedPolicyGroup';
+import type {
+    CreateSharedPolicyGroupPayload,
+    SharedPolicyGroup,
+    SharedPolicyGroupsPagedResponse,
+    UpdateSharedPolicyGroupPayload,
+} from '../types/sharedPolicyGroup';
 
 export async function listSharedPolicyGroupsPaged(
     environmentId: string,
@@ -41,6 +46,17 @@ export async function getSharedPolicyGroup(environmentId: string, sharedPolicyGr
 export async function createSharedPolicyGroup(environmentId: string, data: CreateSharedPolicyGroupPayload): Promise<SharedPolicyGroup> {
     return apimFetchJsonV2<SharedPolicyGroup>(environmentId, '/shared-policy-groups', {
         method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateSharedPolicyGroup(
+    environmentId: string,
+    sharedPolicyGroupId: string,
+    data: UpdateSharedPolicyGroupPayload,
+): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(environmentId, `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}`, {
+        method: 'PUT',
         body: JSON.stringify(data),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
@@ -58,6 +58,8 @@ export interface OriginContext {
     origin: 'MANAGEMENT' | 'KUBERNETES' | 'INTEGRATION';
 }
 
+export type SharedPolicyGroupStep = Record<string, unknown>;
+
 /** v2 `SharedPolicyGroup` (GET/POST .../v2/environments/{envId}/shared-policy-groups...). */
 export interface SharedPolicyGroup {
     id: string;
@@ -68,6 +70,7 @@ export interface SharedPolicyGroup {
     lifecycleState?: 'DEPLOYED' | 'UNDEPLOYED' | 'PENDING';
     apiType: ApiType;
     phase: FlowPhase;
+    steps?: SharedPolicyGroupStep[];
     deployedAt?: string;
     createdAt?: string;
     updatedAt?: string;
@@ -81,6 +84,13 @@ export interface CreateSharedPolicyGroupPayload {
     prerequisiteMessage?: string;
     apiType: ApiType;
     phase: FlowPhase;
+}
+
+export interface UpdateSharedPolicyGroupPayload {
+    name: string;
+    description?: string;
+    prerequisiteMessage?: string;
+    steps?: SharedPolicyGroupStep[];
 }
 
 interface SharedPolicyGroupsPagination {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toUpdateSharedPolicyGroupPayload } from './sharedPolicyGroupPayload';
+
+describe('toUpdateSharedPolicyGroupPayload', () => {
+    it('maps metadata without sending policy steps', () => {
+        expect(
+            toUpdateSharedPolicyGroupPayload({
+                name: 'Updated',
+                description: 'New description',
+                prerequisiteMessage: 'New prerequisite',
+            }),
+        ).toEqual({
+            name: 'Updated',
+            description: 'New description',
+            prerequisiteMessage: 'New prerequisite',
+        });
+    });
+
+    it('sends explicit empty strings when optional metadata is cleared', () => {
+        expect(toUpdateSharedPolicyGroupPayload({ name: 'Updated', description: '', prerequisiteMessage: '' })).toEqual({
+            name: 'Updated',
+            description: '',
+            prerequisiteMessage: '',
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ApiType, FlowPhase } from '../types/sharedPolicyGroup';
+import type { ApiType, FlowPhase, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 
 /** Mirrors classic Console's `PHASE_BY_API_TYPE` (shared-policy-groups-add-edit-dialog.component.ts). */
 export const PHASE_BY_API_TYPE: Record<ApiType, FlowPhase[]> = {
@@ -25,3 +25,22 @@ export const PHASE_BY_API_TYPE: Record<ApiType, FlowPhase[]> = {
     MESSAGE: ['REQUEST', 'RESPONSE', 'PUBLISH', 'SUBSCRIBE'],
     NATIVE: ['PUBLISH', 'SUBSCRIBE', 'ENTRYPOINT_CONNECT', 'INTERACT'],
 };
+
+export const DESCRIPTION_MAX_LENGTH = 1024;
+export const PREREQUISITE_MESSAGE_MAX_LENGTH = 1024;
+export const PREREQUISITE_MESSAGE_PLACEHOLDER =
+    'Message displayed when using SPG in Policy Studio, for example: The resource cache "my-cache" is required.';
+
+export interface SharedPolicyGroupBasicFormValues {
+    name: string;
+    description: string;
+    prerequisiteMessage: string;
+}
+
+export function toUpdateSharedPolicyGroupPayload(values: SharedPolicyGroupBasicFormValues): UpdateSharedPolicyGroupPayload {
+    return {
+        name: values.name,
+        description: values.description,
+        prerequisiteMessage: values.prerequisiteMessage,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
@@ -14,20 +14,35 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { SharedPolicyGroupDetailPage } from './SharedPolicyGroupDetailPage';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
 import { ApimApiError } from '../shared/api/apimClient';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { notify } from '../shared/notify';
+import { installFormActionTestEnvironment } from '../shared/testing/formAction';
 
+let restoreTestEnvironment: () => void;
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
 jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
 jest.mock('../shared/hooks/useForbiddenResourceRedirect');
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
 
+const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseSharedPolicyGroupDetail = jest.mocked(useSharedPolicyGroupDetail);
 const mockUseForbiddenResourceRedirect = jest.mocked(useForbiddenResourceRedirect);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
 
 const SPG: SharedPolicyGroup = {
     id: 'spg-1',
@@ -37,9 +52,14 @@ const SPG: SharedPolicyGroup = {
     lifecycleState: 'DEPLOYED',
     apiType: 'PROXY',
     phase: 'REQUEST',
+    steps: [{ name: 'jwt' }],
     updatedAt: '2024-01-01T00:00:00.000Z',
     deployedAt: '2024-01-02T00:00:00.000Z',
 };
+
+function makeMutation(mutateAsync = jest.fn()) {
+    return { mutateAsync } as unknown as ReturnType<typeof useUpdateSharedPolicyGroup>;
+}
 
 function renderPage() {
     return render(
@@ -52,6 +72,19 @@ function renderPage() {
 }
 
 describe('SharedPolicyGroupDetailPage', () => {
+    beforeAll(() => {
+        restoreTestEnvironment = installFormActionTestEnvironment();
+    });
+
+    afterAll(() => {
+        restoreTestEnvironment();
+    });
+
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation());
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -126,5 +159,74 @@ describe('SharedPolicyGroupDetailPage', () => {
         renderPage();
 
         expect(screen.getByRole('link', { name: /Back to Shared Policy Groups/ }).getAttribute('href')).toBe('/');
+    });
+
+    it('shows Edit when the user can update and opens the edit sheet', async () => {
+        const updateMutateAsync = jest.fn().mockResolvedValue(SPG);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(updateMutateAsync));
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        expect(await screen.findByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Renamed Bundle' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(updateMutateAsync).toHaveBeenCalledWith({
+                id: 'spg-1',
+                payload: {
+                    name: 'Renamed Bundle',
+                    description: 'Reusable auth policies',
+                    prerequisiteMessage: 'Requires the "auth-cache" resource',
+                },
+            });
+        });
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+    });
+
+    it('shows an error and keeps the edit sheet open when update fails', async () => {
+        const error = new Error('update failed');
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group update!'));
+        expect(screen.queryByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
+    });
+
+    it('hides Edit when the user lacks update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    });
+
+    it('hides Edit for a Kubernetes-origin shared policy group', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: { ...SPG, originContext: { origin: 'KUBERNETES' } },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -14,16 +14,28 @@
  * limitations under the License.
  */
 
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button, Card, CardContent, CardHeader, CardTitle, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
-import type { ReactNode } from 'react';
+import { ArrowLeftIcon, LayersIcon, PencilIcon } from '@gravitee/graphene-core/icons';
+import { type ReactNode, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
+import {
+    SharedPolicyGroupEditSheet,
+    type SharedPolicyGroupEditFormValues,
+} from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
 import { SharedPolicyGroupStatusBadge } from '../features/shared-policy-groups/components/SharedPolicyGroupStatusBadge';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import { toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
-import { ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
+import {
+    ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
+    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
+    isKubernetesOrigin,
+} from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { notify } from '../shared/notify';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
 function DetailField({ label, value }: Readonly<{ label: string; value: ReactNode }>) {
@@ -39,12 +51,31 @@ export function SharedPolicyGroupDetailPage() {
     const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
     const { data: sharedPolicyGroup, isLoading, isError, error } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
     const isForbidden = isForbiddenApiError(isError, error);
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const updateMutation = useUpdateSharedPolicyGroup();
+    const [editOpen, setEditOpen] = useState(false);
 
     useForbiddenResourceRedirect({
         isForbidden,
         permissionPrefix: ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
         redirectTo: '../../applications',
     });
+
+    const showEdit = Boolean(sharedPolicyGroup && canEdit && !isKubernetesOrigin(sharedPolicyGroup));
+
+    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
+        if (!sharedPolicyGroup) return;
+        try {
+            await updateMutation.mutateAsync({
+                id: sharedPolicyGroup.id,
+                payload: toUpdateSharedPolicyGroupPayload(values),
+            });
+            notify.success('Shared Policy Group updated');
+            setEditOpen(false);
+        } catch (updateError) {
+            notify.error(updateError, 'Error during Shared Policy Group update!');
+        }
+    }
 
     if (isForbidden) {
         return null;
@@ -84,19 +115,33 @@ export function SharedPolicyGroupDetailPage() {
 
             <Card>
                 <CardContent className="p-5">
-                    <div className="flex items-start gap-3">
-                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-highlight text-highlight-foreground">
-                            <LayersIcon className="size-5" aria-hidden />
-                        </div>
-                        <div className="min-w-0 space-y-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                                <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
-                                <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-highlight text-highlight-foreground">
+                                <LayersIcon className="size-5" aria-hidden />
                             </div>
-                            {sharedPolicyGroup.description && (
-                                <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
-                            )}
+                            <div className="min-w-0 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                                    <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                                </div>
+                                {sharedPolicyGroup.description && (
+                                    <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
+                                )}
+                            </div>
                         </div>
+                        {showEdit ? (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="shrink-0 gap-1.5"
+                                onClick={() => setEditOpen(true)}
+                            >
+                                <PencilIcon className="size-4" aria-hidden />
+                                Edit
+                            </Button>
+                        ) : null}
                     </div>
                 </CardContent>
             </Card>
@@ -135,6 +180,16 @@ export function SharedPolicyGroupDetailPage() {
                     )}
                 </CardContent>
             </Card>
+
+            {editOpen ? (
+                <SharedPolicyGroupEditSheet
+                    key={sharedPolicyGroup.id}
+                    open
+                    sharedPolicyGroup={sharedPolicyGroup}
+                    onClose={() => setEditOpen(false)}
+                    onSubmit={handleEdit}
+                />
+            ) : null}
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -22,12 +22,17 @@ import { SharedPolicyGroupsPage } from './SharedPolicyGroupsPage';
 import {
     useCreateSharedPolicyGroup,
     useDeleteSharedPolicyGroup,
+    useUpdateSharedPolicyGroup,
 } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { ApimApiError } from '../shared/api/apimClient';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { notify } from '../shared/notify';
+import { installFormActionTestEnvironment } from '../shared/testing/formAction';
+
+let restoreTestEnvironment: () => void;
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
@@ -49,16 +54,20 @@ jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable',
     SharedPolicyGroupsTable: ({
         sharedPolicyGroups,
         isFirstUse,
+        canEdit,
         canDelete,
         onView,
+        onEdit,
         onDelete,
         onCreateSharedPolicyGroup,
         onSortingChange,
     }: {
         sharedPolicyGroups: SharedPolicyGroup[];
         isFirstUse: boolean;
+        canEdit: boolean;
         canDelete: boolean;
         onView: (s: SharedPolicyGroup) => void;
+        onEdit: (s: SharedPolicyGroup) => void;
         onDelete: (s: SharedPolicyGroup) => void;
         onCreateSharedPolicyGroup?: () => void;
         onSortingChange: (sorting: { id: string; desc: boolean }[]) => void;
@@ -83,6 +92,11 @@ jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable',
                         <button type="button" onClick={() => onView(s)}>
                             View {s.name}
                         </button>
+                        {canEdit && (
+                            <button type="button" onClick={() => onEdit(s)}>
+                                Edit {s.name}
+                            </button>
+                        )}
                         {canDelete && (
                             <button type="button" onClick={() => onDelete(s)}>
                                 Delete {s.name}
@@ -97,6 +111,7 @@ const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseSharedPolicyGroupsPaged = jest.mocked(useSharedPolicyGroupsPaged);
 const mockUseCreateSharedPolicyGroup = jest.mocked(useCreateSharedPolicyGroup);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
 const mockUseDeleteSharedPolicyGroup = jest.mocked(useDeleteSharedPolicyGroup);
 const mockUseForbiddenResourceRedirect = jest.mocked(useForbiddenResourceRedirect);
 
@@ -106,11 +121,15 @@ const SAMPLE_SPGS: SharedPolicyGroup[] = [
 ];
 
 function makeCreateMutation(mutateAsync = jest.fn()) {
-    return { mutateAsync, isPending: false } as unknown as ReturnType<typeof useCreateSharedPolicyGroup>;
+    return { mutateAsync } as unknown as ReturnType<typeof useCreateSharedPolicyGroup>;
 }
 
 function makeDeleteMutation(mutateAsync = jest.fn()) {
     return { mutateAsync, isPending: false } as unknown as ReturnType<typeof useDeleteSharedPolicyGroup>;
+}
+
+function makeUpdateMutation(mutateAsync = jest.fn()) {
+    return { mutateAsync } as unknown as ReturnType<typeof useUpdateSharedPolicyGroup>;
 }
 
 function makeSpgsResult(data: SharedPolicyGroup[] = SAMPLE_SPGS, totalCount = data.length) {
@@ -126,11 +145,20 @@ function renderPage() {
 }
 
 describe('SharedPolicyGroupsPage', () => {
+    beforeAll(() => {
+        restoreTestEnvironment = installFormActionTestEnvironment();
+    });
+
+    afterAll(() => {
+        restoreTestEnvironment();
+    });
+
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
         mockUseNavigate.mockReturnValue(jest.fn());
         mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult());
         mockUseCreateSharedPolicyGroup.mockReturnValue(makeCreateMutation());
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeUpdateMutation());
         mockUseDeleteSharedPolicyGroup.mockReturnValue(makeDeleteMutation());
     });
 
@@ -313,6 +341,52 @@ describe('SharedPolicyGroupsPage', () => {
             await waitFor(() =>
                 expect(notify.error).toHaveBeenCalledWith(error, 'An error occurred while removing the Shared Policy Group'),
             );
+        });
+    });
+
+    describe('edit flow', () => {
+        it('hides Edit when the user lacks update permission', () => {
+            mockUseHasPermission.mockImplementation(({ anyOf }) => !anyOf.includes(ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION));
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: 'Edit Auth Bundle' })).toBeNull();
+        });
+
+        it('updates metadata without sending policy steps and shows a success toast', async () => {
+            const updateMutateAsync = jest.fn().mockResolvedValue({ id: 'spg-1', name: 'Updated Auth' });
+            mockUseUpdateSharedPolicyGroup.mockReturnValue(makeUpdateMutation(updateMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Auth Bundle' }));
+
+            expect(await screen.findByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Auth' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => {
+                expect(updateMutateAsync).toHaveBeenCalledWith({
+                    id: 'spg-1',
+                    payload: {
+                        name: 'Updated Auth',
+                        description: '',
+                        prerequisiteMessage: '',
+                    },
+                });
+            });
+            expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+        });
+
+        it('shows an error toast when update fails', async () => {
+            const error = new Error('update failed');
+            mockUseUpdateSharedPolicyGroup.mockReturnValue(makeUpdateMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Auth Bundle' }));
+            await screen.findByRole('heading', { name: 'Edit Shared Policy Group' });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group update!'));
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -25,10 +25,15 @@ import {
     SharedPolicyGroupCreateSheet,
     type SharedPolicyGroupCreateFormValues,
 } from '../features/shared-policy-groups/components/SharedPolicyGroupCreateSheet';
+import {
+    SharedPolicyGroupEditSheet,
+    type SharedPolicyGroupEditFormValues,
+} from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
 import { SharedPolicyGroupsTable } from '../features/shared-policy-groups/components/SharedPolicyGroupsTable';
 import {
     useCreateSharedPolicyGroup,
     useDeleteSharedPolicyGroup,
+    useUpdateSharedPolicyGroup,
 } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
@@ -36,21 +41,28 @@ import {
     DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE,
     SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS,
 } from '../features/shared-policy-groups/utils/paginationConstants';
+import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
 import {
     ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION,
     ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION,
     ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
+    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
 } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { notify } from '../shared/notify';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
-type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'delete'; sharedPolicyGroup: SharedPolicyGroup };
+type SheetState =
+    | { type: 'closed' }
+    | { type: 'create' }
+    | { type: 'edit'; sharedPolicyGroup: SharedPolicyGroup }
+    | { type: 'delete'; sharedPolicyGroup: SharedPolicyGroup };
 
 export function SharedPolicyGroupsPage() {
     const navigate = useNavigate();
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION] });
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION] });
 
     const [search, setSearch] = useState('');
@@ -87,6 +99,7 @@ export function SharedPolicyGroupsPage() {
     });
 
     const createMutation = useCreateSharedPolicyGroup();
+    const updateMutation = useUpdateSharedPolicyGroup();
     const deleteMutation = useDeleteSharedPolicyGroup();
 
     const sharedPolicyGroups = data?.data ?? [];
@@ -100,6 +113,10 @@ export function SharedPolicyGroupsPage() {
 
     function closeSheet() {
         setSheet({ type: 'closed' });
+    }
+
+    function handleOpenEdit(sharedPolicyGroup: SharedPolicyGroup) {
+        setSheet({ type: 'edit', sharedPolicyGroup });
     }
 
     async function handleCreate(values: SharedPolicyGroupCreateFormValues) {
@@ -117,6 +134,20 @@ export function SharedPolicyGroupsPage() {
             navigate(created.id);
         } catch (error) {
             notify.error(error, 'Error during Shared Policy Group creation!');
+        }
+    }
+
+    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
+        if (sheet.type !== 'edit') return;
+        try {
+            await updateMutation.mutateAsync({
+                id: sheet.sharedPolicyGroup.id,
+                payload: toUpdateSharedPolicyGroupPayload(values),
+            });
+            notify.success('Shared Policy Group updated');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group update!');
         }
     }
 
@@ -169,18 +200,28 @@ export function SharedPolicyGroupsPage() {
                 page={page}
                 pageSize={pageSize}
                 sorting={sorting}
+                canEdit={canEdit}
                 canDelete={canDelete}
                 onSearchChange={handleSearchChange}
                 onPageChange={setPage}
                 onPageSizeChange={setPageSize}
                 onSortingChange={handleSortingChange}
                 onView={sharedPolicyGroup => navigate(sharedPolicyGroup.id)}
+                onEdit={handleOpenEdit}
                 onDelete={sharedPolicyGroup => setSheet({ type: 'delete', sharedPolicyGroup })}
                 onCreateSharedPolicyGroup={canCreate ? () => setSheet({ type: 'create' }) : undefined}
             />
 
-            {sheet.type === 'create' ? (
-                <SharedPolicyGroupCreateSheet open onClose={closeSheet} onSubmit={handleCreate} isSaving={createMutation.isPending} />
+            {sheet.type === 'create' ? <SharedPolicyGroupCreateSheet open onClose={closeSheet} onSubmit={handleCreate} /> : null}
+
+            {sheet.type === 'edit' ? (
+                <SharedPolicyGroupEditSheet
+                    key={sheet.sharedPolicyGroup.id}
+                    open
+                    sharedPolicyGroup={sheet.sharedPolicyGroup}
+                    onClose={closeSheet}
+                    onSubmit={handleEdit}
+                />
             ) : null}
 
             <ConfirmDialog


### PR DESCRIPTION
## Summary

Adds **Edit Policy Group** to Platform Management so API Platform Engineers can update Shared Policy Group metadata (name, description, prerequisite message) for the selected environment.

Ports the metadata-edit behaviour from console-webui's shared-policy-groups add/edit dialog and studio “Edit general info” flow so API calls and logic match classic Console.

> **Stacked on** [#19130](https://github.com/gravitee-io/gravitee-api-management/pull/19130) (`FOUND-17-list-shared-policy-groups`). Retarget to `master` after that PR merges.

## Stories

### FOUND-18 — Create Shared Policy Group ✅ edit path completed

* Edit sheet fields: name (required), description, prerequisite message
* API type and phase shown read-only (cannot change after create — matches classic Console)
* Save disabled until name is provided
* Success toast on update
* UPDATE permission required (`environment-shared_policy_group-u`)
* Kubernetes-origin groups stay view-only (no Edit)
* API: `PUT /management/v2/environments/{envId}/shared-policy-groups/{id}`
* Existing policy `steps` are preserved on metadata update (list kebab fetches full SPG first)

### Wired entry points

* **List kebab:** View + Edit (Edit opens the sheet)
* **Detail page:** Edit button opens the same sheet

### Not in this PR

* **FOUND-19** (Configure Policies / Policy Studio)
* **FOUND-20** (Deploy / Undeploy / Version History)
* **FOUND-21** (Import via CRD)

## Test plan

- [ ] Open Policy Groups list with UPDATE permission → kebab shows View + Edit
- [ ] Edit from kebab → sheet pre-fills values → Save → success toast; list refreshes
- [ ] Open detail → Edit → change name/description/prerequisite → Save → detail refreshes
- [ ] Clear name → Save stays disabled
- [ ] User without UPDATE → no Edit on kebab or detail
- [ ] Kubernetes-origin SPG → no Edit
- [ ] Confirm updating metadata does not clear configured policies (steps preserved)