### PR TITLE
feat(gateway): Adds infrastructure for deploy-time policy warmup

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -30,9 +30,11 @@ import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.Invoker;
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -643,6 +645,9 @@ public class DefaultApiReactor extends AbstractApiReactor {
         resourceLifecycleManager.start();
         policyManager.start();
 
+        // Warm up policies (e.g. pre-fetch XSD schemas) before the API is marked ready.
+        warmupPolicies();
+
         // Create and start ApiProductPlanPolicyManager when API Product support is enabled
         if (apiProductPlanPolicyManagerFactory != null) {
             apiProductPlanPolicyManager = apiProductPlanPolicyManagerFactory.create(api);
@@ -692,6 +697,39 @@ public class DefaultApiReactor extends AbstractApiReactor {
         log.debug("API reactor started in {} ms", (endTime - startTime));
 
         dumpAcceptors();
+    }
+
+    /**
+     * Pre-creates the API and plan flow policy chains so that policies implementing
+     * {@code WarmablePolicy} are warmed up (e.g. XSD schemas fetched and compiled) before the API
+     * is marked ready. This runs after resources have been started, on the deployment thread.
+     */
+    private void warmupPolicies() {
+        final List<Flow> apiFlows = new ArrayList<>();
+        final List<Flow> planFlows = new ArrayList<>();
+        collectFlows(apiFlows, planFlows);
+
+        if (!planFlows.isEmpty()) {
+            apiPlanFlowChain.warmupPolicies(deploymentContext, planFlows);
+        }
+        if (!apiFlows.isEmpty()) {
+            apiFlowChain.warmupPolicies(deploymentContext, apiFlows);
+        }
+    }
+
+    private void collectFlows(final List<Flow> apiFlows, final List<Flow> planFlows) {
+        final io.gravitee.definition.model.v4.Api definition = api.getDefinition();
+
+        if (definition.getPlans() != null) {
+            for (Plan plan : definition.getPlans()) {
+                if (plan.getFlows() != null) {
+                    planFlows.addAll(plan.getFlows());
+                }
+            }
+        }
+        if (definition.getFlows() != null) {
+            apiFlows.addAll(definition.getFlows());
+        }
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
@@ -21,6 +21,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.hook.ChainHook;
@@ -29,6 +30,7 @@ import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
 import io.gravitee.gateway.reactive.handlers.api.v4.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
+import io.gravitee.gateway.reactive.policy.HttpPolicyFactory;
 import io.gravitee.gateway.reactive.v4.flow.FlowResolver;
 import io.gravitee.gateway.reactive.v4.policy.PolicyChainFactory;
 import io.reactivex.rxjava3.annotations.NonNull;
@@ -89,6 +91,30 @@ public class FlowChain implements Hookable<ChainHook> {
             this.hooks = new ArrayList<>();
         }
         this.hooks.addAll(hooks);
+    }
+
+    /**
+     * Pre-creates policy chains for the given flows, triggering warmup on any {@code WarmablePolicy}
+     * instances created while the warmup context is active.
+     *
+     * @param deploymentContext the deployment context passed through to policy warmup
+     * @param flows the flows whose policy chains to pre-create
+     */
+    public void warmupPolicies(final DeploymentContext deploymentContext, final Iterable<Flow> flows) {
+        HttpPolicyFactory.beginWarmup(deploymentContext);
+        try {
+            for (Flow flow : flows) {
+                if (!flow.isEnabled()) {
+                    continue;
+                }
+                log.debug("Warming up policies of flow '{}' ({} level) for request phase", flow.getName(), id);
+                policyChainFactory.create(id, flow, ExecutionPhase.REQUEST);
+                log.debug("Warming up policies of flow '{}' ({} level) for response phase", flow.getName(), id);
+                policyChainFactory.create(id, flow, ExecutionPhase.RESPONSE);
+            }
+        } finally {
+            HttpPolicyFactory.endWarmup();
+        }
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyWarmupException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyWarmupException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.policy;
+
+/**
+ * Thrown when a {@link io.gravitee.gateway.reactive.api.policy.http.WarmablePolicy} fails to warm up
+ * during API deployment. This exception fails the API deployment (fail-fast) so that the API does not
+ * start with a cold or broken policy configuration.
+ *
+ * @author GraviteeSource Team
+ */
+public class PolicyWarmupException extends RuntimeException {
+
+    private final String policyId;
+
+    public PolicyWarmupException(final String policyId, final String message, final Throwable cause) {
+        super(message, cause);
+        this.policyId = policyId;
+    }
+
+    public String getPolicyId() {
+        return policyId;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyFactory.java
@@ -18,21 +18,52 @@ package io.gravitee.gateway.reactive.policy;
 import io.gravitee.gateway.policy.PolicyManifest;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
+import io.gravitee.gateway.policy.PolicyWarmupException;
 import io.gravitee.gateway.policy.StreamType;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
+import io.gravitee.gateway.reactive.api.policy.http.WarmablePolicy;
 import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
 import io.gravitee.gateway.reactive.policy.adapter.policy.PolicyAdapter;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.api.PolicyConfiguration;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 
 /**
  * @author Guillaume Lamirand (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class HttpPolicyFactory implements PolicyFactory {
+
+    private static final long WARMUP_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Holds the {@link DeploymentContext} of the API currently being deployed, so that policies
+     * implementing {@link WarmablePolicy} can be warmed up inline while their policy chain is built.
+     * Deployment is single-threaded, so a {@code ThreadLocal} is sufficient and avoids changing the
+     * factory's public contract.
+     */
+    private static final ThreadLocal<DeploymentContext> WARMUP_CONTEXT = new ThreadLocal<>();
+
+    /**
+     * Marks the start of a deploy-time warmup phase on the current thread. Policies created while a
+     * context is bound are warmed up immediately.
+     */
+    public static void beginWarmup(final DeploymentContext deploymentContext) {
+        WARMUP_CONTEXT.set(deploymentContext);
+    }
+
+    /**
+     * Ends the deploy-time warmup phase on the current thread.
+     */
+    public static void endWarmup() {
+        WARMUP_CONTEXT.remove();
+    }
 
     protected final Configuration configuration;
     protected final PolicyPluginFactory policyPluginFactory;
@@ -111,9 +142,32 @@ public class HttpPolicyFactory implements PolicyFactory {
             );
         }
 
+        warmupIfNeeded(policyManifest, policy);
+
         policy = decoratePolicy(policyMetadata, policy);
 
         return policy;
+    }
+
+    private void warmupIfNeeded(final PolicyManifest policyManifest, final HttpPolicy policy) {
+        final DeploymentContext deploymentContext = WARMUP_CONTEXT.get();
+        if (deploymentContext == null || !(policy instanceof WarmablePolicy warmable)) {
+            return;
+        }
+
+        final String policyId = policyManifest.id();
+        try {
+            log.debug("Warming up policy '{}'", policyId);
+            warmable
+                .warmup(deploymentContext)
+                .subscribeOn(Schedulers.io())
+                .timeout(WARMUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .blockingAwait();
+            log.info("Policy '{}' warmed up", policyId);
+        } catch (Exception e) {
+            log.error("Failed to warm up policy '{}'", policyId, e);
+            throw new PolicyWarmupException(policyId, "Failed to warm up policy '" + policyId + "': " + e.getMessage(), e);
+        }
     }
 
     protected HttpPolicy decoratePolicy(PolicyMetadata policyMetadata, HttpPolicy policy) {


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14959

## Description
Adds infrastructure for deploy-time policy warmup in the V4 reactive Gateway, enabling policies like XML Validation to pre-fetch and compile schemas before the API is marked ready.
### Key Features
- **WarmablePolicy Integration**: Policies implementing `WarmablePolicy` are automatically warmed up during API deployment
- **Fail-Fast Deployment**: If warmup fails (e.g., registry unreachable), API deployment fails immediately
- **Non-Blocking Warmup**: Uses `subscribeOn(Schedulers.io())` to avoid blocking the event loop
- **Thread-Safe Context**: `ThreadLocal<DeploymentContext>` ensures warmup happens on deployment thread
### Changes
- `HttpPolicyFactory`: Added `beginWarmup()`/`endWarmup()` lifecycle methods and `warmupIfNeeded()` logic
- `FlowChain`: Added `warmupPolicies()` method to pre-create policy chains during deployment
- `DefaultApiReactor`: Calls `warmupPolicies()` after resources are started
- New `PolicyWarmupException` for fail-fast error reporting
### Implementation Details
- Warmup timeout: 30 seconds (configurable in future)
- ThreadLocal context avoids API contract changes
- try-finally ensures ThreadLocal cleanup


