### PR TITLE
[4.12.x] chore(kafka): bump reactor to 7.0.6, use the {domain} placeholder in routing host mode examples

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -185,30 +185,48 @@ secrets:
 #  # Routing Host Mode
 #  routingHostMode:
 #    brokerPrefix: broker-          # default is broker-
-#    domainSeparator: -             # Used to separate broker's name from api & defaultDomain. Default is '-'
+#    domainSeparator: "-"           # Used to separate broker's name from api & domain. Default is '-'
 #
-#    # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
-#    defaultDomain: mycompany.org   # Should set according to the public wildcard DNS/Certificate. Default is empty
+#    # The domains where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org` and `myapi.mycompany.com`
+#    # Each domain should be set according to a public wildcard DNS/Certificate.
+#    domains:
+#      - mycompany.org
+#      - mycompany.com
+#
+#    # For a single domain, `defaultDomain` is still accepted but deprecated. It is ignored -- with a
+#    # warning -- as soon as `domains` is set, so enable one or the other, never both:
+#    #   defaultDomain: mycompany.org
+#
 #    defaultPort:   9092            # Default public port for Kafka APIs. Default is 9092
 #
 #    # With the upper default configuration, the Gravitee Kafka gateway yields bootstrap and broker domains to be as follows:
-#    bootstrapDomainPattern: {apiHost}.mycompany.org
-#    brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org
+#    bootstrapDomainPattern: "{apiHost}.{domain}"
+#    brokerDomainPattern: "broker-{brokerId}-{apiHost}.{domain}"
 #    # Where:
-#    # {apiHost}  is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
-#    # {brokerId} is a placeholder that stands for the broker id
+#    # {apiHost}         is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
+#    # {brokerId}        is a placeholder that stands for the broker id
+#    # {brokerPrefix}    is a placeholder for the 'brokerPrefix' property above
+#    # {domainSeparator} is a placeholder for the 'domainSeparator' property above
+#    # {domain}          is a placeholder for the domain being evaluated: the patterns are applied once per
+#    #                   entry of `domains`, or once to `defaultDomain` when `domains` is not set.
+#    #                   Writing a domain literally here instead of using {domain} makes every entry resolve
+#    #                   to that same hostname, leaving the other domains unroutable. The gateway logs a
+#    #                   warning when it detects it. `{defaultDomain}` is still accepted as a deprecated
+#    #                   alias of `{domain}`.
+#    # The built-in defaults, used when both patterns are left unset, are "{apiHost}.{defaultDomain}" and
+#    # "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}".
 #
 #    # It can be overridden to fit your DNS configuration.
-#    # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'defaultDomain', 'brokerPrefix' and 'domainSeparator' are not used in that case, hence optional.
+#    # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'brokerPrefix' and 'domainSeparator' are substituted only if the patterns reference them as {brokerPrefix} / {domainSeparator}, hence optional.
 #    # Example:
 #    #   defaultPort: 9092
-#    #   bootstrapDomainPattern: bootstrap-{apiHost}.mycompany.org
-#    #   brokerDomainPattern: {apiHost}-broker{brokerId}.mycompany.org
+#    #   bootstrapDomainPattern: "bootstrap-{apiHost}.{domain}"
+#    #   brokerDomainPattern: "{apiHost}-broker{brokerId}.{domain}"
 #    #
-#    #   This configuration yields domains that must target the Gravitee Kafka gateway:
-#    #      bootstrap-myapi.mycompany.org
-#    #      myapi-broker0.mycompany.org
-#    #      myapi-broker1.mycompany.org
+#    #   With the two domains above, this configuration yields domains that must target the Gravitee Kafka gateway:
+#    #      bootstrap-myapi.mycompany.org      bootstrap-myapi.mycompany.com
+#    #      myapi-broker0.mycompany.org        myapi-broker0.mycompany.com
+#    #      myapi-broker1.mycompany.org        myapi-broker1.mycompany.com
 #    #      ...
 #
 #  # Kafka probe

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 ### 4.12.0
 - Render `config/hazelcast.xml` for gateway Hazelcast clustering (`gateway.cluster.type=hazelcast`) with Kubernetes discovery via the `-hz` Service. Cluster name defaults to `<release>-<sharding_tags>` so Redis distributed-event namespace (clusterId) changes when sharding tags change; override with `gateway.cluster.hazelcast.clusterName`. Require `gateway.cluster` when `gateway.distributedSync` is enabled; auto-enable `services.sync.repository` and `services.sync.distributed`.
-- Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set.
+- Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set. The `bootstrapDomainPattern` / `brokerDomainPattern` examples now use the `{domain}` placeholder, which is substituted with each configured domain in turn; hardcoding a domain there collapses every entry onto the same hostname (`{defaultDomain}` remains a supported alias).
 - Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
 - Add support for Kubernetes Gateway API HTTPRoute for all components (API, Gateway, User Interface, Portal).
     - HTTPRoute is compatible alongside Nginx Ingress.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1454,7 +1454,7 @@ gateway:
 #    # Routing Host Mode
 #    routingHostMode:
 #      brokerPrefix: broker-          # default is broker-
-#      domainSeparator: -             # Used to separate broker's name from api & defaultDomain. Default is '-'
+#      domainSeparator: "-"           # Used to separate broker's name from api & domain. Default is '-'
 #
 #      # The domains where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org` and `myapi.mycompany.com`
 #      # Each domain should be set according to a public wildcard DNS/Certificate.
@@ -1462,29 +1462,40 @@ gateway:
 #        - mycompany.org
 #        - mycompany.com
 #
-#      # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
-#      # Deprecated: use `domains` instead. Ignored when `domains` is set.
-#      defaultDomain: mycompany.org   # Should set according to the public wildcard DNS/Certificate. Default is empty
+#      # For a single domain, `defaultDomain` is still accepted but deprecated. It is ignored -- with a
+#      # warning -- as soon as `domains` is set, so enable one or the other, never both:
+#      #   defaultDomain: mycompany.org
+#
 #      defaultPort:   9092            # Default public port for Kafka APIs. Default is 9092
 #
 #      # With the upper default configuration, the Gravitee Kafka gateway yields bootstrap and broker domains to be as follows:
-#      bootstrapDomainPattern: {apiHost}.mycompany.org
-#      brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org
+#      bootstrapDomainPattern: "{apiHost}.{domain}"
+#      brokerDomainPattern: "broker-{brokerId}-{apiHost}.{domain}"
 #      # Where:
-#      # {apiHost}  is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
-#      # {brokerId} is a placeholder that stands for the broker id
+#      # {apiHost}         is a placeholder that will be replaced when the API is deployed, by the API Host Prefix.
+#      # {brokerId}        is a placeholder that stands for the broker id
+#      # {brokerPrefix}    is a placeholder for the 'brokerPrefix' property above
+#      # {domainSeparator} is a placeholder for the 'domainSeparator' property above
+#      # {domain}          is a placeholder for the domain being evaluated: the patterns are applied once per
+#      #                   entry of `domains`, or once to `defaultDomain` when `domains` is not set.
+#      #                   Writing a domain literally here instead of using {domain} makes every entry resolve
+#      #                   to that same hostname, leaving the other domains unroutable. The gateway logs a
+#      #                   warning when it detects it. `{defaultDomain}` is still accepted as a deprecated
+#      #                   alias of `{domain}`.
+#      # The built-in defaults, used when both patterns are left unset, are "{apiHost}.{defaultDomain}" and
+#      # "{brokerPrefix}{brokerId}{domainSeparator}{apiHost}.{defaultDomain}".
 #
 #      # It can be overridden to fit your DNS configuration.
-#      # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'defaultDomain', 'brokerPrefix' and 'domainSeparator' are not used in that case, hence optional.
+#      # Doing so requires BOTH patterns to be set, as well as 'defaultPort'. Please note that 'brokerPrefix' and 'domainSeparator' are substituted only if the patterns reference them as {brokerPrefix} / {domainSeparator}, hence optional.
 #      # Example:
 #      #   defaultPort: 9092
-#      #   bootstrapDomainPattern: bootstrap-{apiHost}.mycompany.org
-#      #   brokerDomainPattern: {apiHost}-broker{brokerId}.mycompany.org
+#      #   bootstrapDomainPattern: "bootstrap-{apiHost}.{domain}"
+#      #   brokerDomainPattern: "{apiHost}-broker{brokerId}.{domain}"
 #      #
-#      #   This configuration yields domains that must target the Gravitee Kafka gateway:
-#      #      bootstrap-myapi.mycompany.org
-#      #      myapi-broker0.mycompany.org
-#      #      myapi-broker1.mycompany.org
+#      #   With the two domains above, this configuration yields domains that must target the Gravitee Kafka gateway:
+#      #      bootstrap-myapi.mycompany.org      bootstrap-myapi.mycompany.com
+#      #      myapi-broker0.mycompany.org        myapi-broker0.mycompany.com
+#      #      myapi-broker1.mycompany.org        myapi-broker1.mycompany.com
 #      #      ...
 #
 #    # Kafka probe

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.5</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.0.6</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
Related to [APIM-14788](https://gravitee.atlassian.net/browse/APIM-14788). Companion of gravitee-io/gravitee-reactor-native-kafka#375 (released in reactor `7.0.2`; 4.12.x ships `7.0.5`).

4.12.x counterpart of #19199 — filed separately rather than backported, because the distribution module was restructured on `master` and `gravitee.yml` has moved (`gravitee-apim-distribution/…-standalone-gateway/` vs `gravitee-apim-gateway/…-standalone-distribution/`). Content is identical.

## Context

The Kafka routing host mode patterns are evaluated **once per configured domain**, with `{domain}` substituted by the domain being evaluated (`{defaultDomain}` is kept as an alias). The example configuration shipped by APIM predates that and contradicts it:

- **`helm/values.yaml`** is the pressing one: it already advertises a two-entry list
  ```yaml
  domains:
    - mycompany.org
    - mycompany.com
  ```
  while keeping `bootstrapDomainPattern: {apiHost}.mycompany.org` / `brokerDomainPattern: broker-{brokerId}-{apiHost}.mycompany.org`. Copying it verbatim makes both domains resolve to `…mycompany.org`, leaves `mycompany.com` unroutable, and now trips the collapse warning the reactor emits — from the official example.
- **`gravitee.yml`** (gateway distribution) never documented the `domains` list at all, only the deprecated scalar `defaultDomain`.

## Changes

- Both patterns in both files now use the placeholder: `{apiHost}.{domain}` and `broker-{brokerId}-{apiHost}.{domain}`, in the default example and in the "override to fit your DNS configuration" example.
- `{domain}` documented alongside `{apiHost}` / `{brokerId}`: per-domain evaluation, the collapse that hardcoding a domain causes, and `{defaultDomain}` as a deprecated alias.
- `gravitee.yml` gains the `domains:` list and the `defaultDomain` deprecation note that `helm/values.yaml` already carried.
- Corrected an inaccuracy carried by both files: the override note claimed `defaultDomain`, `brokerPrefix` and `domainSeparator` "are not used" with custom patterns. `DefaultKafkaAcceptor#evalDomainPattern` substitutes all of them whenever the pattern references them.
- `helm/CHANGELOG.md`: extended the existing 4.12.0 `domains` entry.

## Also in this PR: reactor bump 7.0.5 → 7.0.6

`pom.xml` — the single place the version is pinned on this branch. [7.0.6](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/7.0.6) carries three resource-leak fixes, none of them related to routing or domains:

- `net`: release runtime NetClients from the Vert.x close future
- `probe`: share a single NetClient across TCP health checks
- `virtualcluster`: close connected clusters when a sibling connect fails

Kept as its own commit. Unlike the doc change below, this one does alter the shipped runtime.

## No behaviour change (documentation part)

The `kafka:` block is commented out in its entirety in both files, so this is documentation only — no rendered configuration and no manifest output changes. `{defaultDomain}` keeps working, so no existing configuration breaks either.

## Note on 4.11.x

Not planned. 4.11.x carries the same misleading `helm/values.yaml` example, but ships reactor `6.3.4`, whose `evalDomainPattern` has no `{domain}` alias — the fix there would have to be written with `{defaultDomain}` (already substituted per domain on that branch). Recorded here so the gap is known.


[APIM-14788]: https://gravitee.atlassian.net/browse/APIM-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ