### PR TITLE
feat(tenants): add tenant management support with permissions and UI …

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -93,6 +93,10 @@ jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
 
+jest.mock('../pages/TenantsPage', () => ({
+    TenantsPage: () => <div data-testid="tenants-page" />,
+}));
+
 jest.mock('../features/applications/components/detail', () => ({
     ApplicationDetailLayout: () => <div data-testid="application-detail-layout" />,
     ApplicationDetailIndexRedirect: () => null,
@@ -390,5 +394,54 @@ describe('AppRoutes', () => {
         renderPlatform();
 
         expect(visibleNavKeys()).not.toContain('alerts');
+    });
+
+    it('routes to the Tenants page under the platform module', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'tenants',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/tenants');
+
+        expect(screen.getByTestId('tenants-page')).not.toBeNull();
+    });
+
+    it('shows the Tenants nav item when the user has read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'tenants',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/tenants');
+
+        expect(visibleNavKeys()).toContain('tenants');
+        expect(visibleNavKeys()).toContain('entrypoints-and-sharding-tags');
+    });
+
+    it('hides the Tenants nav item when the user lacks tenant read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'tenants',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        mockUseHasPermission.mockImplementation(
+            ({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-tenant-r') && !anyOf.includes('environment-tenant-r'),
+        );
+
+        renderPlatform('/tenants');
+
+        expect(visibleNavKeys()).not.toContain('tenants');
+    });
+
+    it('redirects away from Tenants when the user lacks tenant read permission', () => {
+        mockUseHasPermission.mockImplementation(
+            ({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-tenant-r') && !anyOf.includes('environment-tenant-r'),
+        );
+
+        renderPlatform('/tenants');
+
+        expect(screen.queryByTestId('tenants-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -64,6 +64,7 @@ import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { TenantsPage } from '../pages/TenantsPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
 import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
@@ -115,6 +116,7 @@ function isNavItemVisible(
     canReadEntrypoints: boolean,
     canReadGroups: boolean,
     canReadAlerts: boolean,
+    canReadTenants: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
@@ -136,6 +138,9 @@ function isNavItemVisible(
     }
     if (itemKey === 'alerts') {
         return !permissionsReady || canReadAlerts;
+    }
+    if (itemKey === 'tenants') {
+        return !permissionsReady || canReadTenants;
     }
     return true;
 }
@@ -219,6 +224,7 @@ function ModuleLayout() {
     const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
     const canReadAlerts = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_READ_PERMISSION] });
+    const canReadTenants = useHasPermission({ anyOf: ['organization-tenant-r', 'environment-tenant-r'] });
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
@@ -235,6 +241,7 @@ function ModuleLayout() {
                     canReadEntrypoints,
                     canReadGroups,
                     canReadAlerts,
+                    canReadTenants,
                 ),
             ),
         [
@@ -246,6 +253,7 @@ function ModuleLayout() {
             canReadEntrypoints,
             canReadGroups,
             canReadAlerts,
+            canReadTenants,
         ],
     );
 
@@ -432,6 +440,17 @@ export function AppRoutes() {
                                     <Route path="monitoring" element={<GatewayInstanceMonitoringPage />} />
                                 </Route>
                             </Route>
+                            <Route
+                                path="tenants"
+                                element={
+                                    <PermissionPageGuard
+                                        anyOf={['organization-tenant-r', 'environment-tenant-r']}
+                                        unauthorizedTo="../applications"
+                                    >
+                                        <TenantsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
                             <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
                             <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
                             <Route

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -37,8 +37,8 @@ describe('platform navigation config', () => {
         expect(NAV_SECTIONS.some(section => section.key === 'general' || section.title === 'General')).toBe(false);
     });
 
-    it('places Entrypoints & Sharding Tags under Organization / Assets', () => {
-        expect(sectionKeys('Organization', 'Assets')).toEqual(['entrypoints-and-sharding-tags']);
+    it('places Tenants then Entrypoints & Sharding Tags under Organization / Assets', () => {
+        expect(sectionKeys('Organization', 'Assets')).toEqual(['tenants', 'entrypoints-and-sharding-tags']);
     });
 
     it('places Access Management under Organization / System & Security', () => {
@@ -73,13 +73,14 @@ describe('platform navigation config', () => {
         expect(findNavSectionKey(NAV_SECTIONS, 'applications')).toBe('environment');
         expect(findNavSectionKey(NAV_SECTIONS, 'users')).toBe('team');
         expect(findNavSectionKey(NAV_SECTIONS, 'access-management')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'tenants')).toBe('organization');
         expect(findNavSectionKey(NAV_SECTIONS, 'missing')).toBeUndefined();
     });
 
     it('returns the first visible item in a section', () => {
         const organization = NAV_SECTIONS.find(section => section.key === 'organization');
         expect(organization).toBeDefined();
-        expect(firstNavItemKey(organization!)).toBe('entrypoints-and-sharding-tags');
+        expect(firstNavItemKey(organization!)).toBe('tenants');
     });
 
     it('filters hidden items and drops empty groups and sections', () => {
@@ -102,5 +103,10 @@ describe('platform navigation config', () => {
     it('declares the user-groups route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('user-groups');
         expect(ROUTES['user-groups']).toEqual({ path: 'user-groups', label: 'Groups' });
+    });
+
+    it('declares the tenants route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('tenants');
+        expect(ROUTES.tenants).toEqual({ path: 'tenants', label: 'Tenants' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -18,6 +18,7 @@ import {
     AppWindowIcon,
     BellIcon,
     BookOpenIcon,
+    BoxesIcon,
     CloudIcon,
     DatabaseIcon,
     GlobeIcon,
@@ -50,6 +51,11 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
             {
                 label: 'Assets',
                 items: [
+                    {
+                        key: 'tenants',
+                        title: ROUTES.tenants.label,
+                        icon: BoxesIcon,
+                    },
                     {
                         key: 'entrypoints-and-sharding-tags',
                         title: ROUTES['entrypoints-and-sharding-tags'].label,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -24,6 +24,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'dictionaries',
     'security-plan-types',
     'gateways',
+    'tenants',
     'entrypoints-and-sharding-tags',
     'alerts',
 ];
@@ -40,6 +41,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     metadata: { path: 'metadata', label: 'Metadata' },
     dictionaries: { path: 'dictionaries', label: 'Dictionaries' },
     gateways: { path: 'gateways', label: 'Gateways' },
+    tenants: { path: 'tenants', label: 'Tenants' },
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
     alerts: { path: 'alerts', label: 'Alerts' },
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.spec.tsx
@@ -61,4 +61,12 @@ describe('TenantDeleteDialog', () => {
         expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
         expect((screen.getByRole('button', { name: 'Deleting…' }) as HTMLButtonElement).disabled).toBe(true);
     });
+
+    it('does not close on Escape while delete is in progress', () => {
+        const onClose = jest.fn();
+        render(<TenantDeleteDialog open tenant={TENANT} onClose={onClose} onConfirm={jest.fn()} isDeleting />);
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).not.toHaveBeenCalled();
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.spec.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TenantDeleteDialog } from './TenantDeleteDialog';
+import type { Tenant } from '../types/tenant';
+
+const TENANT: Tenant = { id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia' };
+
+function renderDialog(open: boolean, tenant: Tenant | undefined = TENANT) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(<TenantDeleteDialog open={open} tenant={tenant} onClose={onClose} onConfirm={onConfirm} isDeleting={false} />);
+    return { onClose, onConfirm };
+}
+
+describe('TenantDeleteDialog', () => {
+    it('does not show dialog content when closed', () => {
+        renderDialog(false);
+        expect(screen.queryByRole('heading', { name: 'Delete a tenant' })).toBeNull();
+    });
+
+    it('confirms deletion using the tenant name, matching Classic console', () => {
+        renderDialog(true);
+        expect(screen.getByRole('heading', { name: 'Delete a tenant' })).not.toBeNull();
+        expect(screen.getByText('US East', { selector: 'strong' })).not.toBeNull();
+        expect(screen.getByText(/Gateways still tagged with this key will no longer match any endpoint that used it\./)).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+    });
+
+    it('invokes onClose when Cancel is clicked', () => {
+        const { onClose } = renderDialog(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onConfirm when Delete is clicked', () => {
+        const { onConfirm } = renderDialog(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows deleting label while the mutation is in progress', () => {
+        render(<TenantDeleteDialog open tenant={TENANT} onClose={jest.fn()} onConfirm={jest.fn()} isDeleting />);
+
+        expect(screen.getByRole('button', { name: 'Deleting…' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+        expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Deleting…' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.tsx
@@ -34,7 +34,12 @@ export function TenantDeleteDialog({
     const displayName = tenant?.name || tenant?.key;
 
     return (
-        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+        <Dialog
+            open={open}
+            onOpenChange={isOpen => {
+                if (!isOpen && !isDeleting) onClose();
+            }}
+        >
             <DialogContent className="max-w-sm">
                 <DialogHeader>
                     <DialogTitle>Delete a tenant</DialogTitle>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantDeleteDialog.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { Tenant } from '../types/tenant';
+
+export function TenantDeleteDialog({
+    open,
+    tenant,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    tenant: Tenant | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    const displayName = tenant?.name || tenant?.key;
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete a tenant</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete the tenant <strong>{displayName}</strong>? Gateways still tagged with this key will
+                        no longer match any endpoint that used it.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !tenant}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.spec.tsx
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { TenantFormSheet } from './TenantFormSheet';
+import { ApimApiError } from '../../../shared/api/apimClient';
+import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
+import type { Tenant } from '../types/tenant';
+
+const EXISTING: Tenant[] = [{ id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia' }];
+
+const EDIT_TENANT: Tenant = {
+    id: 't-2',
+    key: 'eu-west',
+    name: 'EU West',
+    description: 'Frankfurt',
+};
+
+function renderCreateSheet({
+    open = true,
+    isSaving = false,
+    existingTenants = EXISTING,
+    onSubmit = jest.fn().mockResolvedValue(undefined),
+}: {
+    open?: boolean;
+    isSaving?: boolean;
+    existingTenants?: Tenant[];
+    onSubmit?: jest.Mock;
+} = {}) {
+    const onClose = jest.fn();
+    render(
+        <TenantFormSheet
+            open={open}
+            mode="create"
+            existingTenants={existingTenants}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={isSaving}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+function renderEditSheet({
+    open = true,
+    tenant = EDIT_TENANT,
+    isSaving = false,
+    onSubmit = jest.fn().mockResolvedValue(undefined),
+}: {
+    open?: boolean;
+    tenant?: Tenant;
+    isSaving?: boolean;
+    onSubmit?: jest.Mock;
+} = {}) {
+    const onClose = jest.fn();
+    render(
+        <TenantFormSheet
+            open={open}
+            mode="edit"
+            tenant={tenant}
+            existingTenants={EXISTING}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={isSaving}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('TenantFormSheet', () => {
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = jest.fn();
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('does not show sheet content when closed', () => {
+        renderCreateSheet({ open: false });
+        expect(querySheetHeading('Create a tenant')).toBeNull();
+    });
+
+    it('explains that the key is generated from the name', () => {
+        renderCreateSheet();
+        expect(
+            screen.getByText('The key is what you paste into gravitee.yml. It is generated from the name unless you type one.'),
+        ).not.toBeNull();
+    });
+
+    it('generates the key from the name until the key field is typed', () => {
+        renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'AP South' } });
+        expect((screen.getByLabelText(/^Key/) as HTMLInputElement).value).toBe('ap-south');
+        expect((screen.getByRole('button', { name: 'Create tenant' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('stops generating the key after the user types in the key field', () => {
+        renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'AP South' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: 'custom-key' } });
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'AP West' } });
+        expect((screen.getByLabelText(/^Key/) as HTMLInputElement).value).toBe('custom-key');
+    });
+
+    it('keeps Create tenant disabled until name and key are valid', () => {
+        renderCreateSheet();
+        const createBtn = screen.getByRole('button', { name: 'Create tenant' }) as HTMLButtonElement;
+        expect(createBtn.disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: '   ' } });
+        expect((screen.getByRole('button', { name: 'Create tenant' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('explains why the name is rejected once the user has typed into it', () => {
+        renderCreateSheet();
+        expect(screen.queryByText('Name is required.')).toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: '   ' } });
+
+        expect(screen.getByText('Name is required.')).not.toBeNull();
+        expect(screen.getByLabelText(/^Name/).getAttribute('aria-describedby')).toBe('tenant-create-name-error');
+    });
+
+    it('explains why the key is rejected once the user has typed into it', () => {
+        renderCreateSheet();
+        expect(screen.queryByText('Key is required and must contain at least one letter or number.')).toBeNull();
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Lab' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: '---' } });
+
+        expect(screen.getByText('Key is required and must contain at least one letter or number.')).not.toBeNull();
+        expect(screen.getByLabelText(/^Key/).getAttribute('aria-describedby')).toBe('tenant-create-key-error');
+    });
+
+    it('submits create payload with slugified key and optional description', async () => {
+        const { onSubmit } = renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'AP South' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: 'Custom Key!' } });
+        fireEvent.change(screen.getByLabelText(/^Description/), { target: { value: 'Singapore cluster' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                name: 'AP South',
+                key: 'custom-key',
+                description: 'Singapore cluster',
+            });
+        });
+    });
+
+    it('allows a duplicate name when the key differs, matching the API where only the key is unique', async () => {
+        const { onSubmit } = renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'US East' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: 'us-east-2' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({ name: 'US East', key: 'us-east-2', description: undefined });
+        });
+    });
+
+    it('shows inline error for duplicate key on submit', async () => {
+        renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'US West' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: 'us-east' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('The tenant key already exists.')).not.toBeNull();
+        });
+    });
+
+    it('keeps existing key read-only in edit mode', () => {
+        renderEditSheet();
+        expect(screen.getByRole('heading', { name: 'Edit a tenant' })).not.toBeNull();
+        expect(
+            screen.getByText('Change the name or description. The key is already in use on gateways and cannot be renamed.'),
+        ).not.toBeNull();
+        const keyInput = screen.getByLabelText(/^Key/) as HTMLInputElement;
+        expect(keyInput.value).toBe('eu-west');
+        expect(keyInput.readOnly).toBe(true);
+        expect(keyInput.disabled).toBe(true);
+    });
+
+    it('maps create-mode duplicate-key HTTP 400 to the key field error', async () => {
+        const onSubmit = jest
+            .fn()
+            .mockRejectedValue(new ApimApiError(400, 'The tenant already exists.', { technicalCode: 'tenant.exists' }));
+        renderCreateSheet({ onSubmit });
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Lab' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+        await waitFor(() => {
+            expect(screen.queryByText('The tenant already exists.')).not.toBeNull();
+            expect(screen.getByLabelText(/^Key/).getAttribute('aria-invalid')).toBe('true');
+        });
+    });
+
+    it('maps other create-mode HTTP 400s to the form submit error, not the key field', async () => {
+        const onSubmit = jest.fn().mockRejectedValue(new ApimApiError(400, 'size must be between 1 and 40'));
+        renderCreateSheet({ onSubmit });
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Lab' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+        await waitFor(() => {
+            expect(screen.queryByText('size must be between 1 and 40')).not.toBeNull();
+        });
+        expect(screen.getByLabelText(/^Key/).getAttribute('aria-invalid')).not.toBe('true');
+    });
+
+    it('marks the create key as required and invalid when empty', () => {
+        renderCreateSheet();
+        const keyInput = screen.getByLabelText(/^Key/);
+        expect(keyInput).toHaveProperty('required', true);
+        expect(keyInput.getAttribute('aria-required')).toBe('true');
+        expect(keyInput.getAttribute('aria-invalid')).toBe('true');
+        expect(keyInput.getAttribute('maxLength')).toBe('40');
+    });
+
+    it('keeps Create tenant disabled when the key sanitizes to empty', () => {
+        renderCreateSheet();
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'Lab' } });
+        fireEvent.change(screen.getByLabelText(/^Key/), { target: { value: '---' } });
+        expect((screen.getByRole('button', { name: 'Create tenant' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('scopes the form and field ids per mode so both sheets can be mounted at once', () => {
+        const { unmount } = render(
+            <TenantFormSheet
+                open
+                mode="create"
+                existingTenants={EXISTING}
+                onClose={jest.fn()}
+                onSubmit={jest.fn().mockResolvedValue(undefined)}
+                isSaving={false}
+            />,
+        );
+        expect(document.getElementById('tenant-create-form')).not.toBeNull();
+        expect(document.getElementById('tenant-create-name')).not.toBeNull();
+        expect(document.getElementById('tenant-create-key')).not.toBeNull();
+        expect(document.getElementById('tenant-create-description')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Create tenant' }).getAttribute('form')).toBe('tenant-create-form');
+        unmount();
+
+        renderEditSheet();
+        expect(document.getElementById('tenant-edit-form')).not.toBeNull();
+        expect(document.getElementById('tenant-edit-name')).not.toBeNull();
+        expect(document.getElementById('tenant-edit-key')).not.toBeNull();
+        expect(document.getElementById('tenant-edit-description')).not.toBeNull();
+        expect(document.getElementById('tenant-form')).toBeNull();
+        expect(document.getElementById('tenant-name')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Save' }).getAttribute('form')).toBe('tenant-edit-form');
+    });
+
+    it('shows character counters for name, key, and description', () => {
+        renderCreateSheet();
+        expect(screen.getAllByText('0/40')).toHaveLength(2);
+        expect(screen.getByText('0/160')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.spec.tsx
@@ -18,6 +18,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { TenantFormSheet } from './TenantFormSheet';
 import { ApimApiError } from '../../../shared/api/apimClient';
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
 import { querySheetHeading } from '../../applications/components/test/sheetSpecHelpers';
 import type { Tenant } from '../types/tenant';
 
@@ -238,7 +239,7 @@ describe('TenantFormSheet', () => {
         expect((screen.getByRole('button', { name: 'Create tenant' }) as HTMLButtonElement).disabled).toBe(true);
     });
 
-    it('scopes the form and field ids per mode so both sheets can be mounted at once', () => {
+    it('scopes the form and field ids per mode', () => {
         const { unmount } = render(
             <TenantFormSheet
                 open
@@ -270,5 +271,18 @@ describe('TenantFormSheet', () => {
         renderCreateSheet();
         expect(screen.getAllByText('0/40')).toHaveLength(2);
         expect(screen.getByText('0/160')).not.toBeNull();
+    });
+
+    it('renders at the standard sheet width', () => {
+        renderCreateSheet();
+        const content = document.querySelector('[data-slot="sheet-content"]') as HTMLElement | null;
+        expect(content).not.toBeNull();
+        expect(content?.style.maxWidth).toBe(STANDARD_SHEET_WIDTH);
+    });
+
+    it('does not close on Escape while save is in progress', () => {
+        const { onClose } = renderCreateSheet({ isSaving: true });
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).not.toHaveBeenCalled();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.tsx
@@ -1,0 +1,381 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
+
+import { ApimApiError } from '../../../shared/api/apimClient';
+import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
+import type { NewTenantPayload, Tenant, UpdateTenantPayload } from '../types/tenant';
+import {
+    findDuplicateTenantKey,
+    getTenantDescriptionError,
+    getTenantNameError,
+    isTenantDescriptionValid,
+    isTenantKeyValid,
+    isTenantNameValid,
+    slugifyTenantKeyBase,
+    slugifyTenantKeyFinal,
+    TENANT_DESCRIPTION_MAX,
+    TENANT_KEY_MAX,
+    TENANT_NAME_MAX,
+    tenantKeyFromName,
+} from '../utils/tenantFormValidation';
+
+interface TenantForm {
+    name: string;
+    key: string;
+    description: string;
+}
+
+const EMPTY_FORM: TenantForm = {
+    name: '',
+    key: '',
+    description: '',
+};
+
+const NAME_REQUIRED_MESSAGE = 'Name is required.';
+const KEY_REQUIRED_MESSAGE = 'Key is required and must contain at least one letter or number.';
+
+function tenantToForm(tenant: Tenant): TenantForm {
+    return {
+        name: tenant.name,
+        key: tenant.key,
+        description: tenant.description ?? '',
+    };
+}
+
+function isDuplicateTenantKeyApiError(error: unknown): boolean {
+    if (!(error instanceof ApimApiError) || error.status !== 400) return false;
+    const technicalCode = (error.body as { technicalCode?: string } | undefined)?.technicalCode;
+    if (technicalCode === 'tenant.exists') return true;
+    return /already exists/i.test(error.message);
+}
+
+type TenantFormSheetBaseProps = {
+    open: boolean;
+    tenant?: Tenant | null;
+    existingTenants: Tenant[];
+    onClose: () => void;
+    isSaving: boolean;
+};
+
+type TenantFormSheetProps =
+    | (TenantFormSheetBaseProps & {
+          mode: 'create';
+          onSubmit: (data: NewTenantPayload) => Promise<void>;
+      })
+    | (TenantFormSheetBaseProps & {
+          mode: 'edit';
+          onSubmit: (data: UpdateTenantPayload) => Promise<void>;
+      });
+
+export function TenantFormSheet({
+    open,
+    mode,
+    tenant = null,
+    existingTenants,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<TenantFormSheetProps>) {
+    const [form, setForm] = useState<TenantForm>(EMPTY_FORM);
+    const [nameTouched, setNameTouched] = useState(false);
+    const [keyTouched, setKeyTouched] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [duplicateKeyError, setDuplicateKeyError] = useState<string | null>(null);
+    const seededTenantIdRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            seededTenantIdRef.current = null;
+            return;
+        }
+
+        if (mode === 'create') {
+            setForm(EMPTY_FORM);
+            setNameTouched(false);
+            setKeyTouched(false);
+            setSubmitError(null);
+            setDuplicateKeyError(null);
+            seededTenantIdRef.current = null;
+            return;
+        }
+
+        if (!tenant) {
+            if (seededTenantIdRef.current === null) {
+                setForm(EMPTY_FORM);
+                setNameTouched(false);
+                setSubmitError(null);
+                setDuplicateKeyError(null);
+            }
+            return;
+        }
+
+        if (seededTenantIdRef.current === tenant.id) return;
+        seededTenantIdRef.current = tenant.id;
+        setForm(tenantToForm(tenant));
+        setNameTouched(false);
+        setKeyTouched(false);
+        setSubmitError(null);
+        setDuplicateKeyError(null);
+    }, [open, mode, tenant]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    const nameError = getTenantNameError(form.name);
+    const descriptionError = getTenantDescriptionError(form.description);
+    const isNameValid = isTenantNameValid(form.name);
+    const isKeyValid = isTenantKeyValid(form.key);
+    const isValid =
+        (mode === 'create' || Boolean(tenant)) &&
+        isNameValid &&
+        nameError === null &&
+        isKeyValid &&
+        isTenantDescriptionValid(form.description) &&
+        duplicateKeyError === null;
+    const keyFieldInvalid = mode === 'create' && (duplicateKeyError !== null || !isKeyValid);
+    /** Scopes element ids per mode: the page keeps the create and edit sheets mounted at the same time. */
+    const idPrefix = mode === 'create' ? 'tenant-create' : 'tenant-edit';
+    const formId = `${idPrefix}-form`;
+
+    function clearDuplicateKeyError() {
+        if (duplicateKeyError) setDuplicateKeyError(null);
+    }
+
+    function handleNameChange(value: string) {
+        clearDuplicateKeyError();
+        setNameTouched(true);
+        setForm(prev => ({
+            ...prev,
+            name: value,
+            key: mode === 'create' && !keyTouched ? tenantKeyFromName(value) : prev.key,
+        }));
+    }
+
+    function handleKeyChange(value: string) {
+        clearDuplicateKeyError();
+        setKeyTouched(true);
+        setForm(prev => ({ ...prev, key: slugifyTenantKeyBase(value).slice(0, TENANT_KEY_MAX) }));
+    }
+
+    function handleKeyBlur() {
+        setForm(prev => {
+            const finalized = slugifyTenantKeyFinal(prev.key).slice(0, TENANT_KEY_MAX);
+            return finalized === prev.key ? prev : { ...prev, key: finalized };
+        });
+    }
+
+    async function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (!isValid || isSaving) return;
+
+        const name = form.name.trim();
+        const key = mode === 'create' ? slugifyTenantKeyFinal(form.key) : form.key;
+        // Only the key is unique server-side; two tenants may legitimately share a name.
+        if (mode === 'create' && findDuplicateTenantKey(existingTenants, key)) {
+            setDuplicateKeyError('The tenant key already exists.');
+            return;
+        }
+
+        try {
+            setSubmitError(null);
+            setDuplicateKeyError(null);
+            const description = form.description.trim() || undefined;
+            if (mode === 'create') {
+                await (onSubmit as (data: NewTenantPayload) => Promise<void>)({ name, key, description });
+            } else {
+                await (onSubmit as (data: UpdateTenantPayload) => Promise<void>)({ key, name, description });
+            }
+        } catch (error) {
+            const fallback = mode === 'create' ? 'Failed to create tenant' : 'Failed to update tenant';
+            const message = extractErrorMessage(error, fallback);
+            if (mode === 'create' && isDuplicateTenantKeyApiError(error)) {
+                setDuplicateKeyError(message);
+            } else {
+                setSubmitError(message);
+            }
+        }
+    }
+
+    const title = mode === 'create' ? 'Create a tenant' : 'Edit a tenant';
+    const submitLabel = mode === 'create' ? (isSaving ? 'Creating...' : 'Create tenant') : isSaving ? 'Saving...' : 'Save';
+    const nameFieldError = nameError ?? (nameTouched && !isNameValid ? NAME_REQUIRED_MESSAGE : null);
+    const keyFieldError = duplicateKeyError ?? (mode === 'create' && keyTouched && !isKeyValid ? KEY_REQUIRED_MESSAGE : null);
+    const sheetDescription =
+        mode === 'create'
+            ? 'The key is what you paste into gravitee.yml. It is generated from the name unless you type one.'
+            : 'Change the name or description. The key is already in use on gateways and cannot be renamed.';
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" showCloseButton={false} className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <SheetTitle>{title}</SheetTitle>
+                        <SheetDescription>{sheetDescription}</SheetDescription>
+                    </div>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 shrink-0"
+                        aria-label="Close"
+                        onClick={() => handleOpenChange(false)}
+                        disabled={isSaving}
+                    >
+                        <XIcon className="size-4" aria-hidden />
+                    </Button>
+                </SheetHeader>
+
+                <ScrollArea className="min-h-0 flex-1">
+                    <form id={formId} onSubmit={handleSubmit} className="flex flex-col gap-5 px-4 py-4">
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor={`${idPrefix}-name`}>
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id={`${idPrefix}-name`}
+                                value={form.name}
+                                onChange={e => handleNameChange(e.target.value)}
+                                placeholder="e.g. US East"
+                                disabled={isSaving}
+                                required
+                                maxLength={TENANT_NAME_MAX}
+                                aria-invalid={nameFieldError !== null}
+                                aria-describedby={nameFieldError !== null ? `${idPrefix}-name-error` : `${idPrefix}-name-count`}
+                            />
+                            {nameFieldError ? (
+                                <p id={`${idPrefix}-name-error`} className="text-sm text-destructive" role="alert">
+                                    {nameFieldError}
+                                </p>
+                            ) : (
+                                <p id={`${idPrefix}-name-count`} className="text-xs text-muted-foreground">
+                                    {form.name.length}/{TENANT_NAME_MAX}
+                                </p>
+                            )}
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor={`${idPrefix}-key`}>
+                                Key{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            {mode === 'create' ? (
+                                <Input
+                                    id={`${idPrefix}-key`}
+                                    value={form.key}
+                                    onChange={e => handleKeyChange(e.target.value)}
+                                    onBlur={handleKeyBlur}
+                                    placeholder="e.g. us-east"
+                                    disabled={isSaving}
+                                    required
+                                    aria-required
+                                    maxLength={TENANT_KEY_MAX}
+                                    aria-invalid={keyFieldInvalid}
+                                    aria-describedby={keyFieldError !== null ? `${idPrefix}-key-error` : `${idPrefix}-key-count`}
+                                />
+                            ) : (
+                                <Input
+                                    id={`${idPrefix}-key`}
+                                    value={form.key}
+                                    readOnly
+                                    disabled
+                                    placeholder="e.g. us-east"
+                                    className="bg-muted"
+                                    aria-describedby={`${idPrefix}-key-count`}
+                                />
+                            )}
+                            {keyFieldError ? (
+                                <p id={`${idPrefix}-key-error`} className="text-sm text-destructive" role="alert">
+                                    {keyFieldError}
+                                </p>
+                            ) : (
+                                <p id={`${idPrefix}-key-count`} className="text-xs text-muted-foreground">
+                                    {form.key.length}/{TENANT_KEY_MAX}
+                                </p>
+                            )}
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor={`${idPrefix}-description`}>Description</FieldLabel>
+                            <Textarea
+                                id={`${idPrefix}-description`}
+                                value={form.description}
+                                onChange={e => setForm(prev => ({ ...prev, description: e.target.value }))}
+                                placeholder="Optional details"
+                                disabled={isSaving}
+                                maxLength={TENANT_DESCRIPTION_MAX}
+                                aria-invalid={descriptionError !== null}
+                                aria-describedby={
+                                    descriptionError !== null ? `${idPrefix}-description-error` : `${idPrefix}-description-count`
+                                }
+                            />
+                            {descriptionError ? (
+                                <p id={`${idPrefix}-description-error`} className="text-sm text-destructive" role="alert">
+                                    {descriptionError}
+                                </p>
+                            ) : (
+                                <p id={`${idPrefix}-description-count`} className="text-xs text-muted-foreground">
+                                    {form.description.length}/{TENANT_DESCRIPTION_MAX}
+                                </p>
+                            )}
+                        </Field>
+
+                        {submitError ? (
+                            <p className="text-sm text-destructive" role="alert">
+                                {submitError}
+                            </p>
+                        ) : null}
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" form={formId} disabled={!isValid || isSaving}>
+                        {submitLabel}
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantFormSheet.tsx
@@ -33,6 +33,7 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 
 import { ApimApiError } from '../../../shared/api/apimClient';
 import { extractErrorMessage } from '../../../shared/notify/extractErrorMessage';
+import { STANDARD_SHEET_WIDTH } from '../../applications/components/sheetLayout';
 import type { NewTenantPayload, Tenant, UpdateTenantPayload } from '../types/tenant';
 import {
     findDuplicateTenantKey,
@@ -150,9 +151,9 @@ export function TenantFormSheet({
 
     const handleOpenChange = useCallback(
         (isOpen: boolean) => {
-            if (!isOpen) onClose();
+            if (!isOpen && !isSaving) onClose();
         },
-        [onClose],
+        [onClose, isSaving],
     );
 
     const nameError = getTenantNameError(form.name);
@@ -167,7 +168,7 @@ export function TenantFormSheet({
         isTenantDescriptionValid(form.description) &&
         duplicateKeyError === null;
     const keyFieldInvalid = mode === 'create' && (duplicateKeyError !== null || !isKeyValid);
-    /** Scopes element ids per mode: the page keeps the create and edit sheets mounted at the same time. */
+    /** Scopes element ids per mode so create and edit field ids stay unique. */
     const idPrefix = mode === 'create' ? 'tenant-create' : 'tenant-edit';
     const formId = `${idPrefix}-form`;
 
@@ -241,7 +242,12 @@ export function TenantFormSheet({
 
     return (
         <Sheet open={open} onOpenChange={handleOpenChange}>
-            <SheetContent side="right" showCloseButton={false} className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                className="flex max-h-full flex-col"
+                style={{ maxWidth: STANDARD_SHEET_WIDTH }}
+            >
                 <SheetHeader className="flex-row items-start justify-between gap-3 space-y-0">
                     <div className="space-y-1.5 text-left">
                         <SheetTitle>{title}</SheetTitle>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsEmptyState.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsEmptyState.spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { TenantsEmptyState } from './TenantsEmptyState';
+
+describe('TenantsEmptyState', () => {
+    it('explains why to create a tenant and compares with/without', () => {
+        render(<TenantsEmptyState canCreate />);
+
+        expect(screen.getByText('Why create a tenant?')).not.toBeNull();
+        expect(screen.getByText('Without tenants')).not.toBeNull();
+        expect(screen.getByText('With tenants')).not.toBeNull();
+        expect(screen.getByText('Every gateway proxies every endpoint on the API')).not.toBeNull();
+        expect(screen.getByText('Tag a gateway with one tenant in gravitee.yml')).not.toBeNull();
+        expect(screen.getByText('Tag the gateway')).not.toBeNull();
+        expect(screen.getByText('Pin an endpoint')).not.toBeNull();
+        expect(screen.getByText('Keep traffic local')).not.toBeNull();
+        expect(screen.getByText('Create the first tenant, then paste its key into gravitee.yml.')).not.toBeNull();
+    });
+
+    it('does not include an Add a tenant button; the page header owns that CTA', () => {
+        render(<TenantsEmptyState canCreate />);
+        expect(screen.queryByRole('button', { name: /Add a tenant/i })).toBeNull();
+    });
+
+    it('drops the create prompt for a user who cannot create tenants', () => {
+        render(<TenantsEmptyState />);
+
+        expect(screen.getByText('Why create a tenant?')).not.toBeNull();
+        expect(screen.queryByText('Create the first tenant, then paste its key into gravitee.yml.')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsEmptyState.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, CircleXIcon, GlobeIcon, RadioIcon, ServerIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+import { FeatureTile } from '../../shared/components';
+
+const WITHOUT_TENANT_CONS = [
+    'Every gateway proxies every endpoint on the API',
+    'No way to keep US traffic on US backends',
+    'Regional failover has to be configured by hand',
+] as const;
+
+const WITH_TENANT_PROS = [
+    'Tag a gateway with one tenant in gravitee.yml',
+    'Assign endpoints to the regions they should serve',
+    'A request only reaches backends that match that gateway',
+] as const;
+
+const FEATURE_TILES: { readonly Icon: LucideIcon; readonly title: string; readonly description: string }[] = [
+    {
+        Icon: ServerIcon,
+        title: 'Tag the gateway',
+        description: 'Set tenant: usa (or eu) on each gateway so it only loads matching endpoints.',
+    },
+    {
+        Icon: RadioIcon,
+        title: 'Pin an endpoint',
+        description: 'On an API, attach a tenant to an endpoint so only those gateways will proxy to it.',
+    },
+    {
+        Icon: GlobeIcon,
+        title: 'Keep traffic local',
+        description: 'US gateways stay on US backends, EU on EU — without deploying a second API.',
+    },
+];
+
+function FlowNode({ Icon, label }: { Icon: LucideIcon; label: string }) {
+    return (
+        <div className="flex flex-col items-center text-center">
+            <div className="rounded-lg bg-muted p-2">
+                <Icon className="size-4 text-muted-foreground" aria-hidden />
+            </div>
+            <p className="text-xs font-medium mt-1">{label}</p>
+        </div>
+    );
+}
+
+function TenantTag() {
+    return <span className="rounded-md border border-primary bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">usa</span>;
+}
+
+function ComparisonLine({ label, variant }: { label: string; variant: 'positive' | 'negative' }) {
+    return (
+        <li className="flex items-center gap-1 text-xs text-muted-foreground">
+            {variant === 'positive' ? (
+                <CircleCheckIcon className="size-3 shrink-0 text-success" aria-hidden />
+            ) : (
+                <CircleXIcon className="size-3 shrink-0 text-destructive" aria-hidden />
+            )}
+            {label}
+        </li>
+    );
+}
+
+export function TenantsEmptyState({ canCreate = false }: Readonly<{ canCreate?: boolean }>) {
+    return (
+        <Card>
+            <CardContent className="pt-6 space-y-6">
+                <div>
+                    <h2 className="text-base font-semibold">Why create a tenant?</h2>
+                    <p className="text-xs text-muted-foreground mt-1">
+                        A tenant is a label you put on a gateway and on the endpoints that gateway should reach. Without one, every gateway
+                        deploys every endpoint. Create the first tenant, copy its key into gravitee.yml, then attach it to the endpoints
+                        that belong in that region.
+                    </p>
+                </div>
+
+                <div className="flex flex-col gap-4 items-stretch md:flex-row">
+                    <div className="flex-1 rounded-xl border p-4 space-y-3">
+                        <p className="text-xs font-semibold text-muted-foreground">Without tenants</p>
+                        <div className="flex items-center justify-center gap-2">
+                            <FlowNode Icon={ServerIcon} label="Gateway" />
+                            <ArrowRightIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                            <FlowNode Icon={GlobeIcon} label="Every endpoint" />
+                        </div>
+                        <ul className="space-y-1">
+                            {WITHOUT_TENANT_CONS.map(label => (
+                                <ComparisonLine key={label} label={label} variant="negative" />
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div className="flex-1 rounded-xl border-2 border-primary/40 bg-primary/5 p-4 space-y-3">
+                        <p className="text-xs font-semibold text-primary">With tenants</p>
+                        <div className="flex items-center justify-center gap-2">
+                            <FlowNode Icon={ServerIcon} label="USA gateway" />
+                            <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                            <TenantTag />
+                            <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                            <FlowNode Icon={GlobeIcon} label="US backends" />
+                        </div>
+                        <ul className="space-y-1">
+                            {WITH_TENANT_PROS.map(label => (
+                                <ComparisonLine key={label} label={label} variant="positive" />
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="flex flex-col gap-4 border-t pt-5 md:flex-row">
+                    {FEATURE_TILES.map(({ Icon, title, description }) => (
+                        <div key={title} className="flex-1">
+                            <FeatureTile Icon={Icon} title={title} description={description} />
+                        </div>
+                    ))}
+                </div>
+
+                {canCreate ? (
+                    <p className="text-xs text-muted-foreground border-t pt-5">
+                        Create the first tenant, then paste its key into gravitee.yml.
+                    </p>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.spec.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TenantsTable } from './TenantsTable';
+import type { Tenant } from '../types/tenant';
+
+const ROWS: Tenant[] = [
+    { id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia gateway cluster' },
+    { id: 't-2', key: 'eu-west', name: 'EU West', description: 'Frankfurt gateway cluster' },
+];
+
+describe('TenantsTable', () => {
+    it('renders tenant rows', () => {
+        render(<TenantsTable rows={ROWS} />);
+        expect(screen.getByText('us-east')).not.toBeNull();
+        expect(screen.getByText('eu-west')).not.toBeNull();
+        expect(screen.getByText('US East')).not.toBeNull();
+    });
+
+    it('filters rows by search query', () => {
+        render(<TenantsTable rows={ROWS} />);
+        fireEvent.change(screen.getByLabelText('Search tenants'), { target: { value: 'eu-west' } });
+        expect(screen.queryByText('us-east')).toBeNull();
+        expect(screen.getByText('eu-west')).not.toBeNull();
+    });
+
+    it('calls onEdit when Edit is selected from the actions menu', async () => {
+        const user = userEvent.setup();
+        const onEdit = jest.fn();
+        render(<TenantsTable rows={ROWS} canEdit onEdit={onEdit} />);
+        await user.click(screen.getByRole('button', { name: /Actions for us-east/i }));
+        await user.click(await screen.findByRole('menuitem', { name: /^Edit$/ }));
+        expect(onEdit).toHaveBeenCalledWith(ROWS[0]);
+    });
+
+    it('shows no-results empty state when search matches nothing', () => {
+        render(<TenantsTable rows={ROWS} />);
+        fireEvent.change(screen.getByLabelText('Search tenants'), { target: { value: 'does-not-exist' } });
+        expect(screen.getByText('No tenants found')).not.toBeNull();
+    });
+
+    it('calls onDelete when Delete is selected from the actions menu', async () => {
+        const user = userEvent.setup();
+        const onDelete = jest.fn();
+        render(<TenantsTable rows={ROWS} canDelete onDelete={onDelete} />);
+        await user.click(screen.getByRole('button', { name: /Actions for us-east/i }));
+        await user.click(await screen.findByRole('menuitem', { name: /^Delete$/ }));
+        expect(onDelete).toHaveBeenCalledWith(ROWS[0]);
+    });
+
+    it('hides the actions menu when the user cannot edit or delete', () => {
+        render(<TenantsTable rows={ROWS} />);
+        expect(screen.queryByRole('button', { name: /Actions for us-east/i })).toBeNull();
+    });
+
+    it('clamps to the last page when the row count shrinks', () => {
+        const many = Array.from({ length: 11 }, (_, i) => ({
+            id: `t-${i}`,
+            key: `tenant-${i}`,
+            name: `Tenant ${i}`,
+            description: '',
+        }));
+        const { rerender } = render(<TenantsTable rows={many} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+        expect(screen.getByText('tenant-10')).not.toBeNull();
+        expect(screen.queryByText('tenant-0')).toBeNull();
+
+        rerender(<TenantsTable rows={many.slice(0, 10)} />);
+        expect(screen.getByText('tenant-0')).not.toBeNull();
+        expect(screen.queryByText('tenant-10')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
+import type { TableSortingState } from '../../applications/utils/tableSort';
+import { clampPage, paginateClientSideTableItems } from '../../users/utils/clientSideTableUtils';
+import type { Tenant } from '../types/tenant';
+import { filterTenants } from '../utils/tenantFormValidation';
+
+const DEFAULT_PAGE_SIZE = 10;
+const SORTABLE_IDS = new Set(['key', 'name', 'description']);
+
+function sortRows(items: Tenant[], sorting: TableSortingState): Tenant[] {
+    const active = sorting[0];
+    if (!active?.id || !SORTABLE_IDS.has(active.id)) return items;
+    const direction = active.desc ? -1 : 1;
+    return [...items].sort((a, b) => {
+        const av = active.id === 'key' ? a.key : active.id === 'name' ? a.name : (a.description ?? '');
+        const bv = active.id === 'key' ? b.key : active.id === 'name' ? b.name : (b.description ?? '');
+        return av.localeCompare(bv) * direction;
+    });
+}
+
+function TenantActionsCell({
+    tenant,
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    tenant: Tenant;
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (row: Tenant) => void;
+    onDelete: (row: Tenant) => void;
+}>) {
+    const ariaLabel = tenant.key ? `Actions for ${tenant.key}` : 'Tenant actions';
+
+    return (
+        <div className="flex justify-end">
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="size-8" aria-label={ariaLabel}>
+                        <MoreHorizontalIcon className="size-4" aria-hidden />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-48">
+                    {canEdit ? (
+                        <DropdownMenuItem className="whitespace-nowrap" onSelect={() => onEdit(tenant)}>
+                            <PencilIcon className="size-4 mr-2 shrink-0" aria-hidden />
+                            Edit
+                        </DropdownMenuItem>
+                    ) : null}
+                    {canEdit && canDelete ? <DropdownMenuSeparator /> : null}
+                    {canDelete ? (
+                        <DropdownMenuItem variant="destructive" className="whitespace-nowrap" onSelect={() => onDelete(tenant)}>
+                            <Trash2Icon className="size-4 mr-2 shrink-0" aria-hidden />
+                            Delete
+                        </DropdownMenuItem>
+                    ) : null}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+}
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    onEdit: (row: Tenant) => void;
+    onDelete: (row: Tenant) => void;
+}): DataTableProps<Tenant>['columns'] {
+    const columns: DataTableProps<Tenant>['columns'] = [
+        {
+            id: 'key',
+            accessorKey: 'key',
+            header: ({ column }: ColHeader<Tenant>) => <DataTableColumnHeader column={column} title="Key" />,
+            cell: ({ row }: ColCell<Tenant>) => <span className="text-sm font-medium">{row.original.key || '—'}</span>,
+        },
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<Tenant>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<Tenant>) => <span className="text-sm">{row.original.name || '—'}</span>,
+        },
+        {
+            id: 'description',
+            accessorKey: 'description',
+            header: ({ column }: ColHeader<Tenant>) => <DataTableColumnHeader column={column} title="Description" />,
+            cell: ({ row }: ColCell<Tenant>) => <span className="text-sm text-muted-foreground">{row.original.description || '—'}</span>,
+        },
+    ];
+
+    if (canEdit || canDelete) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            enableSorting: false,
+            cell: ({ row }: ColCell<Tenant>) => (
+                <TenantActionsCell tenant={row.original} canEdit={canEdit} canDelete={canDelete} onEdit={onEdit} onDelete={onDelete} />
+            ),
+        });
+    }
+
+    return columns;
+}
+
+export function TenantsTable({
+    rows,
+    canEdit = false,
+    canDelete = false,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    rows: Tenant[];
+    canEdit?: boolean;
+    canDelete?: boolean;
+    onEdit?: (row: Tenant) => void;
+    onDelete?: (row: Tenant) => void;
+}>) {
+    const [search, setSearch] = useState('');
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const filtered = useMemo(() => filterTenants(rows, search), [rows, search]);
+    const sorted = useMemo(() => sortRows(filtered, sorting), [filtered, sorting]);
+    const totalCount = sorted.length;
+    // Clamped during render as well as in the effect: a row count that shrinks would otherwise
+    // slice past the end and flash the no-results state for one render.
+    const currentPage = clampPage(page, totalCount, pageSize);
+    const paginatedData = useMemo(() => paginateClientSideTableItems(sorted, currentPage, pageSize), [sorted, currentPage, pageSize]);
+
+    useEffect(() => {
+        setPage(prev => clampPage(prev, totalCount, pageSize));
+    }, [totalCount, pageSize]);
+    const columns = useMemo(
+        () =>
+            buildColumns({
+                canEdit,
+                canDelete,
+                onEdit: onEdit ?? (() => undefined),
+                onDelete: onDelete ?? (() => undefined),
+            }),
+        [canEdit, canDelete, onEdit, onDelete],
+    );
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handleSortingChange(updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) {
+        setSorting(prev => (typeof updater === 'function' ? updater(prev) : updater));
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="max-w-sm">
+                <InputGroup>
+                    <InputGroupAddon align="inline-start">
+                        <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                        placeholder="Search by key, name, or description..."
+                        value={search}
+                        onChange={e => handleSearchChange(e.target.value)}
+                        aria-label="Search tenants"
+                    />
+                </InputGroup>
+            </div>
+            <div data-testid="tenants-table-body">
+                <DataTable
+                    aria-label="Tenants"
+                    columns={columns}
+                    data={paginatedData}
+                    sorting={sorting}
+                    onSortingChange={handleSortingChange}
+                    pagination={{
+                        page: currentPage,
+                        pageSize,
+                        totalCount,
+                        pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                        onPageChange: setPage,
+                        onPageSizeChange: handlePageSizeChange,
+                    }}
+                    emptyMessage={
+                        <DataTableEmptyState
+                            variant="no-results"
+                            icon={<SearchIcon />}
+                            title="No tenants found"
+                            description="Try adjusting your search."
+                        />
+                    }
+                />
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/components/TenantsTable.tsx
@@ -37,7 +37,7 @@ import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationCons
 import type { TableSortingState } from '../../applications/utils/tableSort';
 import { clampPage, paginateClientSideTableItems } from '../../users/utils/clientSideTableUtils';
 import type { Tenant } from '../types/tenant';
-import { filterTenants } from '../utils/tenantFormValidation';
+import { filterTenants } from '../utils/tenantTableUtils';
 
 const DEFAULT_PAGE_SIZE = 10;
 const SORTABLE_IDS = new Set(['key', 'name', 'description']);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/hooks/useTenantMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/hooks/useTenantMutations.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { createTenant, deleteTenant, updateTenant } from '../services/tenants';
+import type { NewTenantPayload, UpdateTenantPayload } from '../types/tenant';
+import { tenantKeys } from '../utils/queryKeys';
+
+async function invalidateTenantCaches(queryClient: ReturnType<typeof useQueryClient>) {
+    await queryClient.invalidateQueries({ queryKey: tenantKeys.all });
+}
+
+export function useCreateTenant() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: NewTenantPayload) => createTenant(payload),
+        onSuccess: async () => {
+            await invalidateTenantCaches(queryClient);
+        },
+    });
+}
+
+export function useUpdateTenant() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: UpdateTenantPayload) => updateTenant(payload),
+        onSuccess: async () => {
+            await invalidateTenantCaches(queryClient);
+        },
+    });
+}
+
+export function useDeleteTenant() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (tenantKey: string) => deleteTenant(tenantKey),
+        onSuccess: async () => {
+            await invalidateTenantCaches(queryClient);
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/hooks/useTenants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/hooks/useTenants.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { listTenants } from '../services/tenants';
+import { tenantKeys } from '../utils/queryKeys';
+
+export function useTenants() {
+    return useQuery({
+        queryKey: tenantKeys.list(),
+        queryFn: listTenants,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/services/tenants.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/services/tenants.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTenant, deleteTenant, listTenants, updateTenant } from './tenants';
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { NewTenantPayload, UpdateTenantPayload } from '../types/tenant';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+}));
+
+const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+
+describe('tenants service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonOrg.mockResolvedValue([]);
+    });
+
+    it('calls GET on the organization configuration/tenants resource', async () => {
+        await listTenants();
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tenants');
+    });
+
+    it('POSTs a new tenant wrapped in an array', async () => {
+        const payload: NewTenantPayload = { name: 'US East', key: 'us-east', description: 'Virginia' };
+        await createTenant(payload);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tenants', {
+            method: 'POST',
+            body: JSON.stringify([payload]),
+        });
+    });
+
+    it('PUTs an updated tenant wrapped in an array', async () => {
+        const payload: UpdateTenantPayload = { key: 'us-east', name: 'US East', description: 'Updated' };
+        await updateTenant(payload);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tenants', {
+            method: 'PUT',
+            body: JSON.stringify([payload]),
+        });
+    });
+
+    it('DELETEs a tenant by key', async () => {
+        await deleteTenant('us-east');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tenants/us-east', {
+            method: 'DELETE',
+        });
+    });
+
+    it('encodes special characters in the delete path key', async () => {
+        await deleteTenant('us/east');
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/tenants/us%2Feast', {
+            method: 'DELETE',
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/services/tenants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/services/tenants.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+import type { NewTenantPayload, Tenant, UpdateTenantPayload } from '../types/tenant';
+
+export async function listTenants(): Promise<Tenant[]> {
+    return apimFetchJsonOrg<Tenant[]>('/configuration/tenants');
+}
+
+export async function createTenant(payload: NewTenantPayload): Promise<Tenant[]> {
+    return apimFetchJsonOrg<Tenant[]>('/configuration/tenants', {
+        method: 'POST',
+        body: JSON.stringify([payload]),
+    });
+}
+
+export async function updateTenant(payload: UpdateTenantPayload): Promise<Tenant[]> {
+    return apimFetchJsonOrg<Tenant[]>('/configuration/tenants', {
+        method: 'PUT',
+        body: JSON.stringify([payload]),
+    });
+}
+
+export async function deleteTenant(tenantKey: string): Promise<void> {
+    return apimFetchJsonOrg<void>(`/configuration/tenants/${encodeURIComponent(tenantKey)}`, { method: 'DELETE' });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/types/tenant.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/types/tenant.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Tenant {
+    id: string;
+    key: string;
+    name: string;
+    description?: string;
+}
+
+export interface NewTenantPayload {
+    name: string;
+    key: string;
+    description?: string;
+}
+
+export interface UpdateTenantPayload {
+    key: string;
+    name: string;
+    description?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const tenantKeys = {
+    all: ['org-tenants'] as const,
+    list: () => [...tenantKeys.all, 'list'] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.spec.ts
@@ -16,7 +16,6 @@
 
 import {
     findDuplicateTenantKey,
-    filterTenants,
     getTenantDescriptionError,
     getTenantNameError,
     isTenantDescriptionValid,
@@ -120,14 +119,6 @@ describe('tenantFormValidation', () => {
             expect(findDuplicateTenantKey(STUB_TENANTS, 'us-east')?.id).toBe('t-1');
             expect(findDuplicateTenantKey(STUB_TENANTS, 'us-east', 't-1')).toBeUndefined();
             expect(findDuplicateTenantKey(STUB_TENANTS, '')).toBeUndefined();
-        });
-    });
-
-    describe('filterTenants', () => {
-        it('filters by key, name, or description', () => {
-            expect(filterTenants(STUB_TENANTS, 'east').map(row => row.key)).toEqual(['us-east']);
-            expect(filterTenants(STUB_TENANTS, 'frankfurt').map(row => row.key)).toEqual(['eu-west']);
-            expect(filterTenants(STUB_TENANTS, '  ').map(row => row.key)).toEqual(['us-east', 'eu-west']);
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    findDuplicateTenantKey,
+    filterTenants,
+    getTenantDescriptionError,
+    getTenantNameError,
+    isTenantDescriptionValid,
+    isTenantKeyValid,
+    isTenantNameValid,
+    slugifyTenantKeyBase,
+    slugifyTenantKeyFinal,
+    TENANT_DESCRIPTION_MAX,
+    TENANT_KEY_MAX,
+    TENANT_NAME_MAX,
+    tenantKeyFromName,
+} from './tenantFormValidation';
+import type { Tenant } from '../types/tenant';
+
+const STUB_TENANTS: Tenant[] = [
+    { id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia gateway cluster' },
+    { id: 't-2', key: 'eu-west', name: 'EU West', description: 'Frankfurt gateway cluster' },
+];
+
+describe('tenantFormValidation', () => {
+    it('uses backend @Size(max = 40) for name and key', () => {
+        expect(TENANT_NAME_MAX).toBe(40);
+        expect(TENANT_KEY_MAX).toBe(40);
+        expect(TENANT_DESCRIPTION_MAX).toBe(160);
+    });
+
+    describe('slugifyTenantKeyBase', () => {
+        it('converts a simple name to a lowercase hyphenated key', () => {
+            expect(slugifyTenantKeyBase('My Tenant Key')).toBe('my-tenant-key');
+        });
+
+        it('strips diacritics and special characters', () => {
+            expect(slugifyTenantKeyBase('Tênant Spécîal @#$ Nàme!')).toBe('tenant-special-name');
+        });
+    });
+
+    describe('slugifyTenantKeyFinal', () => {
+        it('strips trailing hyphens from the base slug', () => {
+            expect(slugifyTenantKeyFinal('My Tenant Key---')).toBe('my-tenant-key');
+        });
+    });
+
+    describe('tenantKeyFromName', () => {
+        it('generates a key from a display name', () => {
+            expect(tenantKeyFromName('AP South')).toBe('ap-south');
+        });
+
+        it('truncates generated keys to the API max', () => {
+            const longName = 'A '.repeat(TENANT_KEY_MAX);
+            expect(tenantKeyFromName(longName).length).toBeLessThanOrEqual(TENANT_KEY_MAX);
+        });
+    });
+
+    describe('getTenantNameError', () => {
+        it('returns null for empty or whitespace-only names', () => {
+            expect(getTenantNameError('')).toBeNull();
+            expect(getTenantNameError('   ')).toBeNull();
+        });
+
+        it('returns an error when name exceeds max length', () => {
+            const longName = 'a'.repeat(TENANT_NAME_MAX + 1);
+            expect(getTenantNameError(longName)).toBe(`Name must be at most ${TENANT_NAME_MAX} characters`);
+        });
+    });
+
+    describe('isTenantNameValid', () => {
+        it('returns false for empty names and true within max length', () => {
+            expect(isTenantNameValid('')).toBe(false);
+            expect(isTenantNameValid('US East')).toBe(true);
+            expect(isTenantNameValid('a'.repeat(TENANT_NAME_MAX + 1))).toBe(false);
+        });
+    });
+
+    describe('isTenantKeyValid', () => {
+        it('requires a non-empty key within max length', () => {
+            expect(isTenantKeyValid('')).toBe(false);
+            expect(isTenantKeyValid('us-east')).toBe(true);
+            expect(isTenantKeyValid('a'.repeat(TENANT_KEY_MAX + 1))).toBe(false);
+        });
+
+        it('rejects keys that sanitize to empty (hyphen-only)', () => {
+            expect(isTenantKeyValid('-')).toBe(false);
+            expect(isTenantKeyValid('---')).toBe(false);
+        });
+    });
+
+    describe('description limits', () => {
+        it('allows empty description and rejects over max length', () => {
+            expect(isTenantDescriptionValid('')).toBe(true);
+            expect(getTenantDescriptionError('')).toBeNull();
+            expect(isTenantDescriptionValid('a'.repeat(TENANT_DESCRIPTION_MAX))).toBe(true);
+            expect(isTenantDescriptionValid('a'.repeat(TENANT_DESCRIPTION_MAX + 1))).toBe(false);
+            expect(getTenantDescriptionError('a'.repeat(TENANT_DESCRIPTION_MAX + 1))).toBe(
+                `Description must be at most ${TENANT_DESCRIPTION_MAX} characters`,
+            );
+        });
+    });
+
+    describe('findDuplicateTenantKey', () => {
+        it('finds a duplicate by exact key match', () => {
+            expect(findDuplicateTenantKey(STUB_TENANTS, 'us-east')?.id).toBe('t-1');
+            expect(findDuplicateTenantKey(STUB_TENANTS, 'us-east', 't-1')).toBeUndefined();
+            expect(findDuplicateTenantKey(STUB_TENANTS, '')).toBeUndefined();
+        });
+    });
+
+    describe('filterTenants', () => {
+        it('filters by key, name, or description', () => {
+            expect(filterTenants(STUB_TENANTS, 'east').map(row => row.key)).toEqual(['us-east']);
+            expect(filterTenants(STUB_TENANTS, 'frankfurt').map(row => row.key)).toEqual(['eu-west']);
+            expect(filterTenants(STUB_TENANTS, '  ').map(row => row.key)).toEqual(['us-east', 'eu-west']);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Tenant } from '../types/tenant';
+
+/** Backend `@Size(max = 40)` on `NewTenantEntity` name and key. */
+export const TENANT_NAME_MAX = 40;
+export const TENANT_KEY_MAX = 40;
+/** Classic org-settings UI limit; backend has no description max. */
+export const TENANT_DESCRIPTION_MAX = 160;
+
+/**
+ * Port of Classic `sanitizeKeyBase` — live sanitize while typing the key.
+ * Alphanumeric + hyphens only; strips diacritics and special characters.
+ */
+export function slugifyTenantKeyBase(key: string): string {
+    return key
+        .normalize('NFD')
+        .replaceAll(/[\u0300-\u036f]+/g, '')
+        .toLowerCase()
+        .replaceAll(/[^a-z\d\s-]/g, '')
+        .trim()
+        .replaceAll(/[^a-z\d]+/g, '-');
+}
+
+/**
+ * Port of Classic `sanitizeKeyFinal` — strip trailing hyphens for the immutable key.
+ */
+export function slugifyTenantKeyFinal(key: string): string {
+    let sanitized = slugifyTenantKeyBase(key);
+    while (sanitized.endsWith('-')) {
+        sanitized = sanitized.slice(0, -1);
+    }
+    return sanitized;
+}
+
+export function tenantKeyFromName(name: string): string {
+    return slugifyTenantKeyFinal(name).slice(0, TENANT_KEY_MAX);
+}
+
+export function getTenantNameError(name: string): string | null {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    if (trimmed.length > TENANT_NAME_MAX) {
+        return `Name must be at most ${TENANT_NAME_MAX} characters`;
+    }
+    return null;
+}
+
+export function isTenantNameValid(name: string): boolean {
+    const trimmed = name.trim();
+    return trimmed.length >= 1 && trimmed.length <= TENANT_NAME_MAX;
+}
+
+export function isTenantKeyValid(key: string): boolean {
+    const finalized = slugifyTenantKeyFinal(key);
+    return finalized.length >= 1 && finalized.length <= TENANT_KEY_MAX;
+}
+
+export function getTenantDescriptionError(description: string): string | null {
+    if (description.length > TENANT_DESCRIPTION_MAX) {
+        return `Description must be at most ${TENANT_DESCRIPTION_MAX} characters`;
+    }
+    return null;
+}
+
+export function isTenantDescriptionValid(description: string): boolean {
+    return description.length <= TENANT_DESCRIPTION_MAX;
+}
+
+export function findDuplicateTenantKey(rows: Tenant[], key: string, excludeId?: string): Tenant | undefined {
+    if (!key) return undefined;
+    return rows.find(row => row.id !== excludeId && row.key === key);
+}
+
+export function filterTenants(rows: Tenant[], query: string): Tenant[] {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return rows;
+    return rows.filter(
+        row =>
+            row.key.toLowerCase().includes(normalized) ||
+            row.name.toLowerCase().includes(normalized) ||
+            (row.description ?? '').toLowerCase().includes(normalized),
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantFormValidation.ts
@@ -85,14 +85,3 @@ export function findDuplicateTenantKey(rows: Tenant[], key: string, excludeId?: 
     if (!key) return undefined;
     return rows.find(row => row.id !== excludeId && row.key === key);
 }
-
-export function filterTenants(rows: Tenant[], query: string): Tenant[] {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return rows;
-    return rows.filter(
-        row =>
-            row.key.toLowerCase().includes(normalized) ||
-            row.name.toLowerCase().includes(normalized) ||
-            (row.description ?? '').toLowerCase().includes(normalized),
-    );
-}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantTableUtils.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantTableUtils.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filterTenants } from './tenantTableUtils';
+import type { Tenant } from '../types/tenant';
+
+const STUB_TENANTS: Tenant[] = [
+    { id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia gateway cluster' },
+    { id: 't-2', key: 'eu-west', name: 'EU West', description: 'Frankfurt gateway cluster' },
+];
+
+describe('filterTenants', () => {
+    it('filters by key, name, or description', () => {
+        expect(filterTenants(STUB_TENANTS, 'east').map(row => row.key)).toEqual(['us-east']);
+        expect(filterTenants(STUB_TENANTS, 'frankfurt').map(row => row.key)).toEqual(['eu-west']);
+        expect(filterTenants(STUB_TENANTS, '  ').map(row => row.key)).toEqual(['us-east', 'eu-west']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantTableUtils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/tenants/utils/tenantTableUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Tenant } from '../types/tenant';
+
+export function filterTenants(rows: Tenant[], query: string): Tenant[] {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return rows;
+    return rows.filter(
+        row =>
+            row.key.toLowerCase().includes(normalized) ||
+            row.name.toLowerCase().includes(normalized) ||
+            (row.description ?? '').toLowerCase().includes(normalized),
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.spec.tsx
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { TenantsPage } from './TenantsPage';
+import { useCreateTenant, useDeleteTenant, useUpdateTenant } from '../features/tenants/hooks/useTenantMutations';
+import { useTenants } from '../features/tenants/hooks/useTenants';
+import type { Tenant } from '../features/tenants/types/tenant';
+import { ApimApiError } from '../shared/api/apimClient';
+import { notify } from '../shared/notify';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+    useEnvironment: () => ({ id: 'env-1' }),
+}));
+jest.mock('../features/tenants/hooks/useTenants');
+jest.mock('../features/tenants/hooks/useTenantMutations');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../features/tenants/components/TenantsTable', () => ({
+    TenantsTable: ({
+        rows,
+        canEdit,
+        canDelete,
+        onEdit,
+        onDelete,
+    }: {
+        rows: Tenant[];
+        canEdit: boolean;
+        canDelete: boolean;
+        onEdit: (tenant: Tenant) => void;
+        onDelete: (tenant: Tenant) => void;
+    }) => (
+        <div>
+            {rows.map(tenant => (
+                <div key={tenant.key} data-testid={`row-${tenant.key}`}>
+                    <span>{tenant.name}</span>
+                    {canEdit && (
+                        <button type="button" onClick={() => onEdit(tenant)}>
+                            Edit {tenant.name}
+                        </button>
+                    )}
+                    {canDelete && (
+                        <button type="button" onClick={() => onDelete(tenant)}>
+                            Delete {tenant.name}
+                        </button>
+                    )}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseTenants = jest.mocked(useTenants);
+const mockUseCreateTenant = jest.mocked(useCreateTenant);
+const mockUseUpdateTenant = jest.mocked(useUpdateTenant);
+const mockUseDeleteTenant = jest.mocked(useDeleteTenant);
+
+const STUB_TENANTS: Tenant[] = [
+    { id: 't-1', key: 'us-east', name: 'US East', description: 'Virginia gateway cluster' },
+    { id: 't-2', key: 'eu-west', name: 'EU West', description: 'Frankfurt gateway cluster' },
+];
+
+function makeQueryResult(overrides: Partial<ReturnType<typeof useTenants>> = {}): ReturnType<typeof useTenants> {
+    return {
+        data: STUB_TENANTS,
+        isLoading: false,
+        isError: false,
+        ...overrides,
+    } as ReturnType<typeof useTenants>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMutation(mutateAsync = jest.fn()): any {
+    return { mutateAsync, isPending: false };
+}
+
+function renderPage() {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'env-1'], ['organization-tenant-r']);
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/tenants']}>
+                <TenantsPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('TenantsPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseTenants.mockReturnValue(makeQueryResult());
+        mockUseCreateTenant.mockReturnValue(makeMutation());
+        mockUseUpdateTenant.mockReturnValue(makeMutation());
+        mockUseDeleteTenant.mockReturnValue(makeMutation());
+        Element.prototype.scrollIntoView = jest.fn();
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('page header', () => {
+        it('renders the page title, subtitle, and gateway config banner', () => {
+            renderPage();
+            expect(screen.queryByRole('heading', { name: 'Tenants' })).not.toBeNull();
+            expect(
+                screen.queryByText('Segment which API endpoints a gateway will proxy to, so one API can stay local to a region.'),
+            ).not.toBeNull();
+            expect(
+                screen.queryByText(
+                    'Copy the tenant key into the API gateway configuration file so the gateway only receives endpoints tagged with that tenant.',
+                ),
+            ).not.toBeNull();
+        });
+
+        it('shows the Add a tenant button when the user can create and tenants exist', () => {
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Add a tenant/i })).not.toBeNull();
+        });
+
+        it('shows a single header Add a tenant button on the empty page when the user can create', () => {
+            mockUseTenants.mockReturnValue(makeQueryResult({ data: [] }));
+            renderPage();
+            expect(screen.getAllByRole('button', { name: /Add a tenant/i })).toHaveLength(1);
+        });
+
+        it('hides the Add a tenant button when the user cannot create', () => {
+            mockUseHasPermission.mockImplementation(
+                ({ anyOf }) => !!(anyOf?.includes('organization-tenant-u') || anyOf?.includes('environment-tenant-u')),
+            );
+            renderPage();
+            expect(screen.queryByRole('button', { name: /Add a tenant/i })).toBeNull();
+        });
+    });
+
+    describe('loading and error states', () => {
+        it('shows skeleton rows while data is loading', () => {
+            mockUseTenants.mockReturnValue(makeQueryResult({ data: undefined, isLoading: true }));
+            const { container } = renderPage();
+            expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+        });
+
+        it('shows an error message when the query fails', () => {
+            mockUseTenants.mockReturnValue(makeQueryResult({ data: undefined, isError: true }));
+            renderPage();
+            expect(screen.queryByText('Failed to load tenants. Please refresh and try again.')).not.toBeNull();
+        });
+
+        it('redirects away on a 403 without showing the generic error', async () => {
+            mockUseTenants.mockReturnValue(makeQueryResult({ data: undefined, isError: true, error: new ApimApiError(403, 'Forbidden') }));
+
+            renderPage();
+
+            await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+            expect(screen.queryByText('Failed to load tenants. Please refresh and try again.')).toBeNull();
+        });
+    });
+
+    describe('empty state', () => {
+        it('shows the educational empty state instead of the table and banner', () => {
+            mockUseTenants.mockReturnValue(makeQueryResult({ data: [] }));
+            renderPage();
+            expect(screen.getByText('Why create a tenant?')).not.toBeNull();
+            expect(
+                screen.queryByText(
+                    'Copy the tenant key into the API gateway configuration file so the gateway only receives endpoints tagged with that tenant.',
+                ),
+            ).toBeNull();
+        });
+    });
+
+    describe('create and edit', () => {
+        it('opens the create sheet from the header button', () => {
+            renderPage();
+            fireEvent.click(screen.getByRole('button', { name: /Add a tenant/i }));
+            expect(screen.queryByRole('heading', { name: 'Create a tenant' })).not.toBeNull();
+        });
+
+        it('calls createMutation and shows a success toast', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue([]);
+            mockUseCreateTenant.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: /Add a tenant/i }));
+            fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'AP South' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Create tenant' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith({ name: 'AP South', key: 'ap-south', description: undefined });
+                expect(notify.success).toHaveBeenCalledWith('Tenant successfully created!');
+            });
+        });
+
+        it('opens the edit sheet and saves name changes', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue([{ ...STUB_TENANTS[0], name: 'US East 2' }]);
+            mockUseUpdateTenant.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit US East' }));
+            expect(screen.queryByRole('heading', { name: 'Edit a tenant' })).not.toBeNull();
+            fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'US East 2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith({
+                    key: 'us-east',
+                    name: 'US East 2',
+                    description: 'Virginia gateway cluster',
+                });
+                expect(notify.success).toHaveBeenCalledWith('Tenant successfully updated!');
+            });
+        });
+
+        it('reports an error instead of success when the API updates nothing', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue([]);
+            mockUseUpdateTenant.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit US East' }));
+            fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'US East 2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('This tenant no longer exists. Refresh the page and try again.')).not.toBeNull();
+            });
+            expect(notify.success).not.toHaveBeenCalled();
+            expect(screen.queryByRole('heading', { name: 'Edit a tenant' })).not.toBeNull();
+        });
+    });
+
+    describe('delete', () => {
+        it('confirms delete and shows a success toast', async () => {
+            const mutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseDeleteTenant.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete US East' }));
+            expect(screen.queryByRole('heading', { name: 'Delete a tenant' })).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => {
+                expect(mutateAsync).toHaveBeenCalledWith('us-east');
+                expect(notify.success).toHaveBeenCalledWith('Tenant successfully deleted!');
+            });
+        });
+
+        it('shows an error toast when delete fails', async () => {
+            const error = new Error('delete failed');
+            const mutateAsync = jest.fn().mockRejectedValue(error);
+            mockUseDeleteTenant.mockReturnValue(makeMutation(mutateAsync));
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete US East' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+            await waitFor(() => {
+                expect(notify.error).toHaveBeenCalledWith(error, 'Failed to delete tenant');
+            });
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
@@ -149,24 +149,28 @@ export function TenantsPage() {
 
             {renderContent()}
 
-            <TenantFormSheet
-                open={sheet.type === 'create'}
-                mode="create"
-                existingTenants={tenants}
-                onClose={closeSheet}
-                onSubmit={handleCreate}
-                isSaving={createMutation.isPending}
-            />
+            {sheet.type === 'create' ? (
+                <TenantFormSheet
+                    open
+                    mode="create"
+                    existingTenants={tenants}
+                    onClose={closeSheet}
+                    onSubmit={handleCreate}
+                    isSaving={createMutation.isPending}
+                />
+            ) : null}
 
-            <TenantFormSheet
-                open={sheet.type === 'edit'}
-                mode="edit"
-                tenant={sheet.type === 'edit' ? sheet.tenant : undefined}
-                existingTenants={tenants}
-                onClose={closeSheet}
-                onSubmit={handleUpdate}
-                isSaving={updateMutation.isPending}
-            />
+            {sheet.type === 'edit' ? (
+                <TenantFormSheet
+                    open
+                    mode="edit"
+                    tenant={sheet.tenant}
+                    existingTenants={tenants}
+                    onClose={closeSheet}
+                    onSubmit={handleUpdate}
+                    isSaving={updateMutation.isPending}
+                />
+            ) : null}
 
             <TenantDeleteDialog
                 open={sheet.type === 'delete'}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Alert, AlertDescription, Button, Skeleton } from '@gravitee/graphene-core';
+import { InfoIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { TenantDeleteDialog } from '../features/tenants/components/TenantDeleteDialog';
+import { TenantFormSheet } from '../features/tenants/components/TenantFormSheet';
+import { TenantsEmptyState } from '../features/tenants/components/TenantsEmptyState';
+import { TenantsTable } from '../features/tenants/components/TenantsTable';
+import { useCreateTenant, useDeleteTenant, useUpdateTenant } from '../features/tenants/hooks/useTenantMutations';
+import { useTenants } from '../features/tenants/hooks/useTenants';
+import type { NewTenantPayload, Tenant, UpdateTenantPayload } from '../features/tenants/types/tenant';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { notify } from '../shared/notify';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+type SheetState = { type: 'closed' } | { type: 'create' } | { type: 'edit'; tenant: Tenant } | { type: 'delete'; tenant: Tenant };
+
+export function TenantsPage() {
+    const canCreate = useHasPermission({ anyOf: ['organization-tenant-c', 'environment-tenant-c'] });
+    const canEdit = useHasPermission({ anyOf: ['organization-tenant-u', 'environment-tenant-u'] });
+    const canDelete = useHasPermission({ anyOf: ['organization-tenant-d', 'environment-tenant-d'] });
+
+    const { data: tenants = [], isLoading, isError, error } = useTenants();
+    const createMutation = useCreateTenant();
+    const updateMutation = useUpdateTenant();
+    const deleteMutation = useDeleteTenant();
+
+    const isForbidden = isForbiddenApiError(isError, error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: ['organization-tenant-', 'environment-tenant-'],
+        redirectTo: '../applications',
+    });
+
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    async function handleCreate(data: NewTenantPayload) {
+        await createMutation.mutateAsync(data);
+        notify.success('Tenant successfully created!');
+        closeSheet();
+    }
+
+    async function handleUpdate(data: UpdateTenantPayload) {
+        // The API skips entries whose key no longer exists and still answers 200 with an empty list.
+        const updated = await updateMutation.mutateAsync(data);
+        if (updated.length === 0) {
+            throw new Error('This tenant no longer exists. Refresh the page and try again.');
+        }
+        notify.success('Tenant successfully updated!');
+        closeSheet();
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.tenant.key);
+            notify.success('Tenant successfully deleted!');
+            closeSheet();
+        } catch (deleteError) {
+            notify.error(deleteError, 'Failed to delete tenant');
+        }
+    }
+
+    function renderContent() {
+        if (isLoading) {
+            return (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded-md" />
+                    ))}
+                </div>
+            );
+        }
+
+        if (isForbidden) {
+            return null;
+        }
+
+        if (isError) {
+            return (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Failed to load tenants. Please refresh and try again.</p>
+                </div>
+            );
+        }
+
+        if (tenants.length === 0) {
+            return <TenantsEmptyState canCreate={canCreate} />;
+        }
+
+        return (
+            <TenantsTable
+                rows={tenants}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                onEdit={tenant => setSheet({ type: 'edit', tenant })}
+                onDelete={tenant => setSheet({ type: 'delete', tenant })}
+            />
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Tenants</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Segment which API endpoints a gateway will proxy to, so one API can stay local to a region.
+                    </p>
+                </div>
+                {canCreate ? (
+                    <Button className="shrink-0" onClick={() => setSheet({ type: 'create' })}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add a tenant
+                    </Button>
+                ) : null}
+            </div>
+
+            {tenants.length > 0 ? (
+                <Alert>
+                    <InfoIcon className="size-4" aria-hidden />
+                    <AlertDescription>
+                        Copy the tenant key into the API gateway configuration file so the gateway only receives endpoints tagged with that
+                        tenant.
+                    </AlertDescription>
+                </Alert>
+            ) : null}
+
+            {renderContent()}
+
+            <TenantFormSheet
+                open={sheet.type === 'create'}
+                mode="create"
+                existingTenants={tenants}
+                onClose={closeSheet}
+                onSubmit={handleCreate}
+                isSaving={createMutation.isPending}
+            />
+
+            <TenantFormSheet
+                open={sheet.type === 'edit'}
+                mode="edit"
+                tenant={sheet.type === 'edit' ? sheet.tenant : undefined}
+                existingTenants={tenants}
+                onClose={closeSheet}
+                onSubmit={handleUpdate}
+                isSaving={updateMutation.isPending}
+            />
+
+            <TenantDeleteDialog
+                open={sheet.type === 'delete'}
+                tenant={sheet.type === 'delete' ? sheet.tenant : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
@@ -34,7 +34,11 @@ jest.mock('@gravitee/gamma-modules-sdk', () => ({
 
 const mockUseEnvironment = jest.mocked(useEnvironment);
 
-function renderWithClient(isForbidden: boolean, seedPermissions: string[]) {
+function renderWithClient(
+    isForbidden: boolean,
+    seedPermissions: string[],
+    permissionPrefix: string | readonly string[] = 'environment-dictionary-',
+) {
     const queryClient = new QueryClient();
     queryClient.setQueryData(['environment-permissions', 'env-1'], seedPermissions);
     const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
@@ -49,7 +53,7 @@ function renderWithClient(isForbidden: boolean, seedPermissions: string[]) {
         () =>
             useForbiddenResourceRedirect({
                 isForbidden,
-                permissionPrefix: 'environment-dictionary-',
+                permissionPrefix,
                 redirectTo: '../applications',
             }),
         { wrapper },
@@ -91,5 +95,23 @@ describe('useForbiddenResourceRedirect', () => {
         renderWithClient(true, []);
 
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+    });
+
+    it('strips multiple permission prefixes in one redirect', async () => {
+        const { queryClient } = renderWithClient(
+            true,
+            ['organization-tenant-r', 'environment-tenant-c', 'environment-metadata-r'],
+            ['organization-tenant-', 'environment-tenant-'],
+        );
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+    });
+
+    it('keeps every permission when no prefix is given, rather than stripping them all', async () => {
+        const { queryClient } = renderWithClient(true, ['organization-tenant-r', 'environment-metadata-r'], []);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['organization-tenant-r', 'environment-metadata-r']);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
@@ -31,21 +31,25 @@ export function useForbiddenResourceRedirect({
     redirectTo,
 }: {
     isForbidden: boolean;
-    permissionPrefix: string;
+    permissionPrefix: string | readonly string[];
     redirectTo: string;
 }): void {
     const env = useEnvironment();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
+    const prefixes = (typeof permissionPrefix === 'string' ? [permissionPrefix] : permissionPrefix).filter(prefix => prefix !== '');
+    const prefixKey = prefixes.join('\0');
 
     useEffect(() => {
         if (!isForbidden) return;
+        // An empty prefix would match every permission via startsWith, so an empty list strips nothing.
+        const prefixesToStrip = prefixKey === '' ? [] : prefixKey.split('\0');
         if (env?.id) {
             const permissionsKey = environmentPermissionKeys.detail(env.id);
             queryClient.setQueryData<string[]>(permissionsKey, previous =>
-                (previous ?? []).filter(permission => !permission.startsWith(permissionPrefix)),
+                (previous ?? []).filter(permission => !prefixesToStrip.some(prefix => permission.startsWith(prefix))),
             );
         }
         navigate(redirectTo, { replace: true });
-    }, [isForbidden, permissionPrefix, redirectTo, env?.id, queryClient, navigate]);
+    }, [isForbidden, prefixKey, redirectTo, env?.id, queryClient, navigate]);
 }


### PR DESCRIPTION
…enhancements

Introduce tenant management feature, including tenant CRUD operations, UI components, navigation updates, and validation utilities. Update permissions to ensure proper access control. Add tests to validate new functionality.

## Issue

https://gravitee.atlassian.net/browse/FOUND-41
https://gravitee.atlassian.net/browse/FOUND-42
https://gravitee.atlassian.net/browse/FOUND-43

## Summary
- Adds org-level **Tenants** to the Gamma Platform module, matching Classic Console: list/search/sort, create, edit (name/description; key is immutable), and delete.
- Wires `/tenants` with nav + `PermissionPageGuard` on `organization-tenant-r` / `environment-tenant-r`. CRUD uses the existing org Management API (`GET/POST/PUT /configuration/tenants`, `DELETE /configuration/tenants/{key}`).
- Create/edit sheet ports Classic key slugify, enforces backend `@Size(max = 40)` on name and key, blocks hyphen-only keys, and maps duplicate-key `400` (`tenant.exists`) onto the key field. Empty state explains gateway tagging; header owns the single “Add a tenant” CTA.
- 403 handling now accepts multiple permission prefixes so org + env tenant grants are stripped in one redirect.

## Test plan
- [ ] Open Gamma Console Platform → **Tenants** with `organization-tenant-r` (page loads; without it, redirect away).
- [ ] Empty org: educational empty state + one header **Add a tenant** button (create permission required).
- [ ] Create: name generates a key; custom key slugifies; name/key max 40; `---` cannot submit; duplicate key shows an inline error.
- [ ] Edit: key is read-only; name/description save; delete confirms by name and removes the row.
- [ ] Search/sort/pagination; deleting the last row on page 2 does not leave an empty page.
- [ ] Without create/update/delete permissions, CTA and row actions are hidden.

## Additional context

https://github.com/user-attachments/assets/beff6c08-81ab-4b57-a0d1-ccc933766bc5


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

