### PR TITLE
Found 20 deploy undeploy shared policy group

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -89,6 +89,14 @@ jest.mock('../pages/GroupDetailPage', () => ({
     GroupDetailPage: () => <div data-testid="group-detail-page" />,
 }));
 
+jest.mock('../pages/SharedPolicyGroupsPage', () => ({
+    SharedPolicyGroupsPage: () => <div data-testid="shared-policy-groups-page" />,
+}));
+
+jest.mock('../pages/SharedPolicyGroupDetailPage', () => ({
+    SharedPolicyGroupDetailPage: () => <div data-testid="shared-policy-group-detail-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -296,6 +304,52 @@ describe('AppRoutes', () => {
         renderPlatform();
 
         expect(visibleNavKeys()).not.toContain('metadata');
+    });
+
+    it('routes to the Shared Policy Groups page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('shared-policy-groups-page')).not.toBeNull();
+    });
+
+    it('routes to the shared policy group detail page under the platform module', () => {
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups/spg-1']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('shared-policy-group-detail-page')).not.toBeNull();
+    });
+
+    it('redirects away from Shared Policy Groups when the user lacks environment-shared_policy_group-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-shared_policy_group-r'));
+
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('shows the Shared Policy Groups nav item when the user has read permission', () => {
+        renderPlatform();
+
+        expect(visibleNavKeys()).toContain('shared-policy-groups');
+    });
+
+    it('hides the Shared Policy Groups nav item when the user lacks environment-shared_policy_group-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-shared_policy_group-r'));
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('shared-policy-groups');
     });
 
     it('routes to the user detail page under the platform module', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -93,8 +93,28 @@ jest.mock('../pages/SharedPolicyGroupsPage', () => ({
     SharedPolicyGroupsPage: () => <div data-testid="shared-policy-groups-page" />,
 }));
 
+jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Outlet } = require('react-router-dom');
+    return {
+        SharedPolicyGroupDetailLayout: () => (
+            <div data-testid="shared-policy-group-detail-layout">
+                <Outlet />
+            </div>
+        ),
+    };
+});
+
 jest.mock('../pages/SharedPolicyGroupDetailPage', () => ({
-    SharedPolicyGroupDetailPage: () => <div data-testid="shared-policy-group-detail-page" />,
+    SharedPolicyGroupDetailPage: () => <div data-testid="shared-policy-group-overview-page" />,
+}));
+
+jest.mock('../pages/SharedPolicyGroupStudioPage', () => ({
+    SharedPolicyGroupStudioPage: () => <div data-testid="shared-policy-group-studio-page" />,
+}));
+
+jest.mock('../pages/SharedPolicyGroupHistoryPage', () => ({
+    SharedPolicyGroupHistoryPage: () => <div data-testid="shared-policy-group-history-page" />,
 }));
 
 jest.mock('../pages/RegisterApplicationPage', () => ({
@@ -316,14 +336,31 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('shared-policy-groups-page')).not.toBeNull();
     });
 
-    it('routes to the shared policy group detail page under the platform module', () => {
+    it('routes to the shared policy group studio tab by default under the platform module', () => {
         render(
             <MemoryRouter initialEntries={['/shared-policy-groups/spg-1']}>
                 <AppRoutes />
             </MemoryRouter>,
         );
 
-        expect(screen.getByTestId('shared-policy-group-detail-page')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-detail-layout')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-studio-page')).not.toBeNull();
+    });
+
+    it('routes to the shared policy group overview and history tabs', () => {
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups/spg-1/overview']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+        expect(screen.getByTestId('shared-policy-group-overview-page')).not.toBeNull();
+
+        render(
+            <MemoryRouter initialEntries={['/shared-policy-groups/spg-1/history']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+        expect(screen.getByTestId('shared-policy-group-history-page')).not.toBeNull();
     });
 
     it('redirects away from Shared Policy Groups when the user lacks environment-shared_policy_group-r', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -48,6 +48,7 @@ import { GatewayInstanceDetailLayout } from '../features/gateway-instances/compo
 import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
@@ -62,6 +63,8 @@ import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { SharedPolicyGroupDetailPage } from '../pages/SharedPolicyGroupDetailPage';
+import { SharedPolicyGroupsPage } from '../pages/SharedPolicyGroupsPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
 import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
@@ -112,6 +115,7 @@ function isNavItemVisible(
     canReadGateways: boolean,
     canReadEntrypoints: boolean,
     canReadGroups: boolean,
+    canReadSharedPolicyGroups: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
@@ -124,6 +128,9 @@ function isNavItemVisible(
     }
     if (itemKey === 'dictionaries') {
         return !permissionsReady || canReadDictionaries;
+    }
+    if (itemKey === 'shared-policy-groups') {
+        return !permissionsReady || canReadSharedPolicyGroups;
     }
     if (itemKey === 'gateways') {
         return !permissionsReady || canReadGateways;
@@ -212,6 +219,7 @@ function ModuleLayout() {
     const canReadGateways = useHasPermission({ anyOf: ['environment-instance-r'] });
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
+    const canReadSharedPolicyGroups = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION] });
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
@@ -227,9 +235,19 @@ function ModuleLayout() {
                     canReadGateways,
                     canReadEntrypoints,
                     canReadGroups,
+                    canReadSharedPolicyGroups,
                 ),
             ),
-        [permissionsReady, canReadMetadata, canReadDictionaries, canAccessUsers, canReadGateways, canReadEntrypoints, canReadGroups],
+        [
+            permissionsReady,
+            canReadMetadata,
+            canReadDictionaries,
+            canAccessUsers,
+            canReadGateways,
+            canReadEntrypoints,
+            canReadGroups,
+            canReadSharedPolicyGroups,
+        ],
     );
 
     const activeSectionKey = findNavSectionKey(visibleNavSections, activeNavKey) ?? visibleNavSections[0]?.key;
@@ -389,6 +407,30 @@ export function AppRoutes() {
                                             unauthorizedTo="../../applications"
                                         >
                                             <DictionaryDetailPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                            </Route>
+                            <Route path="shared-policy-groups">
+                                <Route
+                                    index
+                                    element={
+                                        <PermissionPageGuard
+                                            permission={ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION}
+                                            unauthorizedTo="../applications"
+                                        >
+                                            <SharedPolicyGroupsPage />
+                                        </PermissionPageGuard>
+                                    }
+                                />
+                                <Route
+                                    path=":sharedPolicyGroupId"
+                                    element={
+                                        <PermissionPageGuard
+                                            permission={ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION}
+                                            unauthorizedTo="../../applications"
+                                        >
+                                            <SharedPolicyGroupDetailPage />
                                         </PermissionPageGuard>
                                     }
                                 />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -48,6 +48,7 @@ import { GatewayInstanceDetailLayout } from '../features/gateway-instances/compo
 import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { SharedPolicyGroupDetailLayout } from '../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout';
 import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
@@ -64,7 +65,9 @@ import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { SharedPolicyGroupDetailPage } from '../pages/SharedPolicyGroupDetailPage';
+import { SharedPolicyGroupHistoryPage } from '../pages/SharedPolicyGroupHistoryPage';
 import { SharedPolicyGroupsPage } from '../pages/SharedPolicyGroupsPage';
+import { SharedPolicyGroupStudioPage } from '../pages/SharedPolicyGroupStudioPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
 import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
@@ -430,10 +433,15 @@ export function AppRoutes() {
                                             permission={ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION}
                                             unauthorizedTo="../../applications"
                                         >
-                                            <SharedPolicyGroupDetailPage />
+                                            <SharedPolicyGroupDetailLayout />
                                         </PermissionPageGuard>
                                     }
-                                />
+                                >
+                                    <Route index element={<Navigate to="studio" replace />} />
+                                    <Route path="overview" element={<SharedPolicyGroupDetailPage />} />
+                                    <Route path="studio" element={<SharedPolicyGroupStudioPage />} />
+                                    <Route path="history" element={<SharedPolicyGroupHistoryPage />} />
+                                </Route>
                             </Route>
                             <Route path="gateways">
                                 <Route

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -45,8 +45,8 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Organization', 'System & Security')).toEqual(['access-management']);
     });
 
-    it('places Applications, Metadata, and Dictionaries under Environment / APIs & Assets', () => {
-        expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries']);
+    it('places Applications, Metadata, Dictionaries, and Shared Policy Groups under Environment / APIs & Assets', () => {
+        expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries', 'shared-policy-groups']);
     });
 
     it('places Gateways and Security Plan Types under Environment / System & Security', () => {
@@ -102,5 +102,10 @@ describe('platform navigation config', () => {
     it('declares the user-groups route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('user-groups');
         expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'Groups' });
+    });
+
+    it('declares the shared-policy-groups route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('shared-policy-groups');
+        expect(ROUTES['shared-policy-groups']).toEqual({ path: 'shared-policy-groups', label: 'Shared Policy Groups' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -22,6 +22,7 @@ import {
     GlobeIcon,
     GroupIcon,
     KeyIcon,
+    LayersIcon,
     RadioIcon,
     ServerIcon,
     ShieldIcon,
@@ -73,6 +74,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                     { key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon },
                     { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
                     { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
+                    { key: 'shared-policy-groups', title: ROUTES['shared-policy-groups'].label, icon: LayersIcon },
                 ],
             },
             {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -22,6 +22,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'access-management',
     'metadata',
     'dictionaries',
+    'shared-policy-groups',
     'security-plan-types',
     'gateways',
     'entrypoints-and-sharding-tags',
@@ -38,6 +39,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'security-plan-types': { path: 'security-plan-types', label: 'Security Plan Types' },
     metadata: { path: 'metadata', label: 'Metadata' },
     dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
+    'shared-policy-groups': { path: 'shared-policy-groups', label: 'Shared Policy Groups' },
     gateways: { path: 'gateways', label: 'Gateways' },
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupBasicFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupBasicFields.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Field, FieldDescription, FieldLabel, Input, Textarea } from '@gravitee/graphene-core';
+
+import {
+    DESCRIPTION_MAX_LENGTH,
+    PREREQUISITE_MESSAGE_MAX_LENGTH,
+    PREREQUISITE_MESSAGE_PLACEHOLDER,
+    type SharedPolicyGroupBasicFormValues,
+} from '../utils/sharedPolicyGroupPayload';
+
+export function SharedPolicyGroupBasicFields({
+    idPrefix,
+    values,
+    disabled,
+    onChange,
+}: Readonly<{
+    idPrefix: string;
+    values: SharedPolicyGroupBasicFormValues;
+    disabled?: boolean;
+    onChange: <K extends keyof SharedPolicyGroupBasicFormValues>(key: K, value: SharedPolicyGroupBasicFormValues[K]) => void;
+}>) {
+    const nameId = `${idPrefix}-name`;
+    const descriptionId = `${idPrefix}-description`;
+    const prerequisiteId = `${idPrefix}-prerequisite-message`;
+
+    return (
+        <>
+            <h3 className="text-sm font-semibold">Basic information</h3>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={nameId} required>
+                    Name
+                </FieldLabel>
+                <Input
+                    id={nameId}
+                    value={values.name}
+                    onChange={e => onChange('name', e.target.value)}
+                    placeholder="e.g. Default authentication"
+                    maxLength={512}
+                    disabled={disabled}
+                    required
+                />
+            </Field>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={descriptionId}>Describe the purpose of this policy group</FieldLabel>
+                <FieldDescription>{DESCRIPTION_MAX_LENGTH} characters max.</FieldDescription>
+                <Textarea
+                    id={descriptionId}
+                    value={values.description}
+                    onChange={e => onChange('description', e.target.value)}
+                    placeholder="Describe what this policy group is used for"
+                    maxLength={DESCRIPTION_MAX_LENGTH}
+                    disabled={disabled}
+                />
+            </Field>
+
+            <Field orientation="vertical" className="gap-1.5">
+                <FieldLabel htmlFor={prerequisiteId}>Prerequisite message</FieldLabel>
+                <FieldDescription>{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</FieldDescription>
+                <Textarea
+                    id={prerequisiteId}
+                    value={values.prerequisiteMessage}
+                    onChange={e => onChange('prerequisiteMessage', e.target.value)}
+                    placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
+                    maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
+                    disabled={disabled}
+                />
+            </Field>
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.spec.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupCreateSheet } from './SharedPolicyGroupCreateSheet';
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof SharedPolicyGroupCreateSheet>> = {}) {
+    return render(<SharedPolicyGroupCreateSheet open onClose={jest.fn()} onSubmit={jest.fn()} isSaving={false} {...overrides} />);
+}
+
+describe('SharedPolicyGroupCreateSheet', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the title and description', () => {
+        renderSheet();
+        expect(screen.queryByRole('heading', { name: 'Add Policy Group' })).not.toBeNull();
+        expect(
+            screen.queryByText('Policy groups can be reused across multiple APIs, so you only need to configure their policies once.'),
+        ).not.toBeNull();
+    });
+
+    it('renders the Basic information and Scope sections', () => {
+        renderSheet();
+        expect(screen.queryByText('Basic information')).not.toBeNull();
+        expect(screen.queryByText('Scope')).not.toBeNull();
+    });
+
+    it('shows the field placeholders and character-limit hints', () => {
+        renderSheet();
+        expect(screen.getByPlaceholderText('e.g. Default authentication')).not.toBeNull();
+        expect(screen.getByPlaceholderText('Describe what this policy group is used for')).not.toBeNull();
+        expect(screen.getAllByText('300 characters max.')).toHaveLength(2);
+    });
+
+    it('defaults to Proxy, offering only the phases valid for a Proxy API', () => {
+        renderSheet();
+        expect(screen.getByRole('radio', { name: 'Proxy' }).getAttribute('aria-checked')).toBe('true');
+        expect(screen.queryByRole('radio', { name: 'Request' })).not.toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Response' })).not.toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Publish' })).toBeNull();
+    });
+
+    it('switches to Message-specific phases when Message is selected', () => {
+        renderSheet();
+        fireEvent.click(screen.getByRole('radio', { name: 'Message' }));
+        expect(screen.queryByRole('radio', { name: 'Publish' })).not.toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Subscribe' })).not.toBeNull();
+    });
+
+    it('disables Create until a name is entered', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', true);
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My SPG' } });
+        expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', false);
+    });
+
+    it('submits the trimmed form values, including api type, description, prerequisite message, and selected phase', () => {
+        const onSubmit = jest.fn();
+        renderSheet({ onSubmit });
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Message' }));
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  My SPG  ' } });
+        fireEvent.change(screen.getByLabelText('Describe the purpose of this policy group'), { target: { value: 'A bundle' } });
+        fireEvent.change(screen.getByLabelText('Prerequisite message'), { target: { value: 'Needs cache' } });
+        fireEvent.click(screen.getByRole('radio', { name: 'Publish' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            name: 'My SPG',
+            description: 'A bundle',
+            prerequisiteMessage: 'Needs cache',
+            apiType: 'MESSAGE',
+            phase: 'PUBLISH',
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = jest.fn();
+        renderSheet({ onClose });
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
@@ -18,7 +18,6 @@ import {
     Button,
     Field,
     FieldLabel,
-    Input,
     ScrollArea,
     Separator,
     Sheet,
@@ -27,27 +26,20 @@ import {
     SheetFooter,
     SheetHeader,
     SheetTitle,
-    Textarea,
     ToggleGroup,
     ToggleGroupItem,
 } from '@gravitee/graphene-core';
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 
+import { SharedPolicyGroupBasicFields } from './SharedPolicyGroupBasicFields';
 import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
 import { toReadableApiType, toReadableFlowPhase, type ApiType, type FlowPhase } from '../types/sharedPolicyGroup';
-import { PHASE_BY_API_TYPE } from '../utils/sharedPolicyGroupPayload';
+import { PHASE_BY_API_TYPE, type SharedPolicyGroupBasicFormValues } from '../utils/sharedPolicyGroupPayload';
 
 const CREATABLE_API_TYPES: readonly ApiType[] = ['PROXY', 'MESSAGE'];
 const DEFAULT_API_TYPE: ApiType = 'PROXY';
-const DESCRIPTION_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_PLACEHOLDER =
-    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
 
-export interface SharedPolicyGroupCreateFormValues {
-    name: string;
-    description: string;
-    prerequisiteMessage: string;
+export interface SharedPolicyGroupCreateFormValues extends SharedPolicyGroupBasicFormValues {
     apiType: ApiType;
     phase: FlowPhase;
 }
@@ -116,63 +108,19 @@ export function SharedPolicyGroupCreateSheet({
 
                 <ScrollArea className="flex-1 min-h-0">
                     <form id="shared-policy-group-create-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
-                        <h3 className="text-sm font-semibold">Basic information</h3>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-name">
-                                Name{' '}
-                                <span className="text-destructive" aria-hidden>
-                                    *
-                                </span>
-                            </FieldLabel>
-                            <Input
-                                id="spg-name"
-                                value={form.name}
-                                onChange={e => setField('name', e.target.value)}
-                                placeholder="e.g. Default authentication"
-                                maxLength={512}
-                                disabled={isSaving}
-                                required
-                            />
-                        </Field>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-description">Describe the purpose of this policy group</FieldLabel>
-                            <p className="text-xs text-muted-foreground">{DESCRIPTION_MAX_LENGTH} characters max.</p>
-                            <Textarea
-                                id="spg-description"
-                                value={form.description}
-                                onChange={e => setField('description', e.target.value)}
-                                placeholder="Describe what this policy group is used for"
-                                maxLength={DESCRIPTION_MAX_LENGTH}
-                                disabled={isSaving}
-                            />
-                        </Field>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-prerequisite-message">Prerequisite message</FieldLabel>
-                            <p className="text-xs text-muted-foreground">{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</p>
-                            <Textarea
-                                id="spg-prerequisite-message"
-                                value={form.prerequisiteMessage}
-                                onChange={e => setField('prerequisiteMessage', e.target.value)}
-                                placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
-                                maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
-                                disabled={isSaving}
-                            />
-                        </Field>
+                        <SharedPolicyGroupBasicFields
+                            idPrefix="spg"
+                            values={form}
+                            disabled={isSaving}
+                            onChange={(key, value) => setField(key, value)}
+                        />
 
                         <Separator />
 
                         <h3 className="text-sm font-semibold">Scope</h3>
 
                         <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel>
-                                API Type{' '}
-                                <span className="text-destructive" aria-hidden>
-                                    *
-                                </span>
-                            </FieldLabel>
+                            <FieldLabel required>API Type</FieldLabel>
                             <ToggleGroup
                                 type="single"
                                 value={form.apiType}
@@ -190,12 +138,7 @@ export function SharedPolicyGroupCreateSheet({
                         </Field>
 
                         <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel>
-                                Phase{' '}
-                                <span className="text-destructive" aria-hidden>
-                                    *
-                                </span>
-                            </FieldLabel>
+                            <FieldLabel required>Phase</FieldLabel>
                             <ToggleGroup
                                 type="single"
                                 value={form.phase}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupCreateSheet.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Separator,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Textarea,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import { toReadableApiType, toReadableFlowPhase, type ApiType, type FlowPhase } from '../types/sharedPolicyGroup';
+import { PHASE_BY_API_TYPE } from '../utils/sharedPolicyGroupPayload';
+
+const CREATABLE_API_TYPES: readonly ApiType[] = ['PROXY', 'MESSAGE'];
+const DEFAULT_API_TYPE: ApiType = 'PROXY';
+const DESCRIPTION_MAX_LENGTH = 300;
+const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
+const PREREQUISITE_MESSAGE_PLACEHOLDER =
+    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
+
+export interface SharedPolicyGroupCreateFormValues {
+    name: string;
+    description: string;
+    prerequisiteMessage: string;
+    apiType: ApiType;
+    phase: FlowPhase;
+}
+
+function buildEmptyForm(): SharedPolicyGroupCreateFormValues {
+    return {
+        name: '',
+        description: '',
+        prerequisiteMessage: '',
+        apiType: DEFAULT_API_TYPE,
+        phase: PHASE_BY_API_TYPE[DEFAULT_API_TYPE][0],
+    };
+}
+
+export function SharedPolicyGroupCreateSheet({
+    open,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (values: SharedPolicyGroupCreateFormValues) => void;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<SharedPolicyGroupCreateFormValues>(buildEmptyForm);
+    const phases = useMemo(() => PHASE_BY_API_TYPE[form.apiType], [form.apiType]);
+
+    useEffect(() => {
+        if (!open) return;
+        setForm(buildEmptyForm());
+    }, [open]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof SharedPolicyGroupCreateFormValues>(key: K, value: SharedPolicyGroupCreateFormValues[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    function handleApiTypeChange(apiType: ApiType) {
+        setForm(prev => ({ ...prev, apiType, phase: PHASE_BY_API_TYPE[apiType][0] }));
+    }
+
+    const isValid = form.name.trim() !== '';
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid) return;
+        onSubmit({ ...form, name: form.name.trim() });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>Add Policy Group</SheetTitle>
+                    <SheetDescription>
+                        Policy groups can be reused across multiple APIs, so you only need to configure their policies once.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="shared-policy-group-create-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                        <h3 className="text-sm font-semibold">Basic information</h3>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="spg-name"
+                                value={form.name}
+                                onChange={e => setField('name', e.target.value)}
+                                placeholder="e.g. Default authentication"
+                                maxLength={512}
+                                disabled={isSaving}
+                                required
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-description">Describe the purpose of this policy group</FieldLabel>
+                            <p className="text-xs text-muted-foreground">{DESCRIPTION_MAX_LENGTH} characters max.</p>
+                            <Textarea
+                                id="spg-description"
+                                value={form.description}
+                                onChange={e => setField('description', e.target.value)}
+                                placeholder="Describe what this policy group is used for"
+                                maxLength={DESCRIPTION_MAX_LENGTH}
+                                disabled={isSaving}
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-prerequisite-message">Prerequisite message</FieldLabel>
+                            <p className="text-xs text-muted-foreground">{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</p>
+                            <Textarea
+                                id="spg-prerequisite-message"
+                                value={form.prerequisiteMessage}
+                                onChange={e => setField('prerequisiteMessage', e.target.value)}
+                                placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
+                                maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
+                                disabled={isSaving}
+                            />
+                        </Field>
+
+                        <Separator />
+
+                        <h3 className="text-sm font-semibold">Scope</h3>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel>
+                                API Type{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <ToggleGroup
+                                type="single"
+                                value={form.apiType}
+                                onValueChange={value => {
+                                    if (value) handleApiTypeChange(value as ApiType);
+                                }}
+                                disabled={isSaving}
+                            >
+                                {CREATABLE_API_TYPES.map(apiType => (
+                                    <ToggleGroupItem key={apiType} value={apiType}>
+                                        {toReadableApiType(apiType)}
+                                    </ToggleGroupItem>
+                                ))}
+                            </ToggleGroup>
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel>
+                                Phase{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <ToggleGroup
+                                type="single"
+                                value={form.phase}
+                                onValueChange={value => {
+                                    if (value) setField('phase', value as FlowPhase);
+                                }}
+                                disabled={isSaving}
+                            >
+                                {phases.map(phase => (
+                                    <ToggleGroupItem key={phase} value={phase}>
+                                        {toReadableFlowPhase(phase)}
+                                    </ToggleGroupItem>
+                                ))}
+                            </ToggleGroup>
+                        </Field>
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="shared-policy-group-create-form" disabled={!isValid || isSaving}>
+                        {isSaving ? 'Creating…' : 'Create'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet.spec.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupDeleteSheet } from './SharedPolicyGroupDeleteSheet';
+
+describe('SharedPolicyGroupDeleteSheet', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the confirmation title and warning copy', () => {
+        render(<SharedPolicyGroupDeleteSheet open onClose={jest.fn()} onConfirm={jest.fn()} isDeleting={false} />);
+        expect(screen.queryByRole('heading', { name: 'Remove Shared Policy Group' })).not.toBeNull();
+        expect(screen.queryByText(/Are you sure you want to remove this Shared Policy Group/)).not.toBeNull();
+        expect(screen.queryByText(/inform API publishers/)).not.toBeNull();
+    });
+
+    it('calls onConfirm when Remove is clicked', () => {
+        const onConfirm = jest.fn();
+        render(<SharedPolicyGroupDeleteSheet open onClose={jest.fn()} onConfirm={onConfirm} isDeleting={false} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+        expect(onConfirm).toHaveBeenCalled();
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = jest.fn();
+        render(<SharedPolicyGroupDeleteSheet open onClose={onClose} onConfirm={jest.fn()} isDeleting={false} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('disables actions while deleting', () => {
+        render(<SharedPolicyGroupDeleteSheet open onClose={jest.fn()} onConfirm={jest.fn()} isDeleting />);
+        expect(screen.getByRole('button', { name: 'Removing…' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfirmDialog } from '../../../shared/components/ConfirmDialog';
+
+/** Mirrors classic Console's `removeSharedPolicyGroup` confirm dialog (shared-policy-groups.component.ts). */
+export function SharedPolicyGroupDeleteSheet({
+    open,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    return (
+        <ConfirmDialog
+            open={open}
+            onOpenChange={isOpen => !isOpen && onClose()}
+            title="Remove Shared Policy Group"
+            description={
+                <span className="space-y-2 block">
+                    <span className="block">Are you sure you want to remove this Shared Policy Group?</span>
+                    <span className="block">
+                        If this Shared Policy Group is used in API flows, be sure to inform API publishers before making this change.
+                    </span>
+                    <span className="block">
+                        If an API flow still uses this Shared Policy Group, the API flow will ignore it and continue to run.
+                    </span>
+                </span>
+            }
+            confirmLabel="Remove"
+            pendingLabel="Removing…"
+            destructive
+            isPending={isDeleting}
+            onConfirm={onConfirm}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeployActions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeployActions.spec.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { SharedPolicyGroupDeployActions } from './SharedPolicyGroupDeployActions';
+import { useSharedPolicyGroupDeployActions } from '../hooks/useSharedPolicyGroupDeployActions';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+jest.mock('../hooks/useSharedPolicyGroupDeployActions');
+
+const mockUseDeployActions = jest.mocked(useSharedPolicyGroupDeployActions);
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    lifecycleState: 'UNDEPLOYED',
+};
+
+function mockActions(
+    overrides: Partial<ReturnType<typeof useSharedPolicyGroupDeployActions>> = {},
+): ReturnType<typeof useSharedPolicyGroupDeployActions> {
+    return {
+        visible: true,
+        deployDisabled: false,
+        undeployDisabled: true,
+        isDeploying: false,
+        isUndeploying: false,
+        onDeploy: jest.fn(),
+        onUndeploy: jest.fn(),
+        ...overrides,
+    };
+}
+
+describe('SharedPolicyGroupDeployActions', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders nothing when actions are not visible', () => {
+        mockUseDeployActions.mockReturnValue(mockActions({ visible: false }));
+        const { container } = render(<SharedPolicyGroupDeployActions sharedPolicyGroup={SPG} />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders Deploy and Undeploy and forwards clicks', async () => {
+        const onDeploy = jest.fn();
+        const onUndeploy = jest.fn();
+        mockUseDeployActions.mockReturnValue(
+            mockActions({
+                deployDisabled: false,
+                undeployDisabled: false,
+                onDeploy,
+                onUndeploy,
+            }),
+        );
+
+        render(<SharedPolicyGroupDeployActions sharedPolicyGroup={{ ...SPG, lifecycleState: 'PENDING' }} />);
+
+        fireEvent.click(screen.getByTestId('shared-policy-group-deploy'));
+        fireEvent.click(screen.getByTestId('shared-policy-group-undeploy'));
+
+        await waitFor(() => {
+            expect(onDeploy).toHaveBeenCalledTimes(1);
+            expect(onUndeploy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('disables Deploy and Undeploy according to the hook', () => {
+        mockUseDeployActions.mockReturnValue(
+            mockActions({
+                deployDisabled: true,
+                undeployDisabled: true,
+            }),
+        );
+
+        render(<SharedPolicyGroupDeployActions sharedPolicyGroup={{ ...SPG, lifecycleState: 'DEPLOYED' }} />);
+
+        expect(screen.getByTestId('shared-policy-group-deploy')).toHaveProperty('disabled', true);
+        expect(screen.getByTestId('shared-policy-group-undeploy')).toHaveProperty('disabled', true);
+    });
+
+    it('shows pending labels while mutations run', () => {
+        mockUseDeployActions.mockReturnValue(
+            mockActions({
+                isDeploying: true,
+                isUndeploying: true,
+                deployDisabled: true,
+                undeployDisabled: true,
+            }),
+        );
+
+        render(<SharedPolicyGroupDeployActions sharedPolicyGroup={SPG} />);
+
+        expect(screen.getByText('Deploying…')).not.toBeNull();
+        expect(screen.getByText('Undeploying…')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeployActions.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDeployActions.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from '@gravitee/graphene-core';
+import { CloudIcon, CloudUploadIcon } from '@gravitee/graphene-core/icons';
+
+import { useSharedPolicyGroupDeployActions } from '../hooks/useSharedPolicyGroupDeployActions';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+type SharedPolicyGroupDeployActionsProps = Readonly<{
+    sharedPolicyGroup: SharedPolicyGroup;
+    /** When Policy Studio lands, pass dirty state so Deploy stays blocked until save. */
+    hasUnsavedChanges?: boolean;
+}>;
+
+/** Classic Console studio header Deploy / Undeploy controls. */
+export function SharedPolicyGroupDeployActions({
+    sharedPolicyGroup,
+    hasUnsavedChanges = false,
+}: SharedPolicyGroupDeployActionsProps) {
+    const { visible, deployDisabled, undeployDisabled, isDeploying, isUndeploying, onDeploy, onUndeploy } =
+        useSharedPolicyGroupDeployActions(sharedPolicyGroup, hasUnsavedChanges);
+
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <div className="flex shrink-0 flex-wrap items-center gap-2" data-testid="shared-policy-group-deploy-actions">
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                onClick={onUndeploy}
+                disabled={undeployDisabled}
+                title="Undeploy"
+                data-testid="shared-policy-group-undeploy"
+            >
+                <CloudIcon className="size-4" aria-hidden />
+                {isUndeploying ? 'Undeploying…' : 'Undeploy'}
+            </Button>
+            <Button
+                type="button"
+                size="sm"
+                className="gap-1.5"
+                onClick={onDeploy}
+                disabled={deployDisabled}
+                title="Deploy"
+                data-testid="shared-policy-group-deploy"
+            >
+                <CloudUploadIcon className="size-4" aria-hidden />
+                {isDeploying ? 'Deploying…' : 'Deploy'}
+            </Button>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
@@ -18,6 +18,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { SharedPolicyGroupDetailLayout } from './SharedPolicyGroupDetailLayout';
+import { useSharedPolicyGroupDeployActions } from '../hooks/useSharedPolicyGroupDeployActions';
 import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
 
@@ -29,8 +30,10 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('../hooks/useSharedPolicyGroups');
+jest.mock('../hooks/useSharedPolicyGroupDeployActions');
 
 const mockUseDetail = jest.mocked(useSharedPolicyGroupDetail);
+const mockUseDeployActions = jest.mocked(useSharedPolicyGroupDeployActions);
 
 const SPG: SharedPolicyGroup = {
     id: 'spg-1',
@@ -39,6 +42,16 @@ const SPG: SharedPolicyGroup = {
     lifecycleState: 'DEPLOYED',
     apiType: 'PROXY',
     phase: 'REQUEST',
+};
+
+const defaultDeployActions = {
+    visible: true,
+    deployDisabled: true,
+    undeployDisabled: false,
+    isDeploying: false,
+    isUndeploying: false,
+    onDeploy: jest.fn(),
+    onUndeploy: jest.fn(),
 };
 
 function renderLayout(path = '/shared-policy-groups/spg-1/studio') {
@@ -56,6 +69,10 @@ function renderLayout(path = '/shared-policy-groups/spg-1/studio') {
 }
 
 describe('SharedPolicyGroupDetailLayout', () => {
+    beforeEach(() => {
+        mockUseDeployActions.mockReturnValue(defaultDeployActions);
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -73,6 +90,14 @@ describe('SharedPolicyGroupDetailLayout', () => {
         expect(screen.getByTestId('shared-policy-group-tab-studio')).not.toBeNull();
         expect(screen.getByTestId('shared-policy-group-tab-history')).not.toBeNull();
         expect(screen.getByText('Studio content')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-deploy-actions')).not.toBeNull();
+    });
+
+    it('hides deploy actions when the deploy hook reports not visible', () => {
+        mockUseDeployActions.mockReturnValue({ ...defaultDeployActions, visible: false });
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout();
+        expect(screen.queryByTestId('shared-policy-group-deploy-actions')).toBeNull();
     });
 
     it('navigates back to the shared policy groups list', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SharedPolicyGroupDetailLayout } from './SharedPolicyGroupDetailLayout';
+import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../hooks/useSharedPolicyGroups');
+
+const mockUseDetail = jest.mocked(useSharedPolicyGroupDetail);
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth policies',
+    lifecycleState: 'DEPLOYED',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+};
+
+function renderLayout(path = '/shared-policy-groups/spg-1/studio') {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/shared-policy-groups/:sharedPolicyGroupId" element={<SharedPolicyGroupDetailLayout />}>
+                    <Route path="overview" element={<div>Overview content</div>} />
+                    <Route path="studio" element={<div>Studio content</div>} />
+                    <Route path="history" element={<div>History content</div>} />
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('SharedPolicyGroupDetailLayout', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders header, status badge, tabs, and outlet content', () => {
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout();
+
+        expect(screen.getByTestId('shared-policy-group-detail')).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Auth Bundle' })).not.toBeNull();
+        expect(screen.getByText('Deployed')).not.toBeNull();
+        expect(screen.getByText('Reusable auth policies')).not.toBeNull();
+        expect(screen.getByText('Proxy · Request')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-tab-overview')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-tab-studio')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-tab-history')).not.toBeNull();
+        expect(screen.getByText('Studio content')).not.toBeNull();
+    });
+
+    it('navigates back to the shared policy groups list', () => {
+        mockUseDetail.mockReturnValue({ data: SPG, isLoading: false, isError: false } as never);
+        renderLayout();
+        fireEvent.click(screen.getByRole('button', { name: /Back to Shared Policy Groups/i }));
+        expect(mockNavigate).toHaveBeenCalledWith('/shared-policy-groups');
+    });
+
+    it('shows not-found state when the detail query fails', () => {
+        mockUseDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true } as never);
+        renderLayout();
+        expect(screen.getByText(/Shared Policy Group not found or failed to load/i)).not.toBeNull();
+    });
+
+    it('shows a loading skeleton while fetching', () => {
+        mockUseDetail.mockReturnValue({ data: undefined, isLoading: true, isError: false } as never);
+        renderLayout();
+        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).toBeNull();
+        expect(screen.queryByTestId('shared-policy-group-detail')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
@@ -18,6 +18,7 @@ import { Button, Skeleton, cn } from '@gravitee/graphene-core';
 import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
 import { NavLink, Outlet, useNavigate, useParams } from 'react-router-dom';
 
+import { SharedPolicyGroupDeployActions } from './SharedPolicyGroupDeployActions';
 import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
 import { resolveListHrefFromDetailBasePath, useDetailBasePath } from '../../shared/hooks/useDetailBasePath';
 import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
@@ -67,22 +68,25 @@ export function SharedPolicyGroupDetailLayout() {
                 Back to Shared Policy Groups
             </Button>
 
-            <div className="flex items-start gap-3">
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
-                    <LayersIcon className="size-5" aria-hidden />
-                </div>
-                <div className="min-w-0 space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <h1 className="truncate text-2xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
-                        <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="flex min-w-0 items-start gap-3">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                        <LayersIcon className="size-5" aria-hidden />
                     </div>
-                    {sharedPolicyGroup.description ? (
-                        <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
-                    ) : null}
-                    <p className="text-sm text-muted-foreground">
-                        {toReadableApiType(sharedPolicyGroup.apiType)} · {toReadableFlowPhase(sharedPolicyGroup.phase)}
-                    </p>
+                    <div className="min-w-0 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h1 className="truncate text-2xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                            <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                        </div>
+                        {sharedPolicyGroup.description ? (
+                            <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
+                        ) : null}
+                        <p className="text-sm text-muted-foreground">
+                            {toReadableApiType(sharedPolicyGroup.apiType)} · {toReadableFlowPhase(sharedPolicyGroup.phase)}
+                        </p>
+                    </div>
                 </div>
+                <SharedPolicyGroupDeployActions sharedPolicyGroup={sharedPolicyGroup} />
             </div>
 
             <div className="border-b">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Skeleton, cn } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
+import { NavLink, Outlet, useNavigate, useParams } from 'react-router-dom';
+
+import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
+import { resolveListHrefFromDetailBasePath, useDetailBasePath } from '../../shared/hooks/useDetailBasePath';
+import { useSharedPolicyGroupDetail } from '../hooks/useSharedPolicyGroups';
+import { toReadableApiType, toReadableFlowPhase } from '../types/sharedPolicyGroup';
+import { SHARED_POLICY_GROUP_DETAIL_TABS } from '../utils/sharedPolicyGroupDetailNavigation';
+
+export function SharedPolicyGroupDetailLayout() {
+    const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
+    const navigate = useNavigate();
+    const basePath = useDetailBasePath('shared-policy-groups', sharedPolicyGroupId);
+    const listHref = resolveListHrefFromDetailBasePath(basePath);
+    const { data: sharedPolicyGroup, isLoading, isError } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-8 w-40" />
+                <div className="flex items-start gap-3">
+                    <Skeleton className="size-10 rounded-lg" />
+                    <div className="space-y-2">
+                        <Skeleton className="h-8 w-64" />
+                        <Skeleton className="h-4 w-96" />
+                    </div>
+                </div>
+                <Skeleton className="h-10 w-72" />
+                <Skeleton className="h-64 w-full" />
+            </div>
+        );
+    }
+
+    if (isError || !sharedPolicyGroup) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" onClick={() => navigate(listHref)}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Shared Policy Groups
+                </Button>
+                <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6" data-testid="shared-policy-group-detail">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0 cursor-pointer" onClick={() => navigate(listHref)}>
+                <ArrowLeftIcon className="size-4" aria-hidden />
+                Back to Shared Policy Groups
+            </Button>
+
+            <div className="flex items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                    <LayersIcon className="size-5" aria-hidden />
+                </div>
+                <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <h1 className="truncate text-2xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                        <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                    </div>
+                    {sharedPolicyGroup.description ? (
+                        <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
+                    ) : null}
+                    <p className="text-sm text-muted-foreground">
+                        {toReadableApiType(sharedPolicyGroup.apiType)} · {toReadableFlowPhase(sharedPolicyGroup.phase)}
+                    </p>
+                </div>
+            </div>
+
+            <div className="border-b">
+                <nav className="flex items-center gap-6" aria-label="Shared Policy Group sections">
+                    {SHARED_POLICY_GROUP_DETAIL_TABS.map(tab => (
+                        <NavLink
+                            key={tab.path}
+                            to={`${basePath}/${tab.path}`}
+                            data-testid={tab.testId}
+                            className={({ isActive }) =>
+                                cn(
+                                    '-mb-px border-b-2 px-0.5 pb-3 text-sm transition-colors',
+                                    isActive
+                                        ? 'border-foreground font-semibold text-foreground'
+                                        : 'border-transparent text-muted-foreground hover:text-foreground',
+                                )
+                            }
+                        >
+                            {tab.label}
+                        </NavLink>
+                    ))}
+                </nav>
+            </div>
+
+            <Outlet />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.spec.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupEditSheet } from './SharedPolicyGroupEditSheet';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth',
+    prerequisiteMessage: 'Needs cache',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    steps: [],
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof SharedPolicyGroupEditSheet>> = {}) {
+    return render(
+        <SharedPolicyGroupEditSheet
+            open
+            sharedPolicyGroup={SPG}
+            onClose={jest.fn()}
+            onSubmit={jest.fn()}
+            isSaving={false}
+            {...overrides}
+        />,
+    );
+}
+
+describe('SharedPolicyGroupEditSheet', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the edit title and pre-fills fields from the shared policy group', () => {
+        renderSheet();
+        expect(screen.queryByRole('heading', { name: 'Edit Policy Group' })).not.toBeNull();
+        expect(screen.getByLabelText(/Name/i)).toHaveProperty('value', 'Auth Bundle');
+        expect(screen.getByLabelText('Describe the purpose of this policy group')).toHaveProperty('value', 'Reusable auth');
+        expect(screen.getByLabelText('Prerequisite message')).toHaveProperty('value', 'Needs cache');
+    });
+
+    it('shows API type and phase as read-only — matching classic Console edit dialog', () => {
+        renderSheet();
+        expect(screen.queryByText('Proxy')).not.toBeNull();
+        expect(screen.queryByText('Request')).not.toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Proxy' })).toBeNull();
+        expect(screen.queryByRole('radio', { name: 'Request' })).toBeNull();
+    });
+
+    it('disables Save when the name is cleared', () => {
+        renderSheet();
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '   ' } });
+        expect(screen.getByRole('button', { name: 'Save' })).toHaveProperty('disabled', true);
+    });
+
+    it('submits the trimmed form values', () => {
+        const onSubmit = jest.fn();
+        renderSheet({ onSubmit });
+
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  Updated Name  ' } });
+        fireEvent.change(screen.getByLabelText('Describe the purpose of this policy group'), { target: { value: 'New description' } });
+        fireEvent.change(screen.getByLabelText('Prerequisite message'), { target: { value: 'New prerequisite' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            name: 'Updated Name',
+            description: 'New description',
+            prerequisiteMessage: 'New prerequisite',
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const onClose = jest.fn();
+        renderSheet({ onClose });
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    Button,
-    ScrollArea,
-    Sheet,
-    SheetContent,
-    SheetDescription,
-    SheetFooter,
-    SheetHeader,
-    SheetTitle,
-} from '@gravitee/graphene-core';
+import { Button, ScrollArea, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
 import { SharedPolicyGroupBasicFields } from './SharedPolicyGroupBasicFields';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
@@ -16,9 +16,6 @@
 
 import {
     Button,
-    Field,
-    FieldLabel,
-    Input,
     ScrollArea,
     Sheet,
     SheetContent,
@@ -26,27 +23,15 @@ import {
     SheetFooter,
     SheetHeader,
     SheetTitle,
-    Textarea,
 } from '@gravitee/graphene-core';
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 
+import { SharedPolicyGroupBasicFields } from './SharedPolicyGroupBasicFields';
 import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
-import {
-    toReadableApiType,
-    toReadableFlowPhase,
-    type SharedPolicyGroup,
-} from '../types/sharedPolicyGroup';
+import { toReadableApiType, toReadableFlowPhase, type SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import type { SharedPolicyGroupBasicFormValues } from '../utils/sharedPolicyGroupPayload';
 
-const DESCRIPTION_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
-const PREREQUISITE_MESSAGE_PLACEHOLDER =
-    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
-
-export interface SharedPolicyGroupEditFormValues {
-    name: string;
-    description: string;
-    prerequisiteMessage: string;
-}
+export type SharedPolicyGroupEditFormValues = SharedPolicyGroupBasicFormValues;
 
 function toFormValues(sharedPolicyGroup: SharedPolicyGroup): SharedPolicyGroupEditFormValues {
     return {
@@ -109,51 +94,12 @@ export function SharedPolicyGroupEditSheet({
 
                 <ScrollArea className="flex-1 min-h-0">
                     <form id="shared-policy-group-edit-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
-                        <h3 className="text-sm font-semibold">Basic information</h3>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-edit-name">
-                                Name{' '}
-                                <span className="text-destructive" aria-hidden>
-                                    *
-                                </span>
-                            </FieldLabel>
-                            <Input
-                                id="spg-edit-name"
-                                value={form.name}
-                                onChange={e => setField('name', e.target.value)}
-                                placeholder="e.g. Default authentication"
-                                maxLength={512}
-                                disabled={isSaving}
-                                required
-                            />
-                        </Field>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-edit-description">Describe the purpose of this policy group</FieldLabel>
-                            <p className="text-xs text-muted-foreground">{DESCRIPTION_MAX_LENGTH} characters max.</p>
-                            <Textarea
-                                id="spg-edit-description"
-                                value={form.description}
-                                onChange={e => setField('description', e.target.value)}
-                                placeholder="Describe what this policy group is used for"
-                                maxLength={DESCRIPTION_MAX_LENGTH}
-                                disabled={isSaving}
-                            />
-                        </Field>
-
-                        <Field orientation="vertical" className="gap-1.5">
-                            <FieldLabel htmlFor="spg-edit-prerequisite-message">Prerequisite message</FieldLabel>
-                            <p className="text-xs text-muted-foreground">{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</p>
-                            <Textarea
-                                id="spg-edit-prerequisite-message"
-                                value={form.prerequisiteMessage}
-                                onChange={e => setField('prerequisiteMessage', e.target.value)}
-                                placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
-                                maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
-                                disabled={isSaving}
-                            />
-                        </Field>
+                        <SharedPolicyGroupBasicFields
+                            idPrefix="spg-edit"
+                            values={form}
+                            disabled={isSaving}
+                            onChange={(key, value) => setField(key, value)}
+                        />
 
                         {sharedPolicyGroup && (
                             <dl className="grid grid-cols-2 gap-4 rounded-lg border bg-muted/30 p-3">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupEditSheet.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
+import {
+    toReadableApiType,
+    toReadableFlowPhase,
+    type SharedPolicyGroup,
+} from '../types/sharedPolicyGroup';
+
+const DESCRIPTION_MAX_LENGTH = 300;
+const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
+const PREREQUISITE_MESSAGE_PLACEHOLDER =
+    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
+
+export interface SharedPolicyGroupEditFormValues {
+    name: string;
+    description: string;
+    prerequisiteMessage: string;
+}
+
+function toFormValues(sharedPolicyGroup: SharedPolicyGroup): SharedPolicyGroupEditFormValues {
+    return {
+        name: sharedPolicyGroup.name,
+        description: sharedPolicyGroup.description ?? '',
+        prerequisiteMessage: sharedPolicyGroup.prerequisiteMessage ?? '',
+    };
+}
+
+export function SharedPolicyGroupEditSheet({
+    open,
+    sharedPolicyGroup,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    sharedPolicyGroup: SharedPolicyGroup | null;
+    onClose: () => void;
+    onSubmit: (values: SharedPolicyGroupEditFormValues) => void;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<SharedPolicyGroupEditFormValues>({
+        name: '',
+        description: '',
+        prerequisiteMessage: '',
+    });
+
+    useEffect(() => {
+        if (!open || !sharedPolicyGroup) return;
+        setForm(toFormValues(sharedPolicyGroup));
+    }, [open, sharedPolicyGroup]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof SharedPolicyGroupEditFormValues>(key: K, value: SharedPolicyGroupEditFormValues[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    const isValid = form.name.trim() !== '';
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid) return;
+        onSubmit({ ...form, name: form.name.trim() });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>Edit Policy Group</SheetTitle>
+                    <SheetDescription>Update the name, description, and prerequisite message for this policy group.</SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="shared-policy-group-edit-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                        <h3 className="text-sm font-semibold">Basic information</h3>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-edit-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="spg-edit-name"
+                                value={form.name}
+                                onChange={e => setField('name', e.target.value)}
+                                placeholder="e.g. Default authentication"
+                                maxLength={512}
+                                disabled={isSaving}
+                                required
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-edit-description">Describe the purpose of this policy group</FieldLabel>
+                            <p className="text-xs text-muted-foreground">{DESCRIPTION_MAX_LENGTH} characters max.</p>
+                            <Textarea
+                                id="spg-edit-description"
+                                value={form.description}
+                                onChange={e => setField('description', e.target.value)}
+                                placeholder="Describe what this policy group is used for"
+                                maxLength={DESCRIPTION_MAX_LENGTH}
+                                disabled={isSaving}
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="spg-edit-prerequisite-message">Prerequisite message</FieldLabel>
+                            <p className="text-xs text-muted-foreground">{PREREQUISITE_MESSAGE_MAX_LENGTH} characters max.</p>
+                            <Textarea
+                                id="spg-edit-prerequisite-message"
+                                value={form.prerequisiteMessage}
+                                onChange={e => setField('prerequisiteMessage', e.target.value)}
+                                placeholder={PREREQUISITE_MESSAGE_PLACEHOLDER}
+                                maxLength={PREREQUISITE_MESSAGE_MAX_LENGTH}
+                                disabled={isSaving}
+                            />
+                        </Field>
+
+                        {sharedPolicyGroup && (
+                            <dl className="grid grid-cols-2 gap-4 rounded-lg border bg-muted/30 p-3">
+                                <div className="space-y-1">
+                                    <dt className="text-xs font-medium text-muted-foreground">API type</dt>
+                                    <dd className="text-sm">{toReadableApiType(sharedPolicyGroup.apiType)}</dd>
+                                </div>
+                                <div className="space-y-1">
+                                    <dt className="text-xs font-medium text-muted-foreground">Phase</dt>
+                                    <dd className="text-sm">{toReadableFlowPhase(sharedPolicyGroup.phase)}</dd>
+                                </div>
+                            </dl>
+                        )}
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="shared-policy-group-edit-form" disabled={!isValid || isSaving}>
+                        {isSaving ? 'Saving…' : 'Save'}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStatusBadge.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStatusBadge.spec.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+describe('SharedPolicyGroupStatusBadge', () => {
+    it.each([
+        ['DEPLOYED', 'Deployed'],
+        ['UNDEPLOYED', 'Undeployed'],
+        ['PENDING', 'Pending'],
+    ] as const)('renders %s as %s', (lifecycleState, label) => {
+        render(<SharedPolicyGroupStatusBadge lifecycleState={lifecycleState} />);
+        expect(screen.queryByText(label)).not.toBeNull();
+    });
+
+    it('renders nothing when lifecycleState is undefined', () => {
+        const { container } = render(<SharedPolicyGroupStatusBadge lifecycleState={undefined as SharedPolicyGroup['lifecycleState']} />);
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStatusBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStatusBadge.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge } from '@gravitee/graphene-core';
+
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+/** Mirrors classic Console's shared-policy-groups-state-badge.component.html. */
+export function SharedPolicyGroupStatusBadge({ lifecycleState }: Readonly<{ lifecycleState: SharedPolicyGroup['lifecycleState'] }>) {
+    switch (lifecycleState) {
+        case 'DEPLOYED':
+            return (
+                <Badge variant="success" className="text-xs font-normal">
+                    Deployed
+                </Badge>
+            );
+        case 'UNDEPLOYED':
+            return (
+                <Badge variant="warning" className="text-xs font-normal">
+                    Undeployed
+                </Badge>
+            );
+        case 'PENDING':
+            return (
+                <Badge variant="secondary" className="text-xs font-normal" title="Last change are not deployed">
+                    Pending
+                </Badge>
+            );
+        default:
+            return null;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStudioEmptyState.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStudioEmptyState.spec.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupStudioEmptyState } from './SharedPolicyGroupStudioEmptyState';
+
+describe('SharedPolicyGroupStudioEmptyState', () => {
+    it('renders the empty-studio educational copy', () => {
+        render(<SharedPolicyGroupStudioEmptyState />);
+        expect(screen.getByTestId('shared-policy-group-studio-empty')).not.toBeNull();
+        expect(screen.getByText('No policies yet')).not.toBeNull();
+        expect(screen.getByText(/Policy Studio configuration lands in a follow-up/i)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStudioEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupStudioEmptyState.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataTableEmptyState } from '@gravitee/graphene-core';
+import { LayersIcon } from '@gravitee/graphene-core/icons';
+
+export function SharedPolicyGroupStudioEmptyState() {
+    return (
+        <div className="rounded-lg border" data-testid="shared-policy-group-studio-empty">
+            <DataTableEmptyState
+                variant="first-use"
+                icon={<LayersIcon className="size-8" aria-hidden />}
+                title="No policies yet"
+                description="Combine policies into this reusable group, then apply it across API flows. Policy Studio configuration lands in a follow-up."
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
@@ -51,6 +51,7 @@ function renderTable(overrides: Partial<React.ComponentProps<typeof SharedPolicy
                 onPageSizeChange={jest.fn()}
                 onSortingChange={jest.fn()}
                 onView={jest.fn()}
+                onEdit={jest.fn()}
                 onDelete={jest.fn()}
                 {...overrides}
             />
@@ -117,11 +118,11 @@ describe('SharedPolicyGroupsTable', () => {
             expect(screen.queryByRole('menuitem', { name: 'Edit' })).toBeNull();
         });
 
-        it('shows Edit (not View) when the user can update', async () => {
+        it('shows View and Edit when the user can update', async () => {
             renderTable({ canEdit: true });
             await openRowMenu();
-            expect(await screen.findByRole('menuitem', { name: 'Edit' })).not.toBeNull();
-            expect(screen.queryByRole('menuitem', { name: 'View' })).toBeNull();
+            expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeNull();
         });
 
         it('shows only View — never Edit — for a Kubernetes-origin row, even with update permission', async () => {
@@ -153,12 +154,20 @@ describe('SharedPolicyGroupsTable', () => {
             expect(onDelete).toHaveBeenCalledWith(SPG);
         });
 
-        it('calls onView when Edit is clicked', async () => {
+        it('calls onView when View is clicked', async () => {
             const onView = jest.fn();
             renderTable({ canEdit: true, onView });
             const user = await openRowMenu();
-            await user.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+            await user.click(await screen.findByRole('menuitem', { name: 'View' }));
             expect(onView).toHaveBeenCalledWith(SPG);
+        });
+
+        it('calls onEdit when Edit is clicked', async () => {
+            const onEdit = jest.fn();
+            renderTable({ canEdit: true, onEdit });
+            const user = await openRowMenu();
+            await user.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+            expect(onEdit).toHaveBeenCalledWith(SPG);
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.spec.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SharedPolicyGroupsTable } from './SharedPolicyGroupsTable';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'My Shared Policy Group',
+    description: 'Reusable auth policies',
+    lifecycleState: 'DEPLOYED',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    deployedAt: '2024-01-02T00:00:00.000Z',
+};
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof SharedPolicyGroupsTable>> = {}) {
+    return render(
+        <MemoryRouter>
+            <SharedPolicyGroupsTable
+                sharedPolicyGroups={[SPG]}
+                totalCount={1}
+                loading={false}
+                isFirstUse={false}
+                search=""
+                page={1}
+                pageSize={25}
+                sorting={[]}
+                canEdit={false}
+                canDelete={false}
+                onSearchChange={jest.fn()}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                onSortingChange={jest.fn()}
+                onView={jest.fn()}
+                onDelete={jest.fn()}
+                {...overrides}
+            />
+        </MemoryRouter>,
+    );
+}
+
+describe('SharedPolicyGroupsTable', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the name as a real link to the detail page — supports open-in-new-tab/middle-click', () => {
+        renderTable();
+        expect(screen.getByRole('link', { name: 'My Shared Policy Group' }).getAttribute('href')).toBe('/spg-1');
+    });
+
+    it('renders the description', () => {
+        renderTable();
+        expect(screen.queryByText('Reusable auth policies')).not.toBeNull();
+    });
+
+    it('renders the lifecycle state badge in its own Status column, not the Name column', () => {
+        renderTable();
+        expect(screen.queryByRole('columnheader', { name: 'Status' })).not.toBeNull();
+        const nameCell = screen.getByRole('link', { name: 'My Shared Policy Group' }).closest('td');
+        expect(nameCell?.textContent).not.toContain('Deployed');
+        expect(screen.queryByText('Deployed')).not.toBeNull();
+    });
+
+    it('renders the API type and phase columns', () => {
+        renderTable();
+        expect(screen.queryByText('Proxy')).not.toBeNull();
+        expect(screen.queryByText('Request')).not.toBeNull();
+    });
+
+    describe('sorting', () => {
+        it("sorts by Name, Phase, Last updated, and Last deployed — matching classic Console's sortBy support", () => {
+            const onSortingChange = jest.fn();
+            renderTable({ onSortingChange });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Name' }));
+            expect(onSortingChange).toHaveBeenCalled();
+        });
+
+        it('does not offer sorting by API type — classic Console has no sortBy value for it', () => {
+            renderTable();
+            expect(screen.queryByRole('button', { name: 'API Type' })).toBeNull();
+            expect(screen.queryByText('API Type')).not.toBeNull();
+        });
+    });
+
+    describe('row-level action gating', () => {
+        async function openRowMenu() {
+            const user = userEvent.setup();
+            await user.click(screen.getByRole('button', { name: 'My Shared Policy Group actions' }));
+            return user;
+        }
+
+        it('shows only a View action when the user lacks update permission', async () => {
+            renderTable({ canEdit: false });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).toBeNull();
+        });
+
+        it('shows Edit (not View) when the user can update', async () => {
+            renderTable({ canEdit: true });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'Edit' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'View' })).toBeNull();
+        });
+
+        it('shows only View — never Edit — for a Kubernetes-origin row, even with update permission', async () => {
+            renderTable({ canEdit: true, sharedPolicyGroups: [{ ...SPG, originContext: { origin: 'KUBERNETES' } }] });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).toBeNull();
+        });
+
+        it('hides Delete without delete permission', async () => {
+            renderTable({ canEdit: true, canDelete: false });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'Edit' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Delete' })).toBeNull();
+        });
+
+        it('hides Delete for a read-only (Kubernetes-origin) row, even with delete permission', async () => {
+            renderTable({ canEdit: true, canDelete: true, sharedPolicyGroups: [{ ...SPG, originContext: { origin: 'KUBERNETES' } }] });
+            await openRowMenu();
+            expect(await screen.findByRole('menuitem', { name: 'View' })).not.toBeNull();
+            expect(screen.queryByRole('menuitem', { name: 'Delete' })).toBeNull();
+        });
+
+        it('shows Delete with delete permission and calls onDelete', async () => {
+            const onDelete = jest.fn();
+            renderTable({ canEdit: true, canDelete: true, onDelete });
+            const user = await openRowMenu();
+            await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+            expect(onDelete).toHaveBeenCalledWith(SPG);
+        });
+
+        it('calls onView when Edit is clicked', async () => {
+            const onView = jest.fn();
+            renderTable({ canEdit: true, onView });
+            const user = await openRowMenu();
+            await user.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+            expect(onView).toHaveBeenCalledWith(SPG);
+        });
+    });
+
+    describe('search', () => {
+        it('calls onSearchChange when typing in the search box', () => {
+            const onSearchChange = jest.fn();
+            renderTable({ onSearchChange });
+            fireEvent.change(screen.getByPlaceholderText('Search by name or description…'), { target: { value: 'auth' } });
+            expect(onSearchChange).toHaveBeenCalledWith('auth');
+        });
+    });
+
+    describe('empty state', () => {
+        it('shows the Create CTA on first use', () => {
+            const onCreateSharedPolicyGroup = jest.fn();
+            renderTable({ isFirstUse: true, sharedPolicyGroups: [], totalCount: 0, onCreateSharedPolicyGroup });
+            expect(screen.queryByText('No Shared Policy Groups')).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+            expect(onCreateSharedPolicyGroup).toHaveBeenCalled();
+        });
+
+        it('hides the Create CTA on first use when the callback is not provided (read-only user)', () => {
+            renderTable({ isFirstUse: true, sharedPolicyGroups: [], totalCount: 0, onCreateSharedPolicyGroup: undefined });
+            expect(screen.queryByRole('button', { name: 'Add Shared Policy Group' })).toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    DateCell,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { EyeIcon, KubernetesIcon, LayersIcon, MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+
+import { SharedPolicyGroupStatusBadge } from './SharedPolicyGroupStatusBadge';
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { TableSortingState } from '../../applications/utils/tableSort';
+import { toReadableApiType, toReadableFlowPhase, type SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { isKubernetesOrigin } from '../utils/sharedPolicyGroupPermissions';
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    onView,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
+}): DataTableProps<SharedPolicyGroup>['columns'] {
+    return [
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) => (
+                <div className="flex flex-col items-start gap-1 text-left">
+                    <Button asChild variant="link" className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline">
+                        <Link to={row.original.id}>{row.original.name}</Link>
+                    </Button>
+                    {row.original.description && <span className="text-xs text-muted-foreground">{row.original.description}</span>}
+                </div>
+            ),
+        },
+        {
+            id: 'status',
+            accessorKey: 'lifecycleState',
+            enableSorting: false,
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Status" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) => <SharedPolicyGroupStatusBadge lifecycleState={row.original.lifecycleState} />,
+        },
+        {
+            id: 'apiType',
+            accessorKey: 'apiType',
+            enableSorting: false,
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="API Type" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) => <span className="text-sm">{toReadableApiType(row.original.apiType)}</span>,
+        },
+        {
+            id: 'phase',
+            accessorKey: 'phase',
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Phase" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) => <span className="text-sm">{toReadableFlowPhase(row.original.phase)}</span>,
+        },
+        {
+            id: 'updatedAt',
+            accessorFn: (row: SharedPolicyGroup) => row.updatedAt ?? '',
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Last updated" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) =>
+                row.original.updatedAt ? (
+                    <DateCell value={new Date(row.original.updatedAt)} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+        {
+            id: 'deployedAt',
+            accessorFn: (row: SharedPolicyGroup) => row.deployedAt ?? '',
+            header: ({ column }: ColHeader<SharedPolicyGroup>) => <DataTableColumnHeader column={column} title="Last deployed" />,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) =>
+                row.original.deployedAt ? (
+                    <DateCell value={new Date(row.original.deployedAt)} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+        {
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 100,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<SharedPolicyGroup>) => {
+                const sharedPolicyGroup = row.original;
+                const readOnlyRow = !canEdit || isKubernetesOrigin(sharedPolicyGroup);
+                const showDelete = !readOnlyRow && canDelete;
+                return (
+                    <div className="flex items-center justify-end gap-1">
+                        {isKubernetesOrigin(sharedPolicyGroup) && <KubernetesIcon className="size-4 text-muted-foreground" aria-hidden />}
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="icon" className="size-8" aria-label={`${sharedPolicyGroup.name} actions`}>
+                                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                {readOnlyRow ? (
+                                    <DropdownMenuItem onSelect={() => onView(sharedPolicyGroup)}>
+                                        <EyeIcon className="size-4 mr-2" aria-hidden />
+                                        View
+                                    </DropdownMenuItem>
+                                ) : (
+                                    <DropdownMenuItem onSelect={() => onView(sharedPolicyGroup)}>
+                                        <PencilIcon className="size-4 mr-2" aria-hidden />
+                                        Edit
+                                    </DropdownMenuItem>
+                                )}
+                                {showDelete && (
+                                    <>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(sharedPolicyGroup)}>
+                                            <Trash2Icon className="size-4 mr-2" aria-hidden />
+                                            Delete
+                                        </DropdownMenuItem>
+                                    </>
+                                )}
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                );
+            },
+        },
+    ];
+}
+
+interface SharedPolicyGroupsTableProps {
+    readonly sharedPolicyGroups: SharedPolicyGroup[];
+    readonly totalCount: number;
+    readonly loading: boolean;
+    readonly isFirstUse: boolean;
+    readonly search: string;
+    readonly page: number;
+    readonly pageSize: number;
+    readonly sorting: TableSortingState;
+    readonly canEdit: boolean;
+    readonly canDelete: boolean;
+    readonly onSearchChange: (value: string) => void;
+    readonly onPageChange: (page: number) => void;
+    readonly onPageSizeChange: (size: number) => void;
+    readonly onSortingChange: (updater: TableSortingState | ((previous: TableSortingState) => TableSortingState)) => void;
+    readonly onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    readonly onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    readonly onCreateSharedPolicyGroup?: () => void;
+}
+
+export function SharedPolicyGroupsTable({
+    sharedPolicyGroups,
+    totalCount,
+    loading,
+    isFirstUse,
+    search,
+    page,
+    pageSize,
+    sorting,
+    canEdit,
+    canDelete,
+    onSearchChange,
+    onPageChange,
+    onPageSizeChange,
+    onSortingChange,
+    onView,
+    onDelete,
+    onCreateSharedPolicyGroup,
+}: SharedPolicyGroupsTableProps) {
+    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onView, onDelete }), [canEdit, canDelete, onView, onDelete]);
+
+    if (isFirstUse) {
+        return (
+            <div className="rounded-lg border">
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<LayersIcon className="size-8" aria-hidden />}
+                    title="No Shared Policy Groups"
+                    description="Shared Policy Groups let you create reusable policy bundles and apply them across multiple API flows."
+                    primaryAction={
+                        onCreateSharedPolicyGroup ? <Button onClick={onCreateSharedPolicyGroup}>Add Shared Policy Group</Button> : undefined
+                    }
+                />
+            </div>
+        );
+    }
+
+    return (
+        <DataTable
+            aria-label="Shared Policy Groups"
+            columns={columns}
+            data={sharedPolicyGroups}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            sorting={sorting}
+            onSortingChange={onSortingChange}
+            pagination={{
+                page,
+                pageSize,
+                totalCount,
+                pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                onPageChange,
+                onPageSizeChange: size => {
+                    onPageSizeChange(size);
+                    onPageChange(1);
+                },
+            }}
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="no-results"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title="No Shared Policy Group matches your search"
+                    description="Try adjusting your search terms."
+                    action={
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                                onSearchChange('');
+                                onPageChange(1);
+                            }}
+                        >
+                            Clear search
+                        </Button>
+                    }
+                />
+            }
+            toolbar={
+                <div className="w-64">
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                            placeholder="Search by name or description…"
+                            value={search}
+                            onChange={e => onSearchChange(e.target.value)}
+                        />
+                    </InputGroup>
+                </div>
+            }
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupsTable.tsx
@@ -45,11 +45,13 @@ function buildColumns({
     canEdit,
     canDelete,
     onView,
+    onEdit,
     onDelete,
 }: {
     canEdit: boolean;
     canDelete: boolean;
     onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    onEdit: (sharedPolicyGroup: SharedPolicyGroup) => void;
     onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
 }): DataTableProps<SharedPolicyGroup>['columns'] {
     return [
@@ -134,10 +136,16 @@ function buildColumns({
                                         View
                                     </DropdownMenuItem>
                                 ) : (
-                                    <DropdownMenuItem onSelect={() => onView(sharedPolicyGroup)}>
-                                        <PencilIcon className="size-4 mr-2" aria-hidden />
-                                        Edit
-                                    </DropdownMenuItem>
+                                    <>
+                                        <DropdownMenuItem onSelect={() => onView(sharedPolicyGroup)}>
+                                            <EyeIcon className="size-4 mr-2" aria-hidden />
+                                            View
+                                        </DropdownMenuItem>
+                                        <DropdownMenuItem onSelect={() => onEdit(sharedPolicyGroup)}>
+                                            <PencilIcon className="size-4 mr-2" aria-hidden />
+                                            Edit
+                                        </DropdownMenuItem>
+                                    </>
                                 )}
                                 {showDelete && (
                                     <>
@@ -173,6 +181,7 @@ interface SharedPolicyGroupsTableProps {
     readonly onPageSizeChange: (size: number) => void;
     readonly onSortingChange: (updater: TableSortingState | ((previous: TableSortingState) => TableSortingState)) => void;
     readonly onView: (sharedPolicyGroup: SharedPolicyGroup) => void;
+    readonly onEdit: (sharedPolicyGroup: SharedPolicyGroup) => void;
     readonly onDelete: (sharedPolicyGroup: SharedPolicyGroup) => void;
     readonly onCreateSharedPolicyGroup?: () => void;
 }
@@ -193,10 +202,14 @@ export function SharedPolicyGroupsTable({
     onPageSizeChange,
     onSortingChange,
     onView,
+    onEdit,
     onDelete,
     onCreateSharedPolicyGroup,
 }: SharedPolicyGroupsTableProps) {
-    const columns = useMemo(() => buildColumns({ canEdit, canDelete, onView, onDelete }), [canEdit, canDelete, onView, onDelete]);
+    const columns = useMemo(
+        () => buildColumns({ canEdit, canDelete, onView, onEdit, onDelete }),
+        [canEdit, canDelete, onView, onEdit, onDelete],
+    );
 
     if (isFirstUse) {
         return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupDeployActions.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupDeployActions.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { renderHook, act } from '@testing-library/react';
+
+import { useSharedPolicyGroupDeployActions } from './useSharedPolicyGroupDeployActions';
+import { useDeploySharedPolicyGroup, useUndeploySharedPolicyGroup } from './useSharedPolicyGroupMutations';
+import { notify } from '../../../shared/notify';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('./useSharedPolicyGroupMutations');
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseDeploy = jest.mocked(useDeploySharedPolicyGroup);
+const mockUseUndeploy = jest.mocked(useUndeploySharedPolicyGroup);
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    lifecycleState: 'UNDEPLOYED',
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn(), isPending = false): any {
+    return { mutateAsync, isPending };
+}
+
+describe('useSharedPolicyGroupDeployActions', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseDeploy.mockReturnValue(makeMutation());
+        mockUseUndeploy.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('hides actions without update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        const { result } = renderHook(() => useSharedPolicyGroupDeployActions(SPG));
+        expect(result.current.visible).toBe(false);
+    });
+
+    it('hides actions for Kubernetes-origin groups', () => {
+        const { result } = renderHook(() =>
+            useSharedPolicyGroupDeployActions({ ...SPG, originContext: { origin: 'KUBERNETES' } }),
+        );
+        expect(result.current.visible).toBe(false);
+    });
+
+    it('disables Deploy when DEPLOYED and Undeploy when UNDEPLOYED', () => {
+        const { result: undeployed } = renderHook(() => useSharedPolicyGroupDeployActions(SPG));
+        expect(undeployed.current.deployDisabled).toBe(false);
+        expect(undeployed.current.undeployDisabled).toBe(true);
+
+        const { result: deployed } = renderHook(() =>
+            useSharedPolicyGroupDeployActions({ ...SPG, lifecycleState: 'DEPLOYED' }),
+        );
+        expect(deployed.current.deployDisabled).toBe(true);
+        expect(deployed.current.undeployDisabled).toBe(false);
+    });
+
+    it('disables Deploy when there are unsaved changes', () => {
+        const { result } = renderHook(() => useSharedPolicyGroupDeployActions(SPG, true));
+        expect(result.current.deployDisabled).toBe(true);
+    });
+
+    it('deploys and shows a success toast', async () => {
+        const mutateAsync = jest.fn().mockResolvedValue({ ...SPG, lifecycleState: 'DEPLOYED' });
+        mockUseDeploy.mockReturnValue(makeMutation(mutateAsync));
+
+        const { result } = renderHook(() => useSharedPolicyGroupDeployActions(SPG));
+        await act(async () => {
+            await result.current.onDeploy();
+        });
+
+        expect(mutateAsync).toHaveBeenCalledWith('spg-1');
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group deployed successfully');
+    });
+
+    it('undeploys and shows a success toast', async () => {
+        const mutateAsync = jest.fn().mockResolvedValue({ ...SPG, lifecycleState: 'UNDEPLOYED' });
+        mockUseUndeploy.mockReturnValue(makeMutation(mutateAsync));
+
+        const { result } = renderHook(() =>
+            useSharedPolicyGroupDeployActions({ ...SPG, lifecycleState: 'DEPLOYED' }),
+        );
+        await act(async () => {
+            await result.current.onUndeploy();
+        });
+
+        expect(mutateAsync).toHaveBeenCalledWith('spg-1');
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group undeployed successfully');
+    });
+
+    it('shows an error toast when deploy fails', async () => {
+        const mutateAsync = jest.fn().mockRejectedValue(new Error('boom'));
+        mockUseDeploy.mockReturnValue(makeMutation(mutateAsync));
+
+        const { result } = renderHook(() => useSharedPolicyGroupDeployActions(SPG));
+        await act(async () => {
+            await result.current.onDeploy();
+        });
+
+        expect(notify.error).toHaveBeenCalledWith(expect.any(Error), 'Error during Shared Policy Group deployment!');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupDeployActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupDeployActions.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+
+import { useDeploySharedPolicyGroup, useUndeploySharedPolicyGroup } from './useSharedPolicyGroupMutations';
+import { notify } from '../../../shared/notify';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import {
+    canShowDeployActions,
+    isDeployDisabled,
+    isUndeployDisabled,
+} from '../utils/sharedPolicyGroupDeploy';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION } from '../utils/sharedPolicyGroupPermissions';
+
+export function useSharedPolicyGroupDeployActions(
+    sharedPolicyGroup: SharedPolicyGroup,
+    hasUnsavedChanges = false,
+) {
+    const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const deployMutation = useDeploySharedPolicyGroup();
+    const undeployMutation = useUndeploySharedPolicyGroup();
+
+    const visible = canShowDeployActions(sharedPolicyGroup, canUpdate);
+    const deployDisabled =
+        isDeployDisabled(sharedPolicyGroup.lifecycleState, hasUnsavedChanges) || deployMutation.isPending;
+    const undeployDisabled = isUndeployDisabled(sharedPolicyGroup.lifecycleState) || undeployMutation.isPending;
+
+    async function onDeploy() {
+        try {
+            await deployMutation.mutateAsync(sharedPolicyGroup.id);
+            notify.success('Shared Policy Group deployed successfully');
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group deployment!');
+        }
+    }
+
+    async function onUndeploy() {
+        try {
+            await undeployMutation.mutateAsync(sharedPolicyGroup.id);
+            notify.success('Shared Policy Group undeployed successfully');
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group undeployment!');
+        }
+    }
+
+    return {
+        visible,
+        deployDisabled,
+        undeployDisabled,
+        isDeploying: deployMutation.isPending,
+        isUndeploying: undeployMutation.isPending,
+        onDeploy,
+        onUndeploy,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
@@ -17,7 +17,13 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createSharedPolicyGroup, deleteSharedPolicyGroup, updateSharedPolicyGroup } from '../services/sharedPolicyGroups';
+import {
+    createSharedPolicyGroup,
+    deleteSharedPolicyGroup,
+    deploySharedPolicyGroup,
+    undeploySharedPolicyGroup,
+    updateSharedPolicyGroup,
+} from '../services/sharedPolicyGroups';
 import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 import { sharedPolicyGroupKeys } from '../utils/queryKeys';
 
@@ -52,4 +58,12 @@ export function useUpdateSharedPolicyGroup() {
 
 export function useDeleteSharedPolicyGroup() {
     return useSharedPolicyGroupMutation<string, void>(deleteSharedPolicyGroup);
+}
+
+export function useDeploySharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<string, SharedPolicyGroup>(deploySharedPolicyGroup);
+}
+
+export function useUndeploySharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<string, SharedPolicyGroup>(undeploySharedPolicyGroup);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
@@ -17,8 +17,8 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { createSharedPolicyGroup, deleteSharedPolicyGroup } from '../services/sharedPolicyGroups';
-import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { createSharedPolicyGroup, deleteSharedPolicyGroup, updateSharedPolicyGroup } from '../services/sharedPolicyGroups';
+import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 import { sharedPolicyGroupKeys } from '../utils/queryKeys';
 
 function useSharedPolicyGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
@@ -42,6 +42,12 @@ function useSharedPolicyGroupMutation<TData, TResult>(mutationFn: (envId: string
 
 export function useCreateSharedPolicyGroup() {
     return useSharedPolicyGroupMutation<CreateSharedPolicyGroupPayload, SharedPolicyGroup>(createSharedPolicyGroup);
+}
+
+export function useUpdateSharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<{ id: string; payload: UpdateSharedPolicyGroupPayload }, SharedPolicyGroup>(
+        (envId, { id, payload }) => updateSharedPolicyGroup(envId, id, payload),
+    );
 }
 
 export function useDeleteSharedPolicyGroup() {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroupMutations.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createSharedPolicyGroup, deleteSharedPolicyGroup } from '../services/sharedPolicyGroups';
+import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { sharedPolicyGroupKeys } from '../utils/queryKeys';
+
+function useSharedPolicyGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: TData) => {
+            if (!env?.id) {
+                return Promise.reject(new Error('No active environment'));
+            }
+            return mutationFn(env.id, data);
+        },
+        onSuccess: () => {
+            if (env?.id) {
+                void queryClient.invalidateQueries({ queryKey: sharedPolicyGroupKeys.all });
+            }
+        },
+    });
+}
+
+export function useCreateSharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<CreateSharedPolicyGroupPayload, SharedPolicyGroup>(createSharedPolicyGroup);
+}
+
+export function useDeleteSharedPolicyGroup() {
+    return useSharedPolicyGroupMutation<string, void>(deleteSharedPolicyGroup);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/hooks/useSharedPolicyGroups.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { getSharedPolicyGroup, listSharedPolicyGroupsPaged } from '../services/sharedPolicyGroups';
+import { sharedPolicyGroupKeys } from '../utils/queryKeys';
+
+export function useSharedPolicyGroupsPaged({
+    query,
+    page,
+    perPage,
+    sortBy,
+}: {
+    query: string;
+    page: number;
+    perPage: number;
+    sortBy?: string;
+}) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: sharedPolicyGroupKeys.list(env?.id ?? '', query, page, perPage, sortBy),
+        queryFn: () => listSharedPolicyGroupsPaged(env!.id, { query, page, perPage, sortBy }),
+        enabled: Boolean(env),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
+}
+
+export function useSharedPolicyGroupDetail(sharedPolicyGroupId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: sharedPolicyGroupKeys.detail(env?.id ?? '', sharedPolicyGroupId ?? ''),
+        queryFn: () => getSharedPolicyGroup(env!.id, sharedPolicyGroupId!),
+        enabled: Boolean(env) && Boolean(sharedPolicyGroupId),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deploySharedPolicyGroup, undeploySharedPolicyGroup } from './sharedPolicyGroups';
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV2: jest.fn(),
+}));
+
+const mockApimFetchJsonV2 = jest.mocked(apimFetchJsonV2);
+
+describe('sharedPolicyGroups service — deploy / undeploy', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV2.mockResolvedValue(undefined);
+    });
+
+    it('deploySharedPolicyGroup POSTs to /_deploy', async () => {
+        await deploySharedPolicyGroup('env-1', 'spg-1');
+        expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/shared-policy-groups/spg-1/_deploy', {
+            method: 'POST',
+            body: JSON.stringify({}),
+        });
+    });
+
+    it('undeploySharedPolicyGroup POSTs to /_undeploy', async () => {
+        await undeploySharedPolicyGroup('env-1', 'spg-1');
+        expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/shared-policy-groups/spg-1/_undeploy', {
+            method: 'POST',
+            body: JSON.stringify({}),
+        });
+    });
+
+    it('encodes the shared policy group id in the path', async () => {
+        await deploySharedPolicyGroup('env-1', 'spg/with spaces');
+        expect(mockApimFetchJsonV2).toHaveBeenCalledWith(
+            'env-1',
+            '/shared-policy-groups/spg%2Fwith%20spaces/_deploy',
+            expect.any(Object),
+        );
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, SharedPolicyGroupsPagedResponse } from '../types/sharedPolicyGroup';
+
+export async function listSharedPolicyGroupsPaged(
+    environmentId: string,
+    params: { query: string; page: number; perPage: number; sortBy?: string },
+): Promise<SharedPolicyGroupsPagedResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('page', String(params.page));
+    searchParams.set('perPage', String(params.perPage));
+    const query = params.query.trim();
+    if (query) {
+        searchParams.set('q', query);
+    }
+    if (params.sortBy) {
+        searchParams.set('sortBy', params.sortBy);
+    }
+    return apimFetchJsonV2<SharedPolicyGroupsPagedResponse>(environmentId, `/shared-policy-groups?${searchParams.toString()}`);
+}
+
+export async function getSharedPolicyGroup(environmentId: string, sharedPolicyGroupId: string): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(environmentId, `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}`);
+}
+
+export async function createSharedPolicyGroup(environmentId: string, data: CreateSharedPolicyGroupPayload): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(environmentId, '/shared-policy-groups', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function deleteSharedPolicyGroup(environmentId: string, sharedPolicyGroupId: string): Promise<void> {
+    return apimFetchJsonV2<void>(environmentId, `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}`, {
+        method: 'DELETE',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
@@ -66,3 +66,21 @@ export async function deleteSharedPolicyGroup(environmentId: string, sharedPolic
         method: 'DELETE',
     });
 }
+
+export async function deploySharedPolicyGroup(environmentId: string, sharedPolicyGroupId: string): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(environmentId, `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}/_deploy`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+}
+
+export async function undeploySharedPolicyGroup(environmentId: string, sharedPolicyGroupId: string): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(
+        environmentId,
+        `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}/_undeploy`,
+        {
+            method: 'POST',
+            body: JSON.stringify({}),
+        },
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/services/sharedPolicyGroups.ts
@@ -15,7 +15,12 @@
  */
 
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { CreateSharedPolicyGroupPayload, SharedPolicyGroup, SharedPolicyGroupsPagedResponse } from '../types/sharedPolicyGroup';
+import type {
+    CreateSharedPolicyGroupPayload,
+    SharedPolicyGroup,
+    SharedPolicyGroupsPagedResponse,
+    UpdateSharedPolicyGroupPayload,
+} from '../types/sharedPolicyGroup';
 
 export async function listSharedPolicyGroupsPaged(
     environmentId: string,
@@ -41,6 +46,17 @@ export async function getSharedPolicyGroup(environmentId: string, sharedPolicyGr
 export async function createSharedPolicyGroup(environmentId: string, data: CreateSharedPolicyGroupPayload): Promise<SharedPolicyGroup> {
     return apimFetchJsonV2<SharedPolicyGroup>(environmentId, '/shared-policy-groups', {
         method: 'POST',
+        body: JSON.stringify(data),
+    });
+}
+
+export async function updateSharedPolicyGroup(
+    environmentId: string,
+    sharedPolicyGroupId: string,
+    data: UpdateSharedPolicyGroupPayload,
+): Promise<SharedPolicyGroup> {
+    return apimFetchJsonV2<SharedPolicyGroup>(environmentId, `/shared-policy-groups/${encodeURIComponent(sharedPolicyGroupId)}`, {
+        method: 'PUT',
         body: JSON.stringify(data),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors classic Console's `ApiType` (v4 API definition). */
+export type ApiType = 'MESSAGE' | 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY' | 'PROXY' | 'NATIVE';
+
+/** Mirrors classic Console's `FlowPhase`. */
+export type FlowPhase = 'REQUEST' | 'RESPONSE' | 'ENTRYPOINT_CONNECT' | 'INTERACT' | 'PUBLISH' | 'SUBSCRIBE';
+
+export function toReadableFlowPhase(phase: FlowPhase): string {
+    switch (phase) {
+        case 'REQUEST':
+            return 'Request';
+        case 'RESPONSE':
+            return 'Response';
+        case 'PUBLISH':
+            return 'Publish';
+        case 'SUBSCRIBE':
+            return 'Subscribe';
+        case 'ENTRYPOINT_CONNECT':
+            return 'Entrypoint connect';
+        case 'INTERACT':
+            return 'Interact';
+    }
+}
+
+export function toReadableApiType(apiType: ApiType): string {
+    switch (apiType) {
+        case 'PROXY':
+            return 'Proxy';
+        case 'MESSAGE':
+            return 'Message';
+        case 'A2A_PROXY':
+            return 'A2A Proxy';
+        case 'LLM_PROXY':
+            return 'LLM Proxy';
+        case 'MCP_PROXY':
+            return 'MCP Proxy';
+        case 'NATIVE':
+            return 'Native';
+    }
+}
+
+export interface OriginContext {
+    origin: 'MANAGEMENT' | 'KUBERNETES' | 'INTEGRATION';
+}
+
+/** v2 `SharedPolicyGroup` (GET/POST .../v2/environments/{envId}/shared-policy-groups...). */
+export interface SharedPolicyGroup {
+    id: string;
+    crossId?: string;
+    name: string;
+    description?: string;
+    prerequisiteMessage?: string;
+    lifecycleState?: 'DEPLOYED' | 'UNDEPLOYED' | 'PENDING';
+    apiType: ApiType;
+    phase: FlowPhase;
+    deployedAt?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    originContext?: OriginContext;
+}
+
+/** v2 `CreateSharedPolicyGroup` (POST .../shared-policy-groups). */
+export interface CreateSharedPolicyGroupPayload {
+    name: string;
+    description?: string;
+    prerequisiteMessage?: string;
+    apiType: ApiType;
+    phase: FlowPhase;
+}
+
+interface SharedPolicyGroupsPagination {
+    page: number;
+    perPage: number;
+    pageCount: number;
+    pageItemsCount: number;
+    totalCount: number;
+}
+
+/** v2 `PagedResult<SharedPolicyGroup>` (GET .../shared-policy-groups). */
+export interface SharedPolicyGroupsPagedResponse {
+    data: SharedPolicyGroup[];
+    pagination: SharedPolicyGroupsPagination;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/types/sharedPolicyGroup.ts
@@ -58,6 +58,12 @@ export interface OriginContext {
     origin: 'MANAGEMENT' | 'KUBERNETES' | 'INTEGRATION';
 }
 
+/**
+ * Policy steps on a shared policy group.
+ * Opaque until Policy Studio (FOUND-19); passed through unchanged on metadata update.
+ */
+export type SharedPolicyGroupStep = Record<string, unknown>;
+
 /** v2 `SharedPolicyGroup` (GET/POST .../v2/environments/{envId}/shared-policy-groups...). */
 export interface SharedPolicyGroup {
     id: string;
@@ -68,6 +74,7 @@ export interface SharedPolicyGroup {
     lifecycleState?: 'DEPLOYED' | 'UNDEPLOYED' | 'PENDING';
     apiType: ApiType;
     phase: FlowPhase;
+    steps?: SharedPolicyGroupStep[];
     deployedAt?: string;
     createdAt?: string;
     updatedAt?: string;
@@ -81,6 +88,15 @@ export interface CreateSharedPolicyGroupPayload {
     prerequisiteMessage?: string;
     apiType: ApiType;
     phase: FlowPhase;
+}
+
+/** v2 `UpdateSharedPolicyGroup` (PUT .../shared-policy-groups/{id}). */
+export interface UpdateSharedPolicyGroupPayload {
+    name: string;
+    description?: string;
+    prerequisiteMessage?: string;
+    /** Must be sent to avoid clearing policies — mirrors classic Console metadata edit. */
+    steps: SharedPolicyGroupStep[];
 }
 
 interface SharedPolicyGroupsPagination {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/paginationConstants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors classic Console's default `perPage` for the shared policy groups list. */
+export const DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE = 25;
+
+export const SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS = 300;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/queryKeys.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const sharedPolicyGroupKeys = {
+    all: ['environment-shared-policy-groups'] as const,
+    list: (envId: string, query: string, page: number, perPage: number, sortBy: string | undefined) =>
+        [...sharedPolicyGroupKeys.all, 'list', envId, query, page, perPage, sortBy] as const,
+    detail: (envId: string, sharedPolicyGroupId: string) => [...sharedPolicyGroupKeys.all, 'detail', envId, sharedPolicyGroupId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDeploy.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDeploy.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { canShowDeployActions, isDeployDisabled, isUndeployDisabled } from './sharedPolicyGroupDeploy';
+
+describe('sharedPolicyGroupDeploy', () => {
+    describe('canShowDeployActions', () => {
+        it('is true when the user can update and origin is not Kubernetes', () => {
+            expect(canShowDeployActions({ originContext: { origin: 'MANAGEMENT' } }, true)).toBe(true);
+            expect(canShowDeployActions({}, true)).toBe(true);
+        });
+
+        it('is false without update permission', () => {
+            expect(canShowDeployActions({ originContext: { origin: 'MANAGEMENT' } }, false)).toBe(false);
+        });
+
+        it('is false for Kubernetes-origin groups', () => {
+            expect(canShowDeployActions({ originContext: { origin: 'KUBERNETES' } }, true)).toBe(false);
+        });
+    });
+
+    describe('isDeployDisabled', () => {
+        it('is true when already DEPLOYED', () => {
+            expect(isDeployDisabled('DEPLOYED')).toBe(true);
+        });
+
+        it('is true when there are unsaved studio changes', () => {
+            expect(isDeployDisabled('UNDEPLOYED', true)).toBe(true);
+            expect(isDeployDisabled('PENDING', true)).toBe(true);
+        });
+
+        it('is false for UNDEPLOYED or PENDING without unsaved changes', () => {
+            expect(isDeployDisabled('UNDEPLOYED')).toBe(false);
+            expect(isDeployDisabled('PENDING')).toBe(false);
+            expect(isDeployDisabled(undefined)).toBe(false);
+        });
+    });
+
+    describe('isUndeployDisabled', () => {
+        it('is true when already UNDEPLOYED', () => {
+            expect(isUndeployDisabled('UNDEPLOYED')).toBe(true);
+        });
+
+        it('is false for DEPLOYED or PENDING', () => {
+            expect(isUndeployDisabled('DEPLOYED')).toBe(false);
+            expect(isUndeployDisabled('PENDING')).toBe(false);
+            expect(isUndeployDisabled(undefined)).toBe(false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDeploy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDeploy.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+import { isKubernetesOrigin } from './sharedPolicyGroupPermissions';
+
+type LifecycleState = SharedPolicyGroup['lifecycleState'];
+
+export function canShowDeployActions(
+    sharedPolicyGroup: Pick<SharedPolicyGroup, 'originContext'>,
+    canUpdate: boolean,
+): boolean {
+    return canUpdate && !isKubernetesOrigin(sharedPolicyGroup);
+}
+
+export function isDeployDisabled(lifecycleState: LifecycleState, hasUnsavedChanges = false): boolean {
+    return lifecycleState === 'DEPLOYED' || hasUnsavedChanges;
+}
+
+export function isUndeployDisabled(lifecycleState: LifecycleState): boolean {
+    return lifecycleState === 'UNDEPLOYED';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SHARED_POLICY_GROUP_DEFAULT_TAB, sharedPolicyGroupDetailHref } from './sharedPolicyGroupDetailNavigation';
+
+describe('sharedPolicyGroupDetailNavigation', () => {
+    it('defaults to the studio tab to match classic Console', () => {
+        expect(SHARED_POLICY_GROUP_DEFAULT_TAB).toBe('studio');
+        expect(sharedPolicyGroupDetailHref('spg-1')).toBe('spg-1/studio');
+    });
+
+    it('builds hrefs for each detail tab', () => {
+        expect(sharedPolicyGroupDetailHref('spg-1', 'overview')).toBe('spg-1/overview');
+        expect(sharedPolicyGroupDetailHref('spg-1', 'history')).toBe('spg-1/history');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Child routes under `shared-policy-groups/:sharedPolicyGroupId`. */
+export const SHARED_POLICY_GROUP_DETAIL_TABS = [
+    { path: 'overview', label: 'Overview', testId: 'shared-policy-group-tab-overview' },
+    { path: 'studio', label: 'Studio', testId: 'shared-policy-group-tab-studio' },
+    { path: 'history', label: 'History', testId: 'shared-policy-group-tab-history' },
+] as const;
+
+export type SharedPolicyGroupDetailTabPath = (typeof SHARED_POLICY_GROUP_DETAIL_TABS)[number]['path'];
+
+export const SHARED_POLICY_GROUP_DEFAULT_TAB: SharedPolicyGroupDetailTabPath = 'studio';
+
+export function sharedPolicyGroupDetailHref(
+    sharedPolicyGroupId: string,
+    tab: SharedPolicyGroupDetailTabPath = SHARED_POLICY_GROUP_DEFAULT_TAB,
+): string {
+    return `${sharedPolicyGroupId}/${tab}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
@@ -45,10 +45,7 @@ describe('toUpdateSharedPolicyGroupPayload', () => {
 
     it('omits empty optional strings and defaults missing steps to an empty array', () => {
         expect(
-            toUpdateSharedPolicyGroupPayload(
-                { ...SPG, steps: undefined },
-                { name: 'Updated', description: '', prerequisiteMessage: '' },
-            ),
+            toUpdateSharedPolicyGroupPayload({ ...SPG, steps: undefined }, { name: 'Updated', description: '', prerequisiteMessage: '' }),
         ).toEqual({
             name: 'Updated',
             description: undefined,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toUpdateSharedPolicyGroupPayload } from './sharedPolicyGroupPayload';
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth',
+    prerequisiteMessage: 'Needs cache',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    steps: [{ name: 'jwt' }],
+};
+
+describe('toUpdateSharedPolicyGroupPayload', () => {
+    it('maps form values and preserves existing steps', () => {
+        expect(
+            toUpdateSharedPolicyGroupPayload(SPG, {
+                name: 'Updated',
+                description: 'New description',
+                prerequisiteMessage: 'New prerequisite',
+            }),
+        ).toEqual({
+            name: 'Updated',
+            description: 'New description',
+            prerequisiteMessage: 'New prerequisite',
+            steps: [{ name: 'jwt' }],
+        });
+    });
+
+    it('omits empty optional strings and defaults missing steps to an empty array', () => {
+        expect(
+            toUpdateSharedPolicyGroupPayload(
+                { ...SPG, steps: undefined },
+                { name: 'Updated', description: '', prerequisiteMessage: '' },
+            ),
+        ).toEqual({
+            name: 'Updated',
+            description: undefined,
+            prerequisiteMessage: undefined,
+            steps: [],
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ApiType, FlowPhase } from '../types/sharedPolicyGroup';
+import type { ApiType, FlowPhase, SharedPolicyGroup, UpdateSharedPolicyGroupPayload } from '../types/sharedPolicyGroup';
 
 /** Mirrors classic Console's `PHASE_BY_API_TYPE` (shared-policy-groups-add-edit-dialog.component.ts). */
 export const PHASE_BY_API_TYPE: Record<ApiType, FlowPhase[]> = {
@@ -25,3 +25,28 @@ export const PHASE_BY_API_TYPE: Record<ApiType, FlowPhase[]> = {
     MESSAGE: ['REQUEST', 'RESPONSE', 'PUBLISH', 'SUBSCRIBE'],
     NATIVE: ['PUBLISH', 'SUBSCRIBE', 'ENTRYPOINT_CONNECT', 'INTERACT'],
 };
+
+export const DESCRIPTION_MAX_LENGTH = 300;
+export const PREREQUISITE_MESSAGE_MAX_LENGTH = 300;
+export const PREREQUISITE_MESSAGE_PLACEHOLDER =
+    'Message displayed when using SPG in Policy Studio. e.g.: "The resource cache "my-cache" is required"....';
+
+/** Shared create/edit metadata fields (name, description, prerequisite). */
+export interface SharedPolicyGroupBasicFormValues {
+    name: string;
+    description: string;
+    prerequisiteMessage: string;
+}
+
+/** Builds the v2 update payload while preserving existing policy steps (classic Console). */
+export function toUpdateSharedPolicyGroupPayload(
+    sharedPolicyGroup: SharedPolicyGroup,
+    values: SharedPolicyGroupBasicFormValues,
+): UpdateSharedPolicyGroupPayload {
+    return {
+        name: values.name,
+        description: values.description || undefined,
+        prerequisiteMessage: values.prerequisiteMessage || undefined,
+        steps: sharedPolicyGroup.steps ?? [],
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPayload.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ApiType, FlowPhase } from '../types/sharedPolicyGroup';
+
+/** Mirrors classic Console's `PHASE_BY_API_TYPE` (shared-policy-groups-add-edit-dialog.component.ts). */
+export const PHASE_BY_API_TYPE: Record<ApiType, FlowPhase[]> = {
+    PROXY: ['REQUEST', 'RESPONSE'],
+    A2A_PROXY: ['REQUEST', 'RESPONSE'],
+    LLM_PROXY: ['REQUEST', 'RESPONSE'],
+    MCP_PROXY: ['REQUEST', 'RESPONSE'],
+    MESSAGE: ['REQUEST', 'RESPONSE', 'PUBLISH', 'SUBSCRIBE'],
+    NATIVE: ['PUBLISH', 'SUBSCRIBE', 'ENTRYPOINT_CONNECT', 'INTERACT'],
+};

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/utils/sharedPolicyGroupPermissions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { SharedPolicyGroup } from '../types/sharedPolicyGroup';
+
+/** Mirrors classic Console's shared-policy-groups.component.ts permission checks. */
+export const ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION = 'environment-shared_policy_group-r' as const;
+export const ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION = 'environment-shared_policy_group-c' as const;
+export const ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION = 'environment-shared_policy_group-u' as const;
+export const ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION = 'environment-shared_policy_group-d' as const;
+
+/** Mirrors classic Console's `element.isKubernetesOrigin` row flag (shared-policy-groups.component.ts). */
+export function isKubernetesOrigin(sharedPolicyGroup: Pick<SharedPolicyGroup, 'originContext'>): boolean {
+    return sharedPolicyGroup.originContext?.origin === 'KUBERNETES';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SharedPolicyGroupDetailPage } from './SharedPolicyGroupDetailPage';
+import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
+
+const mockUseSharedPolicyGroupDetail = jest.mocked(useSharedPolicyGroupDetail);
+
+const SPG: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    description: 'Reusable auth policies',
+    prerequisiteMessage: 'Requires the "auth-cache" resource',
+    lifecycleState: 'DEPLOYED',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    deployedAt: '2024-01-02T00:00:00.000Z',
+};
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/spg-1']}>
+            <Routes>
+                <Route path=":sharedPolicyGroupId" element={<SharedPolicyGroupDetailPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('SharedPolicyGroupDetailPage', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders name, status, description, API type, and phase', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+
+        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).not.toBeNull();
+        expect(screen.queryByText('Deployed')).not.toBeNull();
+        expect(screen.queryByText('Reusable auth policies')).not.toBeNull();
+        expect(screen.queryByText('Proxy')).not.toBeNull();
+        expect(screen.queryByText('Request')).not.toBeNull();
+        expect(screen.queryByText('Requires the "auth-cache" resource')).not.toBeNull();
+    });
+
+    it('shows a not-found message when the shared policy group fails to load', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+
+        expect(screen.queryByText('Shared Policy Group not found or failed to load.')).not.toBeNull();
+    });
+
+    it('shows a loading skeleton while fetching', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+
+        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).toBeNull();
+    });
+
+    it('renders a back link to the list', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+
+        expect(screen.getByRole('link', { name: /Back to Shared Policy Groups/ }).getAttribute('href')).toBe('/');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
@@ -57,9 +57,9 @@ function makeMutation(mutateAsync = jest.fn()): any {
 
 function renderPage() {
     return render(
-        <MemoryRouter initialEntries={['/spg-1']}>
+        <MemoryRouter initialEntries={['/spg-1/overview']}>
             <Routes>
-                <Route path=":sharedPolicyGroupId" element={<SharedPolicyGroupDetailPage />} />
+                <Route path=":sharedPolicyGroupId/overview" element={<SharedPolicyGroupDetailPage />} />
             </Routes>
         </MemoryRouter>,
     );
@@ -75,7 +75,7 @@ describe('SharedPolicyGroupDetailPage', () => {
         jest.clearAllMocks();
     });
 
-    it('renders name, status, description, API type, and phase', () => {
+    it('renders overview details: API type, phase, and prerequisite', () => {
         mockUseSharedPolicyGroupDetail.mockReturnValue({
             data: SPG,
             isLoading: false,
@@ -84,27 +84,13 @@ describe('SharedPolicyGroupDetailPage', () => {
 
         renderPage();
 
-        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).not.toBeNull();
-        expect(screen.queryByText('Deployed')).not.toBeNull();
-        expect(screen.queryByText('Reusable auth policies')).not.toBeNull();
-        expect(screen.queryByText('Proxy')).not.toBeNull();
-        expect(screen.queryByText('Request')).not.toBeNull();
-        expect(screen.queryByText('Requires the "auth-cache" resource')).not.toBeNull();
+        expect(screen.getByTestId('shared-policy-group-overview')).not.toBeNull();
+        expect(screen.getByText('Proxy')).not.toBeNull();
+        expect(screen.getByText('Request')).not.toBeNull();
+        expect(screen.getByText('Requires the "auth-cache" resource')).not.toBeNull();
     });
 
-    it('shows a not-found message when the shared policy group fails to load', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: undefined,
-            isLoading: false,
-            isError: true,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(screen.queryByText('Shared Policy Group not found or failed to load.')).not.toBeNull();
-    });
-
-    it('shows a loading skeleton while fetching', () => {
+    it('renders nothing while loading (layout owns the skeleton)', () => {
         mockUseSharedPolicyGroupDetail.mockReturnValue({
             data: undefined,
             isLoading: true,
@@ -112,20 +98,7 @@ describe('SharedPolicyGroupDetailPage', () => {
         } as ReturnType<typeof useSharedPolicyGroupDetail>);
 
         renderPage();
-
-        expect(screen.queryByRole('heading', { name: 'Auth Bundle' })).toBeNull();
-    });
-
-    it('renders a back link to the list', () => {
-        mockUseSharedPolicyGroupDetail.mockReturnValue({
-            data: SPG,
-            isLoading: false,
-            isError: false,
-        } as ReturnType<typeof useSharedPolicyGroupDetail>);
-
-        renderPage();
-
-        expect(screen.getByRole('link', { name: /Back to Shared Policy Groups/ }).getAttribute('href')).toBe('/');
+        expect(screen.queryByTestId('shared-policy-group-overview')).toBeNull();
     });
 
     it('shows Edit when the user can update and opens the edit sheet', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.spec.tsx
@@ -14,16 +14,28 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { SharedPolicyGroupDetailPage } from './SharedPolicyGroupDetailPage';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import { notify } from '../shared/notify';
 
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
 jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
 
+const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseSharedPolicyGroupDetail = jest.mocked(useSharedPolicyGroupDetail);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
 
 const SPG: SharedPolicyGroup = {
     id: 'spg-1',
@@ -33,9 +45,15 @@ const SPG: SharedPolicyGroup = {
     lifecycleState: 'DEPLOYED',
     apiType: 'PROXY',
     phase: 'REQUEST',
+    steps: [{ name: 'jwt' }],
     updatedAt: '2024-01-01T00:00:00.000Z',
     deployedAt: '2024-01-02T00:00:00.000Z',
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
 
 function renderPage() {
     return render(
@@ -48,6 +66,11 @@ function renderPage() {
 }
 
 describe('SharedPolicyGroupDetailPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation());
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -103,5 +126,58 @@ describe('SharedPolicyGroupDetailPage', () => {
         renderPage();
 
         expect(screen.getByRole('link', { name: /Back to Shared Policy Groups/ }).getAttribute('href')).toBe('/');
+    });
+
+    it('shows Edit when the user can update and opens the edit sheet', async () => {
+        const updateMutateAsync = jest.fn().mockResolvedValue(SPG);
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(updateMutateAsync));
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+        expect(await screen.findByRole('heading', { name: 'Edit Policy Group' })).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Renamed Bundle' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() => {
+            expect(updateMutateAsync).toHaveBeenCalledWith({
+                id: 'spg-1',
+                payload: {
+                    name: 'Renamed Bundle',
+                    description: 'Reusable auth policies',
+                    prerequisiteMessage: 'Requires the "auth-cache" resource',
+                    steps: [{ name: 'jwt' }],
+                },
+            });
+        });
+        expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+    });
+
+    it('hides Edit when the user lacks update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: SPG,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    });
+
+    it('hides Edit for a Kubernetes-origin shared policy group', () => {
+        mockUseSharedPolicyGroupDetail.mockReturnValue({
+            data: { ...SPG, originContext: { origin: 'KUBERNETES' } },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useSharedPolicyGroupDetail>);
+
+        renderPage();
+        expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, DateCell, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
+import { Link, useParams } from 'react-router-dom';
+
+import { SharedPolicyGroupStatusBadge } from '../features/shared-policy-groups/components/SharedPolicyGroupStatusBadge';
+import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import { toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+
+function DetailField({ label, value }: Readonly<{ label: string; value: React.ReactNode }>) {
+    return (
+        <div className="space-y-1">
+            <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+            <dd className="text-sm">{value}</dd>
+        </div>
+    );
+}
+
+export function SharedPolicyGroupDetailPage() {
+    const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
+    const { data: sharedPolicyGroup, isLoading, isError } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-4">
+                <Skeleton className="h-8 w-32" />
+                <Skeleton className="h-32 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (isError || !sharedPolicyGroup) {
+        return (
+            <div className="space-y-4">
+                <Button type="button" variant="ghost" className="gap-1.5 px-0" asChild>
+                    <Link to="..">
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to Shared Policy Groups
+                    </Link>
+                </Button>
+                <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
+                <Link to="..">
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to Shared Policy Groups
+                </Link>
+            </Button>
+
+            <section className="rounded-xl border bg-card p-5">
+                <div className="flex items-start gap-3">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                        <LayersIcon className="size-5" aria-hidden />
+                    </div>
+                    <div className="min-w-0 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                            <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                        </div>
+                        {sharedPolicyGroup.description && <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>}
+                    </div>
+                </div>
+            </section>
+
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <h2 className="text-base font-semibold">Details</h2>
+                <dl className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+                    <DetailField label="API type" value={toReadableApiType(sharedPolicyGroup.apiType)} />
+                    <DetailField label="Phase" value={toReadableFlowPhase(sharedPolicyGroup.phase)} />
+                    <DetailField
+                        label="Last updated"
+                        value={
+                            sharedPolicyGroup.updatedAt ? <DateCell value={new Date(sharedPolicyGroup.updatedAt)} format="absolute" /> : '—'
+                        }
+                    />
+                    <DetailField
+                        label="Last deployed"
+                        value={
+                            sharedPolicyGroup.deployedAt ? (
+                                <DateCell value={new Date(sharedPolicyGroup.deployedAt)} format="absolute" />
+                            ) : (
+                                '—'
+                            )
+                        }
+                    />
+                </dl>
+                {sharedPolicyGroup.prerequisiteMessage && (
+                    <DetailField label="Prerequisite message" value={sharedPolicyGroup.prerequisiteMessage} />
+                )}
+            </section>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -32,6 +32,7 @@ import {
     ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
     isKubernetesOrigin,
 } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
 import { notify } from '../shared/notify';
 
 function DetailField({ label, value }: Readonly<{ label: string; value: React.ReactNode }>) {
@@ -57,12 +58,7 @@ export function SharedPolicyGroupDetailPage() {
         try {
             await updateMutation.mutateAsync({
                 id: sharedPolicyGroup.id,
-                payload: {
-                    name: values.name,
-                    description: values.description || undefined,
-                    prerequisiteMessage: values.prerequisiteMessage || undefined,
-                    steps: sharedPolicyGroup.steps ?? [],
-                },
+                payload: toUpdateSharedPolicyGroupPayload(sharedPolicyGroup, values),
             });
             notify.success('Shared Policy Group updated');
             setEditOpen(false);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -14,13 +14,25 @@
  * limitations under the License.
  */
 
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, LayersIcon } from '@gravitee/graphene-core/icons';
+import { ArrowLeftIcon, LayersIcon, PencilIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
+import {
+    SharedPolicyGroupEditSheet,
+    type SharedPolicyGroupEditFormValues,
+} from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
 import { SharedPolicyGroupStatusBadge } from '../features/shared-policy-groups/components/SharedPolicyGroupStatusBadge';
+import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import { toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import {
+    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
+    isKubernetesOrigin,
+} from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { notify } from '../shared/notify';
 
 function DetailField({ label, value }: Readonly<{ label: string; value: React.ReactNode }>) {
     return (
@@ -34,6 +46,30 @@ function DetailField({ label, value }: Readonly<{ label: string; value: React.Re
 export function SharedPolicyGroupDetailPage() {
     const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
     const { data: sharedPolicyGroup, isLoading, isError } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const updateMutation = useUpdateSharedPolicyGroup();
+    const [editOpen, setEditOpen] = useState(false);
+
+    const showEdit = Boolean(sharedPolicyGroup && canEdit && !isKubernetesOrigin(sharedPolicyGroup));
+
+    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
+        if (!sharedPolicyGroup) return;
+        try {
+            await updateMutation.mutateAsync({
+                id: sharedPolicyGroup.id,
+                payload: {
+                    name: values.name,
+                    description: values.description || undefined,
+                    prerequisiteMessage: values.prerequisiteMessage || undefined,
+                    steps: sharedPolicyGroup.steps ?? [],
+                },
+            });
+            notify.success('Shared Policy Group updated');
+            setEditOpen(false);
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group update!');
+        }
+    }
 
     if (isLoading) {
         return (
@@ -68,17 +104,27 @@ export function SharedPolicyGroupDetailPage() {
             </Button>
 
             <section className="rounded-xl border bg-card p-5">
-                <div className="flex items-start gap-3">
-                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
-                        <LayersIcon className="size-5" aria-hidden />
-                    </div>
-                    <div className="min-w-0 space-y-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                            <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
-                            <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
+                            <LayersIcon className="size-5" aria-hidden />
                         </div>
-                        {sharedPolicyGroup.description && <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>}
+                        <div className="min-w-0 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
+                                <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
+                            </div>
+                            {sharedPolicyGroup.description && (
+                                <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
+                            )}
+                        </div>
                     </div>
+                    {showEdit && (
+                        <Button type="button" variant="outline" size="sm" className="shrink-0 gap-1.5" onClick={() => setEditOpen(true)}>
+                            <PencilIcon className="size-4" aria-hidden />
+                            Edit
+                        </Button>
+                    )}
                 </div>
             </section>
 
@@ -108,6 +154,14 @@ export function SharedPolicyGroupDetailPage() {
                     <DetailField label="Prerequisite message" value={sharedPolicyGroup.prerequisiteMessage} />
                 )}
             </section>
+
+            <SharedPolicyGroupEditSheet
+                open={editOpen}
+                sharedPolicyGroup={sharedPolicyGroup}
+                onClose={() => setEditOpen(false)}
+                onSubmit={handleEdit}
+                isSaving={updateMutation.isPending}
+            />
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupDetailPage.tsx
@@ -15,16 +15,15 @@
  */
 
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, LayersIcon, PencilIcon } from '@gravitee/graphene-core/icons';
+import { Button, DateCell } from '@gravitee/graphene-core';
+import { PencilIcon } from '@gravitee/graphene-core/icons';
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import {
     SharedPolicyGroupEditSheet,
     type SharedPolicyGroupEditFormValues,
 } from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
-import { SharedPolicyGroupStatusBadge } from '../features/shared-policy-groups/components/SharedPolicyGroupStatusBadge';
 import { useUpdateSharedPolicyGroup } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
 import { toReadableApiType, toReadableFlowPhase } from '../features/shared-policy-groups/types/sharedPolicyGroup';
@@ -44,6 +43,7 @@ function DetailField({ label, value }: Readonly<{ label: string; value: React.Re
     );
 }
 
+/** Overview tab — metadata details (header/tabs live on SharedPolicyGroupDetailLayout). */
 export function SharedPolicyGroupDetailPage() {
     const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
     const { data: sharedPolicyGroup, isLoading, isError } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
@@ -67,54 +67,16 @@ export function SharedPolicyGroupDetailPage() {
         }
     }
 
-    if (isLoading) {
-        return (
-            <div className="space-y-4">
-                <Skeleton className="h-8 w-32" />
-                <Skeleton className="h-32 w-full rounded-xl" />
-            </div>
-        );
-    }
-
-    if (isError || !sharedPolicyGroup) {
-        return (
-            <div className="space-y-4">
-                <Button type="button" variant="ghost" className="gap-1.5 px-0" asChild>
-                    <Link to="..">
-                        <ArrowLeftIcon className="size-4" aria-hidden />
-                        Back to Shared Policy Groups
-                    </Link>
-                </Button>
-                <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>
-            </div>
-        );
+    // Layout already handles loading / not-found for the shell; keep a light fallback for the tab outlet.
+    if (isLoading || isError || !sharedPolicyGroup) {
+        return null;
     }
 
     return (
-        <div className="space-y-6">
-            <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" asChild>
-                <Link to="..">
-                    <ArrowLeftIcon className="size-4" aria-hidden />
-                    Back to Shared Policy Groups
-                </Link>
-            </Button>
-
-            <section className="rounded-xl border bg-card p-5">
-                <div className="flex items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-start gap-3">
-                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-700">
-                            <LayersIcon className="size-5" aria-hidden />
-                        </div>
-                        <div className="min-w-0 space-y-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                                <h1 className="text-xl font-semibold tracking-tight">{sharedPolicyGroup.name}</h1>
-                                <SharedPolicyGroupStatusBadge lifecycleState={sharedPolicyGroup.lifecycleState} />
-                            </div>
-                            {sharedPolicyGroup.description && (
-                                <p className="text-sm text-muted-foreground">{sharedPolicyGroup.description}</p>
-                            )}
-                        </div>
-                    </div>
+        <div className="space-y-6" data-testid="shared-policy-group-overview">
+            <section className="space-y-4 rounded-xl border bg-card p-5">
+                <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-base font-semibold">Details</h2>
                     {showEdit && (
                         <Button type="button" variant="outline" size="sm" className="shrink-0 gap-1.5" onClick={() => setEditOpen(true)}>
                             <PencilIcon className="size-4" aria-hidden />
@@ -122,10 +84,6 @@ export function SharedPolicyGroupDetailPage() {
                         </Button>
                     )}
                 </div>
-            </section>
-
-            <section className="space-y-4 rounded-xl border bg-card p-5">
-                <h2 className="text-base font-semibold">Details</h2>
                 <dl className="grid grid-cols-2 gap-4 sm:grid-cols-3">
                     <DetailField label="API type" value={toReadableApiType(sharedPolicyGroup.apiType)} />
                     <DetailField label="Phase" value={toReadableFlowPhase(sharedPolicyGroup.phase)} />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.spec.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { SharedPolicyGroupHistoryPage } from './SharedPolicyGroupHistoryPage';
+
+describe('SharedPolicyGroupHistoryPage', () => {
+    it('renders the history tab placeholder', () => {
+        render(<SharedPolicyGroupHistoryPage />);
+        expect(screen.getByTestId('shared-policy-group-history-empty')).not.toBeNull();
+        expect(screen.getByText('No version history yet')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupHistoryPage.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataTableEmptyState } from '@gravitee/graphene-core';
+import { ClockIcon } from '@gravitee/graphene-core/icons';
+
+/**
+ * Classic Console "Version History" tab shell.
+ * Deploy / histories APIs (FOUND-20) land in a follow-up.
+ */
+export function SharedPolicyGroupHistoryPage() {
+    return (
+        <div className="rounded-lg border" data-testid="shared-policy-group-history-empty">
+            <DataTableEmptyState
+                variant="first-use"
+                icon={<ClockIcon className="size-8" aria-hidden />}
+                title="No version history yet"
+                description="Deploy this Shared Policy Group to start recording versions. History, compare, and restore land in a follow-up."
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.spec.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SharedPolicyGroupStudioPage } from './SharedPolicyGroupStudioPage';
+import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
+
+const mockUseDetail = jest.mocked(useSharedPolicyGroupDetail);
+
+const BASE: SharedPolicyGroup = {
+    id: 'spg-1',
+    name: 'Auth Bundle',
+    apiType: 'PROXY',
+    phase: 'REQUEST',
+};
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/spg-1/studio']}>
+            <Routes>
+                <Route path=":sharedPolicyGroupId/studio" element={<SharedPolicyGroupStudioPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('SharedPolicyGroupStudioPage', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows the empty studio state when there are no policies', () => {
+        mockUseDetail.mockReturnValue({
+            data: { ...BASE, steps: [] },
+            isLoading: false,
+            isError: false,
+        } as never);
+
+        renderPage();
+        expect(screen.getByTestId('shared-policy-group-studio-empty')).not.toBeNull();
+    });
+
+    it('shows a read-only summary when policies are already configured', () => {
+        mockUseDetail.mockReturnValue({
+            data: {
+                ...BASE,
+                steps: [{ name: 'JWT' }, { policy: 'rate-limit' }],
+            },
+            isLoading: false,
+            isError: false,
+        } as never);
+
+        renderPage();
+        expect(screen.getByTestId('shared-policy-group-studio-configured')).not.toBeNull();
+        expect(screen.getByText('2 policies configured')).not.toBeNull();
+        expect(screen.getByText('JWT')).not.toBeNull();
+        expect(screen.getByText('rate-limit')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupStudioPage.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+import { useParams } from 'react-router-dom';
+
+import { SharedPolicyGroupStudioEmptyState } from '../features/shared-policy-groups/components/SharedPolicyGroupStudioEmptyState';
+import { useSharedPolicyGroupDetail } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroupStep } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+
+function stepLabel(step: SharedPolicyGroupStep, index: number): string {
+    const name = typeof step.name === 'string' ? step.name.trim() : '';
+    const policy = typeof step.policy === 'string' ? step.policy.trim() : '';
+    return name || policy || `Policy ${index + 1}`;
+}
+
+function ConfiguredPoliciesSummary({ steps }: Readonly<{ steps: SharedPolicyGroupStep[] }>) {
+    return (
+        <Card data-testid="shared-policy-group-studio-configured">
+            <CardContent className="space-y-3 p-5">
+                <div className="space-y-1">
+                    <h2 className="text-base font-semibold">
+                        {steps.length} {steps.length === 1 ? 'policy' : 'policies'} configured
+                    </h2>
+                    <p className="text-sm text-muted-foreground">Read-only summary for now. Policy Studio editing lands in a follow-up.</p>
+                </div>
+                <ul className="list-disc space-y-1 pl-5 text-sm">
+                    {steps.map((step, index) => (
+                        <li key={`${stepLabel(step, index)}-${index}`}>{stepLabel(step, index)}</li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function SharedPolicyGroupStudioPage() {
+    const { sharedPolicyGroupId } = useParams<{ sharedPolicyGroupId: string }>();
+    const { data: sharedPolicyGroup, isLoading, isError } = useSharedPolicyGroupDetail(sharedPolicyGroupId);
+
+    if (isLoading) {
+        return <Skeleton className="h-48 w-full rounded-xl" />;
+    }
+
+    if (isError || !sharedPolicyGroup) {
+        return <p className="text-sm text-muted-foreground">Shared Policy Group not found or failed to load.</p>;
+    }
+
+    const steps = sharedPolicyGroup.steps ?? [];
+    if (steps.length === 0) {
+        return <SharedPolicyGroupStudioEmptyState />;
+    }
+
+    return <ConfiguredPoliciesSummary steps={steps} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -208,7 +208,7 @@ describe('SharedPolicyGroupsPage', () => {
     });
 
     describe('create flow', () => {
-        it('creates a Proxy shared policy group (the default API type), shows a success toast, and navigates to its detail page', async () => {
+        it('creates a Proxy shared policy group (the default API type), shows a success toast, and navigates to its studio tab', async () => {
             const createMutateAsync = jest.fn().mockResolvedValue({ id: 'new-spg-id', name: 'My SPG' });
             const navigate = jest.fn();
             mockUseNavigate.mockReturnValue(navigate);
@@ -231,7 +231,7 @@ describe('SharedPolicyGroupsPage', () => {
                 });
             });
             expect(notify.success).toHaveBeenCalledWith('Shared Policy Group created');
-            expect(navigate).toHaveBeenCalledWith('new-spg-id');
+            expect(navigate).toHaveBeenCalledWith('new-spg-id/studio');
         });
 
         it('switches to Message-specific phases when the Message API type is selected in the sheet', () => {
@@ -343,13 +343,13 @@ describe('SharedPolicyGroupsPage', () => {
     });
 
     describe('view navigation', () => {
-        it('navigates to the shared policy group detail page', () => {
+        it('navigates to the shared policy group studio tab', () => {
             const navigate = jest.fn();
             mockUseNavigate.mockReturnValue(navigate);
             renderPage();
 
             fireEvent.click(screen.getByRole('button', { name: 'View Auth Bundle' }));
-            expect(navigate).toHaveBeenCalledWith('spg-1');
+            expect(navigate).toHaveBeenCalledWith('spg-1/studio');
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -22,13 +22,16 @@ import { SharedPolicyGroupsPage } from './SharedPolicyGroupsPage';
 import {
     useCreateSharedPolicyGroup,
     useDeleteSharedPolicyGroup,
+    useUpdateSharedPolicyGroup,
 } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import { getSharedPolicyGroup } from '../features/shared-policy-groups/services/sharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
 import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
+    useEnvironment: jest.fn(() => ({ id: 'env-1' })),
 }));
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
@@ -36,6 +39,9 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
 jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
+jest.mock('../features/shared-policy-groups/services/sharedPolicyGroups', () => ({
+    getSharedPolicyGroup: jest.fn(),
+}));
 jest.mock('../shared/notify', () => ({
     notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
 }));
@@ -48,6 +54,7 @@ jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable',
         isFirstUse,
         canDelete,
         onView,
+        onEdit,
         onDelete,
         onCreateSharedPolicyGroup,
         onSortingChange,
@@ -56,6 +63,7 @@ jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable',
         isFirstUse: boolean;
         canDelete: boolean;
         onView: (s: SharedPolicyGroup) => void;
+        onEdit: (s: SharedPolicyGroup) => void;
         onDelete: (s: SharedPolicyGroup) => void;
         onCreateSharedPolicyGroup?: () => void;
         onSortingChange: (sorting: { id: string; desc: boolean }[]) => void;
@@ -80,6 +88,9 @@ jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable',
                         <button type="button" onClick={() => onView(s)}>
                             View {s.name}
                         </button>
+                        <button type="button" onClick={() => onEdit(s)}>
+                            Edit {s.name}
+                        </button>
                         {canDelete && (
                             <button type="button" onClick={() => onDelete(s)}>
                                 Delete {s.name}
@@ -94,7 +105,9 @@ const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseNavigate = jest.mocked(useNavigate);
 const mockUseSharedPolicyGroupsPaged = jest.mocked(useSharedPolicyGroupsPaged);
 const mockUseCreateSharedPolicyGroup = jest.mocked(useCreateSharedPolicyGroup);
+const mockUseUpdateSharedPolicyGroup = jest.mocked(useUpdateSharedPolicyGroup);
 const mockUseDeleteSharedPolicyGroup = jest.mocked(useDeleteSharedPolicyGroup);
+const mockGetSharedPolicyGroup = jest.mocked(getSharedPolicyGroup);
 
 const SAMPLE_SPGS: SharedPolicyGroup[] = [
     { id: 'spg-1', name: 'Auth Bundle', apiType: 'PROXY', phase: 'REQUEST' },
@@ -124,7 +137,9 @@ describe('SharedPolicyGroupsPage', () => {
         mockUseNavigate.mockReturnValue(jest.fn());
         mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult());
         mockUseCreateSharedPolicyGroup.mockReturnValue(makeMutation());
+        mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation());
         mockUseDeleteSharedPolicyGroup.mockReturnValue(makeMutation());
+        mockGetSharedPolicyGroup.mockResolvedValue({ ...SAMPLE_SPGS[0], steps: [{ name: 'policy-1' }] });
     });
 
     afterEach(() => {
@@ -275,6 +290,47 @@ describe('SharedPolicyGroupsPage', () => {
             await waitFor(() =>
                 expect(notify.error).toHaveBeenCalledWith(error, 'An error occurred while removing the Shared Policy Group'),
             );
+        });
+    });
+
+    describe('edit flow', () => {
+        it('fetches the full shared policy group, updates metadata, preserves steps, and shows a success toast', async () => {
+            const updateMutateAsync = jest.fn().mockResolvedValue({ id: 'spg-1', name: 'Updated Auth' });
+            mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(updateMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Auth Bundle' }));
+
+            await waitFor(() => expect(mockGetSharedPolicyGroup).toHaveBeenCalledWith('env-1', 'spg-1'));
+            expect(await screen.findByRole('heading', { name: 'Edit Policy Group' })).not.toBeNull();
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Updated Auth' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => {
+                expect(updateMutateAsync).toHaveBeenCalledWith({
+                    id: 'spg-1',
+                    payload: {
+                        name: 'Updated Auth',
+                        description: undefined,
+                        prerequisiteMessage: undefined,
+                        steps: [{ name: 'policy-1' }],
+                    },
+                });
+            });
+            expect(notify.success).toHaveBeenCalledWith('Shared Policy Group updated');
+        });
+
+        it('shows an error toast when update fails', async () => {
+            const error = new Error('update failed');
+            mockUseUpdateSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit Auth Bundle' }));
+            await screen.findByRole('heading', { name: 'Edit Policy Group' });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group update!'));
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
+
+import { SharedPolicyGroupsPage } from './SharedPolicyGroupsPage';
+import {
+    useCreateSharedPolicyGroup,
+    useDeleteSharedPolicyGroup,
+} from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
+import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+}));
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroups');
+jest.mock('../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+// Stub the table and create-menu to avoid DataTable/DropdownMenu Radix pointer-event complexity in
+// jsdom (mirrors GroupsPage.spec.tsx) — both are exercised directly in their own component specs.
+jest.mock('../features/shared-policy-groups/components/SharedPolicyGroupsTable', () => ({
+    SharedPolicyGroupsTable: ({
+        sharedPolicyGroups,
+        isFirstUse,
+        canDelete,
+        onView,
+        onDelete,
+        onCreateSharedPolicyGroup,
+        onSortingChange,
+    }: {
+        sharedPolicyGroups: SharedPolicyGroup[];
+        isFirstUse: boolean;
+        canDelete: boolean;
+        onView: (s: SharedPolicyGroup) => void;
+        onDelete: (s: SharedPolicyGroup) => void;
+        onCreateSharedPolicyGroup?: () => void;
+        onSortingChange: (sorting: { id: string; desc: boolean }[]) => void;
+    }) =>
+        isFirstUse ? (
+            <div>
+                <p>No Shared Policy Groups</p>
+                {onCreateSharedPolicyGroup && (
+                    <button type="button" onClick={onCreateSharedPolicyGroup}>
+                        Add Shared Policy Group
+                    </button>
+                )}
+            </div>
+        ) : (
+            <div>
+                <button type="button" onClick={() => onSortingChange([{ id: 'name', desc: true }])}>
+                    Sort by Name
+                </button>
+                {sharedPolicyGroups.map(s => (
+                    <div key={s.id} data-testid={`row-${s.id}`}>
+                        <span>{s.name}</span>
+                        <button type="button" onClick={() => onView(s)}>
+                            View {s.name}
+                        </button>
+                        {canDelete && (
+                            <button type="button" onClick={() => onDelete(s)}>
+                                Delete {s.name}
+                            </button>
+                        )}
+                    </div>
+                ))}
+            </div>
+        ),
+}));
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseSharedPolicyGroupsPaged = jest.mocked(useSharedPolicyGroupsPaged);
+const mockUseCreateSharedPolicyGroup = jest.mocked(useCreateSharedPolicyGroup);
+const mockUseDeleteSharedPolicyGroup = jest.mocked(useDeleteSharedPolicyGroup);
+
+const SAMPLE_SPGS: SharedPolicyGroup[] = [
+    { id: 'spg-1', name: 'Auth Bundle', apiType: 'PROXY', phase: 'REQUEST' },
+    { id: 'spg-2', name: 'Rate Limit Bundle', apiType: 'MESSAGE', phase: 'PUBLISH' },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
+
+function makeSpgsResult(data: SharedPolicyGroup[] = SAMPLE_SPGS, totalCount = data.length) {
+    return {
+        data: { data, pagination: { page: 1, perPage: 25, pageCount: 1, pageItemsCount: data.length, totalCount } },
+        isLoading: false,
+        isError: false,
+    } as ReturnType<typeof useSharedPolicyGroupsPaged>;
+}
+
+function renderPage() {
+    return render(<SharedPolicyGroupsPage />);
+}
+
+describe('SharedPolicyGroupsPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseNavigate.mockReturnValue(jest.fn());
+        mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult());
+        mockUseCreateSharedPolicyGroup.mockReturnValue(makeMutation());
+        mockUseDeleteSharedPolicyGroup.mockReturnValue(makeMutation());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('page header', () => {
+        it('renders the page title', () => {
+            renderPage();
+            expect(screen.queryByRole('heading', { name: 'Shared Policy Groups' })).not.toBeNull();
+        });
+
+        it('shows the Add Shared Policy Group button when user can create', () => {
+            renderPage();
+            expect(screen.queryByRole('button', { name: 'Add Shared Policy Group' })).not.toBeNull();
+        });
+
+        it('hides the Add Shared Policy Group button when user lacks create permission', () => {
+            mockUseHasPermission.mockReturnValue(false);
+            renderPage();
+            expect(screen.queryByRole('button', { name: 'Add Shared Policy Group' })).toBeNull();
+        });
+    });
+
+    describe('list', () => {
+        it('renders shared policy groups from the API', () => {
+            renderPage();
+            expect(screen.queryByText('Auth Bundle')).not.toBeNull();
+            expect(screen.queryByText('Rate Limit Bundle')).not.toBeNull();
+        });
+
+        it('shows an error message when the query fails', () => {
+            mockUseSharedPolicyGroupsPaged.mockReturnValue({
+                data: undefined,
+                isLoading: false,
+                isError: true,
+            } as ReturnType<typeof useSharedPolicyGroupsPaged>);
+            renderPage();
+            expect(screen.queryByText('Failed to load Shared Policy Groups. Please refresh and try again.')).not.toBeNull();
+        });
+
+        it('hides the header menu during first-use and keeps the empty-state CTA', () => {
+            mockUseSharedPolicyGroupsPaged.mockReturnValue(makeSpgsResult([], 0));
+            renderPage();
+
+            expect(screen.queryByText('No Shared Policy Groups')).not.toBeNull();
+            expect(screen.getAllByRole('button', { name: 'Add Shared Policy Group' })).toHaveLength(1);
+        });
+
+        it('re-fetches with the classic Console sortBy value and resets to page 1 when sorting changes', () => {
+            renderPage();
+            mockUseSharedPolicyGroupsPaged.mockClear();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Sort by Name' }));
+
+            expect(mockUseSharedPolicyGroupsPaged).toHaveBeenCalledWith(expect.objectContaining({ page: 1, sortBy: '-name' }));
+        });
+    });
+
+    describe('create flow', () => {
+        it('creates a Proxy shared policy group (the default API type), shows a success toast, and navigates to its detail page', async () => {
+            const createMutateAsync = jest.fn().mockResolvedValue({ id: 'new-spg-id', name: 'My SPG' });
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
+            mockUseCreateSharedPolicyGroup.mockReturnValue(makeMutation(createMutateAsync));
+
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+            expect(screen.queryByRole('heading', { name: 'Add Policy Group' })).not.toBeNull();
+
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My SPG' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+            await waitFor(() => {
+                expect(createMutateAsync).toHaveBeenCalledWith({
+                    name: 'My SPG',
+                    description: undefined,
+                    prerequisiteMessage: undefined,
+                    apiType: 'PROXY',
+                    phase: 'REQUEST',
+                });
+            });
+            expect(notify.success).toHaveBeenCalledWith('Shared Policy Group created');
+            expect(navigate).toHaveBeenCalledWith('new-spg-id');
+        });
+
+        it('switches to Message-specific phases when the Message API type is selected in the sheet', () => {
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+
+            fireEvent.click(screen.getByRole('radio', { name: 'Message' }));
+
+            expect(screen.queryByRole('radio', { name: 'Publish' })).not.toBeNull();
+            expect(screen.queryByRole('radio', { name: 'Subscribe' })).not.toBeNull();
+        });
+
+        it('creates a Message shared policy group when Message is selected', async () => {
+            const createMutateAsync = jest.fn().mockResolvedValue({ id: 'new-spg-id', name: 'My SPG' });
+            mockUseCreateSharedPolicyGroup.mockReturnValue(makeMutation(createMutateAsync));
+
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+            fireEvent.click(screen.getByRole('radio', { name: 'Message' }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My SPG' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+            await waitFor(() => {
+                expect(createMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ apiType: 'MESSAGE' }));
+            });
+        });
+
+        it('shows an error toast when create fails', async () => {
+            const error = new Error('create failed');
+            mockUseCreateSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Add Shared Policy Group' }));
+            fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'My SPG' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+            await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Error during Shared Policy Group creation!'));
+        });
+    });
+
+    describe('delete flow', () => {
+        it('deletes the selected shared policy group and shows a success toast', async () => {
+            const deleteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseDeleteSharedPolicyGroup.mockReturnValue(makeMutation(deleteMutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete Auth Bundle' }));
+            expect(screen.queryByRole('heading', { name: 'Remove Shared Policy Group' })).not.toBeNull();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+            await waitFor(() => expect(deleteMutateAsync).toHaveBeenCalledWith('spg-1'));
+            expect(notify.success).toHaveBeenCalledWith('Shared Policy Group removed');
+        });
+
+        it('shows an error toast when delete fails', async () => {
+            const error = new Error('delete failed');
+            mockUseDeleteSharedPolicyGroup.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete Auth Bundle' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+            await waitFor(() =>
+                expect(notify.error).toHaveBeenCalledWith(error, 'An error occurred while removing the Shared Policy Group'),
+            );
+        });
+    });
+
+    describe('view navigation', () => {
+        it('navigates to the shared policy group detail page', () => {
+            const navigate = jest.fn();
+            mockUseNavigate.mockReturnValue(navigate);
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'View Auth Bundle' }));
+            expect(navigate).toHaveBeenCalledWith('spg-1');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
 
@@ -128,7 +129,14 @@ function makeSpgsResult(data: SharedPolicyGroup[] = SAMPLE_SPGS, totalCount = da
 }
 
 function renderPage() {
-    return render(<SharedPolicyGroupsPage />);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <SharedPolicyGroupsPage />
+        </QueryClientProvider>,
+    );
 }
 
 describe('SharedPolicyGroupsPage', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -45,6 +45,7 @@ import {
     SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS,
 } from '../features/shared-policy-groups/utils/paginationConstants';
 import { sharedPolicyGroupKeys } from '../features/shared-policy-groups/utils/queryKeys';
+import { sharedPolicyGroupDetailHref } from '../features/shared-policy-groups/utils/sharedPolicyGroupDetailNavigation';
 import {
     ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION,
     ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION,
@@ -134,7 +135,8 @@ export function SharedPolicyGroupsPage() {
             });
             notify.success('Shared Policy Group created');
             closeSheet();
-            navigate(created.id);
+            // Classic Console opens the studio tab after create.
+            navigate(sharedPolicyGroupDetailHref(created.id));
         } catch (error) {
             notify.error(error, 'Error during Shared Policy Group creation!');
         }
@@ -205,7 +207,7 @@ export function SharedPolicyGroupsPage() {
                 onPageChange={setPage}
                 onPageSizeChange={setPageSize}
                 onSortingChange={handleSortingChange}
-                onView={sharedPolicyGroup => navigate(sharedPolicyGroup.id)}
+                onView={sharedPolicyGroup => navigate(sharedPolicyGroupDetailHref(sharedPolicyGroup.id))}
                 onEdit={handleOpenEdit}
                 onDelete={sharedPolicyGroup => setSheet({ type: 'delete', sharedPolicyGroup })}
                 onCreateSharedPolicyGroup={canCreate ? () => setSheet({ type: 'create' }) : undefined}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { sortToOrder, type TableSortingState } from '../features/applications/utils/tableSort';
+import {
+    SharedPolicyGroupCreateSheet,
+    type SharedPolicyGroupCreateFormValues,
+} from '../features/shared-policy-groups/components/SharedPolicyGroupCreateSheet';
+import { SharedPolicyGroupDeleteSheet } from '../features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet';
+import { SharedPolicyGroupsTable } from '../features/shared-policy-groups/components/SharedPolicyGroupsTable';
+import {
+    useCreateSharedPolicyGroup,
+    useDeleteSharedPolicyGroup,
+} from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
+import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
+import {
+    DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE,
+    SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS,
+} from '../features/shared-policy-groups/utils/paginationConstants';
+import {
+    ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION,
+    ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION,
+    ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
+} from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { notify } from '../shared/notify';
+
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'delete'; sharedPolicyGroup: SharedPolicyGroup };
+
+export function SharedPolicyGroupsPage() {
+    const navigate = useNavigate();
+    const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION] });
+    const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
+    const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION] });
+
+    const [search, setSearch] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE);
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedSearch(search), SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(timer);
+    }, [search]);
+
+    const sortBy = useMemo(() => sortToOrder(sorting), [sorting]);
+
+    const handleSortingChange = useCallback<Dispatch<SetStateAction<TableSortingState>>>(updater => {
+        setSorting(updater);
+        setPage(1);
+    }, []);
+
+    const { data, isLoading, isError } = useSharedPolicyGroupsPaged({ query: debouncedSearch, page, perPage: pageSize, sortBy });
+
+    const createMutation = useCreateSharedPolicyGroup();
+    const deleteMutation = useDeleteSharedPolicyGroup();
+
+    const sharedPolicyGroups = data?.data ?? [];
+    const totalCount = data?.pagination.totalCount ?? 0;
+    const isFirstUse = !isLoading && totalCount === 0 && !search.trim() && !debouncedSearch.trim();
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    async function handleCreate(values: SharedPolicyGroupCreateFormValues) {
+        if (sheet.type !== 'create') return;
+        try {
+            const created = await createMutation.mutateAsync({
+                name: values.name,
+                description: values.description || undefined,
+                prerequisiteMessage: values.prerequisiteMessage || undefined,
+                apiType: values.apiType,
+                phase: values.phase,
+            });
+            notify.success('Shared Policy Group created');
+            closeSheet();
+            navigate(created.id);
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group creation!');
+        }
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.sharedPolicyGroup.id);
+            notify.success('Shared Policy Group removed');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'An error occurred while removing the Shared Policy Group');
+        }
+    }
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">Failed to load Shared Policy Groups. Please refresh and try again.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Shared Policy Groups</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Shared Policy Group allow to apply different policies on your API event phases.
+                    </p>
+                </div>
+                {canCreate && !isFirstUse ? (
+                    <Button className="shrink-0" size="sm" onClick={() => setSheet({ type: 'create' })}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add Shared Policy Group
+                    </Button>
+                ) : null}
+            </div>
+
+            <SharedPolicyGroupsTable
+                sharedPolicyGroups={sharedPolicyGroups}
+                totalCount={totalCount}
+                loading={isLoading}
+                isFirstUse={isFirstUse}
+                search={search}
+                page={page}
+                pageSize={pageSize}
+                sorting={sorting}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                onSearchChange={handleSearchChange}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+                onSortingChange={handleSortingChange}
+                onView={sharedPolicyGroup => navigate(sharedPolicyGroup.id)}
+                onDelete={sharedPolicyGroup => setSheet({ type: 'delete', sharedPolicyGroup })}
+                onCreateSharedPolicyGroup={canCreate ? () => setSheet({ type: 'create' }) : undefined}
+            />
+
+            <SharedPolicyGroupCreateSheet
+                open={sheet.type === 'create'}
+                onClose={closeSheet}
+                onSubmit={handleCreate}
+                isSaving={createMutation.isPending}
+            />
+
+            <SharedPolicyGroupDeleteSheet
+                open={sheet.type === 'delete'}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
 import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
@@ -26,12 +26,18 @@ import {
     type SharedPolicyGroupCreateFormValues,
 } from '../features/shared-policy-groups/components/SharedPolicyGroupCreateSheet';
 import { SharedPolicyGroupDeleteSheet } from '../features/shared-policy-groups/components/SharedPolicyGroupDeleteSheet';
+import {
+    SharedPolicyGroupEditSheet,
+    type SharedPolicyGroupEditFormValues,
+} from '../features/shared-policy-groups/components/SharedPolicyGroupEditSheet';
 import { SharedPolicyGroupsTable } from '../features/shared-policy-groups/components/SharedPolicyGroupsTable';
 import {
     useCreateSharedPolicyGroup,
     useDeleteSharedPolicyGroup,
+    useUpdateSharedPolicyGroup,
 } from '../features/shared-policy-groups/hooks/useSharedPolicyGroupMutations';
 import { useSharedPolicyGroupsPaged } from '../features/shared-policy-groups/hooks/useSharedPolicyGroups';
+import { getSharedPolicyGroup } from '../features/shared-policy-groups/services/sharedPolicyGroups';
 import type { SharedPolicyGroup } from '../features/shared-policy-groups/types/sharedPolicyGroup';
 import {
     DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE,
@@ -44,10 +50,15 @@ import {
 } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
 import { notify } from '../shared/notify';
 
-type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'delete'; sharedPolicyGroup: SharedPolicyGroup };
+type SheetState =
+    | { type: 'closed' }
+    | { type: 'create' }
+    | { type: 'edit'; sharedPolicyGroup: SharedPolicyGroup }
+    | { type: 'delete'; sharedPolicyGroup: SharedPolicyGroup };
 
 export function SharedPolicyGroupsPage() {
     const navigate = useNavigate();
+    const env = useEnvironment();
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION] });
@@ -58,6 +69,7 @@ export function SharedPolicyGroupsPage() {
     const [pageSize, setPageSize] = useState(DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE);
     const [sorting, setSorting] = useState<TableSortingState>([]);
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+    const [isLoadingEdit, setIsLoadingEdit] = useState(false);
 
     useEffect(() => {
         const timer = setTimeout(() => setDebouncedSearch(search), SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS);
@@ -74,6 +86,7 @@ export function SharedPolicyGroupsPage() {
     const { data, isLoading, isError } = useSharedPolicyGroupsPaged({ query: debouncedSearch, page, perPage: pageSize, sortBy });
 
     const createMutation = useCreateSharedPolicyGroup();
+    const updateMutation = useUpdateSharedPolicyGroup();
     const deleteMutation = useDeleteSharedPolicyGroup();
 
     const sharedPolicyGroups = data?.data ?? [];
@@ -87,6 +100,23 @@ export function SharedPolicyGroupsPage() {
 
     function closeSheet() {
         setSheet({ type: 'closed' });
+    }
+
+    async function handleOpenEdit(sharedPolicyGroup: SharedPolicyGroup) {
+        if (!env?.id) {
+            notify.error(new Error('No active environment'), 'Error during Shared Policy Group update!');
+            return;
+        }
+        setIsLoadingEdit(true);
+        try {
+            // List rows may omit steps — fetch full entity so PUT preserves policies (classic Console).
+            const full = await getSharedPolicyGroup(env.id, sharedPolicyGroup.id);
+            setSheet({ type: 'edit', sharedPolicyGroup: full });
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group update!');
+        } finally {
+            setIsLoadingEdit(false);
+        }
     }
 
     async function handleCreate(values: SharedPolicyGroupCreateFormValues) {
@@ -104,6 +134,25 @@ export function SharedPolicyGroupsPage() {
             navigate(created.id);
         } catch (error) {
             notify.error(error, 'Error during Shared Policy Group creation!');
+        }
+    }
+
+    async function handleEdit(values: SharedPolicyGroupEditFormValues) {
+        if (sheet.type !== 'edit') return;
+        try {
+            await updateMutation.mutateAsync({
+                id: sheet.sharedPolicyGroup.id,
+                payload: {
+                    name: values.name,
+                    description: values.description || undefined,
+                    prerequisiteMessage: values.prerequisiteMessage || undefined,
+                    steps: sheet.sharedPolicyGroup.steps ?? [],
+                },
+            });
+            notify.success('Shared Policy Group updated');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Error during Shared Policy Group update!');
         }
     }
 
@@ -146,7 +195,7 @@ export function SharedPolicyGroupsPage() {
             <SharedPolicyGroupsTable
                 sharedPolicyGroups={sharedPolicyGroups}
                 totalCount={totalCount}
-                loading={isLoading}
+                loading={isLoading || isLoadingEdit}
                 isFirstUse={isFirstUse}
                 search={search}
                 page={page}
@@ -159,6 +208,7 @@ export function SharedPolicyGroupsPage() {
                 onPageSizeChange={setPageSize}
                 onSortingChange={handleSortingChange}
                 onView={sharedPolicyGroup => navigate(sharedPolicyGroup.id)}
+                onEdit={handleOpenEdit}
                 onDelete={sharedPolicyGroup => setSheet({ type: 'delete', sharedPolicyGroup })}
                 onCreateSharedPolicyGroup={canCreate ? () => setSheet({ type: 'create' }) : undefined}
             />
@@ -168,6 +218,14 @@ export function SharedPolicyGroupsPage() {
                 onClose={closeSheet}
                 onSubmit={handleCreate}
                 isSaving={createMutation.isPending}
+            />
+
+            <SharedPolicyGroupEditSheet
+                open={sheet.type === 'edit'}
+                sharedPolicyGroup={sheet.type === 'edit' ? sheet.sharedPolicyGroup : null}
+                onClose={closeSheet}
+                onSubmit={handleEdit}
+                isSaving={updateMutation.isPending}
             />
 
             <SharedPolicyGroupDeleteSheet

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -17,6 +17,7 @@
 import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { Button } from '@gravitee/graphene-core';
 import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -43,11 +44,13 @@ import {
     DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE,
     SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS,
 } from '../features/shared-policy-groups/utils/paginationConstants';
+import { sharedPolicyGroupKeys } from '../features/shared-policy-groups/utils/queryKeys';
 import {
     ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION,
     ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION,
     ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION,
 } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { toUpdateSharedPolicyGroupPayload } from '../features/shared-policy-groups/utils/sharedPolicyGroupPayload';
 import { notify } from '../shared/notify';
 
 type SheetState =
@@ -59,6 +62,7 @@ type SheetState =
 export function SharedPolicyGroupsPage() {
     const navigate = useNavigate();
     const env = useEnvironment();
+    const queryClient = useQueryClient();
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_CREATE_PERMISSION] });
     const canEdit = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_SHARED_POLICY_GROUP_DELETE_PERMISSION] });
@@ -69,7 +73,6 @@ export function SharedPolicyGroupsPage() {
     const [pageSize, setPageSize] = useState(DEFAULT_SHARED_POLICY_GROUP_LIST_PAGE_SIZE);
     const [sorting, setSorting] = useState<TableSortingState>([]);
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
-    const [isLoadingEdit, setIsLoadingEdit] = useState(false);
 
     useEffect(() => {
         const timer = setTimeout(() => setDebouncedSearch(search), SHARED_POLICY_GROUP_SEARCH_DEBOUNCE_MS);
@@ -107,15 +110,15 @@ export function SharedPolicyGroupsPage() {
             notify.error(new Error('No active environment'), 'Error during Shared Policy Group update!');
             return;
         }
-        setIsLoadingEdit(true);
         try {
-            // List rows may omit steps — fetch full entity so PUT preserves policies (classic Console).
-            const full = await getSharedPolicyGroup(env.id, sharedPolicyGroup.id);
+            // List rows may omit steps — fetch via React Query so detail cache stays warm and the table is not re-skeletoned.
+            const full = await queryClient.fetchQuery({
+                queryKey: sharedPolicyGroupKeys.detail(env.id, sharedPolicyGroup.id),
+                queryFn: () => getSharedPolicyGroup(env.id, sharedPolicyGroup.id),
+            });
             setSheet({ type: 'edit', sharedPolicyGroup: full });
         } catch (error) {
             notify.error(error, 'Error during Shared Policy Group update!');
-        } finally {
-            setIsLoadingEdit(false);
         }
     }
 
@@ -142,12 +145,7 @@ export function SharedPolicyGroupsPage() {
         try {
             await updateMutation.mutateAsync({
                 id: sheet.sharedPolicyGroup.id,
-                payload: {
-                    name: values.name,
-                    description: values.description || undefined,
-                    prerequisiteMessage: values.prerequisiteMessage || undefined,
-                    steps: sheet.sharedPolicyGroup.steps ?? [],
-                },
+                payload: toUpdateSharedPolicyGroupPayload(sheet.sharedPolicyGroup, values),
             });
             notify.success('Shared Policy Group updated');
             closeSheet();
@@ -195,7 +193,7 @@ export function SharedPolicyGroupsPage() {
             <SharedPolicyGroupsTable
                 sharedPolicyGroups={sharedPolicyGroups}
                 totalCount={totalCount}
-                loading={isLoading || isLoadingEdit}
+                loading={isLoading}
                 isFirstUse={isFirstUse}
                 search={search}
                 page={page}


### PR DESCRIPTION
## Stories

### [FOUND-20](https://gravitee.atlassian.net/browse/FOUND-20) — Deploy and Undeploy Shared Policy Group to Gateway ⚠️ partial
- [x] Deploy action (`POST .../{id}/_deploy`) with success toast and status refresh
- [x] Undeploy action (`POST .../{id}/_undeploy`) with success toast and status refresh
- [x] Status badge updates after deploy/undeploy (query invalidation)
- [x] Deploy disabled when lifecycle is already `DEPLOYED`
- [x] Undeploy disabled when lifecycle is already `UNDEPLOYED`
- [x] Actions hidden without `environment-shared_policy_group-u` or for Kubernetes-origin groups
- [x] Deploy also blocked when studio has unsaved changes (hook param ready for FOUND-19)
- [ ] Deployment history (`GET .../{id}/histories`) — separate follow-up PR
- [ ] Cannot deploy if SPG has validation errors — relies on backend rejection + error toast for now

### Not in this PR
- **FOUND-19** (Configure Policies / Policy Studio) — dirty-state wiring is prepared via `hasUnsavedChanges`
- **FOUND-20** history list / compare / restore — next PR in the stack
- **FOUND-21** (Import via CRD)

## Screen

**Shared Policy Group detail** (`Platform Management → Policy Groups → {group}`)
- Header shows **Undeploy** + **Deploy** next to the title / status badge
- Buttons follow classic Console gating (lifecycle + permissions + K8s origin)
- Works from Overview / Studio / History tabs (actions live on the detail layout shell)

## Test plan
- [ ] As a user with UPDATE permission, open an undeployed SPG → Deploy succeeds, badge becomes Deployed, Deploy disables
- [ ] On a deployed SPG → Undeploy succeeds, badge becomes Undeployed, Undeploy disables
- [ ] Read-only user (no UPDATE) → Deploy/Undeploy hidden
- [ ] Kubernetes-origin SPG → Deploy/Undeploy hidden
- [ ] Failed deploy/undeploy → error toast with backend message when available



[FOUND-20]: https://gravitee.atlassian.net/browse/FOUND-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ