### PR TITLE
feat(gamma): add Shared Policy Group detail tabs shell

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 export default {
     displayName: 'gravitee-gamma-module-platform',
     testEnvironment: 'jest-fixed-jsdom',
-    transformIgnorePatterns: ['/node_modules/(?!(until-async|@gravitee/graphene-core)/)'],
+    transformIgnorePatterns: ['/node_modules/(?!(until-async|@gravitee/graphene-core|@gravitee/graphene-policy-studio)/)'],
     moduleNameMapper: {
         '^react$': '<rootDir>/../../node_modules/react/index.js',
         '^react/jsx-runtime$': '<rootDir>/../../node_modules/react/jsx-runtime.js',
@@ -30,6 +30,7 @@ export default {
         '^@tanstack/query-core$': '<rootDir>/../../node_modules/@tanstack/query-core/build/modern/index.cjs',
         '^@gravitee/graphene-core$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/index.js',
         '^@gravitee/graphene-core/(.*)$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/$1',
+        '^@gravitee/graphene-policy-studio$': '<rootDir>/../../node_modules/@gravitee/graphene-policy-studio/dist/index.js',
         '^@gravitee/gamma-modules-sdk$': '<rootDir>/src/main/ui/shared/gamma-modules-sdk.ts',
         '^@gravitee/gamma-modules-sdk/routing$': '<rootDir>/../../node_modules/@gravitee/gamma-modules-sdk/dist/routing.js',
         '^@gravitee/gamma-ui-shared/api$': '<rootDir>/../gamma-ui-shared/src/api/index.ts',

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-core": "3.12.0",
+        "@gravitee/graphene-policy-studio": "3.12.0",
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import type { ComponentType } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { AppRoutes } from './AppRoutes';
@@ -97,8 +98,27 @@ jest.mock('../pages/SharedPolicyGroupsPage', () => ({
     SharedPolicyGroupsPage: () => <div data-testid="shared-policy-groups-page" />,
 }));
 
+jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout', () => {
+    const { Outlet } = jest.requireActual<{ Outlet: ComponentType }>('react-router-dom');
+    return {
+        SharedPolicyGroupDetailLayout: () => (
+            <div data-testid="shared-policy-group-detail-layout">
+                <Outlet />
+            </div>
+        ),
+    };
+});
+
 jest.mock('../pages/SharedPolicyGroupDetailPage', () => ({
-    SharedPolicyGroupDetailPage: () => <div data-testid="shared-policy-group-detail-page" />,
+    SharedPolicyGroupDetailPage: () => <div data-testid="shared-policy-group-overview-page" />,
+}));
+
+jest.mock('../pages/SharedPolicyGroupStudioPage', () => ({
+    SharedPolicyGroupStudioPage: () => <div data-testid="shared-policy-group-studio-page" />,
+}));
+
+jest.mock('../pages/SharedPolicyGroupHistoryPage', () => ({
+    SharedPolicyGroupHistoryPage: () => <div data-testid="shared-policy-group-history-page" />,
 }));
 
 jest.mock('../pages/AccessManagementPage', () => ({
@@ -416,14 +436,38 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('shared-policy-groups-page')).not.toBeNull();
     });
 
-    it('routes to the shared policy group detail page under the platform module', () => {
+    it('routes to the shared policy group studio tab by default under the platform module', () => {
         render(
             <MemoryRouter initialEntries={['/shared-policy-groups/spg-1']}>
                 <AppRoutes />
             </MemoryRouter>,
         );
 
-        expect(screen.getByTestId('shared-policy-group-detail-page')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-detail-layout')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-studio-page')).not.toBeNull();
+    });
+
+    it.each([
+        ['overview', 'shared-policy-group-overview-page'],
+        ['history', 'shared-policy-group-history-page'],
+    ])('routes to the shared policy group %s tab', (tab, testId) => {
+        render(
+            <MemoryRouter initialEntries={[`/shared-policy-groups/spg-1/${tab}`]}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId(testId)).not.toBeNull();
+    });
+
+    it('redirects unknown shared policy group detail routes to the studio tab', () => {
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups/spg-1/unknown']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('shared-policy-group-studio-page')).not.toBeNull();
     });
 
     it('redirects away from Shared Policy Groups when the user lacks environment-shared_policy_group-r', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -53,6 +53,7 @@ import { GatewayInstanceDetailLayout } from '../features/gateway-instances/compo
 import { ENVIRONMENT_GROUP_READ_PERMISSION, ORGANIZATION_TAG_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { SharedPolicyGroupDetailLayout } from '../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout';
 import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
@@ -78,7 +79,9 @@ import { OrganizationGroupsPage } from '../pages/OrganizationGroupsPage';
 import { OrgAuditLogsPage } from '../pages/OrgAuditLogsPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { SharedPolicyGroupDetailPage } from '../pages/SharedPolicyGroupDetailPage';
+import { SharedPolicyGroupHistoryPage } from '../pages/SharedPolicyGroupHistoryPage';
 import { SharedPolicyGroupsPage } from '../pages/SharedPolicyGroupsPage';
+import { SharedPolicyGroupStudioPage } from '../pages/SharedPolicyGroupStudioPage';
 import { SmtpSettingsPage } from '../pages/SmtpSettingsPage';
 import { TenantsPage } from '../pages/TenantsPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
@@ -563,10 +566,16 @@ export function AppRoutes() {
                                             permission={ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION}
                                             unauthorizedTo="../../applications"
                                         >
-                                            <SharedPolicyGroupDetailPage />
+                                            <SharedPolicyGroupDetailLayout />
                                         </PermissionPageGuard>
                                     }
-                                />
+                                >
+                                    <Route index element={<Navigate to="studio" replace />} />
+                                    <Route path="overview" element={<SharedPolicyGroupDetailPage />} />
+                                    <Route path="studio" element={<SharedPolicyGroupStudioPage />} />
+                                    <Route path="history" element={<SharedPolicyGroupHistoryPage />} />
+                                    <Route path="*" element={<Navigate to="../studio" replace />} />
+                                </Route>
                             </Route>
                             <Route path="gateways">
                                 <Route

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
+
+import { SharedPolicyGroupDetailLayout } from './SharedPolicyGroupDetailLayout';
+import { ApimApiError } from '../../../shared/api/apimClient';
+import { useForbiddenResourceRedirect } from '../../../shared/hooks/useForbiddenResourceRedirect';
+import { useUpdateSharedPolicyGroup } from '../hooks/useSharedPolicyGroupMutations';
+import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+const mockNavigate = jest.fn();
+let capturedLayoutConfig: Record<string, unknown> | null = null;
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/graphene-core', () => ({
+    ...jest.requireActual<object>('@gravitee/graphene-core'),
+    useLayoutConfig: jest.fn((config: Record<string, unknown>) => {
+        capturedLayoutConfig = config;
+    }),
+}));
+
+jest.mock('../hooks/useSharedPolicyGroups');
+jest.mock('../hooks/useSharedPolicyGroupMutations');
+jest.mock('../../../shared/hooks/useForbiddenResourceRedirect');
+
+const mockUseDetail = jest.mocked(useSharedPolicyGroupDetail);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
+const mockUseForbiddenResourceRedirect = jest.mocked(useForbiddenResourceRedirect);
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth policies',
+    lifecycleState: 'DEPLOYED',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+};
+
+function renderLayout(path = '/shared-policy-groups/spg-1/studio') {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/shared-policy-groups">
+                    <Route path=":sharedPolicyGroupId" element={<SharedPolicyGroupDetailLayout />}>
+                        <Route path="overview" element={<div>Overview content</div>} />
+                        <Route path="studio" element={<div>Studio content</div>} />
+                        <Route path="history" element={<div>History content</div>} />
+                    </Route>
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+function StatefulOutlet() {
+    const [dirty, setDirty] = useState(false);
+    return (
+        <>
+            <span>{dirty ? 'Dirty' : 'Clean'}</span>
+            <button type="button" onClick={() => setDirty(true)}>
+                Mark dirty
+            </button>
+        </>
+    );
+}
+
+describe('SharedPolicyGroupDetailLayout', () => {
+    beforeEach(() => {
+        mockUseUpdateSharedPolicyGroup.mockReturnValue({ mutateAsync: jest.fn() } as never);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders header, status badge, tabs, and outlet content', () => {
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout();
+
+        expect(screen.getByTestId('shared-policy-group-detail')).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Auth Bundle' })).not.toBeNull();
+        expect(screen.getByText('Deployed')).not.toBeNull();
+        expect(screen.getByText('Reusable auth policies')).not.toBeNull();
+        expect(screen.getByText('Proxy · Request')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Edit' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Overview' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Studio' }).getAttribute('aria-current')).toBe('page');
+        expect(screen.getByRole('link', { name: 'History' })).not.toBeNull();
+        expect(screen.getByText('Studio content')).not.toBeNull();
+        expect(capturedLayoutConfig).toMatchObject({
+            breadcrumbs: [{ label: 'Shared Policy Groups', href: '/shared-policy-groups' }, { label: 'Auth Bundle' }],
+        });
+    });
+
+    it('builds route links correctly when the Shared Policy Group id is encoded', async () => {
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout('/shared-policy-groups/shared%20policy/studio');
+
+        const overviewLink = screen.getByRole('link', { name: 'Overview' });
+        expect((overviewLink as HTMLAnchorElement).pathname).toBe('/shared-policy-groups/shared%20policy/overview');
+        await userEvent.setup().click(overviewLink);
+
+        expect(screen.getByText('Overview content')).not.toBeNull();
+    });
+
+    it('navigates back to the shared policy groups list', () => {
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout();
+        fireEvent.click(screen.getByRole('button', { name: /Back to Shared Policy Groups/i }));
+        expect(mockNavigate).toHaveBeenCalledWith('/shared-policy-groups');
+    });
+
+    it('shows not-found state when the detail query fails', () => {
+        mockUseDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+        renderLayout();
+        expect(screen.getByText(/Shared Policy Group not found or failed to load/i)).not.toBeNull();
+    });
+
+    it('redirects and hides the not-found state when the detail request is forbidden', () => {
+        mockUseDetail.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as never);
+
+        renderLayout();
+
+        expect(mockUseForbiddenResourceRedirect).toHaveBeenCalledWith({
+            isForbidden: true,
+            permissionPrefix: 'environment-shared_policy_group-',
+            redirectTo: '../../applications',
+        });
+        expect(screen.queryByText(/Shared Policy Group not found or failed to load/i)).toBeNull();
+    });
+
+    it('shows a loading skeleton while fetching', () => {
+        mockUseDetail.mockReturnValue({ data: undefined, isLoading: true, isError: false } as never);
+        renderLayout();
+        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).toBeNull();
+        expect(screen.queryByTestId('shared-policy-group-detail')).toBeNull();
+    });
+
+    it('resets tab state when navigating to a different Shared Policy Group', async () => {
+        mockUseDetail.mockImplementation(
+            sharedPolicyGroupId =>
+                ({
+                    data: { ...SPG, id: sharedPolicyGroupId ?? '', name: sharedPolicyGroupId ?? '' },
+                    isLoading: false,
+                    isError: false,
+                }) as never,
+        );
+        const router = createMemoryRouter(
+            [
+                {
+                    path: '/shared-policy-groups/:sharedPolicyGroupId',
+                    element: <SharedPolicyGroupDetailLayout />,
+                    children: [{ path: 'overview', element: <StatefulOutlet /> }],
+                },
+            ],
+            { initialEntries: ['/shared-policy-groups/spg-1/overview'] },
+        );
+        render(<RouterProvider router={router} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Mark dirty' }));
+        expect(screen.getByText('Dirty')).not.toBeNull();
+
+        await act(() => router.navigate('/shared-policy-groups/spg-2/overview'));
+
+        expect(screen.getByText('Clean')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Skeleton, cn, useLayoutConfig } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
+import { NavLink, Outlet, useNavigate, useParams, useResolvedPath } from 'react-router-dom';
+
+import { SharedPolicyGroupEditAction } from './SharedPolicyGroupEditAction';
+import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
+import { useForbiddenResourceRedirect } from '../../../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../../../shared/utils/apiErrors';
+import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
+import { type SharedPolicyGroup, toReadableApiType, toReadableFlowPhase } from '../types/sharedPolicyGroup';
+import { SHARED_POLICY_GROUP_DETAIL_TABS } from '../utils/sharedPolicyGroupDetailNavigation';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX } from '../utils/sharedPolicyGroupPermissions';
+
+function SharedPolicyGroupHeader({ sharedPolicyGroup }: Readonly<{ sharedPolicyGroup: SharedPolicyGroup }>) {
+    return (
+        <div className="flex items-start gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-highlight text-highlight-foreground">
+                <LayersIcon className="size-5" aria-hidden />
+            </div>
+            <div className="min-w-0 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <h1 className="truncate text-2xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                    <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                </div>
+                {sharedPolicyGroup.description ? <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p> : null}
+                <p className="text-sm text-muted-foreground">
+                    {toReadableApiType(sharedPolicyGroup.apiType)} · {toReadableFlowPhase(sharedPolicyGroup.phase)}
+                </p>
+            </div>
+            <div className="ml-auto shrink-0">
+                <SharedPolicyGroupEditAction key={sharedPolicyGroup.id} sharedPolicyGroup={sharedPolicyGroup} />
+            </div>
+        </div>
+    );
+}
+
+export function SharedPolicyGroupDetailLayout() {
+    const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
+    const navigate = useNavigate();
+    const listHref = useResolvedPath('..').pathname;
+    const { data: sharedPolicyGroup, isLoading, isError, error } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
+    const isForbidden = isForbiddenApiError(isError, error);
+
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
+        redirectTo: '../../applications',
+    });
+
+    useLayoutConfig(
+        {
+            breadcrumbs: [{ label: 'Shared Policy Groups', href: listHref }, { label: sharedPolicyGroup?.name ?? 'Loading…' }],
+        },
+        [listHref, sharedPolicyGroup?.name],
+    );
+
+    if (isForbidden) {
+        return null;
+    }
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-8 w-40" />
+                <div className="flex items-start gap-3">
+                    <Skeleton className="size-10 rounded-lg" />
+                    <div className="space-y-2">
+                        <Skeleton className="h-8 w-64" />
+                        <Skeleton className="h-4 w-96" />
+                    </div>
+                </div>
+                <Skeleton className="h-10 w-72" />
+                <Skeleton className="h-64 w-full" />
+            </div>
+        );
+    }
+
+    if (isError || !sharedPolicyGroup) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate(listHref)}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Shared Policy Groups
+                </Button>
+                <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6" data-testid="shared-policy-group-detail">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate(listHref)}>
+                <ArrowLeftIcon className="size-4" aria-hidden />
+                Back to Shared Policy Groups
+            </Button>
+
+            <SharedPolicyGroupHeader sharedPolicyGroup={sharedPolicyGroup} />
+
+            <div className="border-b">
+                <nav className="flex items-center gap-6" aria-label="Shared Policy Group sections">
+                    {SHARED_POLICY_GROUP_DETAIL_TABS.map(tab => (
+                        <NavLink
+                            key={tab.path}
+                            to={tab.path}
+                            className={({ isActive }) =>
+                                cn(
+                                    '-mb-px border-b-2 px-0.5 pb-3 text-sm transition-colors',
+                                    isActive
+                                        ? 'border-foreground font-semibold text-foreground'
+                                        : 'border-transparent text-muted-foreground hover:text-foreground',
+                                )
+                            }
+                        >
+                            {tab.label}
+                        </NavLink>
+                    ))}
+                </nav>
+            </div>
+
+            <Outlet key={sharedPolicyGroupId} context={sharedPolicyGroup} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditAction.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditAction.spec.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { SharedPolicyGroupEditAction } from './SharedPolicyGroupEditAction';
+import { notify } from '../../../shared/notify';
+import { installFormActionTestEnvironment } from '../../../shared/testing/formAction';
+import { useUpdateSharedPolicyGroup } from '../hooks/useSharedPolicyGroupMutations';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+let restoreTestEnvironment: () => void;
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('../hooks/useSharedPolicyGroupMutations');
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
+
+const SHARED_POLICY_GROUP: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth policies',
+    prerequisiteMessage: 'Requires the "auth-cache" resource',
+    lifecycleState: 'DEPLOYED',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    steps: [{ name: 'jwt' }],
+};
+
+function makeMutation(mutateAsync = jest.fn()) {
+    return { mutateAsync } as unknown as ReturnType<typeof useUpdateSharedPolicyGroup>;
+}
+
+describe('SharedPolicyGroupEditAction', () => {
+    beforeAll(() => {
+        restoreTestEnvironment = installFormActionTestEnvironment();
+    });
+
+    afterAll(() => {
+        restoreTestEnvironment();
+    });
+
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('updates Shared Policy Group metadata', async () => {
+        const updateMutateAsync = jest.fn().mockResolvedValue(SHARED_POLICY_GROUP);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(updateMutateAsync));
+        render(<SharedPolicyGroupEditAction sharedPolicyGroup={SHARED_POLICY_GROUP} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.change(await screen.findByLabelText(/Name/i), { target: { value: 'Renamed Bundle' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+            expect(updateMutateAsync).toHaveBeenCalledWith({
+                id: 'spg-1',
+                payload: {
+                    name: 'Renamed Bundle',
+                    description: 'Reusable auth policies',
+                    prerequisiteMessage: 'Requires the "auth-cache" resource',
+                },
+            }),
+        );
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+    });
+
+    it('keeps the edit sheet open when the update fails', async () => {
+        const error = new Error('update failed');
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+        render(<SharedPolicyGroupEditAction sharedPolicyGroup={SHARED_POLICY_GROUP} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+
+        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group update!'));
+        expect(screen.queryByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
+    });
+
+    it('hides Edit without update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        render(<SharedPolicyGroupEditAction sharedPolicyGroup={SHARED_POLICY_GROUP} />);
+
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    });
+
+    it('hides Edit for a Kubernetes-origin Shared Policy Group', () => {
+        render(<SharedPolicyGroupEditAction sharedPolicyGroup={{ ...SHARED_POLICY_GROUP, originContext: { origin: 'KUBERNETES' } }} />);
+
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditAction.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditAction.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button } from '@gravitee/graphene-core';
+import { PencilIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { SharedPolicyGroupEditSheet, type SharedPolicyGroupEditFormValues } from './SharedPolicyGroupEditSheet';
+import { notify } from '../../../shared/notify';
+import { useUpdateSharedPolicyGroup } from '../hooks/useSharedPolicyGroupMutations';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { toUpdateSharedPolicyGroupPayload } from '../utils/sharedPolicyGroupPayload';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION, isKubernetesOrigin } from '../utils/sharedPolicyGroupPermissions';
+
+export function SharedPolicyGroupEditAction({ sharedPolicyGroup }: Readonly<{ sharedPolicyGroup: SharedPolicyGroup }>) {
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const updateMutation = useUpdateSharedPolicyGroup();
+    const [editOpen, setEditOpen] = useState(false);
+
+    if (!canEdit || isKubernetesOrigin(sharedPolicyGroup)) {
+        return null;
+    }
+
+    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
+        try {
+            await updateMutation.mutateAsync({
+                id: sharedPolicyGroup.id,
+                payload: toUpdateSharedPolicyGroupPayload(values),
+            });
+            notify.success('Shared Policy Group updated');
+            setEditOpen(false);
+        } catch (updateError) {
+            notify.error(updateError, 'Error during Shared Policy Group update!');
+        }
+    }
+
+    return (
+        <>
+            <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setEditOpen(true)}>
+                <PencilIcon className="size-4" aria-hidden />
+                Edit
+            </Button>
+            {editOpen ? (
+                <SharedPolicyGroupEditSheet
+                    key={sharedPolicyGroup.id}
+                    open
+                    sharedPolicyGroup={sharedPolicyGroup}
+                    onClose={() => setEditOpen(false)}
+                    onSubmit={handleEdit}
+                />
+            ) : null}
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicySteps.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicySteps.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { ChevronDownIcon, ChevronUpIcon, CopyIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import type { ResolvedStep } from '@gravitee/graphene-policy-studio';
+
+interface SharedPolicyGroupPolicyStepsProps {
+    readonly resolvedSteps: readonly ResolvedStep[];
+    readonly readOnly: boolean;
+    readonly selectedStepIndex?: number;
+    readonly onSelect: (stepIndex: number) => void;
+    readonly onAdd: () => void;
+    readonly onMove: (oldIndex: number, newIndex: number) => void;
+    readonly onDuplicate: (stepIndex: number) => void;
+    readonly onRemove: (stepIndex: number) => void;
+}
+
+function stepLabel({ policy, step, index }: ResolvedStep): string {
+    return policy?.name ?? step.name?.trim() ?? `Policy ${index + 1}`;
+}
+
+export function SharedPolicyGroupPolicySteps({
+    resolvedSteps,
+    readOnly,
+    selectedStepIndex,
+    onSelect,
+    onAdd,
+    onMove,
+    onDuplicate,
+    onRemove,
+}: SharedPolicyGroupPolicyStepsProps) {
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+                <div>
+                    <h2 className="text-base font-semibold">Configured policies</h2>
+                    <p className="text-sm text-muted-foreground">Policies run in the order shown below.</p>
+                </div>
+                {!readOnly ? (
+                    <Button type="button" size="sm" className="gap-1.5" onClick={onAdd}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add policy
+                    </Button>
+                ) : null}
+            </div>
+
+            {resolvedSteps.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-8 text-center">
+                    <p className="font-medium">No policies configured</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Add a policy to configure this Shared Policy Group.</p>
+                </div>
+            ) : (
+                <ol className="space-y-2">
+                    {resolvedSteps.map((resolvedStep, index) => {
+                        const label = stepLabel(resolvedStep);
+                        return (
+                            <li
+                                key={`${resolvedStep.step.policy ?? 'policy'}-${index}`}
+                                className={selectedStepIndex === index ? 'rounded-lg border border-primary' : 'rounded-lg border'}
+                            >
+                                <div className="flex items-center gap-2 p-3">
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        className="h-auto flex-1 justify-start"
+                                        // An unresolved step has no schema to render, so configuring it would dead-end.
+                                        disabled={resolvedStep.unresolved}
+                                        onClick={() => onSelect(index)}
+                                    >
+                                        <span className="mr-3 text-muted-foreground">{index + 1}</span>
+                                        <span className="flex flex-col items-start gap-0.5 text-left">
+                                            <span>{label}</span>
+                                            {resolvedStep.unresolved ? (
+                                                <span className="text-xs font-normal text-muted-foreground">
+                                                    {resolvedStep.unresolvedMessage ?? 'This policy is not available in this environment.'}
+                                                </span>
+                                            ) : null}
+                                        </span>
+                                    </Button>
+                                    {!readOnly ? (
+                                        <>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="ghost"
+                                                aria-label={`Move ${label} up`}
+                                                disabled={index === 0}
+                                                onClick={() => onMove(index, index - 1)}
+                                            >
+                                                <ChevronUpIcon className="size-4" aria-hidden />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="ghost"
+                                                aria-label={`Move ${label} down`}
+                                                disabled={index === resolvedSteps.length - 1}
+                                                onClick={() => onMove(index, index + 1)}
+                                            >
+                                                <ChevronDownIcon className="size-4" aria-hidden />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="ghost"
+                                                aria-label={`Duplicate ${label}`}
+                                                disabled={resolvedStep.unresolved}
+                                                onClick={() => onDuplicate(index)}
+                                            >
+                                                <CopyIcon className="size-4" aria-hidden />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="ghost"
+                                                aria-label={`Remove ${label}`}
+                                                onClick={() => onRemove(index)}
+                                            >
+                                                <Trash2Icon className="size-4" aria-hidden />
+                                            </Button>
+                                        </>
+                                    ) : null}
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ol>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio.spec.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+
+import { SharedPolicyGroupPolicyStudio } from './SharedPolicyGroupPolicyStudio';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+// Only the panes are stubbed — step/policy resolution comes from the real package so the test exercises
+// the same matching rules the studio uses in production.
+jest.mock('@gravitee/graphene-policy-studio', () => ({
+    ...jest.requireActual('@gravitee/graphene-policy-studio'),
+    PolicyStudioProvider: ({ children }: { children: ReactNode }) => children,
+    PolicyCatalogPane: ({
+        policies,
+        onAddPolicy,
+    }: {
+        policies: Array<{ id: string; name: string }>;
+        onAddPolicy: (policy: { id: string; name: string }) => void;
+    }) => (
+        <div>
+            {policies.map(policy => (
+                <button key={policy.id} type="button" onClick={() => onAddPolicy(policy)}>
+                    Add {policy.name}
+                </button>
+            ))}
+        </div>
+    ),
+    PolicyConfigPanel: ({ step, onStepChange }: { step: { name?: string }; onStepChange?: (patch: { description: string }) => void }) => (
+        <div>
+            <span>Configure {step.name}</span>
+            <button type="button" onClick={() => onStepChange?.({ description: 'Updated description' })}>
+                Update configuration
+            </button>
+        </div>
+    ),
+}));
+
+const SHARED_POLICY_GROUP: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    steps: [
+        { policy: 'jwt', name: 'JWT', enabled: true, configuration: {} },
+        { policy: 'rate-limit', name: 'Rate Limit', enabled: true, configuration: {} },
+    ],
+};
+
+const POLICIES = [
+    { id: 'jwt', name: 'JWT' },
+    { id: 'rate-limit', name: 'Rate Limit' },
+    { id: 'transform-headers', name: 'Transform Headers' },
+];
+
+const FETCH_SCHEMA = jest.fn();
+const FETCH_DOCUMENTATION = jest.fn();
+
+function renderStudio(overrides: Partial<ComponentProps<typeof SharedPolicyGroupPolicyStudio>> = {}) {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(
+        <SharedPolicyGroupPolicyStudio
+            sharedPolicyGroup={SHARED_POLICY_GROUP}
+            policies={POLICIES}
+            readOnly={false}
+            onSave={onSave}
+            onFetchPolicySchema={FETCH_SCHEMA}
+            onFetchPolicyDocumentation={FETCH_DOCUMENTATION}
+            {...overrides}
+        />,
+    );
+    return { onSave };
+}
+
+describe('SharedPolicyGroupPolicyStudio', () => {
+    it('adds and saves a policy using the catalog', async () => {
+        const { onSave } = renderStudio({ sharedPolicyGroup: { ...SHARED_POLICY_GROUP, steps: [] } });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add policy' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Add Transform Headers' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save policies' }));
+
+        await waitFor(() =>
+            expect(onSave).toHaveBeenCalledWith([
+                {
+                    policy: 'transform-headers',
+                    name: 'Transform Headers',
+                    enabled: true,
+                    configuration: {},
+                },
+            ]),
+        );
+    });
+
+    it('reorders, removes, and configures policy steps', async () => {
+        const { onSave } = renderStudio();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Move JWT down' }));
+        fireEvent.click(screen.getByRole('button', { name: '2 JWT' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Update configuration' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Remove Rate Limit' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save policies' }));
+
+        await waitFor(() =>
+            expect(onSave).toHaveBeenCalledWith([
+                expect.objectContaining({ policy: 'jwt', name: 'JWT', description: 'Updated description' }),
+            ]),
+        );
+    });
+
+    it('is read-only without update permission or for a Kubernetes-origin group', () => {
+        renderStudio({ readOnly: true });
+
+        expect(screen.queryByRole('button', { name: 'Add policy' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Save policies' })).toBeNull();
+    });
+
+    describe('a step whose policy is not installed in this environment', () => {
+        const WITH_MISSING_POLICY: SharedPolicyGroup = {
+            ...SHARED_POLICY_GROUP,
+            steps: [{ policy: 'not-installed', name: 'Legacy policy', enabled: true, configuration: {} }],
+        };
+
+        it('cannot be configured, because there is no schema to render', () => {
+            renderStudio({ sharedPolicyGroup: WITH_MISSING_POLICY });
+
+            expect(screen.getByRole('button', { name: /^1 Legacy policy/ })).toHaveProperty('disabled', true);
+            expect(screen.queryByText('Configure Legacy policy')).toBeNull();
+        });
+
+        it('can still be removed so the group is not stuck', async () => {
+            const { onSave } = renderStudio({ sharedPolicyGroup: WITH_MISSING_POLICY });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove Legacy policy' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Save policies' }));
+
+            await waitFor(() => expect(onSave).toHaveBeenCalledWith([]));
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card } from '@gravitee/graphene-core';
+import {
+    buildGenericPolicies,
+    type Policy,
+    PolicyCatalogPane,
+    PolicyConfigPanel,
+    PolicyStudioProvider,
+    resolveStep,
+    type Step,
+} from '@gravitee/graphene-policy-studio';
+import { useMemo, useState } from 'react';
+
+import { SharedPolicyGroupPolicySteps } from './SharedPolicyGroupPolicySteps';
+import type { SharedPolicyGroup, SharedPolicyGroupStep } from '../types/sharedPolicyGroup';
+
+type StudioPanel = { type: 'catalog' } | { type: 'configuration'; stepIndex: number } | null;
+
+const EMPTY_LIST = [] as const;
+
+// A Shared Policy Group is a single phase with no flows, so the studio's own flow-level save has nothing
+// to persist — this component owns the save action instead.
+const NOOP_SAVE = () => undefined;
+
+interface SharedPolicyGroupPolicyStudioProps {
+    readonly sharedPolicyGroup: SharedPolicyGroup;
+    readonly policies: readonly Policy[];
+    readonly readOnly: boolean;
+    readonly onSave: (steps: SharedPolicyGroupStep[]) => Promise<void>;
+    readonly onFetchPolicySchema: (policy: Policy) => Promise<unknown>;
+    readonly onFetchPolicyDocumentation: (policy: Policy) => Promise<string>;
+}
+
+export function SharedPolicyGroupPolicyStudio({
+    sharedPolicyGroup,
+    policies,
+    readOnly,
+    onSave,
+    onFetchPolicySchema,
+    onFetchPolicyDocumentation,
+}: SharedPolicyGroupPolicyStudioProps) {
+    const [steps, setSteps] = useState<Step[]>(sharedPolicyGroup.steps ?? []);
+    const [panel, setPanel] = useState<StudioPanel>(null);
+    const [hasChanges, setHasChanges] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const genericPolicies = useMemo(() => buildGenericPolicies(policies, EMPTY_LIST), [policies]);
+    const resolvedSteps = useMemo(() => steps.map((step, index) => resolveStep(step, index, genericPolicies)), [steps, genericPolicies]);
+
+    const selectedStepIndex = panel?.type === 'configuration' ? panel.stepIndex : undefined;
+    const selectedStep = selectedStepIndex === undefined ? undefined : steps[selectedStepIndex];
+    const selectedGenericPolicy = selectedStepIndex === undefined ? undefined : resolvedSteps[selectedStepIndex]?.policy;
+    const selectedPolicy = selectedGenericPolicy ? policies.find(policy => policy.id === selectedGenericPolicy.policyId) : undefined;
+
+    function replaceSteps(nextSteps: Step[]) {
+        setSteps(nextSteps);
+        setHasChanges(true);
+    }
+
+    function handleAddPolicy(policy: Policy) {
+        const stepIndex = steps.length;
+        replaceSteps([...steps, { policy: policy.id, name: policy.name, enabled: true, configuration: {} }]);
+        setPanel({ type: 'configuration', stepIndex });
+    }
+
+    function handleReorderSteps(oldIndex: number, newIndex: number) {
+        if (oldIndex === newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= steps.length || newIndex >= steps.length) {
+            return;
+        }
+        const reorderedSteps = [...steps];
+        const [movedStep] = reorderedSteps.splice(oldIndex, 1);
+        reorderedSteps.splice(newIndex, 0, movedStep);
+        replaceSteps(reorderedSteps);
+        setPanel(null);
+    }
+
+    function handleRemoveStep(stepIndex: number) {
+        replaceSteps(steps.filter((_, index) => index !== stepIndex));
+        setPanel(null);
+    }
+
+    function handleDuplicateStep(stepIndex: number) {
+        const step = steps[stepIndex];
+        if (!step) {
+            return;
+        }
+        const duplicatedStep = { ...step, name: step.name ? `${step.name} copy` : undefined };
+        replaceSteps([...steps.slice(0, stepIndex + 1), duplicatedStep, ...steps.slice(stepIndex + 1)]);
+        setPanel({ type: 'configuration', stepIndex: stepIndex + 1 });
+    }
+
+    function handleStepChange(stepIndex: number, patch: Partial<Step>) {
+        replaceSteps(steps.map((step, index) => (index === stepIndex ? { ...step, ...patch } : step)));
+    }
+
+    async function handleSave() {
+        setIsSaving(true);
+        try {
+            await onSave(steps.map(step => ({ ...step })));
+            setHasChanges(false);
+        } catch {
+            // The page owns user-facing API error notification.
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+    return (
+        <PolicyStudioProvider
+            apiType={sharedPolicyGroup.apiType}
+            policies={policies}
+            sharedPolicyGroups={EMPTY_LIST}
+            plans={EMPTY_LIST}
+            commonFlows={EMPTY_LIST}
+            entrypointsInfo={EMPTY_LIST}
+            endpointsInfo={EMPTY_LIST}
+            flowExecution={{ mode: 'DEFAULT' }}
+            readOnly={readOnly}
+            onSave={NOOP_SAVE}
+            onFetchPolicySchema={onFetchPolicySchema}
+            onFetchPolicyDocumentation={onFetchPolicyDocumentation}
+        >
+            <Card className="overflow-hidden">
+                {!readOnly ? (
+                    <div className="flex justify-end border-b p-3">
+                        <Button type="button" size="sm" disabled={!hasChanges || isSaving} onClick={() => void handleSave()}>
+                            {isSaving ? 'Saving…' : 'Save policies'}
+                        </Button>
+                    </div>
+                ) : null}
+                <div className={panel ? 'grid min-h-[32rem] grid-cols-[minmax(0,1fr)_24rem]' : 'min-h-[32rem]'}>
+                    <div className="min-w-0 p-6">
+                        <SharedPolicyGroupPolicySteps
+                            resolvedSteps={resolvedSteps}
+                            readOnly={readOnly}
+                            selectedStepIndex={selectedStepIndex}
+                            onSelect={stepIndex => setPanel({ type: 'configuration', stepIndex })}
+                            onAdd={() => setPanel({ type: 'catalog' })}
+                            onMove={handleReorderSteps}
+                            onDuplicate={handleDuplicateStep}
+                            onRemove={handleRemoveStep}
+                        />
+                    </div>
+                    {panel?.type === 'catalog' ? (
+                        <PolicyCatalogPane
+                            className="border-l"
+                            policies={policies}
+                            apiType={sharedPolicyGroup.apiType}
+                            flowPhase={sharedPolicyGroup.phase}
+                            docsLayout="detail"
+                            onAddPolicy={handleAddPolicy}
+                            onClose={() => setPanel(null)}
+                        />
+                    ) : null}
+                    {panel?.type === 'configuration' && selectedStep && selectedPolicy ? (
+                        <PolicyConfigPanel
+                            className="border-l"
+                            policy={selectedPolicy}
+                            step={selectedStep}
+                            flowPhase={sharedPolicyGroup.phase}
+                            docsLayout="tabs"
+                            onClose={() => setPanel(null)}
+                            onRemove={readOnly ? undefined : () => handleRemoveStep(panel.stepIndex)}
+                            onDuplicate={readOnly ? undefined : () => handleDuplicateStep(panel.stepIndex)}
+                            onToggleEnabled={readOnly ? undefined : enabled => handleStepChange(panel.stepIndex, { enabled })}
+                            onStepChange={readOnly ? undefined : patch => handleStepChange(panel.stepIndex, patch)}
+                        />
+                    ) : null}
+                </div>
+            </Card>
+        </PolicyStudioProvider>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
@@ -96,13 +96,21 @@ describe('SharedPolicyGroupsTable', () => {
         expect(screen.queryByText('Request')).not.toBeNull();
     });
 
+    it('does not render timestamp columns', () => {
+        renderTable();
+        expect(screen.queryByRole('columnheader', { name: 'Last updated' })).toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Last deployed' })).toBeNull();
+    });
+
     describe('sorting', () => {
-        it("sorts by Name, Phase, Last updated, and Last deployed — matching classic Console's sortBy support", () => {
+        it('sorts by Name and Phase', () => {
             const onSortingChange = jest.fn();
             renderTable({ onSortingChange });
 
             fireEvent.click(screen.getByRole('button', { name: 'Name' }));
-            expect(onSortingChange).toHaveBeenCalled();
+            fireEvent.click(screen.getByRole('button', { name: 'Phase' }));
+
+            expect(onSortingChange).toHaveBeenCalledTimes(2);
         });
 
         it('sorts by API type — matching classic Console and the Management API sortBy contract', () => {
@@ -219,17 +227,40 @@ describe('SharedPolicyGroupsTable', () => {
     });
 
     describe('empty state', () => {
-        it('shows the Create CTA on first use', () => {
+        it('shows the Create CTA on first use, replacing the table and its search box', () => {
             const onCreateSharedPolicyGroup = jest.fn();
             renderTable({ isFirstUse: true, sharedPolicyGroups: [], totalCount: 0, onCreateSharedPolicyGroup });
+
             expect(screen.queryByText('No Shared Policy Groups')).not.toBeNull();
+            expect(screen.queryByRole('table')).toBeNull();
+            expect(screen.queryByRole('textbox', { name: 'Search Shared Policy Groups' })).toBeNull();
+
             fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
             expect(onCreateSharedPolicyGroup).toHaveBeenCalled();
         });
 
         it('hides the Create CTA on first use when the callback is not provided (read-only user)', () => {
             renderTable({ isFirstUse: true, sharedPolicyGroups: [], totalCount: 0, onCreateSharedPolicyGroup: undefined });
+
+            expect(screen.queryByText('No Shared Policy Groups')).not.toBeNull();
             expect(screen.queryByRole('button', { name: 'Add Shared Policy Group' })).toBeNull();
+        });
+
+        it('does not blame the search when the page is empty and nothing was searched', () => {
+            renderTable({ sharedPolicyGroups: [], totalCount: 26, search: '' });
+
+            expect(screen.queryByText('No Shared Policy Groups to display.')).not.toBeNull();
+            expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull();
+        });
+
+        it('keeps the searchable table with a clear-search action when a search returns nothing', () => {
+            const onSearchChange = jest.fn();
+            renderTable({ search: 'nothing', sharedPolicyGroups: [], totalCount: 0, onSearchChange });
+
+            expect(screen.queryByText('No Shared Policy Group matches your search')).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+            expect(onSearchChange).toHaveBeenCalledWith('');
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
@@ -19,7 +19,6 @@ import {
     DataTable,
     DataTableColumnHeader,
     DataTableEmptyState,
-    DateCell,
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -89,28 +88,6 @@ function buildColumns({
             accessorKey: 'phase',
             header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Phase" />,
             cell: ({ row }: ColCell<SharedPolicyGroup>) => <span className="text-sm">{toReadableFlowPhase(row.original.phase)}</span>,
-        },
-        {
-            id: 'updatedAt',
-            accessorFn: (row: SharedPolicyGroup) => row.updatedAt ?? '',
-            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Last updated" />,
-            cell: ({ row }: ColCell<SharedPolicyGroup>) =>
-                row.original.updatedAt ? (
-                    <DateCell value={new Date(row.original.updatedAt)} format="absolute" />
-                ) : (
-                    <span className="text-sm text-muted-foreground">—</span>
-                ),
-        },
-        {
-            id: 'deployedAt',
-            accessorFn: (row: SharedPolicyGroup) => row.deployedAt ?? '',
-            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Last deployed" />,
-            cell: ({ row }: ColCell<SharedPolicyGroup>) =>
-                row.original.deployedAt ? (
-                    <DateCell value={new Date(row.original.deployedAt)} format="absolute" />
-                ) : (
-                    <span className="text-sm text-muted-foreground">—</span>
-                ),
         },
         {
             id: 'actions',
@@ -253,24 +230,33 @@ export function SharedPolicyGroupsTable({
                 },
             }}
             emptyMessage={
-                <DataTableEmptyState
-                    variant="no-results"
-                    icon={<SearchIcon className="size-8" aria-hidden />}
-                    title="No Shared Policy Group matches your search"
-                    description="Try adjusting your search terms."
-                    action={
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => {
-                                onSearchChange('');
-                                onPageChange(1);
-                            }}
-                        >
-                            Clear search
-                        </Button>
-                    }
-                />
+                search.trim() ? (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No Shared Policy Group matches your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => {
+                                    onSearchChange('');
+                                    onPageChange(1);
+                                }}
+                            >
+                                Clear search
+                            </Button>
+                        }
+                    />
+                ) : (
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<LayersIcon className="size-8" aria-hidden />}
+                        title="No Shared Policy Groups"
+                        description="No Shared Policy Groups to display."
+                    />
+                )
             }
             toolbar={
                 <div className="w-64">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroupPolicies.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroupPolicies.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getPolicyDocumentation, getPolicySchema, listPolicies } from './sharedPolicyGroupPolicies';
+import { apimFetchJsonV2Org } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV2Org: jest.fn(),
+}));
+
+const mockApimFetchJsonV2Org = jest.mocked(apimFetchJsonV2Org);
+
+describe('shared policy group policy catalog service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV2Org.mockResolvedValue(undefined);
+    });
+
+    it('loads the same policy catalog endpoint as Classic Console', async () => {
+        await listPolicies();
+
+        expect(mockApimFetchJsonV2Org).toHaveBeenCalledWith('/plugins/policies');
+    });
+
+    it('loads an encoded policy schema for the Shared Policy Group API protocol', async () => {
+        await getPolicySchema('policy/with spaces', 'HTTP_PROXY');
+
+        expect(mockApimFetchJsonV2Org).toHaveBeenCalledWith('/plugins/policies/policy%2Fwith%20spaces/schema?apiProtocolType=HTTP_PROXY');
+    });
+
+    it('loads encoded policy documentation for the Shared Policy Group API protocol', async () => {
+        await getPolicyDocumentation('policy/with spaces', 'HTTP_MESSAGE');
+
+        expect(mockApimFetchJsonV2Org).toHaveBeenCalledWith(
+            '/plugins/policies/policy%2Fwith%20spaces/documentation-ext?apiProtocolType=HTTP_MESSAGE',
+        );
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroupPolicies.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroupPolicies.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiProtocolType, Policy } from '@gravitee/graphene-policy-studio';
+
+import { apimFetchJsonV2Org } from '../../../shared/api/apimClient';
+
+export function listPolicies(): Promise<Policy[]> {
+    return apimFetchJsonV2Org<Policy[]>('/plugins/policies');
+}
+
+export function getPolicySchema(policyId: string, protocolType: ApiProtocolType): Promise<unknown> {
+    return apimFetchJsonV2Org<unknown>(
+        `/plugins/policies/${encodeURIComponent(policyId)}/schema?apiProtocolType=${encodeURIComponent(protocolType)}`,
+    );
+}
+
+export function getPolicyDocumentation(policyId: string, protocolType: ApiProtocolType): Promise<string> {
+    return apimFetchJsonV2Org<string>(
+        `/plugins/policies/${encodeURIComponent(policyId)}/documentation-ext?apiProtocolType=${encodeURIComponent(protocolType)}`,
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
@@ -58,7 +58,16 @@ export interface OriginContext {
     origin: 'MANAGEMENT' | 'KUBERNETES' | 'INTEGRATION';
 }
 
-export type SharedPolicyGroupStep = Record<string, unknown>;
+export interface SharedPolicyGroupStep {
+    condition?: string;
+    configuration?: unknown;
+    deployed?: boolean;
+    description?: string;
+    enabled?: boolean;
+    messageCondition?: string;
+    name?: string;
+    policy?: string;
+}
 
 /** v2 `SharedPolicyGroup` (GET/POST .../v2/environments/{envId}/shared-policy-groups...). */
 export interface SharedPolicyGroup {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    isSharedPolicyGroupDetailTabPath,
+    SHARED_POLICY_GROUP_DEFAULT_TAB,
+    sharedPolicyGroupDetailHref,
+} from './sharedPolicyGroupDetailNavigation';
+
+describe('sharedPolicyGroupDetailNavigation', () => {
+    it('defaults to the studio tab to match classic Console', () => {
+        expect(SHARED_POLICY_GROUP_DEFAULT_TAB).toBe('studio');
+        expect(sharedPolicyGroupDetailHref('spg-1')).toBe('spg-1/studio');
+    });
+
+    it('builds hrefs for each detail tab', () => {
+        expect(sharedPolicyGroupDetailHref('spg-1', 'overview')).toBe('spg-1/overview');
+        expect(sharedPolicyGroupDetailHref('spg-1', 'history')).toBe('spg-1/history');
+    });
+
+    it('recognizes supported detail tabs', () => {
+        expect(isSharedPolicyGroupDetailTabPath('overview')).toBe(true);
+        expect(isSharedPolicyGroupDetailTabPath('studio')).toBe(true);
+        expect(isSharedPolicyGroupDetailTabPath('history')).toBe(true);
+        expect(isSharedPolicyGroupDetailTabPath('unknown')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Child routes under `shared-policy-groups/:sharedPolicyGroupId`. */
+export const SHARED_POLICY_GROUP_DETAIL_TABS = [
+    { path: 'overview', label: 'Overview' },
+    { path: 'studio', label: 'Studio' },
+    { path: 'history', label: 'History' },
+] as const;
+
+export type SharedPolicyGroupDetailTabPath = (typeof SHARED_POLICY_GROUP_DETAIL_TABS)[number]['path'];
+
+export const SHARED_POLICY_GROUP_DEFAULT_TAB: SharedPolicyGroupDetailTabPath = 'studio';
+
+export function isSharedPolicyGroupDetailTabPath(value: string): value is SharedPolicyGroupDetailTabPath {
+    return SHARED_POLICY_GROUP_DETAIL_TABS.some(tab => tab.path === value);
+}
+
+export function sharedPolicyGroupDetailHref(
+    sharedPolicyGroupId: string,
+    tab: SharedPolicyGroupDetailTabPath = SHARED_POLICY_GROUP_DEFAULT_TAB,
+): string {
+    return `${sharedPolicyGroupId}/${tab}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
@@ -14,35 +14,11 @@
  * limitations under the License.
  */
 
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
 
 import { SharedPolicyGroupDetailPage } from './SharedPolicyGroupDetailPage';
-import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
-import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
-import { ApimApiError } from '../shared/api/apimClient';
-import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
-import { notify } from '../shared/notify';
-import { installFormActionTestEnvironment } from '../shared/testing/formAction';
-
-let restoreTestEnvironment: () => void;
-
-jest.mock('@gravitee/gamma-modules-sdk', () => ({
-    useHasPermission: jest.fn(),
-}));
-jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
-jest.mock('../shared/hooks/useForbiddenResourceRedirect');
-jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
-jest.mock('../shared/notify', () => ({
-    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
-}));
-
-const mockUseHasPermission = jest.mocked(useHasPermission);
-const mockUseSharedPolicyGroupDetail = jest.mocked(useSharedPolicyGroupDetail);
-const mockUseForbiddenResourceRedirect = jest.mocked(useForbiddenResourceRedirect);
-const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
 
 const SPG: SharedPolicyGroup = {
     id: 'spg-1',
@@ -57,176 +33,25 @@ const SPG: SharedPolicyGroup = {
     deployedAt: '2024-01-02T00:00:00.000Z',
 };
 
-function makeMutation(mutateAsync = jest.fn()) {
-    return { mutateAsync } as unknown as ReturnType<typeof useUpdateSharedPolicyGroup>;
-}
-
-function renderPage() {
+function renderPage(sharedPolicyGroup: SharedPolicyGroup = SPG) {
     return render(
-        <MemoryRouter initialEntries={['/spg-1']}>
+        <MemoryRouter initialEntries={['/spg-1/overview']}>
             <Routes>
-                <Route path=":sharedPolicyGroupId" element={<SharedPolicyGroupDetailPage />} />
+                <Route path=":sharedPolicyGroupId" element={<Outlet context={sharedPolicyGroup} />}>
+                    <Route path="overview" element={<SharedPolicyGroupDetailPage />} />
+                </Route>
             </Routes>
         </MemoryRouter>,
     );
 }
 
 describe('SharedPolicyGroupDetailPage', () => {
-    beforeAll(() => {
-        restoreTestEnvironment = installFormActionTestEnvironment();
-    });
-
-    afterAll(() => {
-        restoreTestEnvironment();
-    });
-
-    beforeEach(() => {
-        mockUseHasPermission.mockReturnValue(true);
-        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation());
-    });
-
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
-    it('renders name, status, description, API type, and phase', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
+    it('renders overview details: API type, phase, and prerequisite', () => {
         renderPage();
 
-        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).not.toBeNull();
-        expect(screen.queryByText('Deployed')).not.toBeNull();
-        expect(screen.queryByText('Reusable auth policies')).not.toBeNull();
-        expect(screen.queryByText('Proxy')).not.toBeNull();
-        expect(screen.queryByText('Request')).not.toBeNull();
-        expect(screen.queryByText('Requires the "auth-cache" resource')).not.toBeNull();
-    });
-
-    it('shows a not-found message when the shared policy group fails to load', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: undefined,
-            isLoading: false,
-            isError: true,
-            error: new Error('load failed'),
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(screen.queryByText('Shared Policy Group not found or failed to load.')).not.toBeNull();
-    });
-
-    it('redirects and removes stale permissions when the detail request is forbidden', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: undefined,
-            isLoading: false,
-            isError: true,
-            error: new ApimApiError(403, 'Forbidden'),
-        } as unknown as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(mockUseForbiddenResourceRedirect).toHaveBeenCalledWith({
-            isForbidden: true,
-            permissionPrefix: 'environment-shared_policy_group-',
-            redirectTo: '../../applications',
-        });
-        expect(screen.queryByText('Shared Policy Group not found or failed to load.')).toBeNull();
-    });
-
-    it('shows a loading skeleton while fetching', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: undefined,
-            isLoading: true,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).toBeNull();
-    });
-
-    it('renders a back link to the list', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(screen.getByRole('link', { name: /Back to Shared Policy Groups/ }).getAttribute('href')).toBe('/');
-    });
-
-    it('shows Edit when the user can update and opens the edit sheet', async () => {
-        const updateMutateAsync = jest.fn().mockResolvedValue(SPG);
-        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(updateMutateAsync));
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-        expect(await screen.findByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
-
-        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Renamed Bundle' } });
-        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-        await waitFor(() => {
-            expect(updateMutateAsync).toHaveBeenCalledWith({
-                id: 'spg-1',
-                payload: {
-                    name: 'Renamed Bundle',
-                    description: 'Reusable auth policies',
-                    prerequisiteMessage: 'Requires the "auth-cache" resource',
-                },
-            });
-        });
-        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
-    });
-
-    it('shows an error and keeps the edit sheet open when update fails', async () => {
-        const error = new Error('update failed');
-        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-        fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
-
-        await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group update!'));
-        expect(screen.queryByRole('heading', { name: 'Edit Shared Policy Group' })).not.toBeNull();
-    });
-
-    it('hides Edit when the user lacks update permission', () => {
-        mockUseHasPermission.mockReturnValue(false);
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
-    });
-
-    it('hides Edit for a Kubernetes-origin shared policy group', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: { ...SPG, originContext: { origin: 'KUBERNETES' } },
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+        expect(screen.getByTestId('shared-policy-group-overview')).not.toBeNull();
+        expect(screen.getByText('Proxy')).not.toBeNull();
+        expect(screen.getByText('Request')).not.toBeNull();
+        expect(screen.getByText('Requires the "auth-cache" resource')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -14,29 +14,11 @@
  * limitations under the License.
  */
 
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Button, Card, CardContent, CardHeader, CardTitle, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, LayersIcon, PencilIcon } from '@gravitee/graphene-core/icons';
-import { type ReactNode, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, DateCell } from '@gravitee/graphene-core';
+import type { ReactNode } from 'react';
+import { useOutletContext } from 'react-router-dom';
 
-import {
-    SharedPolicyGroupEditSheet,
-    type SharedPolicyGroupEditFormValues,
-} from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
-import { SharedPolicyGroupStatusBadge } from '../features/shared-policy-groups/components/SharedPolicyGroupStatusBadge';
-import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
-import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
-import { toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
-import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
-import {
-    ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
-    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
-    isKubernetesOrigin,
-} from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
-import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
-import { notify } from '../shared/notify';
-import { isForbiddenApiError } from '../shared/utils/apiErrors';
+import { type SharedPolicyGroup, toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
 
 function DetailField({ label, value }: Readonly<{ label: string; value: ReactNode }>) {
     return (
@@ -47,105 +29,12 @@ function DetailField({ label, value }: Readonly<{ label: string; value: ReactNod
     );
 }
 
+/** Overview tab — metadata details (header/tabs live on SharedPolicyGroupDetailLayout). */
 export function SharedPolicyGroupDetailPage() {
-    const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
-    const { data: sharedPolicyGroup, isLoading, isError, error } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
-    const isForbidden = isForbiddenApiError(isError, error);
-    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
-    const updateMutation = useUpdateSharedPolicyGroup();
-    const [editOpen, setEditOpen] = useState(false);
-
-    useForbiddenResourceRedirect({
-        isForbidden,
-        permissionPrefix: ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
-        redirectTo: '../../applications',
-    });
-
-    const showEdit = Boolean(sharedPolicyGroup && canEdit && !isKubernetesOrigin(sharedPolicyGroup));
-
-    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
-        if (!sharedPolicyGroup) return;
-        try {
-            await updateMutation.mutateAsync({
-                id: sharedPolicyGroup.id,
-                payload: toUpdateSharedPolicyGroupPayload(values),
-            });
-            notify.success('Shared Policy Group updated');
-            setEditOpen(false);
-        } catch (updateError) {
-            notify.error(updateError, 'Error during Shared Policy Group update!');
-        }
-    }
-
-    if (isForbidden) {
-        return null;
-    }
-
-    if (isLoading) {
-        return (
-            <div className="space-y-4">
-                <Skeleton className="h-8 w-32" />
-                <Skeleton className="h-32 w-full rounded-xl" />
-            </div>
-        );
-    }
-
-    if (isError || !sharedPolicyGroup) {
-        return (
-            <div className="space-y-4">
-                <Button type="button" variant="ghost" className="gap-1.5 px-0" asChild>
-                    <Link to="..">
-                        <ArrowLeftIcon className="size-4" aria-hidden />
-                        Back to Shared Policy Groups
-                    </Link>
-                </Button>
-                <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>
-            </div>
-        );
-    }
+    const sharedPolicyGroup = useOutletContext<SharedPolicyGroup>();
 
     return (
-        <div className="space-y-6">
-            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
-                <Link to="..">
-                    <ArrowLeftIcon className="size-4" aria-hidden />
-                    Back to Shared Policy Groups
-                </Link>
-            </Button>
-
-            <Card>
-                <CardContent className="p-5">
-                    <div className="flex items-start justify-between gap-3">
-                        <div className="flex min-w-0 items-start gap-3">
-                            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-highlight text-highlight-foreground">
-                                <LayersIcon className="size-5" aria-hidden />
-                            </div>
-                            <div className="min-w-0 space-y-1">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
-                                    <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
-                                </div>
-                                {sharedPolicyGroup.description && (
-                                    <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
-                                )}
-                            </div>
-                        </div>
-                        {showEdit ? (
-                            <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                className="shrink-0 gap-1.5"
-                                onClick={() => setEditOpen(true)}
-                            >
-                                <PencilIcon className="size-4" aria-hidden />
-                                Edit
-                            </Button>
-                        ) : null}
-                    </div>
-                </CardContent>
-            </Card>
-
+        <div className="space-y-6" data-testid="shared-policy-group-overview">
             <Card>
                 <CardHeader>
                     <CardTitle className="text-base">Details</CardTitle>
@@ -180,16 +69,6 @@ export function SharedPolicyGroupDetailPage() {
                     )}
                 </CardContent>
             </Card>
-
-            {editOpen ? (
-                <SharedPolicyGroupEditSheet
-                    key={sharedPolicyGroup.id}
-                    open
-                    sharedPolicyGroup={sharedPolicyGroup}
-                    onClose={() => setEditOpen(false)}
-                    onSubmit={handleEdit}
-                />
-            ) : null}
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.spec.tsx
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-export const sharedPolicyGroupKeys = {
-    all: ['environment-shared-policy-groups'] as const,
-    list: (envId: string, query: string, page: number, perPage: number, sortBy: string | undefined) =>
-        [...sharedPolicyGroupKeys.all, 'list', envId, query, page, perPage, sortBy] as const,
-    detail: (envId: string, sharedPolicyGroupId: string) => [...sharedPolicyGroupKeys.all, 'detail', envId, sharedPolicyGroupId] as const,
-    policies: () => [...sharedPolicyGroupKeys.all, 'policies'] as const,
-} as const;
+import { render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupHistoryPage } from './SharedPolicyGroupHistoryPage';
+
+describe('SharedPolicyGroupHistoryPage', () => {
+    it('renders the history tab placeholder', () => {
+        render(<SharedPolicyGroupHistoryPage />);
+        expect(screen.getByTestId('shared-policy-group-history-empty')).not.toBeNull();
+        expect(screen.getByText('Version history is not available yet')).not.toBeNull();
+        expect(screen.getByText('Version history, comparison, and restore are not available in this view.')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@gravitee/graphene-core';
+import { ClockIcon } from '@gravitee/graphene-core/icons';
+
+export function SharedPolicyGroupHistoryPage() {
+    return (
+        <Empty className="rounded-lg border py-10" data-testid="shared-policy-group-history-empty">
+            <EmptyHeader>
+                <EmptyMedia variant="icon">
+                    <ClockIcon aria-hidden />
+                </EmptyMedia>
+                <EmptyTitle>Version history is not available yet</EmptyTitle>
+                <EmptyDescription>Version history, comparison, and restore are not available in this view.</EmptyDescription>
+            </EmptyHeader>
+        </Empty>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.spec.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+
+import { SharedPolicyGroupStudioPage } from './SharedPolicyGroupStudioPage';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
+import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk');
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: jest.fn(),
+}));
+jest.mock('@gravitee/graphene-policy-studio', () => ({
+    getProtocolType: () => 'HTTP_PROXY',
+}));
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio', () => ({
+    SharedPolicyGroupPolicyStudio: ({
+        readOnly,
+        onSave,
+    }: {
+        readOnly: boolean;
+        onSave: (steps: Array<{ policy: string }>) => Promise<void>;
+    }) => (
+        <div>
+            <span>{readOnly ? 'Read only studio' : 'Editable studio'}</span>
+            <button type="button" onClick={() => void onSave([{ policy: 'jwt' }])}>
+                Save studio
+            </button>
+        </div>
+    ),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseQuery = jest.mocked(useQuery);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
+
+const BASE: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+};
+
+function renderPage(sharedPolicyGroup: SharedPolicyGroup) {
+    return render(
+        <MemoryRouter initialEntries={['/spg-1/studio']}>
+            <Routes>
+                <Route path=":sharedPolicyGroupId" element={<Outlet context={sharedPolicyGroup} />}>
+                    <Route path="studio" element={<SharedPolicyGroupStudioPage />} />
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('SharedPolicyGroupStudioPage', () => {
+    const mutateAsync = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseQuery.mockReturnValue({
+            data: [{ id: 'jwt', name: 'JWT' }],
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useQuery>);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue({
+            mutateAsync,
+        } as unknown as ReturnType<typeof useUpdateSharedPolicyGroup>);
+        mutateAsync.mockResolvedValue(BASE);
+    });
+
+    it('loads an editable Policy Studio and saves steps through the Shared Policy Group update endpoint', async () => {
+        renderPage(BASE);
+
+        expect(screen.getByText('Editable studio')).not.toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: 'Save studio' }));
+
+        await waitFor(() =>
+            expect(mutateAsync).toHaveBeenCalledWith({
+                id: 'spg-1',
+                payload: {
+                    name: 'Auth Bundle',
+                    description: undefined,
+                    prerequisiteMessage: undefined,
+                    steps: [{ policy: 'jwt' }],
+                },
+            }),
+        );
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+    });
+
+    it.each([
+        ['missing update permission', false, undefined],
+        ['Kubernetes origin', true, { origin: 'KUBERNETES' as const }],
+    ])('makes the Policy Studio read-only for %s', (_, canUpdate, originContext) => {
+        mockUseHasPermission.mockReturnValue(canUpdate);
+
+        renderPage({ ...BASE, originContext });
+
+        expect(screen.getByText('Read only studio')).not.toBeNull();
+    });
+
+    it('shows loading and error states for the policy catalog', () => {
+        mockUseQuery.mockReturnValueOnce({ isLoading: true, isError: false } as ReturnType<typeof useQuery>);
+        const { rerender } = renderPage(BASE);
+        expect(document.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+
+        mockUseQuery.mockReturnValue({ isLoading: false, isError: true } as ReturnType<typeof useQuery>);
+        rerender(
+            <MemoryRouter initialEntries={['/spg-1/studio']}>
+                <Routes>
+                    <Route path=":sharedPolicyGroupId" element={<Outlet context={BASE} />}>
+                        <Route path="studio" element={<SharedPolicyGroupStudioPage />} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+        expect(screen.getByText('Failed to load the policy catalog. Please refresh and try again.')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Skeleton } from '@gravitee/graphene-core';
+import { getProtocolType, type Policy } from '@gravitee/graphene-policy-studio';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useOutletContext } from 'react-router-dom';
+
+import { SharedPolicyGroupPolicyStudio } from '../features/shared-policy-groups/components/SharedPolicyGroupPolicyStudio';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
+import { getPolicyDocumentation, getPolicySchema, listPolicies } from '../features/shared-policy-groups/services/sharedPolicyGroupPolicies';
+import type { SharedPolicyGroup, SharedPolicyGroupStep } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import { sharedPolicyGroupKeys } from '../features/shared-policy-groups/utils/queryKeys';
+import {
+    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
+    isKubernetesOrigin,
+} from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { notify } from '../shared/notify';
+
+export function SharedPolicyGroupStudioPage() {
+    const sharedPolicyGroup = useOutletContext<SharedPolicyGroup>();
+    const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const updateMutation = useUpdateSharedPolicyGroup();
+    const protocolType = getProtocolType(sharedPolicyGroup.apiType);
+    const policiesQuery = useQuery({
+        queryKey: sharedPolicyGroupKeys.policies(),
+        queryFn: listPolicies,
+        staleTime: 5 * 60 * 1000,
+    });
+    const onFetchPolicySchema = useCallback((policy: Policy) => getPolicySchema(policy.id, protocolType), [protocolType]);
+    const onFetchPolicyDocumentation = useCallback((policy: Policy) => getPolicyDocumentation(policy.id, protocolType), [protocolType]);
+    const handleSave = useCallback(
+        async (steps: SharedPolicyGroupStep[]) => {
+            try {
+                await updateMutation.mutateAsync({
+                    id: sharedPolicyGroup.id,
+                    payload: {
+                        name: sharedPolicyGroup.name,
+                        description: sharedPolicyGroup.description,
+                        prerequisiteMessage: sharedPolicyGroup.prerequisiteMessage,
+                        steps,
+                    },
+                });
+                notify.success('Shared Policy Group updated');
+            } catch (error) {
+                notify.error(error, 'Error during Shared Policy Group update!');
+                throw error;
+            }
+        },
+        [sharedPolicyGroup, updateMutation],
+    );
+
+    if (policiesQuery.isLoading) {
+        return <Skeleton className="h-[32rem] w-full rounded-lg" />;
+    }
+
+    if (policiesQuery.isError || !policiesQuery.data) {
+        return <p className="text-sm text-destructive">Failed to load the policy catalog. Please refresh and try again.</p>;
+    }
+
+    return (
+        <SharedPolicyGroupPolicyStudio
+            key={sharedPolicyGroup.id}
+            sharedPolicyGroup={sharedPolicyGroup}
+            policies={policiesQuery.data}
+            readOnly={!canUpdate || isKubernetesOrigin(sharedPolicyGroup)}
+            onSave={handleSave}
+            onFetchPolicySchema={onFetchPolicySchema}
+            onFetchPolicyDocumentation={onFetchPolicyDocumentation}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -240,6 +240,24 @@ describe('SharedPolicyGroupsPage', () => {
             expect(screen.getAllByRole('button', { name: 'Add Shared Policy Group' })).toHaveLength(1);
         });
 
+        it('opens the create sheet from the first-use empty state', () => {
+            mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult([], 0));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+
+            expect(screen.queryByRole('heading', { name: 'Add Shared Policy Group' })).not.toBeNull();
+        });
+
+        it('hides the first-use create action for a user without create permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult([], 0));
+            renderPage();
+
+            expect(screen.queryByText('No Shared Policy Groups')).not.toBeNull();
+            expect(screen.queryByRole('button', { name: 'Add Shared Policy Group' })).toBeNull();
+        });
+
         it('re-fetches with the classic Console sortBy value and resets to page 1 when sorting changes', () => {
             renderPage();
             mockUseSharedPolicyGroupsPaged.mockClear();
@@ -251,7 +269,7 @@ describe('SharedPolicyGroupsPage', () => {
     });
 
     describe('create flow', () => {
-        it('creates a Proxy shared policy group (the default API type), shows a success toast, and navigates to its detail page', async () => {
+        it('creates a Proxy shared policy group (the default API type), shows a success toast, and navigates to its studio tab', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({ id: 'new-spg-id', name: 'My SPG' });
             const navigate = jest.fn();
             mockUseNavigate.mockReturnValue(navigate);
@@ -274,7 +292,7 @@ describe('SharedPolicyGroupsPage', () => {
                 });
             });
             expect(notify.success).toHaveBeenCalledWith('Shared Policy Group created');
-            expect(navigate).toHaveBeenCalledWith('new-spg-id');
+            expect(navigate).toHaveBeenCalledWith('new-spg-id/studio');
         });
 
         it('switches to Message-specific phases when the Message API type is selected in the sheet', () => {
@@ -391,13 +409,13 @@ describe('SharedPolicyGroupsPage', () => {
     });
 
     describe('view navigation', () => {
-        it('navigates to the shared policy group detail page', () => {
+        it('navigates to the shared policy group studio tab', () => {
             const navigate = jest.fn();
             mockUseNavigate.mockReturnValue(navigate);
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: 'View Auth Bundle' }));
-            expect(navigate).toHaveBeenCalledWith('spg-1');
+            expect(navigate).toHaveBeenCalledWith('spg-1/studio');
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -41,6 +41,7 @@ import {
     DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE,
     SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS,
 } from '../features/shared-policy-groups/utils/paginationConstants';
+import { sharedPolicyGroupDetailHref } from '../features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation';
 import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
 import {
     ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION,
@@ -115,6 +116,10 @@ export function SharedPolicyGroupsPage() {
         setSheet({ type: 'closed' });
     }
 
+    function openCreateSheet() {
+        setSheet({ type: 'create' });
+    }
+
     function handleOpenEdit(sharedPolicyGroup: SharedPolicyGroup) {
         setSheet({ type: 'edit', sharedPolicyGroup });
     }
@@ -131,7 +136,7 @@ export function SharedPolicyGroupsPage() {
             });
             notify.success('Shared Policy Group created');
             closeSheet();
-            navigate(created.id);
+            navigate(sharedPolicyGroupDetailHref(created.id));
         } catch (error) {
             notify.error(error, 'Error during Shared Policy Group creation!');
         }
@@ -184,7 +189,7 @@ export function SharedPolicyGroupsPage() {
                     </p>
                 </div>
                 {canCreate && !isLoading && !isFirstUse ? (
-                    <Button className="shrink-0" size="sm" onClick={() => setSheet({ type: 'create' })}>
+                    <Button className="shrink-0" size="sm" onClick={openCreateSheet}>
                         <PlusIcon className="size-4" aria-hidden />
                         Add Shared Policy Group
                     </Button>
@@ -206,10 +211,10 @@ export function SharedPolicyGroupsPage() {
                 onPageChange={setPage}
                 onPageSizeChange={setPageSize}
                 onSortingChange={handleSortingChange}
-                onView={sharedPolicyGroup => navigate(sharedPolicyGroup.id)}
+                onView={sharedPolicyGroup => navigate(sharedPolicyGroupDetailHref(sharedPolicyGroup.id))}
                 onEdit={handleOpenEdit}
                 onDelete={sharedPolicyGroup => setSheet({ type: 'delete', sharedPolicyGroup })}
-                onCreateSharedPolicyGroup={canCreate ? () => setSheet({ type: 'create' }) : undefined}
+                onCreateSharedPolicyGroup={canCreate ? openCreateSheet : undefined}
             />
 
             {sheet.type === 'create' ? <SharedPolicyGroupCreateSheet open onClose={closeSheet} onSubmit={handleCreate} /> : null}


### PR DESCRIPTION
## Summary

Adds the **Shared Policy Group detail tabs shell** to Platform Management: nested Overview / Studio / History routes under `shared-policy-groups/:id`, matching classic Console navigation (default → Studio).

Ports the tab shell from console-webui's `shared-policy-group` (studio + history) and keeps metadata edit on Overview. Policy Studio editor and version history APIs are intentionally out of scope.

## Stories

### [FOUND-19](https://gravitee.atlassian.net/browse/FOUND-19) — Configure Policies (Policy Studio) ⚠️ partial
- [x] Detail shell with Studio tab
- [x] Empty studio CTA when the group has no policies (Figma empty-state shell)
- [x] Create / open navigates to Studio (classic Console behavior)
- [ ] Policy plugin catalog + schema-driven Policy Studio editor — follow-up
- [ ] Add / remove / reorder policies + save `steps` via PUT — follow-up

### Also in this PR
- **Overview tab** — existing metadata details + Edit sheet (from FOUND-18)
- **History tab** — placeholder until FOUND-20 (deploy / histories)

### Not in this PR
- **FOUND-19** Policy Studio editor (configure / save policies)
- **FOUND-20** Deploy / Undeploy / Version History
- **FOUND-21** Import via CRD

## Screen

**Shared Policy Group detail** (`Platform Management → Shared Policy Groups → {group}`)
- Header: name, status badge, API type · phase
- Tabs: Overview | Studio | History
- Studio empty state when no policies are configured
- Studio read-only policy name list when `steps` already exist (editor later)

[FOUND-19]: https://gravitee.atlassian.net/browse/FOUND-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ