### PR TITLE
fix(rest-api): tolerate api metadata without value in v4 definition export

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -39,6 +39,7 @@ import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -217,7 +218,16 @@ public interface GraviteeDefinitionAdapter {
     NewApiMetadata mapMetadata(Metadata source);
 
     default Map<String, Object> map(Collection<NewApiMetadata> sources) {
-        return stream(sources).collect(Collectors.toMap(NewApiMetadata::getName, NewApiMetadata::getValue));
+        // Collectors.toMap() rejects null values, but an API-level metadata may have no value at all
+        // (it then inherits the environment one), so collect with a null-tolerant accumulator.
+        return stream(sources).collect(
+            HashMap::new,
+            (map, metadata) -> {
+                Object value = metadata.getValue() != null ? metadata.getValue() : metadata.getDefaultValue();
+                map.put(metadata.getName(), value);
+            },
+            HashMap::putAll
+        );
     }
 
     default Instant map(ZonedDateTime src) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -122,6 +122,54 @@ class GraviteeDefinitionAdapterTest {
     }
 
     @Test
+    void mapV4_should_export_metadata_even_without_value() {
+        // APIM-14929: an API-level metadata entry stored without a value must not break the export
+        var v4Definition = new io.gravitee.definition.model.v4.Api();
+        v4Definition.setDefinitionVersion(DefinitionVersion.V4);
+        v4Definition.setType(ApiType.PROXY);
+        v4Definition.setApiVersion("1.0.0");
+        v4Definition.setName("my-api");
+
+        Api coreApi = Api.builder()
+            .id("api-id")
+            .environmentId("env-id")
+            .version("1.0.0")
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.PROXY)
+            .apiDefinitionHttpV4(v4Definition)
+            .build();
+
+        var primaryOwner = PrimaryOwnerEntity.builder()
+            .id("po-id")
+            .email("po@acme.test")
+            .displayName("PO")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+
+        var metadata = List.of(
+            NewApiMetadata.builder().key("overridden").name("overridden").value("api-value").defaultValue("env-value").build(),
+            NewApiMetadata.builder().key("inherited").name("inherited").defaultValue("env-value").build(),
+            NewApiMetadata.builder().key("no-value").name("no-value").build()
+        );
+
+        ApiDescriptor.ApiDescriptorV4 descriptor = GraviteeDefinitionAdapter.INSTANCE.mapV4(
+            coreApi,
+            primaryOwner,
+            WorkflowState.REVIEW_OK,
+            Set.of("group-1"),
+            metadata,
+            List.of(new Flow()),
+            false
+        );
+
+        assertThat(descriptor.metadata())
+            .containsEntry("overridden", "api-value")
+            .containsEntry("inherited", "env-value")
+            .containsEntry("no-value", null)
+            .hasSize(3);
+    }
+
+    @Test
     void mapV4_should_leave_allowedInApiProducts_null_for_non_proxy_api() {
         var v4Definition = new io.gravitee.definition.model.v4.Api();
         v4Definition.setDefinitionVersion(DefinitionVersion.V4);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14929

Exporting a v4 API returns HTTP 500 when one of its metadata entries has no value. API-level metadata can be stored without a value (it then inherits the environment one), and such entries already exist in customer databases (db.metadata.find({ value: { $exists: false } })). The same API exported fine while it was v2 through the legacy export path, so migrating to v4 breaks the export without any change to the data.

## Root cause

GraviteeDefinitionAdapter.map(Collection<NewApiMetadata>) builds the descriptor's name-to-value metadata map with Collectors.toMap(...), which throws a NullPointerException on null values. The exception surfaces as an empty 500 on GET /management/v2/environments/{env}/apis/{apiId}/_export/definition. All four descriptor mappers (V2, V4, Native, Federated) go through this method, so a v2 API exported through the management-v2 endpoint fails the same way.

## Fix

Collect with a null-tolerant accumulator and map each entry to its effective value (value when set, otherwise defaultValue), the same convention already used by GetApiMetadataUseCase, the subscription form EL resolver and documentation validation. Import is unaffected: it consumes the top-level NewApiMetadata collection, not this map.

The new unit test reproduces the exact stack trace from the ticket before the fix. Also verified end to end on a local stack against a metadata row stored without a value: export returned 500 before, 200 after.

No previously passing behaviour changes: every input that now produces a different result used to crash (null values, and duplicate metadata names which threw IllegalStateException).

## Out of scope

The ticket also notes that API-level metadata accepts a null value on PUT while environment-level metadata rejects it ("Metadata value is required"). Harmonizing that validation is a separate decision to be taken.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

