### PR TITLE
fix(ci): restore the S3 upload for es-mapping and jdbc-migration resources

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -82,18 +82,20 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-
 
       steps.push(
         /**
-         * In order to upload repositories, endpoints and entrypoints embedded in APIM mono-repository, we browse for all ZIP files in the project and check if they have a "publish folder path" property in pom.xml.
-         * Because we don't want to publish EVERY plugins (we don't want, apim-services or rest-api-idp-memory for instance), we only rely on this publish-folder-path maven property to determine if a ZIP has to be published or not.
-         * Each plugins is uploaded into a folder based on its name.
+         * We browse the distribution reactor for ZIP files and check if they have a "publish folder path" property in
+         * pom.xml. Because we don't want to publish every artefact, we only rely on that maven property to determine
+         * whether a ZIP has to be published. Each artefact is uploaded into a folder based on its name.
          * Example:
-         *   gravitee-apim-repository-mongodb-x.x.x.zip is published into graviteeio-apim/plugins/repositories/gravitee-apim-repository-mongodb
+         *   gravitee-apim-jdbc-migrations-x.x.x.zip is published into graviteeio-apim/resources/gravitee-apim-jdbc-migrations
          *
-         *
+         * The search is scoped to gravitee-apim-distribution on purpose. Repositories, reporters, endpoints and
+         * entrypoints also carry publish-folder-path, and have not been published since 4.8 — widening the search
+         * here would silently resume publishing thirteen more artefacts, which is a product decision of its own.
          */
         new commands.Run({
           name: 'Prepare plugin zip to upload',
           command: `workingDir=$(pwd)
-for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
   # Extract folder of the artefact to publish
   # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
   artefactFolder=\${pathToArtefactFile%/target*}
@@ -126,6 +128,9 @@ for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
     cd $workingDir
   fi
 done`,
+        }),
+        new reusable.ReusedCommand(syncFolderToS3Cmd, {
+          'folder-to-sync': 'folder_to_sync',
         }),
       );
     }

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
@@ -48,7 +48,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-apim/es-index-mappings</publish-folder-path>
+        <publish-folder-path>graviteeio-apim/resources</publish-folder-path>
     </properties>
 
     <dependencies>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/README.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/README.md
@@ -1,0 +1,109 @@
+# APIM — JDBC schema migrations
+
+This module packages every Liquibase changeset APIM and its bundled Gamma modules apply to a JDBC
+management database, so that installations running with `management.jdbc.liquibase=false` can apply
+them themselves instead of opening each installed plugin. It ships as this file's own README inside
+the published archive, which is what a customer reads.
+
+Applies to the JDBC backend only. The `mongodb` backends have no file-based migrations.
+
+You need a Liquibase CLI and a JDBC driver for your database. Nothing else: the changesets in the
+archive are the ones the application runs. The archive filename carries the APIM version it was
+built from.
+
+## Read this first
+
+**Always pass the prefix parameters, even when your installation uses no prefix.** Almost every
+changeset names its tables through a parameter — `${gravitee_prefix}api_products` rather than
+`api_products`. Omitting the parameter leaves the placeholder unresolved, which changes the checksum
+of every changeset, and Liquibase then reports well over a hundred failures of this shape:
+
+```
+Validation Failed:
+     141 changesets check sum
+          liquibase/changelogs/v1_15_0/schema.yml::1.15.0::GraviteeSource Team
+              was: 9:89bae981dae8df68c63aa03c4aa12792 but is now: 9:8259b78599409dec370ffa0c10c4395f
+```
+
+Nothing is corrupted and no version is incompatible: a parameter is missing. Pass
+`-Dgravitee_prefix=` with an empty value if you have no prefix.
+
+## What is in the archive, and what to run it against
+
+One entry point per component. List them:
+
+```
+find . -name master.yml
+```
+
+```
+./liquibase/master.yml       APIM itself
+./liquibase/aim/master.yml   the "aim" Gamma module
+```
+
+`liquibase/master.yml` is always APIM. Every other entry point is a Gamma module, and the directory
+name is the module id. Only modules that own a schema appear — a module absent from this list has
+nothing to migrate.
+
+**Each entry point is a separate run.** Modules keep their migration history in their own tracking
+tables, independently of APIM and of each other, so running APIM's changelog does not migrate the
+modules. Derive the arguments from the id:
+
+| | Changelog | Tracking tables | Parameters |
+|---|---|---|---|
+| APIM | `liquibase/master.yml` | `<prefix>databasechangelog` and `<prefix>databasechangeloglock` | `gravitee_prefix`, `gravitee_rate_limit_prefix` |
+| module `<id>` | `liquibase/<id>/master.yml` | `<prefix><id>_databasechangelog` and `<prefix><id>_databasechangeloglock` | `<id>_prefix` |
+
+`<prefix>` is `management.jdbc.prefix` from your `gravitee.yml`, empty unless you configured one.
+`gravitee_rate_limit_prefix` is `ratelimit.jdbc.prefix`.
+
+## Reviewing what an upgrade would do
+
+`update-sql` writes the pending statements to a file without applying them. Run it from the
+directory you unzipped the archive into.
+
+APIM:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/master.yml --url=<jdbc url> --username=<user> --password=<password> --output-file=apim.sql update-sql -Dgravitee_prefix= -Dgravitee_rate_limit_prefix=
+```
+
+Then one run per module — here `aim`:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/aim/master.yml --url=<jdbc url> --username=<user> --password=<password> --database-changelog-table-name=aim_databasechangelog --database-changelog-lock-table-name=aim_databasechangeloglock --output-file=aim.sql update-sql -Daim_prefix=
+```
+
+Or generate every file in one pass:
+
+```
+liquibase --search-path=. --changelog-file=liquibase/master.yml --url="$URL" --username="$USER" --password="$PASSWORD" --output-file=apim.sql update-sql -Dgravitee_prefix= -Dgravitee_rate_limit_prefix=
+for module in $(find liquibase -mindepth 2 -name master.yml | cut -d/ -f2); do
+  liquibase --search-path=. --changelog-file="liquibase/$module/master.yml" --url="$URL" --username="$USER" --password="$PASSWORD" --database-changelog-table-name="${module}_databasechangelog" --database-changelog-lock-table-name="${module}_databasechangeloglock" --output-file="$module.sql" update-sql "-D${module}_prefix="
+done
+```
+
+The generated files carry their own `INSERT INTO ... databasechangelog` statements. Applying one
+therefore leaves the database in the state the application expects, and it will start without
+replaying anything.
+
+`update-sql` does not change your schema, but it does take the Liquibase lock, so it writes to the
+lock table and creates it if absent. It is not a read-only operation.
+
+## Applying
+
+Replace `update-sql` with `update` to apply, or with `changelog-sync` to record the changesets as
+already applied on a database you brought up to date by other means.
+
+## Two things that will bite you
+
+**Do not move the files inside `liquibase/`.** Liquibase identifies a changeset by *(id, author,
+filename)*, and `filename` is the changelog path as resolved — it is stored in the tracking table.
+The paths in the archive are the ones the application records when it migrates itself. Re-rooting
+them makes your run record different filenames, and the application then considers nothing applied
+and replays everything against an already-migrated database. No error is reported at the time of
+your run.
+
+**The archive describes one combination.** It carries one APIM version and the module versions
+bundled with it. If you upgraded a module on its own, use the changelogs of the version you actually
+run — they are inside that plugin's own archive, under `liquibase/<id>/`.

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.distribution</groupId>
+        <artifactId>gravitee-apim-distribution</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-distribution-jdbc-migrations</artifactId>
+    <packaging>pom</packaging>
+    <name>Gravitee.io APIM - Distribution - JDBC Migrations</name>
+    <description>Liquibase changesets of APIM and of the bundled Gamma modules, in one archive. JDBC only: the mongodb and dbless backends have no file-based migrations.</description>
+
+    <properties>
+        <!--
+            The umbrella turns deployment off for the assembly poms; this module is an exception, like
+            es-index-mappings — the archive it produces is the deliverable, and it is meant to reach the download
+            website so that installations running with management.jdbc.liquibase=false have somewhere to get the
+            changesets from.
+        -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/jdbc-migrations</publish-folder-path>
+
+    </properties>
+
+    <!--
+        Published so that an installation running with management.jdbc.liquibase=false has one place to get every
+        changelog it needs, instead of opening each installed plugin.
+
+        The dependencies below are the ordinary plugin zips, the same ones the standalone distribution bundles, at
+        the same versions. Each carries its changelogs at its root under liquibase/, and unpack-dependencies keeps
+        only that. A component with no schema contributes nothing and needs no declaration of its own — which is
+        what keeps this list stable while modules adopt JDBC one at a time.
+
+        The trees are disjoint by construction: APIM owns liquibase/master.yml and liquibase/changelogs/, each
+        module owns liquibase/<module id>/. A module taking liquibase/changelogs/ for itself would silently
+        overwrite APIM's files here; that path is reserved.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-jdbc</artifactId>
+            <version>${apim.server.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.graviteesource.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-aim</artifactId>
+            <version>${gravitee-gamma-module-aim.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-authz</artifactId>
+            <version>${gravitee-gamma-module-authz.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-edge</artifactId>
+            <version>${gravitee-gamma-module-edge.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-esm</artifactId>
+            <version>${gravitee-gamma-module-esm.version}</version>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                The changelogs live inside each plugin's jar, which lives inside the plugin zip, so collecting them
+                takes two stages. Maven does the first, Ant the second.
+
+                Only the jar at the root of each zip is taken — deliberately "*.jar" and not "**/*.jar". The jars
+                under lib/ include liquibase-core, whose own Java package is also called liquibase: unpacking it
+                would pour 1426 class files into an archive meant for a DBA, and the changelog assertion below would
+                still pass. Keeping lib/ out is what makes that impossible rather than merely filtered.
+            -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-plugin-jars</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>*.jar</includes>
+                            <outputDirectory>${project.build.directory}/plugin-jars</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>collect-changelogs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip dest="${project.build.directory}/migrations">
+                                    <fileset dir="${project.build.directory}/plugin-jars" includes="*.jar" erroronmissingdir="false" />
+                                    <patternset>
+                                        <include name="liquibase/**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                An empty collection is a silent failure: the assembly happily produces a valid, empty zip. That
+                happens if the include pattern stops matching, or if a component stops shipping its changelogs at
+                the zip root. APIM's own changelog is always expected, so assert it and fail loudly instead.
+            -->
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>changelogs-were-collected</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesExist>
+                                    <files>
+                                        <file>${project.build.directory}/migrations/liquibase/master.yml</file>
+                                    </files>
+                                </requireFilesExist>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-migrations-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>gravitee-apim-jdbc-migrations-${project.version}</finalName>
+                            <descriptors>
+                                <descriptor>src/main/assembly/migrations-assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/pom.xml
@@ -42,8 +42,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
 
         <!-- Property used by the publication job in CI-->
-        <publish-folder-path>graviteeio-apim/jdbc-migrations</publish-folder-path>
-
+        <publish-folder-path>graviteeio-apim/resources</publish-folder-path>
     </properties>
 
     <!--

--- a/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/src/main/assembly/migrations-assembly.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-jdbc-migrations/src/main/assembly/migrations-assembly.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>migrations</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!--
+		The changesets alone are not usable: they name their tables through parameters, and nothing in them says
+		which tracking tables to write to. The README carries the coordinates, and tells the reader to discover the
+		components to run rather than listing them — the archive contents are the list, so it cannot drift as
+		modules adopt JDBC.
+	-->
+	<files>
+		<file>
+			<source>README.md</source>
+			<outputDirectory>/</outputDirectory>
+		</file>
+	</files>
+
+	<!-- Filled by dependency:unpack-dependencies, which keeps only liquibase/** from each plugin zip. -->
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/migrations</directory>
+			<outputDirectory>/</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -424,6 +424,7 @@
     <modules>
         <module>gravitee-apim-distribution-standalone</module>
         <module>gravitee-apim-distribution-es-index-mappings</module>
+        <module>gravitee-apim-distribution-jdbc-migrations</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-183

## What

Restores the `cmd-sync-folder-to-s3` step in `job-backend-build-and-publish-on-download-website`, and scopes the artefact search to the distribution reactor so that only `gravitee-apim-distribution-es-index-mappings` and `gravitee-apim-distribution-jdbc-migrations` are published.

## Why

The job has two halves: shell steps that *stage* zips and checksums into a local `folder_to_sync/`, and one reusable command that *uploads* that folder to S3.

`d9c7d3dbdb` ("chore: remove backend standalone zip and sync on S3", March 2025) legitimately removed the two staging steps for the mAPI and Gateway standalone zips, replaced by the Docker images. But the four entries were contiguous in the same `steps.push(...)`, and the deletion took the fourth with them:

```diff
-        new reusable.ReusedCommand(syncFolderToS3Cmd, {
-          'folder-to-sync': 'folder_to_sync',
-        }),
```

That one was not specific to the standalone zips: it was the shared upload, serving also the generic `publish-folder-path` loop, which survived.

Since then the job stages everything correctly and the container dies with the folder. Nothing fails and the logs look clean. Two things kept it hidden. Lines 80-81 still register the reusable command, so it keeps appearing under `commands:` in the generated YAML and a grep looks reassuring. And the download website does not look empty, because `job-package-bundle` builds its own `folder_to_sync` and calls the sync itself; it is currently the only caller left in the repo.

Confirmed against the bucket:

| Prefix | Newest object | |
|---|---|---|
| `graviteeio-apim/distributions/` | `graviteeio-full-4.12.15.zip`, 2026-08-12 | alive, published by `job-package-bundle` |
| `graviteeio-apim/plugins/repositories/` | `...elasticsearch-4.4.23.zip`, 2025-03-27 | dead since `d9c7d3dbdb` |
| `graviteeio-apim/resources/` | 0 objects | `es-index-mappings` never landed |

No plugin zip exists for 4.8, 4.9, 4.10, 4.11 or 4.12, checked prefix by prefix.

## Scope of the search

The `find` is narrowed to `./gravitee-apim-distribution`. Restoring the upload without narrowing it would silently resume publishing thirteen plugin artefacts (repositories, reporters, endpoints, entrypoints) that have been absent from the download website for a year and a half.

Whether to resume them, or instead to drop the now-inert `publish-folder-path` properties, is a product decision, and one to backport across 4.8.x to 4.12.x. This PR deliberately keeps master's current behaviour and only adds the two distribution archives.

## What will be published

Replayed the job's shell script against a local build:

```
gravitee-apim-distribution-es-index-mappings-4.13.0.zip -> graviteeio-apim/resources/gravitee-apim-distribution-es-index-mappings/
gravitee-apim-jdbc-migrations-4.13.0.zip                -> graviteeio-apim/resources/gravitee-apim-jdbc-migrations/
```

These two and nothing else. Three filters stack up:

- the narrowed `find` returns 2 zips instead of 40;
- `publish-folder-path` is declared by only those two poms in the reactor, and the script reads each module's own `pom.xml`, so nothing inherits it by accident;
- `gravitee-apim-distribution-integration-tests` is profile-gated and produces no zip.

The case worth noting: `target/distribution/plugins/` under the two standalone modules holds 372 plugin zips. They do not match, because the pattern requires the literal `target/gravitee-apim` and here `target/` is followed by `distribution/`. Even if they did, `${pathToArtefactFile%/target*}` would attribute them to the standalone module, whose pom carries no `publish-folder-path`. The guard holds at two levels.

No double upload: nothing persists `folder_to_sync` to the workspace, so `job-package-bundle`'s `attach_workspace` cannot pick up the backend job's folder; the two prefixes are disjoint anyway; and `aws s3 sync` runs without `--delete`, so re-running a release overwrites the same keys rather than accumulating.

The restored step needs no companion. The reusable command already carries the two `keeper/env-export` for the AWS credentials and the `aws-cli/setup`, and the job already runs with `context: cicd-orchestrator`, the same context `job-package-bundle` uses and the one this job already relies on for GPG.

## Tested

- `npx jest`: 153 tests, 29 suites, green
- `npm run validate:test`: 52 configs valid, 0 invalid
- the 7 regenerated fixtures were diffed: they contain the two changes replicated 7 times, with no absorbed drift

Dry-run is safe to try: the sync targets `s3://gravitee-dry-releases-downloads`, and a qualified version goes under `/pre-releases`.

## Note

`npm run build` fails on `circleci-config/config.ts:103` (`lineWidth` missing from `Options`). Verified pre-existing by stashing, unrelated to this change, likely a `yaml` version drift.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

