### PR TITLE
fix: hide subscribe action for APIs nested in API products

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -16,22 +16,22 @@
 
 -->
 <app-sidenav-layout [breadcrumbs]="breadcrumbs()" [breadcrumbsLoading]="folderLoading()">
-  @if (subscriptionTarget()) {
+  @if (hasBreadcrumbActions()) {
     <div breadcrumbActions class="documentation-folder__breadcrumb-actions">
-      @if (apiId()) {
-        @if (apiHasMcp()) {
-          <button mat-stroked-button type="button" (click)="this.mcpDrawerOpen.set(true)" data-testid="mcp-button">
-            <span i18n="@@documentationMcpButton">MCP</span>
-          </button>
-        }
+      @if (apiHasMcp()) {
+        <button mat-stroked-button type="button" (click)="this.mcpDrawerOpen.set(true)" data-testid="mcp-button">
+          <span i18n="@@documentationMcpButton">MCP</span>
+        </button>
       }
-      <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
-        @if (currentUser()) {
-          <span i18n="@@subscribeToApiButton">Subscribe</span>
-        } @else {
-          <span i18n="@@signInToSubscribeButton">Sign in to subscribe</span>
-        }
-      </button>
+      @if (subscriptionTarget()) {
+        <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
+          @if (currentUser()) {
+            <span i18n="@@subscribeToApiButton">Subscribe</span>
+          } @else {
+            <span i18n="@@signInToSubscribeButton">Sign in to subscribe</span>
+          }
+        </button>
+      }
     </div>
   }
   <div sidenavContent class="documentation-folder__sidenav__content">

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -475,23 +475,22 @@ describe('DocumentationFolderComponent', () => {
       expect(await harness.getMcpButton()).toBeNull();
     });
 
-    it('should preserve API behavior for documentation nested under an API Product', async () => {
+    it('should hide Subscribe and preserve API tooling for documentation nested under an API Product', async () => {
       const apiProduct = makeItem('product1', 'API_PRODUCT', 'API Product 1', 0, undefined, 'root1');
       const apiItem = makeItem('api1', 'API', 'API 1', 0, 'product1', 'root1');
       const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1', 'root1');
 
-      await init({ items: [apiProduct, apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
+      await init({
+        items: [apiProduct, apiItem, apiPage],
+        queryParams: { selectedId: 'p-api1' },
+        content: MOCK_CONTENT,
+        apiHasMcp: true,
+      });
 
       expect(routerSpy.navigate).not.toHaveBeenCalled();
-      const subscribeButton = await harness.getSubscribeButton();
-      expect(subscribeButton).not.toBeNull();
-
-      await subscribeButton!.click();
-
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['api', 'api-api1', 'subscribe'], {
-        relativeTo: expect.anything(),
-        queryParamsHandling: 'preserve',
-      });
+      expect(await harness.getSubscribeButton()).toBeNull();
+      expect(apiServiceSpy.details).toHaveBeenCalledWith('api-api1');
+      expect(await harness.getMcpButton()).not.toBeNull();
 
       const breadcrumbs = await harness.getBreadcrumbs();
       expect(await breadcrumbs?.getText()).toEqual('Test item/API Product 1/API 1/API 1 Documentation');
@@ -505,7 +504,7 @@ describe('DocumentationFolderComponent', () => {
         rootId: 'root1',
       });
       const productPage = makeItem('product-overview1', 'PAGE', 'Product Overview', 0, 'product1', 'root1');
-      const apiItem = makeItem('api1', 'API', 'API 1', 1, 'product1', 'root1');
+      const apiItem = makeItem('api1', 'API', 'API 1', 1, undefined, 'root1');
       const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1', 'root1');
 
       await init({ items: [apiProduct, productPage, apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -39,7 +39,7 @@ import { ApiService } from '../../../../services/api.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { PortalNavigationItemsService } from '../../../../services/portal-navigation-items.service';
 import { ApiTabToolsComponent } from '../../../api/api-details/api-tab-tools/api-tab-tools.component';
-import { DocumentationSubscriptionTarget, TreeNode, TreeService } from '../../services/tree.service';
+import { DocumentationActionContext, TreeNode, TreeService } from '../../services/tree.service';
 
 interface FolderData {
   children: PortalNavigationItem[];
@@ -85,17 +85,16 @@ export class DocumentationFolderComponent {
   tree = signal<TreeNode[]>([]);
   breadcrumbs = signal<Breadcrumb[]>([]);
 
-  subscriptionTarget = signal<DocumentationSubscriptionTarget | null>(null);
-  apiId = computed(() => {
-    const target = this.subscriptionTarget();
-    return target?.type === 'API' ? target.apiId : null;
-  });
+  documentationActionContext = signal<DocumentationActionContext>({ apiId: null, subscriptionTarget: null });
+  mcpDrawerOpen = signal(false);
+  subscriptionTarget = computed(() => this.documentationActionContext().subscriptionTarget);
+  apiId = computed(() => this.documentationActionContext().apiId);
   api = rxResource<Api | null, string | null>({
     params: this.apiId,
     stream: ({ params }) => (params ? this.apiService.details(params) : of(null)),
   });
   apiHasMcp = computed(() => !this.api.error() && !!this.api.value()?.mcp);
-  mcpDrawerOpen = signal(false);
+  hasBreadcrumbActions = computed(() => !!this.subscriptionTarget() || this.apiHasMcp());
 
   constructor(
     private readonly router: Router,
@@ -156,7 +155,7 @@ export class DocumentationFolderComponent {
   }
 
   private loadContentOrRedirect(selectedId: string, children = this.folderData()?.children ?? []): Observable<FolderData> {
-    this.subscriptionTarget.set(null);
+    this.documentationActionContext.set({ apiId: null, subscriptionTarget: null });
 
     if (!selectedId) {
       return of({ children, selectedPageContent: null }).pipe(
@@ -176,10 +175,10 @@ export class DocumentationFolderComponent {
       return of({ children, selectedPageContent: null }).pipe(tap(() => firstPageId && this.navigateToPage(firstPageId)));
     }
 
-    const subscriptionTarget = this.treeService.getSubscriptionTarget(selectedId);
+    const documentationActionContext = this.treeService.getDocumentationActionContext(selectedId);
     return this.itemsService.getNavigationItemContent(selectedId).pipe(
       tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByNodeId(selectedId))),
-      tap(() => this.subscriptionTarget.set(subscriptionTarget)),
+      tap(() => this.documentationActionContext.set(documentationActionContext)),
       map(selectedPageContent => ({ children, selectedPageContent })),
     );
   }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
@@ -119,14 +119,17 @@ describe('DocumentationTreeService', () => {
     });
   });
 
-  describe('getSubscriptionTarget', () => {
-    it('should return an API target when page is under a standalone API', () => {
+  describe('getDocumentationActionContext', () => {
+    it('should return an API context and subscription target when page is under a standalone API', () => {
       const items = [makeItem('api1', 'API', 'API 1', 0), makeItem('p-api1', 'PAGE', 'API doc', 0, 'api1')];
       service.init(parentItem, items);
-      expect(service.getSubscriptionTarget('p-api1')).toEqual({ type: 'API', apiId: 'api-api1' });
+      expect(service.getDocumentationActionContext('p-api1')).toEqual({
+        apiId: 'api-api1',
+        subscriptionTarget: { type: 'API', apiId: 'api-api1' },
+      });
     });
 
-    it('should return an API Product target when page is under an API Product folder', () => {
+    it('should return an API Product subscription target when page is under an API Product folder', () => {
       const items = [
         fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'product1' }),
         makeItem('product-folder1', 'FOLDER', 'Product documentation', 0, 'product1', 'product1'),
@@ -134,10 +137,13 @@ describe('DocumentationTreeService', () => {
       ];
       service.init(parentItem, items);
 
-      expect(service.getSubscriptionTarget('product-page1')).toEqual({ type: 'API_PRODUCT', apiProductId: 'api-product-1' });
+      expect(service.getDocumentationActionContext('product-page1')).toEqual({
+        apiId: null,
+        subscriptionTarget: { type: 'API_PRODUCT', apiProductId: 'api-product-1' },
+      });
     });
 
-    it('should prefer a nested API over its enclosing API Product', () => {
+    it('should preserve API context without a subscription target when API is nested under an API Product', () => {
       const items = [
         fakePortalNavigationApiProduct({ id: 'product1', apiProductId: 'api-product-1', rootId: 'product1' }),
         makeItem('api1', 'API', 'API 1', 0, 'product1', 'product1'),
@@ -145,12 +151,15 @@ describe('DocumentationTreeService', () => {
       ];
       service.init(parentItem, items);
 
-      expect(service.getSubscriptionTarget('p-api1')).toEqual({ type: 'API', apiId: 'api-api1' });
+      expect(service.getDocumentationActionContext('p-api1')).toEqual({
+        apiId: 'api-api1',
+        subscriptionTarget: null,
+      });
     });
 
-    it('should return null when page has no subscribable ancestor', () => {
-      expect(service.getSubscriptionTarget('p1')).toBeNull();
-      expect(service.getSubscriptionTarget('p3')).toBeNull();
+    it('should return an empty context when page has no API or API Product ancestor', () => {
+      expect(service.getDocumentationActionContext('p1')).toEqual({ apiId: null, subscriptionTarget: null });
+      expect(service.getDocumentationActionContext('p3')).toEqual({ apiId: null, subscriptionTarget: null });
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
@@ -29,6 +29,11 @@ export interface TreeNode {
 
 export type DocumentationSubscriptionTarget = { type: 'API'; apiId: string } | { type: 'API_PRODUCT'; apiProductId: string };
 
+export interface DocumentationActionContext {
+  apiId: string | null;
+  subscriptionTarget: DocumentationSubscriptionTarget | null;
+}
+
 type ProcessingNode = TreeNode & {
   __order: number;
   __parentId: string | null;
@@ -61,18 +66,25 @@ export class TreeService {
     return this.parentItemBreadcrumb ? [this.parentItemBreadcrumb] : [];
   }
 
-  getSubscriptionTarget(nodeId: string): DocumentationSubscriptionTarget | null {
+  getDocumentationActionContext(nodeId: string): DocumentationActionContext {
+    let apiId: string | null = null;
     let node = this.treeNodesById.get(nodeId);
     while (node) {
       if (node.data?.type === 'API') {
-        return { type: 'API', apiId: node.data.apiId };
+        apiId ??= node.data.apiId;
       }
       if (node.data?.type === 'API_PRODUCT') {
-        return { type: 'API_PRODUCT', apiProductId: node.data.apiProductId };
+        return {
+          apiId,
+          subscriptionTarget: apiId ? null : { type: 'API_PRODUCT', apiProductId: node.data.apiProductId },
+        };
       }
       node = node.__parentId ? this.treeNodesById.get(node.__parentId) : undefined;
     }
-    return null;
+    return {
+      apiId,
+      subscriptionTarget: apiId ? { type: 'API', apiId } : null,
+    };
   }
 
   findFirstPageId(): string | null {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-128

## Description

This PR hides the subscription action on documentation pages belonging to APIs nested inside an API Product.

It separates the API tooling context from the subscription target so that nested APIs:

- do not display the Subscribe action;
- continue loading API details;
- retain API-specific tooling such as MCP.

Product-level documentation continues to open the API Product subscription flow, while standalone APIs preserve their existing subscription behavior and route.



https://github.com/user-attachments/assets/da86e913-ab12-442b-be09-4f9c17c05409




