### PR TITLE
chore(kafka): bump reactor to 7.1.0-alpha.7, use the {domain} placeholder in routing host mode examples

### DIFF
--- a/docker/quick-setup/native-kafka-mesh/docker-compose.yml
+++ b/docker/quick-setup/native-kafka-mesh/docker-compose.yml
@@ -117,7 +117,7 @@ services:
             - gravitee_kafka_ssl_keystore_password=gravitee
             - gravitee_kafka_ssl_keystore_path=$${gravitee.home}/ssl/server.keystore.jks
             - gravitee_kafka_ssl_keystore_type=jks
-            - 'gravitee_kafka_routingHostMode_defaultDomain=kafka.local'
+            - 'gravitee_kafka_routingHostMode_domains_0=kafka.local'
         networks:
             storage:
             frontend:

--- a/docker/quick-setup/native-kafka/README.md
+++ b/docker/quick-setup/native-kafka/README.md
@@ -44,7 +44,7 @@ The gateway runs in HOST routing mode (the default) and resolves API hostnames v
 1. Console: `http://localhost:8084/` (`admin` / `admin`).
 2. Organization → Entrypoints & Sharding Tags → Entrypoint Configuration → **Default Kafka Domain** = `kafka.local`.
 
-The gateway is already configured with `gravitee_kafka_routingHostMode_defaultDomain=kafka.local`; the console value above mirrors that to the management plane.
+The gateway is already configured with `gravitee_kafka_routingHostMode_domains_0=kafka.local`; the console value above mirrors that to the management plane.
 
 ## 2. Create a Native Kafka API
 

--- a/docker/quick-setup/native-kafka/docker-compose.yml
+++ b/docker/quick-setup/native-kafka/docker-compose.yml
@@ -116,7 +116,7 @@ services:
             - gravitee_kafka_ssl_keystore_password=gravitee
             - gravitee_kafka_ssl_keystore_path=$${gravitee.home}/ssl/server.keystore.jks
             - gravitee_kafka_ssl_keystore_type=jks
-            - 'gravitee_kafka_routingHostMode_defaultDomain=kafka.local'
+            - 'gravitee_kafka_routingHostMode_domains_0=kafka.local'
         networks:
             storage:
             frontend:

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/config/gravitee.yml
@@ -185,30 +185,54 @@ secrets:
 #  # Routing Host Mode
 #  routingHostMode:
 #    brokerPrefix: broker-          # default is broker-
-#    domainSeparator: -             # Used to separate broker's name from api & defaultDomain. Default is '-'
+#    domainSeparator: "-"           # Used to separate broker's name from api & domain. Default is '-'
 #
-#    # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
-#    defaultDomain: mycompany.org   # Should set according to the public wildcard DNS/Certificate. Default is empty
+#    # The domains where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org` and `myapi.mycompany.com`
+#    # Each domain should be set according to a public wildcard DNS/Certificate.
+#    # Must be a list, even for a single domain: a scalar value is rejected at startup.
+#    domains:
+#      - mycompany.org
+#      - mycompany.com
+#
+#    # For a single domain, `defaultDomain` is still accepted but deprecated. It is ignored -- with a
+#    # warning -- as soon as `domains` is set, so enable one or the other, never both:
+#    #   defaultDomain: mycompany.org
+#
 #    defaultPort:   9092            # Default public port for Kafka APIs. Default is 9092
 #
-#    # With the upper default configuration, the Gravitee Kafka gateway yields bootstrap and broker domains to be as follows:
-#    bootstrapDomainPattern: {apiHost}.mycompany.org
-#    brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org
+#    # The patterns below are the built-in behaviour, written out explicitly. Each is evaluated once per configured domain:
+#    bootstrapDomainPattern: "{apiHost}.{domain}"
+#    brokerDomainPattern: "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{domain}"
+#    # {domain} requires a gateway bundling native Kafka reactor 7.0.2 or later (APIM 4.12.14+). On an
+#    # earlier gateway it is left unsubstituted and the API fails to deploy with a PatternSyntaxException;
+#    # use {defaultDomain} there, which resolves to the same value.
 #    # Where:
-#    # {apiHost}  is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
-#    # {brokerId} is a placeholder that stands for the broker id
+#    # {apiHost}         is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
+#    # {brokerId}        is a placeholder that stands for the broker id
+#    # {brokerPrefix}    is a placeholder for the 'brokerPrefix' property above
+#    # {domainSeparator} is a placeholder for the 'domainSeparator' property above
+#    # {domain}          is a placeholder for the domain being evaluated: the patterns are applied once per
+#    #                   entry of `domains`, or once to `defaultDomain` when `domains` is not set.
+#    #                   An entry that itself contains {apiHost} becomes the bootstrap pattern, and both
+#    #                   patterns configured here are then ignored.
+#    #                   Writing a domain literally here instead of using {domain} makes every entry resolve
+#    #                   to that same hostname, leaving the other domains unroutable. The gateway logs a
+#    #                   warning when it detects it. `{defaultDomain}` is still accepted as a deprecated
+#    #                   alias of `{domain}`.
+#    # The built-in defaults, used for whichever pattern is left unset, are "{apiHost}.{defaultDomain}" and
+#    # "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}".
 #
 #    # It can be overridden to fit your DNS configuration.
-#    # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'defaultDomain', 'brokerPrefix' and 'domainSeparator' are not used in that case, hence optional.
+#    # Each pattern falls back to its own default independently, so overriding only one of them is fine, and 'defaultPort' defaults to 9092. Please note that 'brokerPrefix' and 'domainSeparator' are substituted only if the patterns reference them as {brokerPrefix} / {domainSeparator}, hence optional.
 #    # Example:
 #    #   defaultPort: 9092
-#    #   bootstrapDomainPattern: bootstrap-{apiHost}.mycompany.org
-#    #   brokerDomainPattern: {apiHost}-broker{brokerId}.mycompany.org
+#    #   bootstrapDomainPattern: "bootstrap-{apiHost}.{domain}"
+#    #   brokerDomainPattern: "{apiHost}-broker{brokerId}.{domain}"
 #    #
-#    #   This configuration yields domains that must target the Gravitee Kafka gateway:
-#    #      bootstrap-myapi.mycompany.org
-#    #      myapi-broker0.mycompany.org
-#    #      myapi-broker1.mycompany.org
+#    #   With the two domains above, this configuration yields domains that must target the Gravitee Kafka gateway:
+#    #      bootstrap-myapi.mycompany.org      bootstrap-myapi.mycompany.com
+#    #      myapi-broker0.mycompany.org        myapi-broker0.mycompany.com
+#    #      myapi-broker1.mycompany.org        myapi-broker1.mycompany.com
 #    #      ...
 #
 #  # Kafka probe

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -238,7 +238,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.1.0-alpha.6</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.1.0-alpha.7</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.2.0</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>4.1.0</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 ### 4.13.0
 - Render `config/hazelcast.xml` for gateway Hazelcast clustering (`gateway.cluster.type=hazelcast`) with Kubernetes discovery via the `-hz` Service. Cluster name defaults to `<release>-<sharding_tags>` so Redis distributed-event namespace (clusterId) changes when sharding tags change; override with `gateway.cluster.hazelcast.clusterName`. Require `gateway.cluster` when `gateway.distributedSync` is enabled; auto-enable `services.sync.repository` and `services.sync.distributed`.
-- Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set.
+- Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set. The `bootstrapDomainPattern` / `brokerDomainPattern` examples now use the `{domain}` placeholder, which is substituted with each configured domain in turn; hardcoding a domain there collapses every entry onto the same hostname (`{defaultDomain}` remains a supported alias).
 - Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -37,6 +37,8 @@ annotations:
           url: https://github.com/gravitee-io/gravitee-api-management/pull/17691
     - kind: deprecated
       description: "`gateway.kafka.routingHostMode.defaultDomain` is deprecated in favor of `domains` and ignored when `domains` is set"
+    - kind: changed
+      description: "`gateway.kafka.routingHostMode` pattern examples now use the `{domain}` placeholder, substituted with each configured domain in turn; hardcoding a domain there collapses every entry onto the same hostname (`{defaultDomain}` remains a supported alias)"
     - kind: added
       description: "Document `gateway.services.metrics.kafka.durations.principalName` to add the principal_name tag to Kafka duration metrics (disabled by default)"
     - kind: added

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1454,37 +1454,54 @@ gateway:
 #    # Routing Host Mode
 #    routingHostMode:
 #      brokerPrefix: broker-          # default is broker-
-#      domainSeparator: -             # Used to separate broker's name from api & defaultDomain. Default is '-'
+#      domainSeparator: "-"           # Used to separate broker's name from api & domain. Default is '-'
 #
 #      # The domains where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org` and `myapi.mycompany.com`
 #      # Each domain should be set according to a public wildcard DNS/Certificate.
+#      # Must be a list, even for a single domain: a scalar value is rejected at startup.
 #      domains:
 #        - mycompany.org
 #        - mycompany.com
 #
-#      # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
-#      # Deprecated: use `domains` instead. Ignored when `domains` is set.
-#      defaultDomain: mycompany.org   # Should set according to the public wildcard DNS/Certificate. Default is empty
+#      # For a single domain, `defaultDomain` is still accepted but deprecated. It is ignored -- with a
+#      # warning -- as soon as `domains` is set, so enable one or the other, never both:
+#      #   defaultDomain: mycompany.org
+#
 #      defaultPort:   9092            # Default public port for Kafka APIs. Default is 9092
 #
-#      # With the upper default configuration, the Gravitee Kafka gateway yields bootstrap and broker domains to be as follows:
-#      bootstrapDomainPattern: {apiHost}.mycompany.org
-#      brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org
+#      # The patterns below are the built-in behaviour, written out explicitly. Each is evaluated once per configured domain:
+#      bootstrapDomainPattern: "{apiHost}.{domain}"
+#      brokerDomainPattern: "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{domain}"
+#      # {domain} requires a gateway bundling native Kafka reactor 7.0.2 or later (APIM 4.12.14+). On an
+#      # earlier gateway it is left unsubstituted and the API fails to deploy with a PatternSyntaxException;
+#      # use {defaultDomain} there, which resolves to the same value.
 #      # Where:
-#      # {apiHost}  is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
-#      # {brokerId} is a placeholder that stands for the broker id
+#      # {apiHost}         is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
+#      # {brokerId}        is a placeholder that stands for the broker id
+#      # {brokerPrefix}    is a placeholder for the 'brokerPrefix' property above
+#      # {domainSeparator} is a placeholder for the 'domainSeparator' property above
+#      # {domain}          is a placeholder for the domain being evaluated: the patterns are applied once per
+#      #                   entry of `domains`, or once to `defaultDomain` when `domains` is not set.
+#      #                   An entry that itself contains {apiHost} becomes the bootstrap pattern, and both
+#      #                   patterns configured here are then ignored.
+#      #                   Writing a domain literally here instead of using {domain} makes every entry resolve
+#      #                   to that same hostname, leaving the other domains unroutable. The gateway logs a
+#      #                   warning when it detects it. `{defaultDomain}` is still accepted as a deprecated
+#      #                   alias of `{domain}`.
+#      # The built-in defaults, used for whichever pattern is left unset, are "{apiHost}.{defaultDomain}" and
+#      # "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}".
 #
 #      # It can be overridden to fit your DNS configuration.
-#      # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'defaultDomain', 'brokerPrefix' and 'domainSeparator' are not used in that case, hence optional.
+#      # Each pattern falls back to its own default independently, so overriding only one of them is fine, and 'defaultPort' defaults to 9092. Please note that 'brokerPrefix' and 'domainSeparator' are substituted only if the patterns reference them as {brokerPrefix} / {domainSeparator}, hence optional.
 #      # Example:
 #      #   defaultPort: 9092
-#      #   bootstrapDomainPattern: bootstrap-{apiHost}.mycompany.org
-#      #   brokerDomainPattern: {apiHost}-broker{brokerId}.mycompany.org
+#      #   bootstrapDomainPattern: "bootstrap-{apiHost}.{domain}"
+#      #   brokerDomainPattern: "{apiHost}-broker{brokerId}.{domain}"
 #      #
-#      #   This configuration yields domains that must target the Gravitee Kafka gateway:
-#      #      bootstrap-myapi.mycompany.org
-#      #      myapi-broker0.mycompany.org
-#      #      myapi-broker1.mycompany.org
+#      #   With the two domains above, this configuration yields domains that must target the Gravitee Kafka gateway:
+#      #      bootstrap-myapi.mycompany.org      bootstrap-myapi.mycompany.com
+#      #      myapi-broker0.mycompany.org        myapi-broker0.mycompany.com
+#      #      myapi-broker1.mycompany.org        myapi-broker1.mycompany.com
 #      #      ...
 #
 #    # Kafka probe


### PR DESCRIPTION
Related to [APIM-14788](https://gravitee.atlassian.net/browse/APIM-14788). Companion of gravitee-io/gravitee-reactor-native-kafka#375 (released in reactor `7.0.2`).

## Context

The Kafka routing host mode patterns are evaluated **once per configured domain**, with `{domain}` substituted by the domain being evaluated (`{defaultDomain}` is kept as an alias). The example configuration shipped by APIM predates that and contradicts it:

- **`helm/values.yaml`** is the pressing one: it already advertises a two-entry list
  ```yaml
  domains:
    - mycompany.org
    - mycompany.com
  ```
  while keeping `bootstrapDomainPattern: {apiHost}.mycompany.org` / `brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org`. Copying it verbatim makes both domains resolve to `…mycompany.org`, leaves `mycompany.com` unroutable, and now trips the collapse warning the reactor emits — from the official example.
- **`gravitee.yml`** (gateway distribution) never documented the `domains` list at all, only the deprecated scalar `defaultDomain`.

## Changes

- Both patterns in both files now use the placeholder: `{apiHost}.{domain}` and `broker-{brokerId}-{apiHost}.{domain}`, in the default example and in the "override to fit your DNS configuration" example.
- `{domain}` documented alongside `{apiHost}` / `{brokerId}`: per-domain evaluation, the collapse that hardcoding a domain causes, and `{defaultDomain}` as a deprecated alias.
- `gravitee.yml` gains the `domains:` list and the `defaultDomain` deprecation note that `helm/values.yaml` already carried.
- Corrected an inaccuracy carried by both files: the override note claimed `defaultDomain`, `brokerPrefix` and `domainSeparator` "are not used" with custom patterns. `DefaultKafkaAcceptor#evalDomainPattern` substitutes all of them whenever the pattern references them.
- `helm/CHANGELOG.md`: extended the existing 4.13.0 `domains` entry.

## Reactor bump — this PR is not comment-only

`gravitee-apim-distribution/pom.xml:241` moves from `7.1.0-alpha.6` to `7.1.0-alpha.7`. **This changes the shipped runtime**, and it is required: `alpha.6` was cut before the `alpha` branch was synced with `main`, so it has no `{domain}` substitution. On it, the examples this PR ships would leave `{domain}` literal, `buildPattern` would call `Pattern.compile("myapi\\.{domain}")` and throw `PatternSyntaxException: Illegal repetition` — the acceptor is never built and the API does not deploy.

`alpha.7` brings the `{domain}` alias, the collapse warning, the `defaultDomain`-is-ignored warning, and the three NetClient leak fixes from `7.0.6`.

The quick-setup stacks are updated in the same move: `alpha.7` warns on every startup for the deprecated `defaultDomain`, which `docker/quick-setup/native-kafka` and `native-kafka-mesh` still set. They now use `domains_0`.

**Not identical to #19200**, contrary to what this description said earlier: that PR bumped 4.12.x to `7.0.6`, this one bumps `master` to `7.1.0-alpha.7`, and it carries review corrections that #19200 was merged without.

## The documentation part is comment-only

The `kafka:` block is commented out in its entirety in both config files, so that half changes no rendered configuration and no manifest output. `{defaultDomain}` keeps working, so no existing configuration breaks.

## Follow-up

**4.12.x**: same change in #19200. Filed as a separate PR rather than a backport, because the distribution module was restructured on `master` and `gravitee.yml` has moved (`gravitee-apim-distribution/…-standalone-gateway/` here vs `gravitee-apim-gateway/…-standalone-distribution/` there). Content is identical.

**4.11.x**: not planned. It carries the same misleading `helm/values.yaml` example, but ships reactor `6.3.4`, whose `evalDomainPattern` has no `{domain}` alias — the fix there would have to be written with `{defaultDomain}` (already substituted per domain on that branch). Recorded here so the gap is known.


[APIM-14788]: https://gravitee.atlassian.net/browse/APIM-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ