### PR TITLE
feat(console): add fetch actions for sourced portal navigation items

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -16,6 +16,7 @@
 import { isFunction } from 'lodash';
 
 import {
+  PortalNavigationItemsFetchSummary,
   PortalNavigationPage,
   PortalNavigationFolder,
   PortalNavigationLink,
@@ -157,6 +158,25 @@ export function fakePortalNavigationApiProduct(overrides?: Partial<PortalNavigat
 export function fakePortalNavigationItemsResponse(overrides?: Partial<PortalNavigationItemsResponse>): PortalNavigationItemsResponse {
   const base: PortalNavigationItemsResponse = {
     items: [fakePortalNavigationPage()],
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakePortalNavigationItemsFetchSummary(
+  overrides?: Partial<PortalNavigationItemsFetchSummary>,
+): PortalNavigationItemsFetchSummary {
+  const base: PortalNavigationItemsFetchSummary = {
+    succeeded: 1,
+    failed: 0,
+    results: [{ navigationItemId: 'nav-item-1', title: 'Home', success: true }],
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -74,6 +74,60 @@ export type PortalNavigationItem =
   | PortalNavigationApi
   | PortalNavigationApiProduct;
 
+/** Only PAGE and FOLDER items can carry an external source. */
+export function getPortalNavigationItemSource(item: PortalNavigationItem): PortalNavigationItemSource | undefined {
+  return item.type === 'PAGE' || item.type === 'FOLDER' ? item.source : undefined;
+}
+
+/**
+ * Ids of the items carrying at least one sourced PAGE below them — exactly what the backend `_fetch`
+ * endpoint walks. An item carrying a source itself but no sourced PAGE below it is absent from the
+ * set: the endpoint rejects it with a 400.
+ */
+export function collectNodeIdsWithSourcedPageDescendants(items: PortalNavigationItem[] | null | undefined): Set<string> {
+  const nodeIds = new Set<string>();
+
+  if (!items || !Array.isArray(items)) {
+    return nodeIds;
+  }
+
+  const itemsById = new Map<string, PortalNavigationItem>(items.map(item => [item.id, item]));
+
+  for (const item of items) {
+    if (item.type !== 'PAGE' || !item.source) {
+      continue;
+    }
+    let ancestor = item.parentId ? itemsById.get(item.parentId) : undefined;
+    // Stopping on an already-marked ancestor both short-circuits shared chains and ends parentId cycles
+    while (ancestor && !nodeIds.has(ancestor.id)) {
+      nodeIds.add(ancestor.id);
+      ancestor = ancestor.parentId ? itemsById.get(ancestor.parentId) : undefined;
+    }
+  }
+
+  return nodeIds;
+}
+
+export interface PortalNavigationItemFetchResult {
+  navigationItemId: string;
+  title: string;
+  success: boolean;
+  /** Why the fetch failed. Absent when the fetch succeeded. */
+  error?: string;
+}
+
+export interface PortalNavigationItemsFetchSummary {
+  succeeded: number;
+  failed: number;
+  results: PortalNavigationItemFetchResult[];
+}
+
+/** Exactly one of item or summary is set: item for a sourced PAGE, summary for a container's sourced descendants. */
+export interface FetchPortalNavigationItemResponse {
+  item?: PortalNavigationItem;
+  summary?: PortalNavigationItemsFetchSummary;
+}
+
 interface BaseNewPortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;
   type: T;

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
@@ -158,6 +158,24 @@ export class FlatTreeComponentHarness extends ComponentHarness {
     return this.getMenuItemByTestId('publish-node-button');
   }
 
+  async hasSourceIndicatorByTitle(title: string): Promise<boolean> {
+    const node = await this.getNodeHarnessByTitle(title);
+    return (await node.getHarnessOrNull(MatIconHarness.with({ selector: '[data-test-icon="source"]' }))) !== null;
+  }
+
+  async openMoreActionsMenuById(id: string): Promise<void> {
+    const moreActionsButton = await this.getMoreActionsButtonById(id)();
+    return moreActionsButton.click();
+  }
+
+  async selectFetchAllById(id: string): Promise<void> {
+    await this.openMoreActionsMenuById(id);
+    const fetchAllButton = await this._documentRootLocator.locatorFor(
+      MatMenuItemHarness.with({ selector: '[data-testid="fetch-all-button"]' }),
+    )();
+    return fetchAllButton.click();
+  }
+
   async getMenuItemByText(text: string): Promise<MatMenuItemHarness | null> {
     return this._documentRootLocator.locatorForOptional(MatMenuItemHarness.with({ text }))();
   }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -108,6 +108,15 @@
       {{ node.label }}
     </span>
 
+    @if (isSourced(node)) {
+      <mat-icon
+        class="tree__icon tree__icon__status"
+        svgIcon="gio:link"
+        matTooltip="Content from external source"
+        [attr.data-test-icon]="'source'"
+      ></mat-icon>
+    }
+
     @if (isUnpublished(node)) {
       <mat-icon class="tree__icon tree__icon__status" svgIcon="gio:eye-off" aria-hidden="true" [attr.data-test-icon]="'eye-off'"></mat-icon>
     }
@@ -196,6 +205,13 @@
       <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
         <mat-icon svgIcon="gio:eye-off"></mat-icon>
         Unpublish
+      </button>
+    }
+
+    @if (canFetchAll(node)) {
+      <button mat-menu-item [disabled]="fetchInProgress()" (click)="onFetchAll(node)" data-testid="fetch-all-button">
+        <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+        Fetch All
       </button>
     }
   }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -407,6 +407,86 @@ describe('FlatTreeComponent', () => {
     );
   });
 
+  describe('sourced items', () => {
+    const source = { type: 'github-fetcher', configuration: {} };
+
+    it('should show a source indicator on sourced items only', async () => {
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Folder 1', order: 0, source }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Sourced Page', order: 0, parentId: 'f1', source }),
+        fakePortalNavigationPage({ id: 'p2', title: 'Plain Page', order: 1 }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expandTree();
+
+      expect(await harness.hasSourceIndicatorByTitle('Folder 1')).toBe(true);
+      expect(await harness.hasSourceIndicatorByTitle('Sourced Page')).toBe(true);
+      expect(await harness.hasSourceIndicatorByTitle('Plain Page')).toBe(false);
+    });
+
+    it('should disable Fetch All while a fetch is in progress', async () => {
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Folder 1', order: 0 }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Sourced Page', order: 0, parentId: 'f1', source }),
+      ]);
+      fixture.componentRef.setInput('fetchInProgress', true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.openMoreActionsMenuById('f1');
+      const fetchAllButton = await harness.getMenuItemByTestId('fetch-all-button');
+
+      expect(await fetchAllButton!.isDisabled()).toBe(true);
+    });
+
+    it('should emit fetchAll for a container with a nested sourced page', async () => {
+      const actionSpy = jest.fn();
+      component.nodeMenuAction.subscribe(actionSpy);
+
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Folder 1', order: 0 }),
+        fakePortalNavigationFolder({ id: 'f2', title: 'Nested Folder', order: 0, parentId: 'f1' }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Sourced Page', order: 0, parentId: 'f2', source }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.selectFetchAllById('f1');
+      await fixture.whenStable();
+
+      expect(actionSpy).toHaveBeenCalledTimes(1);
+      expect(actionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'fetchAll',
+          itemType: 'FOLDER',
+          node: expect.objectContaining({ id: 'f1' }),
+        }),
+      );
+    });
+
+    it('should not show Fetch All for a container without sourced page descendants', async () => {
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Folder 1', order: 0 }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Plain Page', order: 0, parentId: 'f1' }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.openMoreActionsMenuById('f1');
+      expect(await harness.getMenuItemByTestId('fetch-all-button')).toBeNull();
+    });
+
+    it('should not show Fetch All for a sourced page itself', async () => {
+      fixture.componentRef.setInput('links', [fakePortalNavigationPage({ id: 'p1', title: 'Sourced Page', order: 0, source })]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.openMoreActionsMenuById('p1');
+      expect(await harness.getMenuItemByTestId('fetch-all-button')).toBeNull();
+    });
+  });
+
   describe('publish disabled state', () => {
     const findNode = (id: string, nodes: SectionNode[] = component.tree()): SectionNode | undefined => {
       for (const node of nodes) {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -35,7 +35,12 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { CommonModule } from '@angular/common';
 import { CdkDragDrop, CdkDragMove, CdkDragStart, DragDropModule } from '@angular/cdk/drag-drop';
 
-import { PortalNavigationItem, PortalNavigationItemType } from '../../../entities/management-api-v2';
+import {
+  collectNodeIdsWithSourcedPageDescendants,
+  getPortalNavigationItemSource,
+  PortalNavigationItem,
+  PortalNavigationItemType,
+} from '../../../entities/management-api-v2';
 import { EmptyStateComponent } from '../../../shared/components/empty-state/empty-state.component';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
@@ -56,7 +61,7 @@ export interface NodeMovedEvent {
   newOrder: number;
 }
 
-type NodeMenuActionType = 'create' | 'edit' | 'delete' | 'publish' | 'unpublish';
+type NodeMenuActionType = 'create' | 'edit' | 'delete' | 'publish' | 'unpublish' | 'fetchAll';
 
 export interface NodeMenuActionEvent {
   node: SectionNode;
@@ -118,6 +123,7 @@ export class FlatTreeComponent {
 
   links = input<PortalNavigationItem[] | null>(null);
   selectedId = input<string | null>(null);
+  fetchInProgress = input(false);
 
   nodeSelect = output<SectionNode>();
   nodeMenuAction = output<NodeMenuActionEvent>();
@@ -185,6 +191,9 @@ export class FlatTreeComponent {
     return creationAllowedByNodeId;
   });
 
+  // "Fetch All" targets the sourced PAGE descendants, matching what the backend _fetch endpoint collects
+  private readonly nodeIdsWithSourcedPageDescendants = computed(() => collectNodeIdsWithSourcedPageDescendants(this.links()));
+
   publishStateByNodeId = computed(() => {
     const links = this.links();
     const publishStateByNodeId = new Map<string, PublishActionState>();
@@ -233,6 +242,12 @@ export class FlatTreeComponent {
   isSelected = (node: FlatTreeNode) => this.selectedId() === node.id;
 
   isUnpublished = (node: FlatTreeNode) => node.data?.published === false;
+
+  isSourced = (node: FlatTreeNode) => !!node.data && !!getPortalNavigationItemSource(node.data);
+
+  canFetchAll(node: FlatTreeNode): boolean {
+    return this.canUpdate && this.isContainer(node) && this.nodeIdsWithSourcedPageDescendants().has(node.id);
+  }
 
   isPublishDisabled(node: SectionNode): boolean {
     return this.getPublishActionState(node).disabled;
@@ -355,6 +370,14 @@ export class FlatTreeComponent {
   onUnpublish(node: FlatTreeNode) {
     this.nodeMenuAction.emit({
       action: 'unpublish',
+      itemType: node.type,
+      node: this.mapFlatTreeNodeToSectionNode(node),
+    });
+  }
+
+  onFetchAll(node: FlatTreeNode) {
+    this.nodeMenuAction.emit({
+      action: 'fetchAll',
       itemType: node.type,
       node: this.mapFlatTreeNodeToSectionNode(node),
     });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -68,6 +68,7 @@
         <portal-flat-tree-component
           [links]="menuLinks"
           [selectedId]="navId()"
+          [fetchInProgress]="isFetching()"
           (nodeSelect)="onSelect($event)"
           (nodeMenuAction)="onNodeMenuAction($event)"
           (nodeMoved)="onNodeMoved($event)"
@@ -175,6 +176,7 @@
             <div class="source-mention" data-testid="folder-managed-by-source-banner">
               <mat-icon class="source-mention__icon" svgIcon="gio:link" />
               <span>Folder content from {{ selectedSourceTypeLabel() }} — read only</span>
+              <ng-container *ngTemplateOutlet="fetchNowButton"></ng-container>
             </div>
           }
           <ng-container *ngTemplateOutlet="emptyEditorState"></ng-container>
@@ -244,6 +246,7 @@
     <div class="source-mention" data-testid="content-managed-by-source-banner">
       <mat-icon class="source-mention__icon" svgIcon="gio:link" />
       <span>Content from {{ selectedSourceTypeLabel() }} — read only</span>
+      <ng-container *ngTemplateOutlet="fetchNowButton"></ng-container>
     </div>
     @if (source.lastFetchError; as lastFetchError) {
       <gio-banner-error class="source-banner" data-testid="content-fetch-error-banner">
@@ -252,4 +255,24 @@
       </gio-banner-error>
     }
   }
+</ng-template>
+
+<ng-template #fetchNowButton>
+  <span
+    *gioPermission="{ anyOf: ['environment-documentation-u'] }"
+    class="source-mention__fetch"
+    matTooltip="No page below this folder carries an external source to fetch"
+    [matTooltipDisabled]="canFetchSelectedItem()"
+  >
+    <button
+      mat-stroked-button
+      type="button"
+      data-testid="fetch-now-button"
+      [disabled]="isFetching() || !canFetchSelectedItem()"
+      (click)="onFetchNow()"
+    >
+      <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+      Fetch now
+    </button>
+  </span>
 </ng-template>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -171,6 +171,11 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
       height: 16px;
       flex-shrink: 0;
     }
+
+    &__fetch {
+      margin-left: auto;
+      flex-shrink: 0;
+    }
   }
 
   .source-banner {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -47,12 +47,14 @@ import {
   fakePortalNavigationApi,
   fakePortalNavigationApiProduct,
   fakePortalNavigationFolder,
+  fakePortalNavigationItemsFetchSummary,
   fakePortalNavigationItemsResponse,
   fakePortalNavigationLink,
   fakePortalNavigationPage,
   fakeUpdateApiPortalNavigationItem,
   fakeUpdateApiProductPortalNavigationItem,
   fakeUpdatePagePortalNavigationItem,
+  FetchPortalNavigationItemResponse,
   NewPortalNavigationItem,
   NewPagePortalNavigationItem,
   PortalNavigationItem,
@@ -70,7 +72,7 @@ import {
   OpenApiViewer,
   OpenApiViewerConfiguration,
 } from '../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
-import { SectionNode } from '../components/flat-tree/flat-tree.component';
+import { NodeMenuActionEvent, SectionNode } from '../components/flat-tree/flat-tree.component';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
 import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
@@ -4253,6 +4255,15 @@ describe('PortalNavigationItemsComponent', () => {
       return rootLoader.getHarness(SectionEditorDialogHarness);
     }
 
+    function expectFetchNavigationItem(id: string, response: FetchPortalNavigationItemResponse) {
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${id}/_fetch`,
+      });
+      req.flush(response);
+      fixture.detectChanges();
+    }
+
     function expectPutNavigationItemAndCaptureBody(id: string, response: PortalNavigationItem): UpdatePortalNavigationItem {
       const req = httpTestingController.expectOne({
         method: 'PUT',
@@ -4638,6 +4649,38 @@ describe('PortalNavigationItemsComponent', () => {
         expect(await harness.getFolderManagedBySourceBannerText()).toContain('Folder content from GitHub — read only');
       });
 
+      it('disables Fetch now on a sourced folder with no sourced page below it', async () => {
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR', source: githubSource });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+        expect(await harness.isFetchNowButtonDisabled()).toBe(true);
+      });
+
+      it('shows a Fetch now button for a sourced folder and reports the fetch summary', async () => {
+        const snackBarSuccessSpy = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR', source: githubSource });
+        const sourcedChild = fakePortalNavigationPage({
+          id: 'page-1',
+          title: 'Child Page',
+          area: 'TOP_NAVBAR',
+          parentId: 'folder-1',
+          portalPageContentId: 'content-1',
+          source: githubSource,
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, sourcedChild] }));
+        expectGetPageContent('content-1', 'Child content');
+        await harness.selectNavigationItemByTitle('My Folder');
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(await harness.isFetchNowButtonDisabled()).toBe(false);
+        await harness.clickFetchNowButton();
+        expectFetchNavigationItem('folder-1', { summary: fakePortalNavigationItemsFetchSummary({ succeeded: 2, failed: 0 }) });
+
+        expect(snackBarSuccessSpy).toHaveBeenCalledWith(expect.stringContaining('2 pages'));
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, sourcedChild] }));
+      });
+
       it('adds a source on the folder from the Edit dialog', async () => {
         const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR' });
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
@@ -4667,6 +4710,192 @@ describe('PortalNavigationItemsComponent', () => {
         await expectGetNavigationItems(
           fakePortalNavigationItemsResponse({ items: [fakePortalNavigationFolder({ ...folder, source: githubSource })] }),
         );
+      });
+    });
+
+    describe('fetch actions', () => {
+      let snackBarSuccessSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        snackBarErrorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+        snackBarSuccessSpy = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+      });
+
+      describe('Fetch Now on a sourced page', () => {
+        const sourcedPage = fakePortalNavigationPage({
+          id: 'page-1',
+          title: 'Page 1',
+          area: 'TOP_NAVBAR',
+          portalPageContentId: 'content-1',
+          source: githubSource,
+        });
+
+        beforeEach(async () => {
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedPage] }));
+          expectGetPageContent('content-1', 'Fetched content');
+        });
+
+        it('fetches and refreshes the displayed content on success', async () => {
+          await harness.clickFetchNowButton();
+          expectFetchNavigationItem('page-1', { item: sourcedPage });
+
+          expect(snackBarSuccessSpy).toHaveBeenCalledWith(expect.stringContaining('fetched'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedPage] }));
+          expectGetPageContent('content-1', 'Updated content');
+          expect(await harness.getEditorContentText()).toContain('Updated content');
+        });
+
+        it('shows the fetch error when the fetch fails', async () => {
+          const failedPage = fakePortalNavigationPage({
+            ...sourcedPage,
+            source: { ...githubSource, lastFetchError: 'Repository not found' },
+          });
+
+          await harness.clickFetchNowButton();
+          expectFetchNavigationItem('page-1', { item: failedPage });
+
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Repository not found'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [failedPage] }));
+          expectGetPageContent('content-1', 'Fetched content');
+          expect(await harness.getContentFetchErrorBannerText()).toContain('Repository not found');
+        });
+
+        it('re-enables the button after the server rejects the fetch with a 400', async () => {
+          await harness.clickFetchNowButton();
+          httpTestingController
+            .expectOne({
+              method: 'POST',
+              url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/page-1/_fetch`,
+            })
+            .flush({ message: 'No page below this item carries a source' }, { status: 400, statusText: 'Bad Request' });
+          fixture.detectChanges();
+
+          expect(snackBarErrorSpy).not.toHaveBeenCalled();
+          expect(await harness.isFetchNowButtonDisabled()).toBe(false);
+        });
+
+        it('does not show a generic snackbar when the fetch fails with an HTTP error (interceptor handles it)', async () => {
+          await harness.clickFetchNowButton();
+          httpTestingController
+            .expectOne({
+              method: 'POST',
+              url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/page-1/_fetch`,
+            })
+            .flush({ message: 'Internal error' }, { status: 500, statusText: 'Server Error' });
+          fixture.detectChanges();
+
+          expect(snackBarErrorSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('page without source', () => {
+        it('does not show the Fetch now button', async () => {
+          const page = fakePortalNavigationPage({ id: 'page-1', title: 'Page 1', area: 'TOP_NAVBAR', portalPageContentId: 'content-1' });
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [page] }));
+          expectGetPageContent('content-1', 'Some content');
+
+          expect(await harness.isFetchNowButtonVisible()).toBe(false);
+        });
+      });
+
+      describe('Fetch All from the tree context menu', () => {
+        const sourcedFolder = fakePortalNavigationFolder({
+          id: 'folder-1',
+          title: 'Docs Folder',
+          area: 'TOP_NAVBAR',
+          source: githubSource,
+        });
+        const sourcedChildPage = fakePortalNavigationPage({
+          id: 'page-1',
+          title: 'Child Page',
+          area: 'TOP_NAVBAR',
+          parentId: 'folder-1',
+          portalPageContentId: 'content-1',
+          source: githubSource,
+        });
+
+        beforeEach(async () => {
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
+
+        it('fetches all sourced descendants and shows a success summary', async () => {
+          await harness.fetchAllNodeById('folder-1');
+          expectFetchNavigationItem('folder-1', {
+            summary: fakePortalNavigationItemsFetchSummary({
+              succeeded: 1,
+              failed: 0,
+              results: [{ navigationItemId: 'page-1', title: 'Child Page', success: true }],
+            }),
+          });
+
+          expect(snackBarSuccessSpy).toHaveBeenCalledWith(expect.stringContaining('1 page'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
+
+        it('shows a failure summary when some fetches fail', async () => {
+          await harness.fetchAllNodeById('folder-1');
+          expectFetchNavigationItem('folder-1', {
+            summary: fakePortalNavigationItemsFetchSummary({
+              succeeded: 1,
+              failed: 1,
+              results: [
+                { navigationItemId: 'page-1', title: 'Child Page', success: true },
+                { navigationItemId: 'page-2', title: 'Other Page', success: false, error: 'Repository not found' },
+              ],
+            }),
+          });
+
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2'));
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('"Other Page"'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
+
+        it('warns without issuing a request when a Fetch All is triggered while a fetch is already in flight', async () => {
+          await harness.fetchAllNodeById('folder-1');
+          component.onNodeMenuAction({
+            action: 'fetchAll',
+            itemType: 'FOLDER',
+            node: fakeSectionNode({ id: 'folder-1', label: 'Docs Folder', type: 'FOLDER' }),
+          } as NodeMenuActionEvent);
+
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('already in progress'));
+
+          // expectOne fails if the second trigger issued a request too
+          const req = httpTestingController.expectOne({
+            method: 'POST',
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/folder-1/_fetch`,
+          });
+          req.flush({ summary: fakePortalNavigationItemsFetchSummary({ succeeded: 1, failed: 0 }) });
+          fixture.detectChanges();
+
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
+
+        it('does not claim success when the summary contains no pages', async () => {
+          await harness.fetchAllNodeById('folder-1');
+          expectFetchNavigationItem('folder-1', {
+            summary: fakePortalNavigationItemsFetchSummary({ succeeded: 0, failed: 0, results: [] }),
+          });
+
+          expect(snackBarSuccessSpy).not.toHaveBeenCalled();
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No pages'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
+
+        it('reports an error when the fetch response carries neither item nor summary', async () => {
+          await harness.fetchAllNodeById('folder-1');
+          expectFetchNavigationItem('folder-1', {});
+
+          expect(snackBarSuccessSpy).not.toHaveBeenCalled();
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unexpected'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedFolder, sourcedChildPage] }));
+          expectGetPageContent('content-1', 'Child content');
+        });
       });
     });
   });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -29,7 +29,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { rxResource, takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { catchError, exhaustMap, filter, map, shareReplay, skip, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, exhaustMap, filter, finalize, map, shareReplay, skip, switchMap, take, tap } from 'rxjs/operators';
 import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
@@ -68,6 +68,9 @@ import { PortalHeaderComponent } from '../components/header/portal-header.compon
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { FlatTreeComponent, NodeMenuActionEvent, NodeMovedEvent, SectionNode } from '../components/flat-tree/flat-tree.component';
 import {
+  collectNodeIdsWithSourcedPageDescendants,
+  FetchPortalNavigationItemResponse,
+  getPortalNavigationItemSource,
   NewPortalNavigationItem,
   PortalArea,
   PortalNavigationApi,
@@ -242,7 +245,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   // --- External source state ---
   readonly selectedItemSource: Signal<PortalNavigationItemSource | null> = computed(() => {
     const navItem = this.selectedNavigationItem()?.data;
-    return navItem && (navItem.type === 'PAGE' || navItem.type === 'FOLDER') ? (navItem.source ?? null) : null;
+    return navItem ? (getPortalNavigationItemSource(navItem) ?? null) : null;
   });
   readonly selectedSourceTypeLabel = computed(() => {
     const sourceType = this.selectedItemSource()?.type;
@@ -263,6 +266,18 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     return navItem ? this.findSourcedFolderAbove(navItem) : null;
   });
   readonly isContentEditingLocked = computed(() => !!this.selectedItemSource() || !!this.parentSourcedFolder());
+  readonly isFetching = signal(false);
+  // A folder carries a source but is never fetched itself: only the sourced pages below it are.
+  // Fetching one without such a page is rejected by the backend, so the action stays disabled.
+  readonly canFetchSelectedItem = computed(() => {
+    const navItem = this.selectedNavigationItem()?.data;
+    if (!navItem) {
+      return false;
+    }
+    return navItem.type === 'PAGE'
+      ? !!getPortalNavigationItemSource(navItem)
+      : collectNodeIdsWithSourcedPageDescendants(this.menuLinks()).has(navItem.id);
+  });
 
   // --- Resize Configuration ---
   private readonly ngZone = inject(NgZone);
@@ -391,6 +406,11 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   onNodeMenuAction(event: NodeMenuActionEvent) {
     this.checkUnsavedChangesAndRun(() => {
+      // A fetch refreshes content without mutating the structure, so the read-only guard does not apply
+      if (event.action === 'fetchAll') {
+        this.executeFetch(event.node.id);
+        return;
+      }
       if (this.blockActionOnSourcedItem(event)) {
         return;
       }
@@ -924,6 +944,68 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   onPublishToggle() {
     this.checkUnsavedChangesAndRun(() => this.handlePublishToggle(this.selectedNavigationItem()!.data));
+  }
+
+  onFetchNow() {
+    const navId = this.navId();
+    if (navId) {
+      this.checkUnsavedChangesAndRun(() => this.executeFetch(navId));
+    }
+  }
+
+  private executeFetch(navigationItemId: string): void {
+    // The disabled state of the tree entry only lands on the next change detection, so a second
+    // trigger can still reach here: this guard is what actually prevents overlapping fetches
+    if (this.isFetching()) {
+      this.snackBarService.error('A fetch is already in progress');
+      return;
+    }
+    this.isFetching.set(true);
+    this.portalNavigationItemsService
+      .fetchNavigationItem(navigationItemId)
+      .pipe(
+        finalize(() => this.isFetching.set(false)),
+        catchError(error => {
+          // HTTP errors are already caught by HttpErrorInterceptor and displayed in the snackbar
+          if (!(error instanceof HttpErrorResponse)) {
+            this.snackBarService.error('Failed to fetch content from the external source');
+          }
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(response => {
+        this.notifyFetchResult(response);
+        this.refreshMenuList.next(1);
+      });
+  }
+
+  private notifyFetchResult(response: FetchPortalNavigationItemResponse): void {
+    if (response.summary) {
+      const { succeeded, failed, results } = response.summary;
+      if (failed > 0) {
+        const failedTitles = results.filter(result => !result.success).map(result => `"${result.title}"`);
+        const failedList = failedTitles.slice(0, 3).join(', ') + (failedTitles.length > 3 ? ', …' : '');
+        this.snackBarService.error(`Fetched ${succeeded} of ${succeeded + failed} pages — failed: ${failedList}`);
+      } else if (succeeded > 0) {
+        this.snackBarService.success(`Successfully fetched ${succeeded} page${succeeded === 1 ? '' : 's'}`);
+      } else {
+        this.snackBarService.error('No pages were fetched');
+      }
+      return;
+    }
+
+    if (response.item) {
+      const lastFetchError = getPortalNavigationItemSource(response.item)?.lastFetchError;
+      if (lastFetchError) {
+        this.snackBarService.error(`Fetch failed: ${lastFetchError}`);
+      } else {
+        this.snackBarService.success('Content fetched from the external source');
+      }
+      return;
+    }
+
+    this.snackBarService.error('Unexpected fetch response from the server');
   }
 
   onDeleteSection(node: SectionNode): Observable<void> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -56,6 +56,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
       message: 'Failed to load page content.',
     }),
   );
+  private readonly getFetchNowButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="fetch-now-button"]' }));
   private readonly getContentManagedBySourceBanner = this.locatorForOptional('[data-testid="content-managed-by-source-banner"]');
   private readonly getContentManagedByParentBanner = this.locatorForOptional('[data-testid="content-managed-by-parent-banner"]');
   private readonly getContentFetchErrorBanner = this.locatorForOptional('[data-testid="content-fetch-error-banner"]');
@@ -285,6 +286,31 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async isPageNotFoundDisplayed(): Promise<boolean> {
     const emptyState = await this.getPageNotFoundEmptyState();
     return emptyState !== null;
+  }
+
+  async isFetchNowButtonVisible(): Promise<boolean> {
+    return (await this.getFetchNowButton()) !== null;
+  }
+
+  async isFetchNowButtonDisabled(): Promise<boolean> {
+    const button = await this.getFetchNowButton();
+    if (!button) {
+      throw new Error('Fetch now button not found');
+    }
+    return button.isDisabled();
+  }
+
+  async clickFetchNowButton(): Promise<void> {
+    const button = await this.getFetchNowButton();
+    if (!button) {
+      throw new Error('Fetch now button not found');
+    }
+    return button.click();
+  }
+
+  async fetchAllNodeById(id: string): Promise<void> {
+    const tree = await this.getTree();
+    return tree.selectFetchAllById(id);
   }
 
   async isContentManagedBySourceBannerDisplayed(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -31,6 +31,7 @@ import {
   fakeNewLinkPortalNavigationItem,
   fakeNewApiPortalNavigationItem,
   fakeNewApiProductPortalNavigationItem,
+  fakePortalNavigationItemsFetchSummary,
   fakeUpdateFolderPortalNavigationItem,
 } from '../entities/management-api-v2';
 
@@ -221,6 +222,42 @@ describe('PortalNavigationItemService', () => {
       });
       expect(req.request.body).toEqual({ ids });
       req.flush(null);
+    });
+  });
+
+  describe('fetchNavigationItem', () => {
+    it('should return the fetched item for a sourced page', done => {
+      const fetchedPage = fakePortalNavigationPage({ id: 'page-1' });
+
+      service.fetchNavigationItem('page-1').subscribe(response => {
+        expect(response.item).toEqual(fetchedPage);
+        expect(response.summary).toBeUndefined();
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/page-1/_fetch`,
+      });
+      expect(req.request.body).toBeNull();
+      req.flush({ item: fetchedPage });
+    });
+
+    it('should return the fetch summary for a container', done => {
+      const summary = fakePortalNavigationItemsFetchSummary({ succeeded: 2, failed: 1 });
+
+      service.fetchNavigationItem('folder-1').subscribe(response => {
+        expect(response.summary).toEqual(summary);
+        expect(response.item).toBeUndefined();
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          method: 'POST',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/folder-1/_fetch`,
+        })
+        .flush({ summary });
     });
   });
 

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -19,6 +19,7 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
 import {
+  FetchPortalNavigationItemResponse,
   NewPortalNavigationItem,
   PortalArea,
   PortalNavigationItem,
@@ -65,6 +66,13 @@ export class PortalNavigationItemService {
       `${this.constants.env.v2BaseURL}/portal-navigation-items/${portalNavigationItemId}`,
       updatePortalNavigationItem,
       { params },
+    );
+  }
+
+  public fetchNavigationItem(portalNavigationItemId: string): Observable<FetchPortalNavigationItemResponse> {
+    return this.http.post<FetchPortalNavigationItemResponse>(
+      `${this.constants.env.v2BaseURL}/portal-navigation-items/${portalNavigationItemId}/_fetch`,
+      null,
     );
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-90

## Description

Adds manual fetch actions for source-backed portal navigation items in the Console.

- **Fetch now** button in the "Content/Folder from … — read only" banner of the editor, for a sourced page or folder (requires `environment-documentation-u`).
- **Fetch All** entry in the tree context menu, on containers that have at least one sourced page in their subtree.
- Sourced nodes are now flagged with a link icon in the tree.
- Both actions call `POST /portal-navigation-items/{id}/_fetch` and report the outcome in a snackbar: single-page success, the source's fetch error, or a "X of Y pages" summary listing the failed titles (capped at 3).

## Additional context

https://github.com/user-attachments/assets/4b941f79-172f-4cd7-a83b-5f7d647b4987