### PR TITLE
feat(gamma): added crud on env alerts

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AggregationConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AggregationConditionForm.tsx
@@ -15,6 +15,7 @@
  */
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from './alertPositiveNumber';
 import { AGGREGATION_FUNCTIONS, ALERT_OPERATORS, TIME_UNITS, type AlertMetricDefinition } from '../../../constants/alertConstants';
 import type { AlertAggregationFunction, AlertFormCondition, AlertOperator, AlertTimeUnit } from '../../../types';
 
@@ -85,9 +86,15 @@ export function AggregationConditionForm({ condition, metrics, onChange }: Props
                     <Label className="text-xs">Threshold</Label>
                     <Input
                         type="number"
+                        min={ALERT_POSITIVE_NUMBER_MIN}
                         placeholder="e.g. 500"
                         value={condition.threshold ?? ''}
-                        onChange={e => onChange({ ...condition, threshold: e.target.value ? Number(e.target.value) : undefined })}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                            })
+                        }
                     />
                 </div>
             </div>
@@ -96,10 +103,15 @@ export function AggregationConditionForm({ condition, metrics, onChange }: Props
                     <Label className="text-xs">Duration</Label>
                     <Input
                         type="number"
-                        min={1}
+                        min={ALERT_POSITIVE_NUMBER_MIN}
                         placeholder="e.g. 1"
                         value={condition.duration ?? ''}
-                        onChange={e => onChange({ ...condition, duration: e.target.value ? Number(e.target.value) : undefined })}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                            })
+                        }
                     />
                 </div>
                 <div className="space-y-1.5">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/FilterRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/FilterRow.tsx
@@ -29,6 +29,7 @@ import {
 } from '@gravitee/graphene-core';
 import { Trash2Icon } from '@gravitee/graphene-core/icons';
 
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from './alertPositiveNumber';
 import {
     ALERT_OPERATORS,
     ALERT_STRING_OPERATORS,
@@ -156,10 +157,14 @@ export function FilterRow({ filter, index, metrics, onChange, onRemove }: Props)
                             <Label className="text-xs">Threshold</Label>
                             <Input
                                 type="number"
+                                min={ALERT_POSITIVE_NUMBER_MIN}
                                 placeholder="e.g. 500"
                                 value={filter.threshold ?? ''}
                                 onChange={e =>
-                                    onChange(index, { ...filter, threshold: e.target.value ? Number(e.target.value) : undefined })
+                                    onChange(index, {
+                                        ...filter,
+                                        threshold: nextAlertPositiveNumber(e.target.value, filter.threshold),
+                                    })
                                 }
                             />
                         </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.spec.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { HistoryTab } from './HistoryTab';
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+describe('HistoryTab', () => {
+    it('renders a date from created_at epoch millis, not Invalid Date', () => {
+        const createdAt = Date.now() - 3 * 60_000;
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [{ message: '[response.response_time: 304] is greater than [100.0]', created_at: createdAt }],
+                    totalElements: 1,
+                }}
+            />,
+        );
+
+        expect(screen.queryByText('Invalid Date')).toBeNull();
+        expect(screen.getByText(/response.response_time: 304/)).not.toBeNull();
+    });
+
+    it('renders two events that share a message', () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const message = 'Health check failed';
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [
+                        { message, created_at: Date.now() - 60_000 },
+                        { message, created_at: Date.now() - 120_000 },
+                    ],
+                    totalElements: 2,
+                }}
+            />,
+        );
+
+        expect(screen.getAllByText(message)).toHaveLength(2);
+        expect(error.mock.calls.flat().join(' ')).not.toMatch(/same key/);
+        error.mockRestore();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
@@ -52,9 +52,9 @@ export function HistoryTab({ historyPage }: HistoryTabProps) {
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
-                                    {historyPage.content.map(evt => (
-                                        <TableRow key={evt.id}>
-                                            <TableCell className="text-sm">{new Date(evt.createdAt).toLocaleString()}</TableCell>
+                                    {historyPage.content.map((evt, i) => (
+                                        <TableRow key={`${evt.created_at}-${i}`}>
+                                            <TableCell className="text-sm">{new Date(evt.created_at).toLocaleString()}</TableCell>
                                             <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
                                         </TableRow>
                                     ))}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/MissingDataConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/MissingDataConditionForm.tsx
@@ -15,6 +15,7 @@
  */
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from './alertPositiveNumber';
 import { TIME_UNITS } from '../../../constants/alertConstants';
 import type { AlertFormCondition, AlertTimeUnit } from '../../../types';
 
@@ -30,10 +31,15 @@ export function MissingDataConditionForm({ condition, onChange }: Props) {
                 <Label className="text-xs">Duration</Label>
                 <Input
                     type="number"
-                    min={1}
+                    min={ALERT_POSITIVE_NUMBER_MIN}
                     placeholder="e.g. 5"
                     value={condition.duration ?? ''}
-                    onChange={e => onChange({ ...condition, duration: e.target.value ? Number(e.target.value) : undefined })}
+                    onChange={e =>
+                        onChange({
+                            ...condition,
+                            duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                        })
+                    }
                 />
             </div>
             <div className="space-y-1.5">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/RateConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/RateConditionForm.tsx
@@ -15,6 +15,7 @@
  */
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
+import { ALERT_POSITIVE_NUMBER_MIN, ALERT_RATE_PERCENT_MAX, nextAlertPositiveNumber } from './alertPositiveNumber';
 import {
     ALERT_OPERATORS,
     ALERT_STRING_OPERATORS,
@@ -66,9 +67,15 @@ export function RateConditionForm({ condition, metrics, onChange }: Props) {
                     ) : (
                         <Input
                             type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
                             placeholder="e.g. 500"
                             value={condition.threshold ?? ''}
-                            onChange={e => onChange({ ...condition, threshold: e.target.value ? Number(e.target.value) : undefined })}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                                })
+                            }
                         />
                     )}
                 </div>
@@ -114,11 +121,18 @@ export function RateConditionForm({ condition, metrics, onChange }: Props) {
                     <Label className="text-xs">Rate threshold (%)</Label>
                     <Input
                         type="number"
-                        min={0}
-                        max={100}
+                        min={ALERT_POSITIVE_NUMBER_MIN}
+                        max={ALERT_RATE_PERCENT_MAX}
                         placeholder="e.g. 50"
                         value={condition.rateThreshold ?? ''}
-                        onChange={e => onChange({ ...condition, rateThreshold: e.target.value ? Number(e.target.value) : undefined })}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                rateThreshold: nextAlertPositiveNumber(e.target.value, condition.rateThreshold, {
+                                    max: ALERT_RATE_PERCENT_MAX,
+                                }),
+                            })
+                        }
                     />
                 </div>
             </div>
@@ -145,10 +159,15 @@ export function RateConditionForm({ condition, metrics, onChange }: Props) {
                     <Label className="text-xs">Duration</Label>
                     <Input
                         type="number"
-                        min={1}
+                        min={ALERT_POSITIVE_NUMBER_MIN}
                         placeholder="e.g. 1"
                         value={condition.duration ?? ''}
-                        onChange={e => onChange({ ...condition, duration: e.target.value ? Number(e.target.value) : undefined })}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                            })
+                        }
                     />
                 </div>
                 <div className="space-y-1.5">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.spec.tsx
@@ -16,7 +16,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { SimpleConditionForm } from './SimpleConditionForm';
-import { API_METRICS } from '../constants/alertConstants';
+import { API_METRICS } from '../../../constants/alertConstants';
 
 jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
 
@@ -37,18 +37,5 @@ describe('SimpleConditionForm', () => {
         fireEvent.change(input, { target: { value: '-8' } });
 
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ threshold: 10 }));
-    });
-
-    it('keeps STRING fields when the metric is not in the catalog', () => {
-        render(
-            <SimpleConditionForm
-                condition={{ type: 'STRING', property: 'custom.unknown', operator: 'EQUALS', pattern: 'foo' }}
-                metrics={API_METRICS}
-                onChange={jest.fn()}
-            />,
-        );
-
-        expect(screen.getByPlaceholderText('e.g. API_KEY_MISSING')).not.toBeNull();
-        expect(screen.queryByPlaceholderText('e.g. 500')).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.tsx
@@ -15,6 +15,7 @@
  */
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from './alertPositiveNumber';
 import {
     ALERT_OPERATORS,
     ALERT_STRING_OPERATORS,
@@ -61,7 +62,16 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                 {availableTypes.length > 1 && (
                     <div className="space-y-1.5">
                         <Label className="text-xs">Condition type</Label>
-                        <Select value={condType} onValueChange={(val: AlertConditionType) => onChange({ ...condition, type: val })}>
+                        <Select
+                            value={condType}
+                            onValueChange={(val: AlertConditionType) =>
+                                onChange({
+                                    ...condition,
+                                    type: val,
+                                    property2: val === 'COMPARE' ? (condition.property2 ?? metrics[0]?.key) : condition.property2,
+                                })
+                            }
+                        >
                             <SelectTrigger>
                                 <SelectValue />
                             </SelectTrigger>
@@ -112,18 +122,32 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                         <Label className="text-xs">Low threshold</Label>
                         <Input
                             type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
                             placeholder="e.g. 200"
                             value={condition.thresholdLow ?? ''}
-                            onChange={e => onChange({ ...condition, thresholdLow: e.target.value ? Number(e.target.value) : undefined })}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    thresholdLow: nextAlertPositiveNumber(e.target.value, condition.thresholdLow),
+                                })
+                            }
                         />
                     </div>
                     <div className="space-y-1.5">
                         <Label className="text-xs">High threshold</Label>
                         <Input
                             type="number"
+                            min={condition.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN}
                             placeholder="e.g. 500"
                             value={condition.thresholdHigh ?? ''}
-                            onChange={e => onChange({ ...condition, thresholdHigh: e.target.value ? Number(e.target.value) : undefined })}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    thresholdHigh: nextAlertPositiveNumber(e.target.value, condition.thresholdHigh, {
+                                        min: condition.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN,
+                                    }),
+                                })
+                            }
                         />
                     </div>
                 </div>
@@ -151,17 +175,20 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                         <Label className="text-xs">Multiplier (%)</Label>
                         <Input
                             type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
                             placeholder="e.g. 150"
                             value={condition.multiplier ?? ''}
-                            onChange={e => onChange({ ...condition, multiplier: e.target.value ? Number(e.target.value) : undefined })}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    multiplier: nextAlertPositiveNumber(e.target.value, condition.multiplier),
+                                })
+                            }
                         />
                     </div>
                     <div className="space-y-1.5">
                         <Label className="text-xs">Property to compare</Label>
-                        <Select
-                            value={condition.property2 || metrics[0]?.key}
-                            onValueChange={val => onChange({ ...condition, property2: val })}
-                        >
+                        <Select value={condition.property2} onValueChange={val => onChange({ ...condition, property2: val })}>
                             <SelectTrigger>
                                 <SelectValue />
                             </SelectTrigger>
@@ -199,9 +226,15 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                         <Label className="text-xs">Threshold</Label>
                         <Input
                             type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
                             placeholder="e.g. 500"
                             value={condition.threshold ?? ''}
-                            onChange={e => onChange({ ...condition, threshold: e.target.value ? Number(e.target.value) : undefined })}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                                })
+                            }
                         />
                     </div>
                 </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/alertPositiveNumber.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/alertPositiveNumber.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { nextAlertPositiveNumber } from './alertPositiveNumber';
+
+describe('nextAlertPositiveNumber', () => {
+    it('clears when the field is emptied', () => {
+        expect(nextAlertPositiveNumber('', 10)).toBeUndefined();
+    });
+
+    it('accepts values of 1 or more', () => {
+        expect(nextAlertPositiveNumber('1', undefined)).toBe(1);
+        expect(nextAlertPositiveNumber('500', 10)).toBe(500);
+    });
+
+    it('keeps the current value for negatives, zero, and non-numeric input (classic min=1)', () => {
+        expect(nextAlertPositiveNumber('-8', 10)).toBe(10);
+        expect(nextAlertPositiveNumber('0', 10)).toBe(10);
+        expect(nextAlertPositiveNumber('-', 10)).toBe(10);
+    });
+
+    it('rejects values above max when a max is set (classic rate threshold 1–99)', () => {
+        expect(nextAlertPositiveNumber('50', 10, { max: 99 })).toBe(50);
+        expect(nextAlertPositiveNumber('100', 50, { max: 99 })).toBe(50);
+    });
+
+    it('rejects values below a custom min (classic high threshold >= low)', () => {
+        expect(nextAlertPositiveNumber('150', 500, { min: 200 })).toBe(500);
+        expect(nextAlertPositiveNumber('250', 500, { min: 200 })).toBe(250);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/alertPositiveNumber.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/alertPositiveNumber.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classic platform alert number fields: `min="1"` (“must be higher than 0”). */
+export const ALERT_POSITIVE_NUMBER_MIN = 1;
+
+/** Classic rate threshold (%) is `min="1"` `max="99"`. */
+export const ALERT_RATE_PERCENT_MAX = 99;
+
+export function nextAlertPositiveNumber(
+    raw: string,
+    current: number | undefined,
+    bounds?: { min?: number; max?: number },
+): number | undefined {
+    if (raw === '') {
+        return undefined;
+    }
+    const min = bounds?.min ?? ALERT_POSITIVE_NUMBER_MIN;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < min) {
+        return current;
+    }
+    if (bounds?.max !== undefined && n > bounds.max) {
+        return current;
+    }
+    return n;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/alert.ts
@@ -128,9 +128,8 @@ export interface AlertTrigger {
 }
 
 export interface AlertHistoryEvent {
-    id: string;
     message: string;
-    createdAt: string;
+    created_at: number;
 }
 
 export interface AlertHistoryPage {

--- a/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
@@ -23,6 +23,7 @@ export default {
         '^react/jsx-dev-runtime$': '<rootDir>/../../node_modules/react/jsx-dev-runtime.js',
         '^react-dom$': '<rootDir>/../../node_modules/react-dom/index.js',
         '^react-dom/client$': '<rootDir>/../../node_modules/react-dom/client.js',
+        '^react-hook-form$': '<rootDir>/../../node_modules/react-hook-form/dist/index.cjs.js',
         '^@tanstack/react-query$': '<rootDir>/../../node_modules/@tanstack/react-query/build/modern/index.cjs',
         '^@tanstack/query-core$': '<rootDir>/../../node_modules/@tanstack/query-core/build/modern/index.cjs',
         '^@gravitee/graphene-core$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/index.js',

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -7,6 +7,7 @@
         "@tanstack/react-query": "5.100.14",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "react-hook-form": "7.76.1",
         "react-router-dom": "7.15.1"
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -42,6 +42,7 @@ import {
     type PlatformNavSection,
 } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
+import { AlertFormPage } from '../features/alerts/pages/AlertFormPage';
 import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { ENVIRONMENT_AUDIT_READ_PERMISSIONS, ORGANIZATION_AUDIT_READ_PERMISSIONS } from '../features/audit-logs/utils/auditPermissions';
@@ -474,10 +475,14 @@ export function AppRoutes() {
                                 path="alerts"
                                 element={
                                     <PermissionPageGuard permission={ENVIRONMENT_ALERT_READ_PERMISSION} unauthorizedTo="../applications">
-                                        <AlertsPage />
+                                        <Outlet />
                                     </PermissionPageGuard>
                                 }
-                            />
+                            >
+                                <Route index element={<AlertsPage />} />
+                                <Route path="new" element={<AlertFormPage />} />
+                                <Route path=":alertId" element={<AlertFormPage />} />
+                            </Route>
                             <Route
                                 path="organization-audit"
                                 element={

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AggregationConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AggregationConditionForm.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import { AGGREGATION_FUNCTIONS, ALERT_OPERATORS, TIME_UNITS, type AlertMetricDefinition } from '../constants/alertConstants';
+import type { AlertAggregationFunction, AlertFormCondition, AlertOperator, AlertTimeUnit } from '../types';
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
+
+interface Props {
+    condition: AlertFormCondition;
+    metrics: AlertMetricDefinition[];
+    onChange: (c: AlertFormCondition) => void;
+}
+
+export function AggregationConditionForm({ condition, metrics, onChange }: Props) {
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Metric</Label>
+                    <Select value={condition.property ?? metrics[0]?.key} onValueChange={val => onChange({ ...condition, property: val })}>
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {metrics.map(m => (
+                                <SelectItem key={m.key} value={m.key}>
+                                    {m.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Function</Label>
+                    <Select
+                        value={condition.aggregationFunction || 'AVG'}
+                        onValueChange={(val: AlertAggregationFunction) => onChange({ ...condition, aggregationFunction: val })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {AGGREGATION_FUNCTIONS.map(f => (
+                                <SelectItem key={f.value} value={f.value}>
+                                    {f.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Operator</Label>
+                    <Select
+                        value={(condition.operator as string) || 'GT'}
+                        onValueChange={(val: AlertOperator) => onChange({ ...condition, operator: val })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {ALERT_OPERATORS.map(op => (
+                                <SelectItem key={op.value} value={op.value}>
+                                    {op.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Threshold</Label>
+                    <Input
+                        type="number"
+                        min={ALERT_POSITIVE_NUMBER_MIN}
+                        placeholder="e.g. 500"
+                        value={condition.threshold ?? ''}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                            })
+                        }
+                    />
+                </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Duration</Label>
+                    <Input
+                        type="number"
+                        min={ALERT_POSITIVE_NUMBER_MIN}
+                        placeholder="e.g. 1"
+                        value={condition.duration ?? ''}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                            })
+                        }
+                    />
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Time unit</Label>
+                    <Select
+                        value={condition.timeUnit || 'MINUTES'}
+                        onValueChange={(val: AlertTimeUnit) => onChange({ ...condition, timeUnit: val })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {TIME_UNITS.map(tu => (
+                                <SelectItem key={tu.value} value={tu.value}>
+                                    {tu.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsTab.tsx
@@ -105,7 +105,6 @@ export interface AlertsTabProps {
     setSeverity: Dispatch<SetStateAction<AlertSeverity>>;
     enabled: boolean;
     setEnabled: Dispatch<SetStateAction<boolean>>;
-    ruleId: AlertRuleId;
     handleRuleChange: (newRuleId: AlertRuleId) => void;
     isUpdate: boolean;
     canEdit: boolean;
@@ -127,6 +126,7 @@ export interface AlertsTabProps {
     updateFilter: (index: number, f: AlertFormCondition) => void;
     removeFilter: (index: number) => void;
     selectedRule: AlertRuleDefinition | undefined;
+    ruleLabel: string;
 }
 
 export function AlertsTab({
@@ -138,7 +138,6 @@ export function AlertsTab({
     setSeverity,
     enabled,
     setEnabled,
-    ruleId,
     handleRuleChange,
     isUpdate,
     canEdit,
@@ -160,7 +159,9 @@ export function AlertsTab({
     updateFilter,
     removeFilter,
     selectedRule,
+    ruleLabel,
 }: AlertsTabProps) {
+    const conditionRuleId = selectedRule?.id;
     return (
         <div className="mt-6 space-y-6">
             {/* General */}
@@ -209,31 +210,35 @@ export function AlertsTab({
                             <Label className="text-xs">
                                 Rule <span className="text-destructive">*</span>
                             </Label>
-                            <Select
-                                value={ruleId}
-                                disabled={isUpdate || !canEdit}
-                                onValueChange={val => handleRuleChange(val as AlertRuleId)}
-                            >
-                                <SelectTrigger className={isUpdate ? 'w-full min-w-0 opacity-60' : 'w-full min-w-0'}>
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {RULE_CATEGORY_ORDER.map(category => {
-                                        const rules = ALERT_RULES.filter(rule => rule.category === category);
-                                        if (rules.length === 0) return null;
-                                        return (
-                                            <SelectGroup key={category}>
-                                                <SelectLabel>{category.toUpperCase()}</SelectLabel>
-                                                {rules.map(rule => (
-                                                    <SelectItem key={rule.id} value={rule.id}>
-                                                        {rule.description}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectGroup>
-                                        );
-                                    })}
-                                </SelectContent>
-                            </Select>
+                            {selectedRule ? (
+                                <Select
+                                    value={selectedRule.id}
+                                    disabled={isUpdate || !canEdit}
+                                    onValueChange={val => handleRuleChange(val as AlertRuleId)}
+                                >
+                                    <SelectTrigger className={isUpdate ? 'w-full min-w-0 opacity-60' : 'w-full min-w-0'}>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {RULE_CATEGORY_ORDER.map(category => {
+                                            const rules = ALERT_RULES.filter(rule => rule.category === category);
+                                            if (rules.length === 0) return null;
+                                            return (
+                                                <SelectGroup key={category}>
+                                                    <SelectLabel>{category.toUpperCase()}</SelectLabel>
+                                                    {rules.map(rule => (
+                                                        <SelectItem key={rule.id} value={rule.id}>
+                                                            {rule.description}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectGroup>
+                                            );
+                                        })}
+                                    </SelectContent>
+                                </Select>
+                            ) : (
+                                <Input value={ruleLabel} disabled className="opacity-60" />
+                            )}
                         </div>
                         <div className="w-40 shrink-0 space-y-1.5">
                             <Label className="text-xs">
@@ -422,26 +427,42 @@ export function AlertsTab({
                     <CardDescription>Field metrics and condition for the rule</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    {(ruleId === 'REQUEST@METRICS_SIMPLE_CONDITION' || ruleId === 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION') &&
-                        conditions[0] && (
-                            <SimpleConditionForm condition={conditions[0]} metrics={metricsForRule} onChange={c => updateCondition(0, c)} />
+                    {errors.conditions && <p className="mb-3 text-xs text-destructive">{errors.conditions}</p>}
+                    <fieldset disabled={!canEdit} className="contents">
+                        {(conditionRuleId === 'REQUEST@METRICS_SIMPLE_CONDITION' ||
+                            conditionRuleId === 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION') &&
+                            conditions[0] && (
+                                <SimpleConditionForm
+                                    condition={conditions[0]}
+                                    metrics={metricsForRule}
+                                    onChange={c => updateCondition(0, c)}
+                                />
+                            )}
+                        {conditionRuleId === 'REQUEST@MISSING_DATA' && conditions[0] && (
+                            <MissingDataConditionForm condition={conditions[0]} onChange={c => updateCondition(0, c)} />
                         )}
-                    {ruleId === 'REQUEST@MISSING_DATA' && conditions[0] && (
-                        <MissingDataConditionForm condition={conditions[0]} onChange={c => updateCondition(0, c)} />
-                    )}
-                    {(ruleId === 'REQUEST@METRICS_AGGREGATION' || ruleId === 'NODE_HEARTBEAT@METRICS_AGGREGATION') && conditions[0] && (
-                        <AggregationConditionForm
-                            condition={conditions[0]}
-                            metrics={metricsForRule}
-                            onChange={c => updateCondition(0, c)}
-                        />
-                    )}
-                    {(ruleId === 'REQUEST@METRICS_RATE' || ruleId === 'NODE_HEARTBEAT@METRICS_RATE') && conditions[0] && (
-                        <RateConditionForm condition={conditions[0]} metrics={metricsForRule} onChange={c => updateCondition(0, c)} />
-                    )}
-                    {isInfoOnlyRule(ruleId) && (
-                        <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">{infoOnlyMessage(ruleId)}</div>
-                    )}
+                        {(conditionRuleId === 'REQUEST@METRICS_AGGREGATION' || conditionRuleId === 'NODE_HEARTBEAT@METRICS_AGGREGATION') &&
+                            conditions[0] && (
+                                <AggregationConditionForm
+                                    condition={conditions[0]}
+                                    metrics={metricsForRule}
+                                    onChange={c => updateCondition(0, c)}
+                                />
+                            )}
+                        {(conditionRuleId === 'REQUEST@METRICS_RATE' || conditionRuleId === 'NODE_HEARTBEAT@METRICS_RATE') &&
+                            conditions[0] && (
+                                <RateConditionForm
+                                    condition={conditions[0]}
+                                    metrics={metricsForRule}
+                                    onChange={c => updateCondition(0, c)}
+                                />
+                            )}
+                        {conditionRuleId && isInfoOnlyRule(conditionRuleId) && (
+                            <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+                                {infoOnlyMessage(conditionRuleId)}
+                            </div>
+                        )}
+                    </fieldset>
                 </CardContent>
             </Card>
 
@@ -468,16 +489,23 @@ export function AlertsTab({
                     </CardContent>
                 ) : filters.length > 0 ? (
                     <CardContent className="space-y-3 pt-0">
-                        {filters.map((f, idx) => (
-                            <FilterRow
-                                key={idx}
-                                filter={f}
-                                index={idx}
-                                metrics={metricsForRule}
-                                onChange={updateFilter}
-                                onRemove={removeFilter}
-                            />
-                        ))}
+                        {errors.filters && <p className="text-xs text-destructive">{errors.filters}</p>}
+                        <fieldset disabled={!canEdit} className="contents">
+                            {filters.map((f, idx) => (
+                                <FilterRow
+                                    key={idx}
+                                    filter={f}
+                                    index={idx}
+                                    metrics={metricsForRule}
+                                    onChange={updateFilter}
+                                    onRemove={removeFilter}
+                                />
+                            ))}
+                        </fieldset>
+                    </CardContent>
+                ) : errors.filters ? (
+                    <CardContent className="pt-0">
+                        <p className="text-xs text-destructive">{errors.filters}</p>
                     </CardContent>
                 ) : null}
             </Card>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsTab.tsx
@@ -1,0 +1,486 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectTrigger,
+    SelectValue,
+    Switch,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { ArrowRightIcon, ClockIcon, XIcon } from '@gravitee/graphene-core/icons';
+import type { Dispatch, MouseEvent, SetStateAction } from 'react';
+
+import { AggregationConditionForm } from './AggregationConditionForm';
+import { FilterRow } from './FilterRow';
+import { MissingDataConditionForm } from './MissingDataConditionForm';
+import { RateConditionForm } from './RateConditionForm';
+import { SimpleConditionForm } from './SimpleConditionForm';
+import {
+    ALERT_RULES,
+    type AlertMetricDefinition,
+    type AlertRuleCategory,
+    type AlertRuleDefinition,
+    isInfoOnlyRule,
+} from '../constants/alertConstants';
+import type { AlertFormCondition, AlertFormTimeframe, AlertRuleId, AlertSeverity } from '../types';
+import {
+    END_OF_DAY_SECONDS,
+    OFFICE_END_SECONDS,
+    OFFICE_START_SECONDS,
+    isOfficeHours,
+    secondsSinceMidnightToTimeInput,
+    timeInputToSecondsSinceMidnight,
+} from '../utils/timeframeTime';
+
+/** Classic-style rule dropdown groups; order requested: Node → API → Health-check. */
+const RULE_CATEGORY_ORDER: AlertRuleCategory[] = ['Node', 'API metrics', 'Health-check'];
+
+function infoOnlyMessage(ruleId: AlertRuleId): string {
+    switch (ruleId) {
+        case 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED':
+            return "This alert triggers automatically when a node's lifecycle status changes. No additional condition configuration is required.";
+        case 'NODE_HEALTHCHECK@NODE_HEALTHCHECK':
+            return 'This alert triggers automatically based on the health status of the node. No additional condition configuration is required.';
+        case 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED':
+        default:
+            return "This alert triggers automatically when an endpoint's health check status transitions between healthy and unhealthy states. No additional condition configuration is required.";
+    }
+}
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const BUSINESS_DAYS = [1, 2, 3, 4, 5];
+
+function isBusinessDays(days: number[]): boolean {
+    if (days.length !== BUSINESS_DAYS.length) return false;
+    const sorted = [...days].sort((a, b) => a - b);
+    return BUSINESS_DAYS.every((d, i) => sorted[i] === d);
+}
+
+function openNativeTimePicker(event: MouseEvent<HTMLInputElement>) {
+    const input = event.currentTarget;
+    if (input.disabled) {
+        return;
+    }
+    try {
+        input.showPicker?.();
+    } catch {
+        // Already open, or the browser rejected the call.
+    }
+}
+
+const TIME_INPUT_CLASS =
+    'h-8 cursor-pointer border-0 shadow-none focus-visible:ring-0 relative [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:inset-0 [&::-webkit-calendar-picker-indicator]:h-full [&::-webkit-calendar-picker-indicator]:w-full [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0';
+
+export interface AlertsTabProps {
+    name: string;
+    setName: Dispatch<SetStateAction<string>>;
+    description: string;
+    setDescription: Dispatch<SetStateAction<string>>;
+    severity: AlertSeverity;
+    setSeverity: Dispatch<SetStateAction<AlertSeverity>>;
+    enabled: boolean;
+    setEnabled: Dispatch<SetStateAction<boolean>>;
+    ruleId: AlertRuleId;
+    handleRuleChange: (newRuleId: AlertRuleId) => void;
+    isUpdate: boolean;
+    canEdit: boolean;
+    errors: Record<string, string>;
+    setErrors: Dispatch<SetStateAction<Record<string, string>>>;
+    markDirty: () => void;
+    timeframes: AlertFormTimeframe[];
+    addTimeframe: () => void;
+    removeTimeframe: (index: number) => void;
+    toggleTimeframeDay: (index: number, dayNum: number) => void;
+    updateTimeframeHour: (index: number, field: 'startHour' | 'endHour', value: number) => void;
+    setTimeframeDays: (index: number, days: number[]) => void;
+    updateTimeframeHours: (index: number, startHour: number, endHour: number) => void;
+    conditions: AlertFormCondition[];
+    updateCondition: (index: number, c: AlertFormCondition) => void;
+    metricsForRule: AlertMetricDefinition[];
+    filters: AlertFormCondition[];
+    addFilter: () => void;
+    updateFilter: (index: number, f: AlertFormCondition) => void;
+    removeFilter: (index: number) => void;
+    selectedRule: AlertRuleDefinition | undefined;
+}
+
+export function AlertsTab({
+    name,
+    setName,
+    description,
+    setDescription,
+    severity,
+    setSeverity,
+    enabled,
+    setEnabled,
+    ruleId,
+    handleRuleChange,
+    isUpdate,
+    canEdit,
+    errors,
+    setErrors,
+    markDirty,
+    timeframes,
+    addTimeframe,
+    removeTimeframe,
+    toggleTimeframeDay,
+    updateTimeframeHour,
+    setTimeframeDays,
+    updateTimeframeHours,
+    conditions,
+    updateCondition,
+    metricsForRule,
+    filters,
+    addFilter,
+    updateFilter,
+    removeFilter,
+    selectedRule,
+}: AlertsTabProps) {
+    return (
+        <div className="mt-6 space-y-6">
+            {/* General */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">General</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="flex items-end gap-4">
+                        <div className="flex-1 space-y-1.5">
+                            <Label htmlFor="alert-name" className="text-xs">
+                                Name <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="alert-name"
+                                placeholder="Alert name"
+                                value={name}
+                                disabled={!canEdit}
+                                className={errors.name ? 'border-destructive' : ''}
+                                onChange={e => {
+                                    setName(e.target.value);
+                                    markDirty();
+                                    if (errors.name) setErrors(p => ({ ...p, name: '' }));
+                                }}
+                            />
+                            {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+                        </div>
+                        <div className="flex items-center gap-2 pb-1">
+                            <Label htmlFor="alert-enabled" className="text-xs text-muted-foreground">
+                                Enable alert
+                            </Label>
+                            <Switch
+                                id="alert-enabled"
+                                checked={enabled}
+                                disabled={!canEdit}
+                                onCheckedChange={v => {
+                                    setEnabled(v);
+                                    markDirty();
+                                }}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex items-start gap-4">
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                            <Label className="text-xs">
+                                Rule <span className="text-destructive">*</span>
+                            </Label>
+                            <Select
+                                value={ruleId}
+                                disabled={isUpdate || !canEdit}
+                                onValueChange={val => handleRuleChange(val as AlertRuleId)}
+                            >
+                                <SelectTrigger className={isUpdate ? 'w-full min-w-0 opacity-60' : 'w-full min-w-0'}>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {RULE_CATEGORY_ORDER.map(category => {
+                                        const rules = ALERT_RULES.filter(rule => rule.category === category);
+                                        if (rules.length === 0) return null;
+                                        return (
+                                            <SelectGroup key={category}>
+                                                <SelectLabel>{category.toUpperCase()}</SelectLabel>
+                                                {rules.map(rule => (
+                                                    <SelectItem key={rule.id} value={rule.id}>
+                                                        {rule.description}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectGroup>
+                                        );
+                                    })}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="w-40 shrink-0 space-y-1.5">
+                            <Label className="text-xs">
+                                Severity <span className="text-destructive">*</span>
+                            </Label>
+                            <Select
+                                value={severity}
+                                disabled={!canEdit}
+                                onValueChange={val => {
+                                    setSeverity(val as AlertSeverity);
+                                    markDirty();
+                                }}
+                            >
+                                <SelectTrigger className="w-full">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="INFO">info</SelectItem>
+                                    <SelectItem value="WARNING">warning</SelectItem>
+                                    <SelectItem value="CRITICAL">critical</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <Label htmlFor="alert-desc" className="text-xs">
+                            Description
+                        </Label>
+                        <Textarea
+                            id="alert-desc"
+                            placeholder="Description"
+                            value={description}
+                            disabled={!canEdit}
+                            rows={3}
+                            maxLength={256}
+                            className="resize-none"
+                            onChange={e => {
+                                setDescription(e.target.value);
+                                markDirty();
+                            }}
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* Timeframes */}
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <CardTitle className="text-base">Timeframes</CardTitle>
+                            <CardDescription>Choose timeframe when notifications should be sent.</CardDescription>
+                        </div>
+                        {canEdit && (
+                            <Button variant="outline" size="sm" onClick={addTimeframe}>
+                                Add timeframe
+                            </Button>
+                        )}
+                    </div>
+                </CardHeader>
+                {timeframes.length === 0 ? (
+                    <CardContent className="pt-0">
+                        <p className="text-sm text-muted-foreground">No timeframe defined, it will send all the time.</p>
+                    </CardContent>
+                ) : (
+                    <CardContent className="space-y-3 pt-0">
+                        {timeframes.map((tf, idx) => {
+                            const businessDayOn = isBusinessDays(tf.days);
+                            const officeHoursOn = isOfficeHours(tf.startHour, tf.endHour);
+                            return (
+                                <Card key={idx}>
+                                    <CardContent className="px-4 py-3 space-y-3">
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-sm font-medium">Configure timeframe</span>
+                                            {canEdit && (
+                                                <Button variant="ghost" size="icon" className="size-7" onClick={() => removeTimeframe(idx)}>
+                                                    <XIcon className="size-3.5 text-muted-foreground" />
+                                                </Button>
+                                            )}
+                                        </div>
+                                        <div className="flex flex-wrap gap-1.5">
+                                            {DAY_LABELS.map((day, dayIdx) => {
+                                                const dayNum = dayIdx + 1;
+                                                const isSelected = tf.days.includes(dayNum);
+                                                return (
+                                                    <button
+                                                        key={day}
+                                                        type="button"
+                                                        disabled={!canEdit}
+                                                        className={`rounded-md px-2.5 py-1 text-xs font-medium border transition-colors ${
+                                                            isSelected
+                                                                ? 'bg-primary text-primary-foreground border-primary'
+                                                                : 'bg-background text-muted-foreground border-border hover:bg-accent'
+                                                        }`}
+                                                        onClick={() => toggleTimeframeDay(idx, dayNum)}
+                                                    >
+                                                        {day}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                        <div className="flex flex-col gap-4 border-t pt-3 lg:flex-row lg:items-end">
+                                            <div className="min-w-0 flex-1 space-y-1.5">
+                                                <Label className="text-xs">Time range</Label>
+                                                <div className="flex items-center gap-2 rounded-md border border-input bg-background px-2 py-1">
+                                                    <ClockIcon className="size-4 shrink-0 text-muted-foreground" />
+                                                    <Input
+                                                        type="time"
+                                                        step={1}
+                                                        disabled={!canEdit}
+                                                        aria-label="Start time"
+                                                        className={TIME_INPUT_CLASS}
+                                                        value={secondsSinceMidnightToTimeInput(tf.startHour)}
+                                                        onClick={openNativeTimePicker}
+                                                        onChange={e =>
+                                                            updateTimeframeHour(
+                                                                idx,
+                                                                'startHour',
+                                                                timeInputToSecondsSinceMidnight(e.target.value),
+                                                            )
+                                                        }
+                                                    />
+                                                    <ArrowRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                                                    <Input
+                                                        type="time"
+                                                        step={1}
+                                                        disabled={!canEdit}
+                                                        aria-label="End time"
+                                                        className={TIME_INPUT_CLASS}
+                                                        value={secondsSinceMidnightToTimeInput(tf.endHour)}
+                                                        onClick={openNativeTimePicker}
+                                                        onChange={e =>
+                                                            updateTimeframeHour(
+                                                                idx,
+                                                                'endHour',
+                                                                timeInputToSecondsSinceMidnight(e.target.value),
+                                                            )
+                                                        }
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center justify-between gap-3 lg:w-72 lg:shrink-0">
+                                                <div className="min-w-0">
+                                                    <p className="text-sm font-medium">Office hours</p>
+                                                    <p className="text-xs text-muted-foreground">Set time range from 9:00 AM to 6:00 PM</p>
+                                                </div>
+                                                <Switch
+                                                    checked={officeHoursOn}
+                                                    disabled={!canEdit}
+                                                    aria-label="Office hours"
+                                                    onCheckedChange={on =>
+                                                        updateTimeframeHours(
+                                                            idx,
+                                                            on ? OFFICE_START_SECONDS : 0,
+                                                            on ? OFFICE_END_SECONDS : END_OF_DAY_SECONDS,
+                                                        )
+                                                    }
+                                                />
+                                            </div>
+                                        </div>
+                                        <div className="flex items-center justify-between gap-3 border-t pt-3">
+                                            <div className="min-w-0">
+                                                <p className="text-sm font-medium">Business day</p>
+                                                <p className="text-xs text-muted-foreground">Set any day except weekend</p>
+                                            </div>
+                                            <Switch
+                                                checked={businessDayOn}
+                                                disabled={!canEdit}
+                                                aria-label="Business day"
+                                                onCheckedChange={on => setTimeframeDays(idx, on ? [...BUSINESS_DAYS] : [])}
+                                            />
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
+                    </CardContent>
+                )}
+            </Card>
+
+            {/* Conditions */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Conditions</CardTitle>
+                    <CardDescription>Field metrics and condition for the rule</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {(ruleId === 'REQUEST@METRICS_SIMPLE_CONDITION' || ruleId === 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION') &&
+                        conditions[0] && (
+                            <SimpleConditionForm condition={conditions[0]} metrics={metricsForRule} onChange={c => updateCondition(0, c)} />
+                        )}
+                    {ruleId === 'REQUEST@MISSING_DATA' && conditions[0] && (
+                        <MissingDataConditionForm condition={conditions[0]} onChange={c => updateCondition(0, c)} />
+                    )}
+                    {(ruleId === 'REQUEST@METRICS_AGGREGATION' || ruleId === 'NODE_HEARTBEAT@METRICS_AGGREGATION') && conditions[0] && (
+                        <AggregationConditionForm
+                            condition={conditions[0]}
+                            metrics={metricsForRule}
+                            onChange={c => updateCondition(0, c)}
+                        />
+                    )}
+                    {(ruleId === 'REQUEST@METRICS_RATE' || ruleId === 'NODE_HEARTBEAT@METRICS_RATE') && conditions[0] && (
+                        <RateConditionForm condition={conditions[0]} metrics={metricsForRule} onChange={c => updateCondition(0, c)} />
+                    )}
+                    {isInfoOnlyRule(ruleId) && (
+                        <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">{infoOnlyMessage(ruleId)}</div>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Filters */}
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <CardTitle className="text-base">Filters</CardTitle>
+                            <CardDescription>Filters to apply condition only on a subset of events</CardDescription>
+                        </div>
+                        {selectedRule && canEdit && (
+                            <Button variant="outline" size="sm" onClick={addFilter}>
+                                Add filter
+                            </Button>
+                        )}
+                    </div>
+                </CardHeader>
+                {!selectedRule ? (
+                    <CardContent className="pt-0">
+                        <div className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+                            Select a rule before setting the filters.
+                        </div>
+                    </CardContent>
+                ) : filters.length > 0 ? (
+                    <CardContent className="space-y-3 pt-0">
+                        {filters.map((f, idx) => (
+                            <FilterRow
+                                key={idx}
+                                filter={f}
+                                index={idx}
+                                metrics={metricsForRule}
+                                onChange={updateFilter}
+                                onRemove={removeFilter}
+                            />
+                        ))}
+                    </CardContent>
+                ) : null}
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/FilterRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/FilterRow.tsx
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Input,
+} from '@gravitee/graphene-core';
+import { Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import {
+    ALERT_OPERATORS,
+    ALERT_STRING_OPERATORS,
+    getConditionTypesForMetric,
+    isStringMetric,
+    type AlertMetricDefinition,
+} from '../constants/alertConstants';
+import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../types';
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
+
+interface Props {
+    filter: AlertFormCondition;
+    index: number;
+    metrics: AlertMetricDefinition[];
+    onChange: (index: number, f: AlertFormCondition) => void;
+    onRemove: (index: number) => void;
+}
+
+export function FilterRow({ filter, index, metrics, onChange, onRemove }: Props) {
+    const selectedMetric = filter.property ?? metrics[0]?.key ?? '';
+    const isStr = isStringMetric(selectedMetric);
+    const availableTypes = getConditionTypesForMetric(selectedMetric, metrics);
+    const condType: AlertConditionType = filter.type && availableTypes.includes(filter.type) ? filter.type : availableTypes[0];
+
+    const handleMetricChange = (val: string) => {
+        const newTypes = getConditionTypesForMetric(val, metrics);
+        const nextType = newTypes[0];
+        const defaultOperator = isStringMetric(val) || nextType === 'STRING' ? 'EQUALS' : 'GT';
+        onChange(index, {
+            ...filter,
+            property: val,
+            type: nextType,
+            operator: defaultOperator,
+            threshold: undefined,
+            thresholdLow: undefined,
+            thresholdHigh: undefined,
+            pattern: undefined,
+            property2: undefined,
+            multiplier: undefined,
+        });
+    };
+
+    return (
+        <Card>
+            <CardHeader className="py-3 px-4">
+                <div className="flex items-center justify-between">
+                    <CardTitle className="text-sm">Filter {index + 1}</CardTitle>
+                    <Button variant="ghost" size="icon" className="size-7" onClick={() => onRemove(index)}>
+                        <Trash2Icon className="size-3.5 text-muted-foreground" />
+                    </Button>
+                </div>
+            </CardHeader>
+            <CardContent className="px-4 pb-4 pt-0 space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Metric</Label>
+                        <Select value={selectedMetric} onValueChange={handleMetricChange}>
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {metrics.map(m => (
+                                    <SelectItem key={m.key} value={m.key}>
+                                        {m.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    {availableTypes.length > 1 && (
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Condition type</Label>
+                            <Select
+                                value={condType}
+                                onValueChange={(val: AlertConditionType) =>
+                                    onChange(index, {
+                                        ...filter,
+                                        type: val,
+                                        operator: val === 'STRING' ? 'EQUALS' : val === 'THRESHOLD' || val === 'COMPARE' ? 'GT' : undefined,
+                                        threshold: undefined,
+                                        thresholdLow: undefined,
+                                        thresholdHigh: undefined,
+                                        pattern: undefined,
+                                        property2: undefined,
+                                        multiplier: undefined,
+                                    })
+                                }
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {availableTypes.map(t => (
+                                        <SelectItem key={t} value={t}>
+                                            {t.replace(/_/g, ' ').toLowerCase()}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    )}
+                </div>
+
+                {isStr || condType === 'STRING' ? (
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Operator</Label>
+                            <Select
+                                value={(filter.operator as string) || 'EQUALS'}
+                                onValueChange={(val: AlertStringOperator) => onChange(index, { ...filter, operator: val })}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {ALERT_STRING_OPERATORS.map(op => (
+                                        <SelectItem key={op.value} value={op.value}>
+                                            {op.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Pattern</Label>
+                            <Input
+                                placeholder="Value to match"
+                                value={filter.pattern ?? ''}
+                                onChange={e => onChange(index, { ...filter, pattern: e.target.value })}
+                            />
+                        </div>
+                    </div>
+                ) : condType === 'THRESHOLD_RANGE' ? (
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Low threshold</Label>
+                            <Input
+                                type="number"
+                                min={ALERT_POSITIVE_NUMBER_MIN}
+                                placeholder="e.g. 200"
+                                value={filter.thresholdLow ?? ''}
+                                onChange={e =>
+                                    onChange(index, {
+                                        ...filter,
+                                        type: 'THRESHOLD_RANGE',
+                                        thresholdLow: nextAlertPositiveNumber(e.target.value, filter.thresholdLow),
+                                    })
+                                }
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">High threshold</Label>
+                            <Input
+                                type="number"
+                                min={filter.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN}
+                                placeholder="e.g. 500"
+                                value={filter.thresholdHigh ?? ''}
+                                onChange={e =>
+                                    onChange(index, {
+                                        ...filter,
+                                        type: 'THRESHOLD_RANGE',
+                                        thresholdHigh: nextAlertPositiveNumber(e.target.value, filter.thresholdHigh, {
+                                            min: filter.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN,
+                                        }),
+                                    })
+                                }
+                            />
+                        </div>
+                    </div>
+                ) : condType === 'COMPARE' ? (
+                    <div className="grid grid-cols-3 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Operator</Label>
+                            <Select
+                                value={(filter.operator as string) || 'GT'}
+                                onValueChange={(val: AlertOperator) => onChange(index, { ...filter, operator: val })}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {ALERT_OPERATORS.map(op => (
+                                        <SelectItem key={op.value} value={op.value}>
+                                            {op.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Multiplier (%)</Label>
+                            <Input
+                                type="number"
+                                min={ALERT_POSITIVE_NUMBER_MIN}
+                                placeholder="e.g. 150"
+                                value={filter.multiplier ?? ''}
+                                onChange={e =>
+                                    onChange(index, {
+                                        ...filter,
+                                        multiplier: nextAlertPositiveNumber(e.target.value, filter.multiplier),
+                                    })
+                                }
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Property to compare</Label>
+                            <Select
+                                value={filter.property2 || metrics[0]?.key}
+                                onValueChange={val => onChange(index, { ...filter, property2: val })}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {metrics.map(m => (
+                                        <SelectItem key={m.key} value={m.key}>
+                                            {m.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Operator</Label>
+                            <Select
+                                value={(filter.operator as string) || 'GT'}
+                                onValueChange={(val: AlertOperator) => onChange(index, { ...filter, operator: val })}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {ALERT_OPERATORS.map(op => (
+                                        <SelectItem key={op.value} value={op.value}>
+                                            {op.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Threshold</Label>
+                            <Input
+                                type="number"
+                                min={ALERT_POSITIVE_NUMBER_MIN}
+                                placeholder="e.g. 500"
+                                value={filter.threshold ?? ''}
+                                onChange={e =>
+                                    onChange(index, {
+                                        ...filter,
+                                        threshold: nextAlertPositiveNumber(e.target.value, filter.threshold),
+                                    })
+                                }
+                            />
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/FilterRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/FilterRow.tsx
@@ -37,6 +37,7 @@ import {
     type AlertMetricDefinition,
 } from '../constants/alertConstants';
 import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../types';
+import { conditionWithType } from '../utils/alertConditionComplete';
 import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
 
 interface Props {
@@ -51,11 +52,15 @@ export function FilterRow({ filter, index, metrics, onChange, onRemove }: Props)
     const selectedMetric = filter.property ?? metrics[0]?.key ?? '';
     const isStr = isStringMetric(selectedMetric);
     const availableTypes = getConditionTypesForMetric(selectedMetric, metrics);
-    const condType: AlertConditionType = filter.type && availableTypes.includes(filter.type) ? filter.type : availableTypes[0];
+    const condType: AlertConditionType =
+        availableTypes.length === 0 || availableTypes.includes(filter.type) ? filter.type : (availableTypes[0] ?? filter.type);
 
     const handleMetricChange = (val: string) => {
         const newTypes = getConditionTypesForMetric(val, metrics);
         const nextType = newTypes[0];
+        if (!nextType) {
+            return;
+        }
         const defaultOperator = isStringMetric(val) || nextType === 'STRING' ? 'EQUALS' : 'GT';
         onChange(index, {
             ...filter,
@@ -104,17 +109,7 @@ export function FilterRow({ filter, index, metrics, onChange, onRemove }: Props)
                             <Select
                                 value={condType}
                                 onValueChange={(val: AlertConditionType) =>
-                                    onChange(index, {
-                                        ...filter,
-                                        type: val,
-                                        operator: val === 'STRING' ? 'EQUALS' : val === 'THRESHOLD' || val === 'COMPARE' ? 'GT' : undefined,
-                                        threshold: undefined,
-                                        thresholdLow: undefined,
-                                        thresholdHigh: undefined,
-                                        pattern: undefined,
-                                        property2: undefined,
-                                        multiplier: undefined,
-                                    })
+                                    onChange(index, conditionWithType(filter, val, metrics[0]?.key))
                                 }
                             >
                                 <SelectTrigger>
@@ -235,10 +230,7 @@ export function FilterRow({ filter, index, metrics, onChange, onRemove }: Props)
                         </div>
                         <div className="space-y-1.5">
                             <Label className="text-xs">Property to compare</Label>
-                            <Select
-                                value={filter.property2 || metrics[0]?.key}
-                                onValueChange={val => onChange(index, { ...filter, property2: val })}
-                            >
+                            <Select value={filter.property2} onValueChange={val => onChange(index, { ...filter, property2: val })}>
                                 <SelectTrigger>
                                     <SelectValue />
                                 </SelectTrigger>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.spec.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { HistoryTab } from './HistoryTab';
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+describe('HistoryTab', () => {
+    it('renders a date from created_at epoch millis, not Invalid Date', () => {
+        const createdAt = Date.now() - 3 * 60_000;
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [{ message: '[response.response_time: 304] is greater than [100.0]', created_at: createdAt }],
+                    totalElements: 1,
+                }}
+            />,
+        );
+
+        expect(screen.queryByText('Invalid Date')).toBeNull();
+        expect(screen.getByText(/response.response_time: 304/)).not.toBeNull();
+    });
+
+    it('renders two events that share a message', () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const message = 'Health check failed';
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [
+                        { message, created_at: Date.now() - 60_000 },
+                        { message, created_at: Date.now() - 120_000 },
+                    ],
+                    totalElements: 2,
+                }}
+            />,
+        );
+
+        expect(screen.getAllByText(message)).toHaveLength(2);
+        expect(error.mock.calls.flat().join(' ')).not.toMatch(/same key/);
+        error.mockRestore();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
@@ -64,9 +64,9 @@ export function HistoryTab({ historyPage, onRefresh, isRefreshing = false }: His
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
-                                    {historyPage.content.map(evt => (
-                                        <TableRow key={evt.id}>
-                                            <TableCell className="text-sm">{new Date(evt.createdAt).toLocaleString()}</TableCell>
+                                    {historyPage.content.map((evt, i) => (
+                                        <TableRow key={`${evt.created_at}-${i}`}>
+                                            <TableCell className="text-sm">{new Date(evt.created_at).toLocaleString()}</TableCell>
                                             <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
                                         </TableRow>
                                     ))}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+
+import type { AlertHistoryPage } from '../types';
+
+export interface HistoryTabProps {
+    historyPage: AlertHistoryPage | undefined;
+    onRefresh?: () => void;
+    isRefreshing?: boolean;
+}
+
+export function HistoryTab({ historyPage, onRefresh, isRefreshing = false }: HistoryTabProps) {
+    return (
+        <div className="mt-6">
+            <Card>
+                <CardHeader>
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <CardTitle className="text-base">History</CardTitle>
+                            <CardDescription>Events history for this alert</CardDescription>
+                        </div>
+                        {onRefresh && (
+                            <Button type="button" variant="outline" size="sm" disabled={isRefreshing} onClick={onRefresh}>
+                                {isRefreshing ? 'Refreshing…' : 'Refresh'}
+                            </Button>
+                        )}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {historyPage && historyPage.content.length > 0 ? (
+                        <div className="rounded-lg border">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Date</TableHead>
+                                        <TableHead>Message</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {historyPage.content.map(evt => (
+                                        <TableRow key={evt.id}>
+                                            <TableCell className="text-sm">{new Date(evt.createdAt).toLocaleString()}</TableCell>
+                                            <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    ) : (
+                        <div className="py-8 text-center text-sm text-muted-foreground">No data to display.</div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/MissingDataConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/MissingDataConditionForm.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import { TIME_UNITS } from '../constants/alertConstants';
+import type { AlertFormCondition, AlertTimeUnit } from '../types';
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
+
+interface Props {
+    condition: AlertFormCondition;
+    onChange: (c: AlertFormCondition) => void;
+}
+
+export function MissingDataConditionForm({ condition, onChange }: Props) {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+                <Label className="text-xs">Duration</Label>
+                <Input
+                    type="number"
+                    min={ALERT_POSITIVE_NUMBER_MIN}
+                    placeholder="e.g. 5"
+                    value={condition.duration ?? ''}
+                    onChange={e =>
+                        onChange({
+                            ...condition,
+                            duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                        })
+                    }
+                />
+            </div>
+            <div className="space-y-1.5">
+                <Label className="text-xs">Time unit</Label>
+                <Select
+                    value={condition.timeUnit || 'MINUTES'}
+                    onValueChange={(val: AlertTimeUnit) => onChange({ ...condition, timeUnit: val })}
+                >
+                    <SelectTrigger>
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {TIME_UNITS.map(tu => (
+                            <SelectItem key={tu.value} value={tu.value}>
+                                {tu.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationSchemaFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationSchemaFields.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { extractDefaults, JsonSchemaForm, jsonSchemaResolver, Skeleton } from '@gravitee/graphene-core';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef } from 'react';
+import { type FieldValues, type Resolver, useForm } from 'react-hook-form';
+
+import { getNotifierSchema } from '../services/notifiers';
+import { adaptNotifierSchemaForForm } from '../utils/notifierSchema';
+import { platformAlertKeys } from '../utils/queryKeys';
+
+export function NotificationSchemaFields({
+    environmentId,
+    notifierId,
+    value,
+    onChange,
+    disabled,
+}: Readonly<{
+    environmentId: string;
+    notifierId: string;
+    value: Record<string, unknown>;
+    onChange: (configuration: Record<string, unknown>) => void;
+    disabled: boolean;
+}>) {
+    const {
+        data: schema,
+        isLoading,
+        isError,
+    } = useQuery({
+        queryKey: platformAlertKeys.notifierSchema(environmentId, notifierId),
+        queryFn: () => getNotifierSchema(environmentId, notifierId),
+        enabled: !!environmentId && !!notifierId,
+    });
+
+    if (!notifierId) {
+        return null;
+    }
+    if (isLoading) {
+        return <Skeleton className="h-24 w-full rounded" />;
+    }
+    if (isError || !schema) {
+        return <p className="text-sm text-muted-foreground">Unable to load notification fields for this channel.</p>;
+    }
+
+    return <NotificationSchemaForm schema={schema} value={value} onChange={onChange} disabled={disabled} />;
+}
+
+function NotificationSchemaForm({
+    schema,
+    value,
+    onChange,
+    disabled,
+}: Readonly<{
+    schema: Record<string, unknown>;
+    value: Record<string, unknown>;
+    onChange: (configuration: Record<string, unknown>) => void;
+    disabled: boolean;
+}>) {
+    const formSchema = useMemo(() => adaptNotifierSchemaForForm(schema), [schema]);
+    const resolver = useMemo<Resolver<FieldValues>>(() => jsonSchemaResolver(formSchema, { basePath: 'configuration' }), [formSchema]);
+    const defaultValues = useMemo(
+        () => ({ configuration: { ...((extractDefaults(formSchema) ?? {}) as Record<string, unknown>), ...value } }),
+        // Seed from the current value when the schema (channel) mounts; later edits flow through watch.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [formSchema],
+    );
+    const form = useForm<FieldValues>({ resolver, mode: 'onChange', defaultValues });
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+    const lastSent = useRef<string>(JSON.stringify(value));
+
+    useEffect(() => {
+        const push = (next: Record<string, unknown>) => {
+            const serialized = JSON.stringify(next);
+            if (serialized === lastSent.current) {
+                return;
+            }
+            lastSent.current = serialized;
+            onChangeRef.current(next);
+        };
+        push((form.getValues('configuration') ?? {}) as Record<string, unknown>);
+        const sub = form.watch(values => {
+            push((values.configuration ?? {}) as Record<string, unknown>);
+        });
+        return () => sub.unsubscribe();
+    }, [form]);
+
+    return <JsonSchemaForm schema={formSchema} control={form.control} name="configuration" disabled={disabled} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.spec.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { NotificationsTab } from './NotificationsTab';
+import type { AlertFormNotification } from '../types';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+jest.mock('@gravitee/graphene-core', () => {
+    const actual = jest.requireActual('@gravitee/graphene-core');
+    return {
+        ...actual,
+        JsonSchemaForm: ({ schema }: { schema: { properties?: Record<string, { title?: string }> } }) => (
+            <div>
+                {Object.entries(schema.properties ?? {}).map(([key, prop]) => (
+                    <label key={key}>
+                        {prop.title ?? key}
+                        <input aria-label={prop.title ?? key} />
+                    </label>
+                ))}
+            </div>
+        ),
+    };
+});
+
+const DEFAULT_EMAIL_SCHEMA = {
+    type: 'object',
+    properties: {
+        from: { title: 'From', type: 'string' },
+        to: { title: 'Recipients', type: 'string' },
+        subject: { title: 'Subject', type: 'string' },
+        body: { title: 'Body', type: 'string' },
+    },
+};
+
+const WEBHOOK_SCHEMA = {
+    type: 'object',
+    properties: {
+        method: { title: 'HTTP Method', type: 'string', default: 'POST' },
+        url: { title: 'URL', type: 'string' },
+    },
+    required: ['url', 'method'],
+};
+
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: jest.fn(),
+}));
+
+beforeAll(() => {
+    Element.prototype.hasPointerCapture = jest.fn();
+    Element.prototype.setPointerCapture = jest.fn();
+    Element.prototype.releasePointerCapture = jest.fn();
+});
+
+function mockNotifiersQuery(config: { queryKey: unknown[]; enabled?: boolean }) {
+    const key = config.queryKey as unknown[];
+    if (config.enabled === false) {
+        return { data: undefined, isLoading: false, isError: false };
+    }
+    if (key.includes('notifier-schema')) {
+        const notifierId = String(key[key.length - 1]);
+        return {
+            data: notifierId === 'webhook-notifier' ? WEBHOOK_SCHEMA : DEFAULT_EMAIL_SCHEMA,
+            isLoading: false,
+            isError: false,
+        };
+    }
+    if (key.includes('notifiers')) {
+        return {
+            data: [
+                { id: 'email-notifier', name: 'E-mail' },
+                { id: 'slack-notifier', name: 'Slack' },
+                { id: 'default-email', name: 'System e-mail' },
+                { id: 'webhook-notifier', name: 'Webhook' },
+            ],
+            isLoading: false,
+            isError: false,
+        };
+    }
+    return { data: undefined, isLoading: false, isError: false };
+}
+
+function Harness({ initial }: { initial?: AlertFormNotification[] }) {
+    const [notifications, setNotifications] = useState<AlertFormNotification[]>(initial ?? []);
+    return (
+        <NotificationsTab
+            dampening={{ mode: 'STRICT_COUNT', trueEvaluations: 1 }}
+            setDampening={() => undefined}
+            notifications={notifications}
+            addNotification={() => setNotifications(prev => [...prev, { type: '', configuration: {} }])}
+            removeNotification={index => setNotifications(prev => prev.filter((_, i) => i !== index))}
+            setNotificationType={(index, type) =>
+                setNotifications(prev => prev.map((n, i) => (i === index ? { type, configuration: {} } : n)))
+            }
+            updateNotification={(index, configuration) =>
+                setNotifications(prev => prev.map((n, i) => (i === index ? { ...n, configuration } : n)))
+            }
+            canEdit
+            markDirty={() => undefined}
+        />
+    );
+}
+
+describe('NotificationsTab', () => {
+    beforeEach(() => {
+        const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+        useQuery.mockImplementation(mockNotifiersQuery);
+    });
+
+    it('shows a Notifications header and Add button without an empty-state placeholder', () => {
+        render(<Harness />);
+
+        expect(screen.getByText('Notifications')).not.toBeNull();
+        expect(screen.getByText(/via email, Slack, or webhooks/i)).not.toBeNull();
+        expect(screen.getByRole('button', { name: /^add$/i })).not.toBeNull();
+        expect(screen.queryByText('No data to display.')).toBeNull();
+        expect(screen.queryByText(/channel/i)).toBeNull();
+    });
+
+    it('adds a notification card with a required channel select', async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+        expect(screen.getAllByText(/channel/i).length).toBeGreaterThan(0);
+        expect(screen.queryByText('Notification')).toBeNull();
+    });
+
+    it('renders system email schema fields from the notifier schema', () => {
+        render(<Harness initial={[{ type: 'default-email', configuration: {} }]} />);
+
+        expect(screen.getByLabelText('From')).not.toBeNull();
+        expect(screen.getByLabelText('Recipients')).not.toBeNull();
+        expect(screen.getByLabelText('Subject')).not.toBeNull();
+        expect(screen.getByLabelText('Body')).not.toBeNull();
+    });
+
+    it('renders webhook schema fields from the notifier schema', () => {
+        render(<Harness initial={[{ type: 'webhook-notifier', configuration: {} }]} />);
+
+        expect(screen.getByLabelText('HTTP Method')).not.toBeNull();
+        expect(screen.getByLabelText('URL')).not.toBeNull();
+    });
+
+    it('pushes schema defaults into parent configuration without an edit', async () => {
+        const updateNotification = jest.fn();
+        render(
+            <NotificationsTab
+                dampening={{ mode: 'STRICT_COUNT', trueEvaluations: 1 }}
+                setDampening={() => undefined}
+                notifications={[{ type: 'webhook-notifier', configuration: {} }]}
+                addNotification={() => undefined}
+                removeNotification={() => undefined}
+                setNotificationType={() => undefined}
+                updateNotification={updateNotification}
+                canEdit
+                markDirty={() => undefined}
+            />,
+        );
+
+        await waitFor(() => expect(updateNotification).toHaveBeenCalledWith(0, expect.objectContaining({ method: 'POST' })));
+    });
+
+    it('does not invent channel plugins when the notifier list is empty', async () => {
+        const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+        useQuery.mockImplementation((config: { queryKey: unknown[]; enabled?: boolean }) => {
+            const key = config.queryKey as unknown[];
+            if (config.enabled === false) {
+                return { data: undefined, isLoading: false, isError: false };
+            }
+            if (key.includes('notifiers')) {
+                return { data: [], isLoading: false, isError: false };
+            }
+            return { data: undefined, isLoading: false, isError: false };
+        });
+
+        const user = userEvent.setup();
+        render(<Harness />);
+        await user.click(screen.getByRole('button', { name: /^add$/i }));
+        const channelSelect = screen.getAllByRole('combobox').find(el => el.textContent?.includes('Channel'));
+        expect(channelSelect).toBeDefined();
+        await user.click(channelSelect!);
+
+        expect(screen.queryByRole('option', { name: 'E-mail' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'System e-mail' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'Slack' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'Webhook' })).toBeNull();
+    });
+
+    it('does not invent channel plugins when the notifier list request fails', async () => {
+        const { useQuery } = jest.requireMock('@tanstack/react-query') as { useQuery: jest.Mock };
+        useQuery.mockImplementation((config: { queryKey: unknown[]; enabled?: boolean }) => {
+            const key = config.queryKey as unknown[];
+            if (config.enabled === false) {
+                return { data: undefined, isLoading: false, isError: false };
+            }
+            if (key.includes('notifiers')) {
+                return { data: undefined, isLoading: false, isError: true };
+            }
+            return { data: undefined, isLoading: false, isError: false };
+        });
+
+        const user = userEvent.setup();
+        render(<Harness />);
+        await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+        expect(screen.getByText(/failed to load notification channels/i)).not.toBeNull();
+        const channelSelect = screen.getAllByRole('combobox').find(el => el.textContent?.includes('Channel'));
+        expect(channelSelect).toBeDefined();
+        await user.click(channelSelect!);
+
+        expect(screen.queryByRole('option', { name: 'E-mail' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'System e-mail' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'Slack' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'Webhook' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.tsx
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Separator,
+} from '@gravitee/graphene-core';
+import { MailIcon, MessageSquareIcon, PlusIcon, WebhookIcon } from '@gravitee/graphene-core/icons';
+import type { Dispatch, SetStateAction } from 'react';
+
+import { DAMPENING_MODES, NOTIFICATION_CHANNELS, TIME_UNITS } from '../constants/alertConstants';
+import type { AlertFormData } from '../services/alerts';
+import type { AlertDampeningMode, AlertFormNotification, AlertNotificationChannel, AlertTimeUnit } from '../types';
+
+const CHANNEL_META: Record<
+    AlertNotificationChannel,
+    { label: string; icon: React.ComponentType<{ className?: string }>; placeholder: string; inputLabel: string }
+> = {
+    'email-notifier': { label: 'E-mail', icon: MailIcon, placeholder: 'ops@company.com', inputLabel: 'Recipient email' },
+    'default-email': { label: 'System e-mail', icon: MailIcon, placeholder: 'ops@company.com', inputLabel: 'Recipient email' },
+    'slack-notifier': {
+        label: 'Slack',
+        icon: MessageSquareIcon,
+        placeholder: 'https://hooks.slack.com/services/…',
+        inputLabel: 'Slack webhook URL',
+    },
+    'webhook-notifier': { label: 'Webhook', icon: WebhookIcon, placeholder: 'https://hooks.example.com/…', inputLabel: 'Webhook URL' },
+};
+
+export interface NotificationsTabProps {
+    dampening: AlertFormData['dampening'];
+    setDampening: Dispatch<SetStateAction<AlertFormData['dampening']>>;
+    notifications: AlertFormNotification[];
+    addNotification: (channel: AlertNotificationChannel) => void;
+    removeNotification: (index: number) => void;
+    updateNotificationTarget: (index: number, target: string) => void;
+    canEdit: boolean;
+    markDirty: () => void;
+}
+
+export function NotificationsTab({
+    dampening,
+    setDampening,
+    notifications,
+    addNotification,
+    removeNotification,
+    updateNotificationTarget,
+    canEdit,
+    markDirty,
+}: NotificationsTabProps) {
+    return (
+        <div className="mt-6 space-y-6">
+            {/* Dampening */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Dampening</CardTitle>
+                    <CardDescription>
+                        Allows you to limit the number of notifications if the trigger is fired multiple times for the same condition
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Mode</Label>
+                        <Select
+                            value={dampening?.mode || 'STRICT_COUNT'}
+                            disabled={!canEdit}
+                            onValueChange={val => {
+                                const mode = val as AlertDampeningMode;
+                                const next = { mode } as AlertFormData['dampening'];
+                                if (mode === 'STRICT_COUNT') next!.trueEvaluations = 1;
+                                if (mode === 'RELAXED_COUNT') {
+                                    next!.trueEvaluations = 1;
+                                }
+                                if (mode === 'RELAXED_TIME') {
+                                    next!.trueEvaluations = 1;
+                                    next!.timeUnit = 'MINUTES';
+                                }
+                                if (mode === 'STRICT_TIME') {
+                                    next!.timeUnit = 'MINUTES';
+                                }
+                                setDampening(next);
+                                markDirty();
+                            }}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {DAMPENING_MODES.map(dm => (
+                                    <SelectItem key={dm.value} value={dm.value}>
+                                        {dm.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <p className="text-xs text-muted-foreground">Select the most appropriate dampening mode for this alert.</p>
+                    </div>
+
+                    {(dampening?.mode === 'STRICT_COUNT' || dampening?.mode === 'RELAXED_COUNT' || dampening?.mode === 'RELAXED_TIME') && (
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Number of true evaluations</Label>
+                            <Input
+                                type="number"
+                                min={1}
+                                max={100}
+                                disabled={!canEdit}
+                                value={dampening?.trueEvaluations ?? ''}
+                                onChange={e => {
+                                    setDampening(d => ({
+                                        ...d!,
+                                        trueEvaluations: e.target.value ? Number(e.target.value) : undefined,
+                                    }));
+                                    markDirty();
+                                }}
+                            />
+                            <p className="text-xs text-muted-foreground">The number from 1 to 100 of consecutive true evaluations.</p>
+                        </div>
+                    )}
+
+                    {dampening?.mode === 'RELAXED_COUNT' && (
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Number of total evaluations</Label>
+                            <Input
+                                type="number"
+                                disabled={!canEdit}
+                                value={dampening?.totalEvaluations ?? ''}
+                                onChange={e => {
+                                    setDampening(d => ({
+                                        ...d!,
+                                        totalEvaluations: e.target.value ? Number(e.target.value) : undefined,
+                                    }));
+                                    markDirty();
+                                }}
+                            />
+                            <p className="text-xs text-muted-foreground">The number of total evaluations.</p>
+                        </div>
+                    )}
+
+                    {(dampening?.mode === 'STRICT_TIME' || dampening?.mode === 'RELAXED_TIME') && (
+                        <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-1.5">
+                                <Label className="text-xs">Duration</Label>
+                                <Input
+                                    type="number"
+                                    disabled={!canEdit}
+                                    value={dampening?.duration ?? ''}
+                                    onChange={e => {
+                                        setDampening(d => ({
+                                            ...d!,
+                                            duration: e.target.value ? Number(e.target.value) : undefined,
+                                        }));
+                                        markDirty();
+                                    }}
+                                />
+                            </div>
+                            <div className="space-y-1.5">
+                                <Label className="text-xs">Time unit</Label>
+                                <Select
+                                    value={dampening?.timeUnit || 'MINUTES'}
+                                    disabled={!canEdit}
+                                    onValueChange={val => {
+                                        setDampening(d => ({ ...d!, timeUnit: val as AlertTimeUnit }));
+                                        markDirty();
+                                    }}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {TIME_UNITS.map(tu => (
+                                            <SelectItem key={tu.value} value={tu.value}>
+                                                {tu.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Notifications */}
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <CardTitle className="text-base">Notifications</CardTitle>
+                            <CardDescription>Allow you to receive notifications via email, Slack or webhooks.</CardDescription>
+                        </div>
+                        {canEdit && (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button size="sm">
+                                        <PlusIcon className="size-4" />
+                                        Add notification
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    {NOTIFICATION_CHANNELS.map(ch => (
+                                        <DropdownMenuItem key={ch.value} onSelect={() => addNotification(ch.value)}>
+                                            {ch.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        )}
+                    </div>
+                </CardHeader>
+                {notifications.length > 0 && (
+                    <CardContent className="space-y-4 pt-0">
+                        {notifications.map((notif, idx) => {
+                            const meta = CHANNEL_META[notif.channel];
+                            const ChIcon = meta.icon;
+                            return (
+                                <div key={idx}>
+                                    <Separator className="mb-4" />
+                                    <div className="space-y-3">
+                                        <div className="flex items-center justify-between">
+                                            <h4 className="flex items-center gap-2 text-sm font-medium">
+                                                <ChIcon className="size-4 text-muted-foreground" />
+                                                Configure {meta.label} notification
+                                            </h4>
+                                            {canEdit && (
+                                                <Button variant="outline" size="sm" onClick={() => removeNotification(idx)}>
+                                                    Remove
+                                                </Button>
+                                            )}
+                                        </div>
+                                        <div className="space-y-1.5">
+                                            <Label className="text-xs">{meta.inputLabel}</Label>
+                                            <Input
+                                                placeholder={meta.placeholder}
+                                                value={notif.target}
+                                                disabled={!canEdit}
+                                                onChange={e => updateNotificationTarget(idx, e.target.value)}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </CardContent>
+                )}
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/NotificationsTab.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import {
     Button,
     Card,
@@ -20,10 +21,6 @@ import {
     CardDescription,
     CardHeader,
     CardTitle,
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
     Input,
     Label,
     Select,
@@ -31,39 +28,43 @@ import {
     SelectItem,
     SelectTrigger,
     SelectValue,
-    Separator,
 } from '@gravitee/graphene-core';
-import { MailIcon, MessageSquareIcon, PlusIcon, WebhookIcon } from '@gravitee/graphene-core/icons';
+import { PlusIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
 import type { Dispatch, SetStateAction } from 'react';
 
-import { DAMPENING_MODES, NOTIFICATION_CHANNELS, TIME_UNITS } from '../constants/alertConstants';
+import { NotificationSchemaFields } from './NotificationSchemaFields';
+import { DAMPENING_MODES, TIME_UNITS } from '../constants/alertConstants';
 import type { AlertFormData } from '../services/alerts';
-import type { AlertDampeningMode, AlertFormNotification, AlertNotificationChannel, AlertTimeUnit } from '../types';
+import { listNotifiers, type NotifierListItem } from '../services/notifiers';
+import type { AlertDampeningMode, AlertFormNotification, AlertTimeUnit } from '../types';
+import { platformAlertKeys } from '../utils/queryKeys';
 
-const CHANNEL_META: Record<
-    AlertNotificationChannel,
-    { label: string; icon: React.ComponentType<{ className?: string }>; placeholder: string; inputLabel: string }
-> = {
-    'email-notifier': { label: 'E-mail', icon: MailIcon, placeholder: 'ops@company.com', inputLabel: 'Recipient email' },
-    'default-email': { label: 'System e-mail', icon: MailIcon, placeholder: 'ops@company.com', inputLabel: 'Recipient email' },
-    'slack-notifier': {
-        label: 'Slack',
-        icon: MessageSquareIcon,
-        placeholder: 'https://hooks.slack.com/services/…',
-        inputLabel: 'Slack webhook URL',
-    },
-    'webhook-notifier': { label: 'Webhook', icon: WebhookIcon, placeholder: 'https://hooks.example.com/…', inputLabel: 'Webhook URL' },
-};
+const CHANNEL_ORDER = ['email-notifier', 'slack-notifier', 'default-email', 'webhook-notifier'];
+
+function sortNotifiers(items: NotifierListItem[]): NotifierListItem[] {
+    return [...items].sort((a, b) => {
+        const ia = CHANNEL_ORDER.indexOf(a.id);
+        const ib = CHANNEL_ORDER.indexOf(b.id);
+        if (ia === -1 && ib === -1) return a.name.localeCompare(b.name);
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+    });
+}
 
 export interface NotificationsTabProps {
     dampening: AlertFormData['dampening'];
     setDampening: Dispatch<SetStateAction<AlertFormData['dampening']>>;
     notifications: AlertFormNotification[];
-    addNotification: (channel: AlertNotificationChannel) => void;
+    addNotification: () => void;
     removeNotification: (index: number) => void;
-    updateNotificationTarget: (index: number, target: string) => void;
+    setNotificationType: (index: number, type: string) => void;
+    updateNotification: (index: number, configuration: Record<string, unknown>) => void;
     canEdit: boolean;
     markDirty: () => void;
+    channelError?: string;
+    dampeningError?: string;
 }
 
 export function NotificationsTab({
@@ -72,13 +73,24 @@ export function NotificationsTab({
     notifications,
     addNotification,
     removeNotification,
-    updateNotificationTarget,
+    setNotificationType,
+    updateNotification,
     canEdit,
     markDirty,
+    channelError,
+    dampeningError,
 }: NotificationsTabProps) {
+    const env = useEnvironment();
+    const environmentId = env?.id ?? '';
+    const { data: notifierList, isError: notifierListFailed } = useQuery({
+        queryKey: platformAlertKeys.notifiers(environmentId),
+        queryFn: () => listNotifiers(environmentId),
+        enabled: !!environmentId,
+    });
+    const notifiers = sortNotifiers(notifierList ?? []);
+
     return (
         <div className="mt-6 space-y-6">
-            {/* Dampening */}
             <Card>
                 <CardHeader>
                     <CardTitle className="text-base">Dampening</CardTitle>
@@ -87,8 +99,11 @@ export function NotificationsTab({
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
+                    {dampeningError && <p className="text-xs text-destructive">{dampeningError}</p>}
                     <div className="space-y-1.5">
-                        <Label className="text-xs">Mode</Label>
+                        <Label className="text-xs">
+                            Mode <span className="text-destructive">*</span>
+                        </Label>
                         <Select
                             value={dampening?.mode || 'STRICT_COUNT'}
                             disabled={!canEdit}
@@ -126,7 +141,9 @@ export function NotificationsTab({
 
                     {(dampening?.mode === 'STRICT_COUNT' || dampening?.mode === 'RELAXED_COUNT' || dampening?.mode === 'RELAXED_TIME') && (
                         <div className="space-y-1.5">
-                            <Label className="text-xs">Number of true evaluations</Label>
+                            <Label className="text-xs">
+                                Number of true evaluations <span className="text-destructive">*</span>
+                            </Label>
                             <Input
                                 type="number"
                                 min={1}
@@ -141,13 +158,15 @@ export function NotificationsTab({
                                     markDirty();
                                 }}
                             />
-                            <p className="text-xs text-muted-foreground">The number from 1 to 100 of consecutive true evaluations.</p>
+                            <p className="text-xs text-muted-foreground">The number of consecutive true evaluations.</p>
                         </div>
                     )}
 
                     {dampening?.mode === 'RELAXED_COUNT' && (
                         <div className="space-y-1.5">
-                            <Label className="text-xs">Number of total evaluations</Label>
+                            <Label className="text-xs">
+                                Number of total evaluations <span className="text-destructive">*</span>
+                            </Label>
                             <Input
                                 type="number"
                                 disabled={!canEdit}
@@ -167,7 +186,9 @@ export function NotificationsTab({
                     {(dampening?.mode === 'STRICT_TIME' || dampening?.mode === 'RELAXED_TIME') && (
                         <div className="grid grid-cols-2 gap-4">
                             <div className="space-y-1.5">
-                                <Label className="text-xs">Duration</Label>
+                                <Label className="text-xs">
+                                    Duration <span className="text-destructive">*</span>
+                                </Label>
                                 <Input
                                     type="number"
                                     disabled={!canEdit}
@@ -208,68 +229,72 @@ export function NotificationsTab({
                 </CardContent>
             </Card>
 
-            {/* Notifications */}
             <Card>
-                <CardHeader>
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <CardTitle className="text-base">Notifications</CardTitle>
-                            <CardDescription>Allow you to receive notifications via email, Slack or webhooks.</CardDescription>
-                        </div>
-                        {canEdit && (
-                            <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                    <Button size="sm">
-                                        <PlusIcon className="size-4" />
-                                        Add notification
-                                    </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                    {NOTIFICATION_CHANNELS.map(ch => (
-                                        <DropdownMenuItem key={ch.value} onSelect={() => addNotification(ch.value)}>
-                                            {ch.label}
-                                        </DropdownMenuItem>
-                                    ))}
-                                </DropdownMenuContent>
-                            </DropdownMenu>
-                        )}
+                <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+                    <div className="space-y-1.5">
+                        <CardTitle className="text-base">Notifications</CardTitle>
+                        <CardDescription>Allows you to receive notifications via email, Slack, or webhooks.</CardDescription>
                     </div>
+                    {canEdit ? (
+                        <Button type="button" size="sm" className="shrink-0" onClick={addNotification}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            Add
+                        </Button>
+                    ) : null}
                 </CardHeader>
-                {notifications.length > 0 && (
-                    <CardContent className="space-y-4 pt-0">
-                        {notifications.map((notif, idx) => {
-                            const meta = CHANNEL_META[notif.channel];
-                            const ChIcon = meta.icon;
-                            return (
-                                <div key={idx}>
-                                    <Separator className="mb-4" />
-                                    <div className="space-y-3">
-                                        <div className="flex items-center justify-between">
-                                            <h4 className="flex items-center gap-2 text-sm font-medium">
-                                                <ChIcon className="size-4 text-muted-foreground" />
-                                                Configure {meta.label} notification
-                                            </h4>
-                                            {canEdit && (
-                                                <Button variant="outline" size="sm" onClick={() => removeNotification(idx)}>
-                                                    Remove
-                                                </Button>
-                                            )}
-                                        </div>
-                                        <div className="space-y-1.5">
-                                            <Label className="text-xs">{meta.inputLabel}</Label>
-                                            <Input
-                                                placeholder={meta.placeholder}
-                                                value={notif.target}
-                                                disabled={!canEdit}
-                                                onChange={e => updateNotificationTarget(idx, e.target.value)}
-                                            />
-                                        </div>
-                                    </div>
+                {channelError || notifierListFailed || notifications.length > 0 ? (
+                    <CardContent className="space-y-4">
+                        {channelError && <p className="text-xs text-destructive">{channelError}</p>}
+                        {notifierListFailed && (
+                            <p className="text-xs text-destructive">Failed to load notification channels. Please try again.</p>
+                        )}
+                        {notifications.map((notif, idx) => (
+                            <div key={`${idx}-${notif.type || 'unset'}`} className="relative space-y-4 rounded-lg border p-4">
+                                {canEdit ? (
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="absolute top-2 right-2 size-7"
+                                        aria-label="Remove notification"
+                                        onClick={() => removeNotification(idx)}
+                                    >
+                                        <XIcon className="size-3.5 text-muted-foreground" />
+                                    </Button>
+                                ) : null}
+                                <div className="space-y-1.5 pr-8">
+                                    <Label className="text-xs">
+                                        Channel <span className="text-destructive">*</span>
+                                    </Label>
+                                    <Select
+                                        value={notif.type || undefined}
+                                        disabled={!canEdit}
+                                        onValueChange={val => setNotificationType(idx, val)}
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Channel" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {notifiers.map(notifier => (
+                                                <SelectItem key={notifier.id} value={notifier.id}>
+                                                    {notifier.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
                                 </div>
-                            );
-                        })}
+                                {notif.type ? (
+                                    <NotificationSchemaFields
+                                        environmentId={environmentId}
+                                        notifierId={notif.type}
+                                        value={notif.configuration}
+                                        disabled={!canEdit}
+                                        onChange={configuration => updateNotification(idx, configuration)}
+                                    />
+                                ) : null}
+                            </div>
+                        ))}
                     </CardContent>
-                )}
+                ) : null}
             </Card>
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.spec.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { rateConditionWithMetric } from './RateConditionForm';
+
+describe('rateConditionWithMetric', () => {
+    const numericRate = {
+        type: 'RATE' as const,
+        property: 'response.response_time',
+        operator: 'GT' as const,
+        threshold: 500,
+        rateOperator: 'GT' as const,
+        rateThreshold: 50,
+        duration: 1,
+        timeUnit: 'MINUTES' as const,
+    };
+
+    it('resets to a string operator when switching to a string metric', () => {
+        expect(rateConditionWithMetric(numericRate, 'error.key')).toEqual(
+            expect.objectContaining({
+                property: 'error.key',
+                operator: 'EQUALS',
+                threshold: undefined,
+                pattern: undefined,
+            }),
+        );
+    });
+
+    it('resets to a numeric operator when switching to a numeric metric', () => {
+        expect(
+            rateConditionWithMetric(
+                { ...numericRate, property: 'error.key', operator: 'CONTAINS', pattern: 'foo' },
+                'response.response_time',
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                property: 'response.response_time',
+                operator: 'GTE',
+                threshold: undefined,
+                pattern: undefined,
+            }),
+        );
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import {
+    ALERT_OPERATORS,
+    ALERT_STRING_OPERATORS,
+    TIME_UNITS,
+    isStringMetric,
+    type AlertMetricDefinition,
+} from '../constants/alertConstants';
+import type { AlertFormCondition, AlertOperator, AlertStringOperator, AlertTimeUnit } from '../types';
+import { ALERT_POSITIVE_NUMBER_MIN, ALERT_RATE_PERCENT_MAX, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
+
+interface Props {
+    condition: AlertFormCondition;
+    metrics: AlertMetricDefinition[];
+    onChange: (c: AlertFormCondition) => void;
+}
+
+export function RateConditionForm({ condition, metrics, onChange }: Props) {
+    const selectedMetric = condition.property ?? metrics[0]?.key ?? '';
+    const isStr = isStringMetric(selectedMetric);
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Comparison metric</Label>
+                    <Select
+                        value={selectedMetric}
+                        onValueChange={val => onChange({ ...condition, property: val, threshold: undefined, pattern: undefined })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {metrics.map(m => (
+                                <SelectItem key={m.key} value={m.key}>
+                                    {m.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">{isStr ? 'Pattern' : 'Threshold value'}</Label>
+                    {isStr ? (
+                        <Input
+                            placeholder="e.g. API_KEY_MISSING"
+                            value={condition.pattern ?? ''}
+                            onChange={e => onChange({ ...condition, pattern: e.target.value })}
+                        />
+                    ) : (
+                        <Input
+                            type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
+                            placeholder="e.g. 500"
+                            value={condition.threshold ?? ''}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                                })
+                            }
+                        />
+                    )}
+                </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">{isStr ? 'Operator' : 'Comparison operator'}</Label>
+                    {isStr ? (
+                        <Select
+                            value={(condition.operator as string) || 'EQUALS'}
+                            onValueChange={(val: AlertStringOperator) => onChange({ ...condition, operator: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_STRING_OPERATORS.map(op => (
+                                    <SelectItem key={op.value} value={op.value}>
+                                        {op.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    ) : (
+                        <Select
+                            value={(condition.operator as string) || 'GTE'}
+                            onValueChange={(val: AlertOperator) => onChange({ ...condition, operator: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_OPERATORS.map(op => (
+                                    <SelectItem key={op.value} value={op.value}>
+                                        {op.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    )}
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Rate threshold (%)</Label>
+                    <Input
+                        type="number"
+                        min={ALERT_POSITIVE_NUMBER_MIN}
+                        max={ALERT_RATE_PERCENT_MAX}
+                        placeholder="e.g. 50"
+                        value={condition.rateThreshold ?? ''}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                rateThreshold: nextAlertPositiveNumber(e.target.value, condition.rateThreshold, {
+                                    max: ALERT_RATE_PERCENT_MAX,
+                                }),
+                            })
+                        }
+                    />
+                </div>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Rate operator</Label>
+                    <Select
+                        value={(condition.rateOperator as string) || 'GT'}
+                        onValueChange={(val: AlertOperator) => onChange({ ...condition, rateOperator: val })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {ALERT_OPERATORS.map(op => (
+                                <SelectItem key={op.value} value={op.value}>
+                                    {op.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Duration</Label>
+                    <Input
+                        type="number"
+                        min={ALERT_POSITIVE_NUMBER_MIN}
+                        placeholder="e.g. 1"
+                        value={condition.duration ?? ''}
+                        onChange={e =>
+                            onChange({
+                                ...condition,
+                                duration: nextAlertPositiveNumber(e.target.value, condition.duration),
+                            })
+                        }
+                    />
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Time unit</Label>
+                    <Select
+                        value={condition.timeUnit || 'MINUTES'}
+                        onValueChange={(val: AlertTimeUnit) => onChange({ ...condition, timeUnit: val })}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {TIME_UNITS.map(tu => (
+                                <SelectItem key={tu.value} value={tu.value}>
+                                    {tu.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/RateConditionForm.tsx
@@ -31,6 +31,16 @@ interface Props {
     onChange: (c: AlertFormCondition) => void;
 }
 
+export function rateConditionWithMetric(condition: AlertFormCondition, metricKey: string): AlertFormCondition {
+    return {
+        ...condition,
+        property: metricKey,
+        operator: isStringMetric(metricKey) ? 'EQUALS' : 'GTE',
+        threshold: undefined,
+        pattern: undefined,
+    };
+}
+
 export function RateConditionForm({ condition, metrics, onChange }: Props) {
     const selectedMetric = condition.property ?? metrics[0]?.key ?? '';
     const isStr = isStringMetric(selectedMetric);
@@ -40,10 +50,7 @@ export function RateConditionForm({ condition, metrics, onChange }: Props) {
             <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-1.5">
                     <Label className="text-xs">Comparison metric</Label>
-                    <Select
-                        value={selectedMetric}
-                        onValueChange={val => onChange({ ...condition, property: val, threshold: undefined, pattern: undefined })}
-                    >
+                    <Select value={selectedMetric} onValueChange={val => onChange(rateConditionWithMetric(condition, val))}>
                         <SelectTrigger>
                             <SelectValue />
                         </SelectTrigger>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.spec.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SimpleConditionForm } from './SimpleConditionForm';
+import { API_METRICS } from '../constants/alertConstants';
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+describe('SimpleConditionForm', () => {
+    it('does not accept a negative threshold (classic min=1)', () => {
+        const onChange = jest.fn();
+        render(
+            <SimpleConditionForm
+                condition={{ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT', threshold: 10 }}
+                metrics={API_METRICS}
+                onChange={onChange}
+            />,
+        );
+
+        const input = screen.getByPlaceholderText('e.g. 500') as HTMLInputElement;
+        expect(input.min).toBe('1');
+
+        fireEvent.change(input, { target: { value: '-8' } });
+
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ threshold: 10 }));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import {
+    ALERT_OPERATORS,
+    ALERT_STRING_OPERATORS,
+    getConditionTypesForMetric,
+    isStringMetric,
+    type AlertMetricDefinition,
+} from '../constants/alertConstants';
+import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../types';
+import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
+
+interface Props {
+    condition: AlertFormCondition;
+    metrics: AlertMetricDefinition[];
+    onChange: (c: AlertFormCondition) => void;
+}
+
+export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
+    const selectedMetric = condition.property ?? metrics[0]?.key ?? '';
+    const availableTypes = getConditionTypesForMetric(selectedMetric, metrics);
+    const condType: AlertConditionType = condition.type && availableTypes.includes(condition.type) ? condition.type : availableTypes[0];
+
+    const handleMetricChange = (val: string) => {
+        const newTypes = getConditionTypesForMetric(val, metrics);
+        const nextType = newTypes[0];
+        const defaultOperator = isStringMetric(val) || nextType === 'STRING' ? 'EQUALS' : 'GT';
+        onChange({
+            ...condition,
+            property: val,
+            type: nextType,
+            operator: defaultOperator,
+            threshold: undefined,
+            thresholdLow: undefined,
+            thresholdHigh: undefined,
+            pattern: undefined,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                    <Label className="text-xs">Metric</Label>
+                    <Select value={selectedMetric} onValueChange={handleMetricChange}>
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {metrics.map(m => (
+                                <SelectItem key={m.key} value={m.key}>
+                                    {m.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {availableTypes.length > 1 && (
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Condition type</Label>
+                        <Select value={condType} onValueChange={(val: AlertConditionType) => onChange({ ...condition, type: val })}>
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {availableTypes.map(t => (
+                                    <SelectItem key={t} value={t}>
+                                        {t.replace(/_/g, ' ').toLowerCase()}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                )}
+            </div>
+
+            {condType === 'STRING' ? (
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Operator</Label>
+                        <Select
+                            value={(condition.operator as string) || 'EQUALS'}
+                            onValueChange={(val: AlertStringOperator) => onChange({ ...condition, operator: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_STRING_OPERATORS.map(op => (
+                                    <SelectItem key={op.value} value={op.value}>
+                                        {op.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Pattern</Label>
+                        <Input
+                            placeholder="e.g. API_KEY_MISSING"
+                            value={condition.pattern ?? ''}
+                            onChange={e => onChange({ ...condition, pattern: e.target.value })}
+                        />
+                    </div>
+                </div>
+            ) : condType === 'THRESHOLD_RANGE' ? (
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Low threshold</Label>
+                        <Input
+                            type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
+                            placeholder="e.g. 200"
+                            value={condition.thresholdLow ?? ''}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    thresholdLow: nextAlertPositiveNumber(e.target.value, condition.thresholdLow),
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">High threshold</Label>
+                        <Input
+                            type="number"
+                            min={condition.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN}
+                            placeholder="e.g. 500"
+                            value={condition.thresholdHigh ?? ''}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    thresholdHigh: nextAlertPositiveNumber(e.target.value, condition.thresholdHigh, {
+                                        min: condition.thresholdLow ?? ALERT_POSITIVE_NUMBER_MIN,
+                                    }),
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+            ) : condType === 'COMPARE' ? (
+                <div className="grid grid-cols-3 gap-4">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Operator</Label>
+                        <Select
+                            value={(condition.operator as string) || 'GT'}
+                            onValueChange={(val: AlertOperator) => onChange({ ...condition, operator: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_OPERATORS.map(op => (
+                                    <SelectItem key={op.value} value={op.value}>
+                                        {op.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Multiplier (%)</Label>
+                        <Input
+                            type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
+                            placeholder="e.g. 150"
+                            value={condition.multiplier ?? ''}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    multiplier: nextAlertPositiveNumber(e.target.value, condition.multiplier),
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Property to compare</Label>
+                        <Select
+                            value={condition.property2 || metrics[0]?.key}
+                            onValueChange={val => onChange({ ...condition, property2: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {metrics.map(m => (
+                                    <SelectItem key={m.key} value={m.key}>
+                                        {m.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+            ) : (
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Operator</Label>
+                        <Select
+                            value={(condition.operator as string) || 'GT'}
+                            onValueChange={(val: AlertOperator) => onChange({ ...condition, operator: val })}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_OPERATORS.map(op => (
+                                    <SelectItem key={op.value} value={op.value}>
+                                        {op.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                        <Label className="text-xs">Threshold</Label>
+                        <Input
+                            type="number"
+                            min={ALERT_POSITIVE_NUMBER_MIN}
+                            placeholder="e.g. 500"
+                            value={condition.threshold ?? ''}
+                            onChange={e =>
+                                onChange({
+                                    ...condition,
+                                    threshold: nextAlertPositiveNumber(e.target.value, condition.threshold),
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/SimpleConditionForm.tsx
@@ -23,6 +23,7 @@ import {
     type AlertMetricDefinition,
 } from '../constants/alertConstants';
 import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../types';
+import { conditionWithType } from '../utils/alertConditionComplete';
 import { ALERT_POSITIVE_NUMBER_MIN, nextAlertPositiveNumber } from '../utils/alertPositiveNumber';
 
 interface Props {
@@ -34,11 +35,15 @@ interface Props {
 export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
     const selectedMetric = condition.property ?? metrics[0]?.key ?? '';
     const availableTypes = getConditionTypesForMetric(selectedMetric, metrics);
-    const condType: AlertConditionType = condition.type && availableTypes.includes(condition.type) ? condition.type : availableTypes[0];
+    const condType: AlertConditionType =
+        availableTypes.length === 0 || availableTypes.includes(condition.type) ? condition.type : (availableTypes[0] ?? condition.type);
 
     const handleMetricChange = (val: string) => {
         const newTypes = getConditionTypesForMetric(val, metrics);
         const nextType = newTypes[0];
+        if (!nextType) {
+            return;
+        }
         const defaultOperator = isStringMetric(val) || nextType === 'STRING' ? 'EQUALS' : 'GT';
         onChange({
             ...condition,
@@ -74,7 +79,10 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                 {availableTypes.length > 1 && (
                     <div className="space-y-1.5">
                         <Label className="text-xs">Condition type</Label>
-                        <Select value={condType} onValueChange={(val: AlertConditionType) => onChange({ ...condition, type: val })}>
+                        <Select
+                            value={condType}
+                            onValueChange={(val: AlertConditionType) => onChange(conditionWithType(condition, val, metrics[0]?.key))}
+                        >
                             <SelectTrigger>
                                 <SelectValue />
                             </SelectTrigger>
@@ -191,10 +199,7 @@ export function SimpleConditionForm({ condition, metrics, onChange }: Props) {
                     </div>
                     <div className="space-y-1.5">
                         <Label className="text-xs">Property to compare</Label>
-                        <Select
-                            value={condition.property2 || metrics[0]?.key}
-                            onValueChange={val => onChange({ ...condition, property2: val })}
-                        >
+                        <Select value={condition.property2} onValueChange={val => onChange({ ...condition, property2: val })}>
                             <SelectTrigger>
                                 <SelectValue />
                             </SelectTrigger>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { API_METRICS, getConditionTypesForMetric, sourceTypeToRuleId } from './alertConstants';
+
+describe('sourceTypeToRuleId', () => {
+    it('maps a known source and type to its rule id', () => {
+        expect(sourceTypeToRuleId('REQUEST', 'METRICS_SIMPLE_CONDITION')).toBe('REQUEST@METRICS_SIMPLE_CONDITION');
+    });
+
+    it('does not fall back to a default rule for an unrecognized type', () => {
+        expect(sourceTypeToRuleId('CUSTOM', 'UNKNOWN_TYPE')).toBeUndefined();
+    });
+});
+
+describe('getConditionTypesForMetric', () => {
+    it('returns no types for an unrecognized metric instead of inventing THRESHOLD', () => {
+        expect(getConditionTypesForMetric('not.a.metric', API_METRICS)).toEqual([]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+    AlertAggregationFunction,
+    AlertConditionType,
+    AlertDampeningMode,
+    AlertNotificationChannel,
+    AlertOperator,
+    AlertRuleId,
+    AlertStringOperator,
+    AlertTimeUnit,
+} from '../types';
+
+export type AlertRuleCategory = 'API metrics' | 'Health-check' | 'Node';
+
+export interface AlertRuleDefinition {
+    id: AlertRuleId;
+    source: string;
+    type: string;
+    description: string;
+    category: AlertRuleCategory;
+}
+
+export const ALERT_RULES: AlertRuleDefinition[] = [
+    {
+        id: 'REQUEST@METRICS_SIMPLE_CONDITION',
+        source: 'REQUEST',
+        type: 'METRICS_SIMPLE_CONDITION',
+        description: 'Alert when a metric of the request validates a condition',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@MISSING_DATA',
+        source: 'REQUEST',
+        type: 'MISSING_DATA',
+        description: 'Alert when there is no request matching filters received for a period of time',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@METRICS_AGGREGATION',
+        source: 'REQUEST',
+        type: 'METRICS_AGGREGATION',
+        description: 'Alert when the aggregated value of a request metric rises a threshold',
+        category: 'API metrics',
+    },
+    {
+        id: 'REQUEST@METRICS_RATE',
+        source: 'REQUEST',
+        type: 'METRICS_RATE',
+        description: 'Alert when the rate of a given condition rises a threshold',
+        category: 'API metrics',
+    },
+    {
+        id: 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED',
+        source: 'ENDPOINT_HEALTH_CHECK',
+        type: 'API_HC_ENDPOINT_STATUS_CHANGED',
+        description: 'Alert when the health status of an endpoint has changed',
+        category: 'Health-check',
+    },
+    {
+        id: 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED',
+        source: 'NODE_LIFECYCLE',
+        type: 'NODE_LIFECYCLE_CHANGED',
+        description: 'Alert when the lifecycle status of a node has changed',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_SIMPLE_CONDITION',
+        description: 'Alert when a metric of the node validates a condition',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_AGGREGATION',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_AGGREGATION',
+        description: 'Alert when the aggregated value of a node metric rises a threshold',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEARTBEAT@METRICS_RATE',
+        source: 'NODE_HEARTBEAT',
+        type: 'METRICS_RATE',
+        description: 'Alert when the rate of a given condition rises a threshold',
+        category: 'Node',
+    },
+    {
+        id: 'NODE_HEALTHCHECK@NODE_HEALTHCHECK',
+        source: 'NODE_HEALTHCHECK',
+        type: 'NODE_HEALTHCHECK',
+        description: 'Alert on the health status of the node',
+        category: 'Node',
+    },
+];
+
+export interface AlertMetricDefinition {
+    key: string;
+    label: string;
+    conditionTypes: AlertConditionType[];
+}
+
+export const API_METRICS: AlertMetricDefinition[] = [
+    { key: 'response.response_time', label: 'Response Time (ms)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+    {
+        key: 'response.upstream_response_time',
+        label: 'Upstream Response Time (ms)',
+        conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'],
+    },
+    { key: 'response.status', label: 'Status Code', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'request.content_length', label: 'Request Content-Length', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+    { key: 'response.content_length', label: 'Response Content-Length', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+    { key: 'error.key', label: 'Error Key', conditionTypes: ['STRING'] },
+    { key: 'tenant', label: 'Tenant', conditionTypes: ['STRING'] },
+    { key: 'api', label: 'API', conditionTypes: ['STRING'] },
+    { key: 'application', label: 'Application', conditionTypes: ['STRING'] },
+    { key: 'plan', label: 'Plan', conditionTypes: ['STRING'] },
+];
+
+export const AGGREGATION_METRICS: AlertMetricDefinition[] = [
+    { key: 'response.response_time', label: 'Response Time (ms)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+    {
+        key: 'response.upstream_response_time',
+        label: 'Upstream Response Time (ms)',
+        conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'],
+    },
+    { key: 'request.content_length', label: 'Request Content-Length', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+    { key: 'response.content_length', label: 'Response Content-Length', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE', 'COMPARE'] },
+];
+
+/** Node heartbeat metrics from classic `node.metrics.ts`. */
+export const NODE_METRICS: AlertMetricDefinition[] = [
+    { key: 'node.hostname', label: 'Hostname', conditionTypes: ['STRING'] },
+    { key: 'node.application', label: 'Type', conditionTypes: ['STRING'] },
+    { key: 'os.cpu.percent', label: 'OS CPU (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'process.cpu.percent', label: 'Process CPU (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'process.cpu.total', label: 'Process CPU (total)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.used', label: 'JVM Heap used', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.max', label: 'JVM Heap max', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.percent', label: 'JVM Heap (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+];
+
+export const NODE_AGGREGATION_METRICS: AlertMetricDefinition[] = [
+    { key: 'os.cpu.percent', label: 'OS CPU (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'process.cpu.percent', label: 'Process CPU (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'process.cpu.total', label: 'Process CPU (total)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.used', label: 'JVM Heap used', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.max', label: 'JVM Heap max', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+    { key: 'jvm.mem.heap.percent', label: 'JVM Heap (%)', conditionTypes: ['THRESHOLD', 'THRESHOLD_RANGE'] },
+];
+
+export const ALERT_OPERATORS: { value: AlertOperator; label: string }[] = [
+    { value: 'LT', label: 'less than' },
+    { value: 'LTE', label: 'less than or equals to' },
+    { value: 'GTE', label: 'greater than or equals to' },
+    { value: 'GT', label: 'greater than' },
+];
+
+export const ALERT_STRING_OPERATORS: { value: AlertStringOperator; label: string }[] = [
+    { value: 'EQUALS', label: 'equals to' },
+    { value: 'NOT_EQUALS', label: 'not equals to' },
+    { value: 'STARTS_WITH', label: 'starts with' },
+    { value: 'ENDS_WITH', label: 'ends with' },
+    { value: 'CONTAINS', label: 'contains' },
+    { value: 'MATCHES', label: 'matches' },
+];
+
+export const AGGREGATION_FUNCTIONS: { value: AlertAggregationFunction; label: string }[] = [
+    { value: 'COUNT', label: 'count' },
+    { value: 'AVG', label: 'average' },
+    { value: 'MIN', label: 'min' },
+    { value: 'MAX', label: 'max' },
+    { value: 'P50', label: '50th percentile' },
+    { value: 'P90', label: '90th percentile' },
+    { value: 'P95', label: '95th percentile' },
+    { value: 'P99', label: '99th percentile' },
+];
+
+export const TIME_UNITS: { value: AlertTimeUnit; label: string }[] = [
+    { value: 'SECONDS', label: 'Seconds' },
+    { value: 'MINUTES', label: 'Minutes' },
+    { value: 'HOURS', label: 'Hours' },
+];
+
+export const DAMPENING_MODES: { value: AlertDampeningMode; label: string }[] = [
+    { value: 'STRICT_COUNT', label: 'N consecutive true evaluations' },
+    { value: 'RELAXED_COUNT', label: 'N true evaluations out of M total evaluations' },
+    { value: 'RELAXED_TIME', label: 'N true evaluations in T time' },
+    { value: 'STRICT_TIME', label: 'Only true evaluations for at least T time' },
+];
+
+export const NOTIFICATION_CHANNELS: { value: AlertNotificationChannel; label: string }[] = [
+    { value: 'email-notifier', label: 'E-mail' },
+    { value: 'slack-notifier', label: 'Slack' },
+    { value: 'default-email', label: 'System e-mail' },
+    { value: 'webhook-notifier', label: 'Webhook' },
+];
+
+export function getConditionTypesForMetric(metricKey: string, metrics: AlertMetricDefinition[]): AlertConditionType[] {
+    return metrics.find(m => m.key === metricKey)?.conditionTypes ?? ['THRESHOLD'];
+}
+
+export function isStringMetric(metricKey: string): boolean {
+    const all = [...API_METRICS, ...NODE_METRICS];
+    const m = all.find(met => met.key === metricKey);
+    return !!m && m.conditionTypes.includes('STRING') && !m.conditionTypes.includes('THRESHOLD');
+}
+
+export function getMetricsForRuleId(ruleId: AlertRuleId): AlertMetricDefinition[] {
+    switch (ruleId) {
+        case 'REQUEST@METRICS_AGGREGATION':
+            return AGGREGATION_METRICS;
+        case 'NODE_HEARTBEAT@METRICS_AGGREGATION':
+            return NODE_AGGREGATION_METRICS;
+        case 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION':
+        case 'NODE_HEARTBEAT@METRICS_RATE':
+            return NODE_METRICS;
+        default:
+            return API_METRICS;
+    }
+}
+
+export function ruleIdToSourceType(ruleId: AlertRuleId): { source: string; type: string } {
+    const atIdx = ruleId.indexOf('@');
+    return { source: ruleId.slice(0, atIdx), type: ruleId.slice(atIdx + 1) };
+}
+
+export function sourceTypeToRuleId(source: string, type: string): AlertRuleId {
+    return ALERT_RULES.find(r => r.id === `${source}@${type}`)?.id ?? 'REQUEST@METRICS_SIMPLE_CONDITION';
+}
+
+export function getAlertRuleLabel(source: string, type: string): string {
+    const ruleId = `${source}@${type}`;
+    return ALERT_RULES.find(rule => rule.id === ruleId)?.description ?? `${source} / ${type}`;
+}
+
+/** Rules with no configurable condition fields (status-change / lifecycle). */
+export function isInfoOnlyRule(ruleId: AlertRuleId): boolean {
+    return (
+        ruleId === 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED' ||
+        ruleId === 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED' ||
+        ruleId === 'NODE_HEALTHCHECK@NODE_HEALTHCHECK'
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/alertConstants.ts
@@ -17,7 +17,6 @@ import type {
     AlertAggregationFunction,
     AlertConditionType,
     AlertDampeningMode,
-    AlertNotificationChannel,
     AlertOperator,
     AlertRuleId,
     AlertStringOperator,
@@ -202,15 +201,8 @@ export const DAMPENING_MODES: { value: AlertDampeningMode; label: string }[] = [
     { value: 'STRICT_TIME', label: 'Only true evaluations for at least T time' },
 ];
 
-export const NOTIFICATION_CHANNELS: { value: AlertNotificationChannel; label: string }[] = [
-    { value: 'email-notifier', label: 'E-mail' },
-    { value: 'slack-notifier', label: 'Slack' },
-    { value: 'default-email', label: 'System e-mail' },
-    { value: 'webhook-notifier', label: 'Webhook' },
-];
-
 export function getConditionTypesForMetric(metricKey: string, metrics: AlertMetricDefinition[]): AlertConditionType[] {
-    return metrics.find(m => m.key === metricKey)?.conditionTypes ?? ['THRESHOLD'];
+    return metrics.find(m => m.key === metricKey)?.conditionTypes ?? [];
 }
 
 export function isStringMetric(metricKey: string): boolean {
@@ -238,8 +230,8 @@ export function ruleIdToSourceType(ruleId: AlertRuleId): { source: string; type:
     return { source: ruleId.slice(0, atIdx), type: ruleId.slice(atIdx + 1) };
 }
 
-export function sourceTypeToRuleId(source: string, type: string): AlertRuleId {
-    return ALERT_RULES.find(r => r.id === `${source}@${type}`)?.id ?? 'REQUEST@METRICS_SIMPLE_CONDITION';
+export function sourceTypeToRuleId(source: string, type: string): AlertRuleId | undefined {
+    return ALERT_RULES.find(r => r.id === `${source}@${type}`)?.id;
 }
 
 export function getAlertRuleLabel(source: string, type: string): string {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/hooks/useAlertForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/hooks/useAlertForm.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -24,8 +24,9 @@ import {
     ALERT_RULES,
     type AlertMetricDefinition,
     type AlertRuleDefinition,
+    getAlertRuleLabel,
     getMetricsForRuleId,
-    isStringMetric,
+    isInfoOnlyRule,
     ruleIdToSourceType,
     sourceTypeToRuleId,
 } from '../constants/alertConstants';
@@ -37,16 +38,11 @@ import {
     listPlatformAlerts,
     updatePlatformAlertFromForm,
 } from '../services/alerts';
-import type {
-    AlertFormCondition,
-    AlertFormNotification,
-    AlertFormTimeframe,
-    AlertHistoryPage,
-    AlertNotificationChannel,
-    AlertRuleId,
-    AlertSeverity,
-} from '../types';
+import { getNotifierSchema } from '../services/notifiers';
+import type { AlertFormCondition, AlertFormNotification, AlertFormTimeframe, AlertHistoryPage, AlertRuleId, AlertSeverity } from '../types';
+import { defaultFilterCondition, isAlertConditionComplete, isAlertDampeningComplete } from '../utils/alertConditionComplete';
 import { ENVIRONMENT_ALERT_CREATE_PERMISSION, ENVIRONMENT_ALERT_UPDATE_PERMISSION } from '../utils/alertPermissions';
+import { alertNotificationsIncompleteReason, areAlertNotificationsComplete } from '../utils/notifierSchema';
 import { platformAlertKeys } from '../utils/queryKeys';
 
 function getDefaultCondition(ruleId: AlertRuleId): AlertFormCondition[] {
@@ -111,8 +107,14 @@ export interface UseAlertFormReturn {
     historyPage: AlertHistoryPage | undefined;
     isRefreshingHistory: boolean;
     isLoadingAlert: boolean;
+    isAlertListError: boolean;
+    hydrateError: boolean;
+    alertNotFound: boolean;
     isPending: boolean;
+    notificationsComplete: boolean;
+    notificationsIncompleteReason: string | null;
     selectedRule: AlertRuleDefinition | undefined;
+    ruleLabel: string;
     metricsForRule: AlertMetricDefinition[];
 
     setName: Dispatch<SetStateAction<string>>;
@@ -133,9 +135,10 @@ export interface UseAlertFormReturn {
     addFilter: () => void;
     updateFilter: (index: number, f: AlertFormCondition) => void;
     removeFilter: (index: number) => void;
-    addNotification: (channel: AlertNotificationChannel) => void;
+    addNotification: () => void;
     removeNotification: (index: number) => void;
-    updateNotificationTarget: (index: number, target: string) => void;
+    setNotificationType: (index: number, type: string) => void;
+    updateNotification: (index: number, configuration: Record<string, unknown>) => void;
     addTimeframe: () => void;
     removeTimeframe: (index: number) => void;
     toggleTimeframeDay: (index: number, dayNum: number) => void;
@@ -152,54 +155,76 @@ export function useAlertForm(): UseAlertFormReturn {
     const queryClient = useQueryClient();
     const environmentId = env?.id ?? '';
 
-    const isUpdate = !!alertId && alertId !== 'new';
+    const isUpdate = !!alertId;
     const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_CREATE_PERMISSION] });
     const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_UPDATE_PERMISSION] });
-    const canEdit = isUpdate ? canUpdate : canCreate;
 
+    const defaultSourceType = ruleIdToSourceType('REQUEST@METRICS_SIMPLE_CONDITION');
     const [name, setName] = useState('');
     const [description, setDescription] = useState('');
     const [severity, setSeverity] = useState<AlertSeverity>('INFO');
     const [enabled, setEnabled] = useState(true);
     const [ruleId, setRuleId] = useState<AlertRuleId>('REQUEST@METRICS_SIMPLE_CONDITION');
+    const [source, setSource] = useState(defaultSourceType.source);
+    const [type, setType] = useState(defaultSourceType.type);
     const [conditions, setConditions] = useState<AlertFormCondition[]>(getDefaultCondition('REQUEST@METRICS_SIMPLE_CONDITION'));
     const [filters, setFilters] = useState<AlertFormCondition[]>([]);
     const [notifications, setNotifications] = useState<AlertFormNotification[]>([]);
     const [timeframes, setTimeframes] = useState<AlertFormTimeframe[]>([]);
     const [dampening, setDampening] = useState<AlertFormData['dampening']>({ mode: 'STRICT_COUNT', trueEvaluations: 1 });
     const [errors, setErrors] = useState<Record<string, string>>({});
-    const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'alerts');
+    const allowedTabs = isUpdate ? ['alerts', 'notifications', 'history'] : ['alerts', 'notifications'];
+    const tabFromUrl = searchParams.get('tab');
+    const [activeTab, setActiveTab] = useState(tabFromUrl && allowedTabs.includes(tabFromUrl) ? tabFromUrl : 'alerts');
     const [isDirty, setIsDirty] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
 
     const initializedForRef = useRef<string | undefined>(undefined);
+    const [hydrateError, setHydrateError] = useState(false);
     const markDirty = useCallback(() => setIsDirty(true), []);
 
-    const { data: existingAlerts, isLoading: isLoadingAlert } = useQuery({
+    const {
+        data: existingAlerts,
+        isLoading: isLoadingAlert,
+        isError: isAlertListError,
+    } = useQuery({
         queryKey: platformAlertKeys.list(environmentId),
         queryFn: () => listPlatformAlerts(environmentId),
         enabled: isUpdate && !!environmentId,
+        staleTime: 30_000,
     });
 
     const existingAlert = useMemo(
         () => (isUpdate && existingAlerts ? existingAlerts.find(a => a.id === alertId) : undefined),
         [isUpdate, existingAlerts, alertId],
     );
+    const alertNotFound = isUpdate && !isLoadingAlert && !isAlertListError && !!existingAlerts && !existingAlert;
+    const canEdit = (isUpdate ? canUpdate : canCreate) && !existingAlert?.template;
 
     useEffect(() => {
         if (!existingAlert || initializedForRef.current === alertId) return;
+        try {
+            const fd = alertTriggerToFormData(existingAlert);
+            setName(fd.name);
+            setDescription(fd.description);
+            setSeverity(fd.severity);
+            setEnabled(fd.enabled);
+            setSource(fd.source);
+            setType(fd.type);
+            const mappedRuleId = sourceTypeToRuleId(fd.source, fd.type);
+            if (mappedRuleId) {
+                setRuleId(mappedRuleId);
+            }
+            setConditions(fd.conditions);
+            setFilters(fd.filters);
+            setNotifications(fd.notifications);
+            setTimeframes(fd.timeframes);
+            setDampening(fd.dampening ?? { mode: 'STRICT_COUNT', trueEvaluations: 1 });
+            setHydrateError(false);
+        } catch {
+            setHydrateError(true);
+        }
         initializedForRef.current = alertId;
-        const fd = alertTriggerToFormData(existingAlert);
-        setName(fd.name);
-        setDescription(fd.description);
-        setSeverity(fd.severity);
-        setEnabled(fd.enabled);
-        setRuleId(sourceTypeToRuleId(fd.source, fd.type));
-        setConditions(fd.conditions);
-        setFilters(fd.filters);
-        setNotifications(fd.notifications);
-        setTimeframes(fd.timeframes);
-        setDampening(fd.dampening ?? { mode: 'STRICT_COUNT', trueEvaluations: 1 });
     }, [existingAlert, alertId]);
 
     const {
@@ -212,12 +237,69 @@ export function useAlertForm(): UseAlertFormReturn {
         enabled: isUpdate && activeTab === 'history' && !!environmentId && !!alertId,
     });
 
+    const notifierTypes = useMemo(() => [...new Set(notifications.map(n => n.type).filter(Boolean))], [notifications]);
+    const schemaResults = useQueries({
+        queries: notifierTypes.map(notifierId => ({
+            queryKey: platformAlertKeys.notifierSchema(environmentId, notifierId),
+            queryFn: () => getNotifierSchema(environmentId, notifierId),
+            enabled: !!environmentId,
+        })),
+    });
+    const notificationSchemaState = useMemo(() => {
+        const schemas: Record<string, Record<string, unknown> | undefined> = {};
+        const failedNotifierIds = new Set<string>();
+        notifierTypes.forEach((id, index) => {
+            schemas[id] = schemaResults[index]?.data;
+            if (schemaResults[index]?.isError && !schemaResults[index]?.data) {
+                failedNotifierIds.add(id);
+            }
+        });
+        const schemasLoading = schemaResults.some(result => result.isLoading || (result.isFetching && !result.data));
+        return { schemas, failedNotifierIds, schemasLoading };
+    }, [notifierTypes, schemaResults]);
+
+    const notificationsComplete = useMemo(
+        () =>
+            areAlertNotificationsComplete(
+                notifications,
+                notificationSchemaState.schemas,
+                notificationSchemaState.schemasLoading,
+                notificationSchemaState.failedNotifierIds,
+                { treatSchemaErrorAsComplete: isUpdate },
+            ),
+        [notifications, notificationSchemaState, isUpdate],
+    );
+
+    const notificationsIncompleteReason = useMemo(
+        () =>
+            alertNotificationsIncompleteReason(
+                notifications,
+                notificationSchemaState.schemas,
+                notificationSchemaState.schemasLoading,
+                notificationSchemaState.failedNotifierIds,
+                { treatSchemaErrorAsComplete: isUpdate },
+            ),
+        [notifications, notificationSchemaState, isUpdate],
+    );
+
     const mutation = useMutation({
         mutationFn: (data: AlertFormData) =>
-            isUpdate && alertId ? updatePlatformAlertFromForm(environmentId, alertId, data) : createPlatformAlert(environmentId, data),
+            isUpdate && alertId
+                ? updatePlatformAlertFromForm(environmentId, alertId, data, {
+                      template: existingAlert?.template,
+                      event_rules: existingAlert?.event_rules,
+                      projections: existingAlert?.projections,
+                  })
+                : createPlatformAlert(environmentId, data),
         onSuccess: saved => {
             queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
             notify.success(isUpdate ? `Alert "${saved.name}" updated.` : `Alert "${saved.name}" created.`);
+            if (isUpdate) {
+                setIsDirty(false);
+                setActiveTab('alerts');
+                setSaveError(null);
+                return;
+            }
             navigate('..');
         },
         onError: (e: Error) => {
@@ -226,35 +308,48 @@ export function useAlertForm(): UseAlertFormReturn {
         },
     });
 
-    const validate = (): boolean => {
+    const selectedRule = useMemo(() => ALERT_RULES.find(r => r.source === source && r.type === type), [source, type]);
+    const metricsForRule = useMemo(() => (selectedRule ? getMetricsForRuleId(selectedRule.id) : []), [selectedRule]);
+    const ruleLabel = selectedRule?.description ?? getAlertRuleLabel(source, type);
+
+    const handleSave = () => {
         const errs: Record<string, string> = {};
         if (!name.trim()) errs.name = 'Name is required.';
         else if (name.length < 3) errs.name = 'Name has to be at least 3 characters long.';
         else if (name.length > 50) errs.name = 'Name length must not exceed 50 characters.';
+        if (notifications.some(n => !n.type)) {
+            errs.notifications = 'Channel is required for each notification.';
+        } else if (!notificationsComplete) {
+            errs.notifications = 'Fill in the required fields for each notification.';
+        }
+        if (selectedRule && !isInfoOnlyRule(selectedRule.id) && conditions.some(c => !isAlertConditionComplete(c))) {
+            errs.conditions = 'Fill in the required condition fields.';
+        }
+        if (filters.some(c => !isAlertConditionComplete(c))) {
+            errs.filters = 'Fill in the required filter fields.';
+        }
+        if (!isAlertDampeningComplete(dampening)) {
+            errs.dampening = 'Fill in the required dampening fields.';
+        }
         setErrors(errs);
-        return Object.keys(errs).length === 0;
-    };
-
-    const handleSave = () => {
-        if (!validate()) {
-            setActiveTab('alerts');
+        if (Object.keys(errs).length > 0) {
+            setActiveTab(errs.name || errs.conditions || errs.filters ? 'alerts' : 'notifications');
             return;
         }
-        const { source, type } = ruleIdToSourceType(ruleId);
         mutation.mutate({ name, description, severity, enabled, source, type, conditions, filters, notifications, timeframes, dampening });
     };
 
     const handleCancel = () => navigate('..');
 
     const handleRuleChange = (newRuleId: AlertRuleId) => {
+        const nextSourceType = ruleIdToSourceType(newRuleId);
         setRuleId(newRuleId);
+        setSource(nextSourceType.source);
+        setType(nextSourceType.type);
         setConditions(getDefaultCondition(newRuleId));
         setFilters([]);
         markDirty();
     };
-
-    const metricsForRule = useMemo(() => getMetricsForRuleId(ruleId), [ruleId]);
-    const selectedRule = useMemo(() => ALERT_RULES.find(r => r.id === ruleId), [ruleId]);
 
     const updateCondition = useCallback(
         (index: number, c: AlertFormCondition) => {
@@ -266,8 +361,7 @@ export function useAlertForm(): UseAlertFormReturn {
 
     const addFilter = () => {
         const defaultProperty = metricsForRule[0]?.key ?? 'response.response_time';
-        const defaultOperator = isStringMetric(defaultProperty) ? 'EQUALS' : 'GT';
-        setFilters(prev => [...prev, { type: 'THRESHOLD', property: defaultProperty, operator: defaultOperator }]);
+        setFilters(prev => [...prev, defaultFilterCondition(defaultProperty)]);
         markDirty();
     };
     const updateFilter = useCallback(
@@ -285,18 +379,25 @@ export function useAlertForm(): UseAlertFormReturn {
         [markDirty],
     );
 
-    const addNotification = (channel: AlertNotificationChannel) => {
-        setNotifications(prev => [...prev, { channel, target: '' }]);
+    const addNotification = () => {
+        setNotifications(prev => [...prev, { type: '', configuration: {} }]);
         markDirty();
     };
     const removeNotification = (index: number) => {
         setNotifications(prev => prev.filter((_, i) => i !== index));
         markDirty();
     };
-    const updateNotificationTarget = (index: number, target: string) => {
-        setNotifications(prev => prev.map((n, i) => (i === index ? { ...n, target } : n)));
+    const setNotificationType = (index: number, type: string) => {
+        setNotifications(prev => prev.map((n, i) => (i === index ? { type, configuration: {} } : n)));
         markDirty();
     };
+    const updateNotification = useCallback(
+        (index: number, configuration: Record<string, unknown>) => {
+            setNotifications(prev => prev.map((n, i) => (i === index ? { ...n, configuration } : n)));
+            markDirty();
+        },
+        [markDirty],
+    );
 
     const addTimeframe = () => {
         setTimeframes(prev => [...prev, { days: [1, 2, 3, 4, 5], startHour: 9 * 3600, endHour: 18 * 3600 }]);
@@ -360,8 +461,14 @@ export function useAlertForm(): UseAlertFormReturn {
         historyPage,
         isRefreshingHistory,
         isLoadingAlert,
+        isAlertListError,
+        hydrateError,
+        alertNotFound,
         isPending: mutation.isPending,
+        notificationsComplete,
+        notificationsIncompleteReason,
         selectedRule,
+        ruleLabel,
         metricsForRule,
         setName,
         setDescription,
@@ -383,7 +490,8 @@ export function useAlertForm(): UseAlertFormReturn {
         removeFilter,
         addNotification,
         removeNotification,
-        updateNotificationTarget,
+        setNotificationType,
+        updateNotification,
         addTimeframe,
         removeTimeframe,
         toggleTimeframeDay,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/hooks/useAlertForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/hooks/useAlertForm.ts
@@ -1,0 +1,394 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+
+import { notify } from '../../../shared/notify';
+import {
+    ALERT_RULES,
+    type AlertMetricDefinition,
+    type AlertRuleDefinition,
+    getMetricsForRuleId,
+    isStringMetric,
+    ruleIdToSourceType,
+    sourceTypeToRuleId,
+} from '../constants/alertConstants';
+import {
+    type AlertFormData,
+    alertTriggerToFormData,
+    createPlatformAlert,
+    listPlatformAlertEvents,
+    listPlatformAlerts,
+    updatePlatformAlertFromForm,
+} from '../services/alerts';
+import type {
+    AlertFormCondition,
+    AlertFormNotification,
+    AlertFormTimeframe,
+    AlertHistoryPage,
+    AlertNotificationChannel,
+    AlertRuleId,
+    AlertSeverity,
+} from '../types';
+import { ENVIRONMENT_ALERT_CREATE_PERMISSION, ENVIRONMENT_ALERT_UPDATE_PERMISSION } from '../utils/alertPermissions';
+import { platformAlertKeys } from '../utils/queryKeys';
+
+function getDefaultCondition(ruleId: AlertRuleId): AlertFormCondition[] {
+    switch (ruleId) {
+        case 'REQUEST@METRICS_SIMPLE_CONDITION':
+            return [{ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT' }];
+        case 'REQUEST@MISSING_DATA':
+            return [{ type: 'MISSING_DATA', timeUnit: 'MINUTES' }];
+        case 'REQUEST@METRICS_AGGREGATION':
+            return [
+                {
+                    type: 'AGGREGATION',
+                    property: 'response.response_time',
+                    aggregationFunction: 'AVG',
+                    operator: 'GT',
+                    timeUnit: 'MINUTES',
+                },
+            ];
+        case 'REQUEST@METRICS_RATE':
+            return [{ type: 'RATE', property: 'response.status', operator: 'GTE', rateOperator: 'GT', timeUnit: 'MINUTES' }];
+        case 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION':
+            return [{ type: 'THRESHOLD', property: 'os.cpu.percent', operator: 'GT' }];
+        case 'NODE_HEARTBEAT@METRICS_AGGREGATION':
+            return [
+                {
+                    type: 'AGGREGATION',
+                    property: 'os.cpu.percent',
+                    aggregationFunction: 'AVG',
+                    operator: 'GT',
+                    timeUnit: 'MINUTES',
+                },
+            ];
+        case 'NODE_HEARTBEAT@METRICS_RATE':
+            return [{ type: 'RATE', property: 'os.cpu.percent', operator: 'GTE', rateOperator: 'GT', timeUnit: 'MINUTES' }];
+        case 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED':
+        case 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED':
+        case 'NODE_HEALTHCHECK@NODE_HEALTHCHECK':
+        default:
+            return [];
+    }
+}
+
+export interface UseAlertFormReturn {
+    alertId: string | undefined;
+    isUpdate: boolean;
+    canEdit: boolean;
+
+    name: string;
+    description: string;
+    severity: AlertSeverity;
+    enabled: boolean;
+    ruleId: AlertRuleId;
+    conditions: AlertFormCondition[];
+    filters: AlertFormCondition[];
+    notifications: AlertFormNotification[];
+    timeframes: AlertFormTimeframe[];
+    dampening: AlertFormData['dampening'];
+    errors: Record<string, string>;
+    activeTab: string;
+    isDirty: boolean;
+    saveError: string | null;
+    historyPage: AlertHistoryPage | undefined;
+    isRefreshingHistory: boolean;
+    isLoadingAlert: boolean;
+    isPending: boolean;
+    selectedRule: AlertRuleDefinition | undefined;
+    metricsForRule: AlertMetricDefinition[];
+
+    setName: Dispatch<SetStateAction<string>>;
+    setDescription: Dispatch<SetStateAction<string>>;
+    setSeverity: Dispatch<SetStateAction<AlertSeverity>>;
+    setEnabled: Dispatch<SetStateAction<boolean>>;
+    setDampening: Dispatch<SetStateAction<AlertFormData['dampening']>>;
+    setErrors: Dispatch<SetStateAction<Record<string, string>>>;
+    setActiveTab: Dispatch<SetStateAction<string>>;
+
+    handleSave: () => void;
+    handleCancel: () => void;
+    handleRuleChange: (newRuleId: AlertRuleId) => void;
+    refreshHistory: () => void;
+    markDirty: () => void;
+
+    updateCondition: (index: number, c: AlertFormCondition) => void;
+    addFilter: () => void;
+    updateFilter: (index: number, f: AlertFormCondition) => void;
+    removeFilter: (index: number) => void;
+    addNotification: (channel: AlertNotificationChannel) => void;
+    removeNotification: (index: number) => void;
+    updateNotificationTarget: (index: number, target: string) => void;
+    addTimeframe: () => void;
+    removeTimeframe: (index: number) => void;
+    toggleTimeframeDay: (index: number, dayNum: number) => void;
+    updateTimeframeHour: (index: number, field: 'startHour' | 'endHour', value: number) => void;
+    setTimeframeDays: (index: number, days: number[]) => void;
+    updateTimeframeHours: (index: number, startHour: number, endHour: number) => void;
+}
+
+export function useAlertForm(): UseAlertFormReturn {
+    const { alertId } = useParams<{ alertId: string }>();
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const environmentId = env?.id ?? '';
+
+    const isUpdate = !!alertId && alertId !== 'new';
+    const canCreate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_CREATE_PERMISSION] });
+    const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_UPDATE_PERMISSION] });
+    const canEdit = isUpdate ? canUpdate : canCreate;
+
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [severity, setSeverity] = useState<AlertSeverity>('INFO');
+    const [enabled, setEnabled] = useState(true);
+    const [ruleId, setRuleId] = useState<AlertRuleId>('REQUEST@METRICS_SIMPLE_CONDITION');
+    const [conditions, setConditions] = useState<AlertFormCondition[]>(getDefaultCondition('REQUEST@METRICS_SIMPLE_CONDITION'));
+    const [filters, setFilters] = useState<AlertFormCondition[]>([]);
+    const [notifications, setNotifications] = useState<AlertFormNotification[]>([]);
+    const [timeframes, setTimeframes] = useState<AlertFormTimeframe[]>([]);
+    const [dampening, setDampening] = useState<AlertFormData['dampening']>({ mode: 'STRICT_COUNT', trueEvaluations: 1 });
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'alerts');
+    const [isDirty, setIsDirty] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    const initializedForRef = useRef<string | undefined>(undefined);
+    const markDirty = useCallback(() => setIsDirty(true), []);
+
+    const { data: existingAlerts, isLoading: isLoadingAlert } = useQuery({
+        queryKey: platformAlertKeys.list(environmentId),
+        queryFn: () => listPlatformAlerts(environmentId),
+        enabled: isUpdate && !!environmentId,
+    });
+
+    const existingAlert = useMemo(
+        () => (isUpdate && existingAlerts ? existingAlerts.find(a => a.id === alertId) : undefined),
+        [isUpdate, existingAlerts, alertId],
+    );
+
+    useEffect(() => {
+        if (!existingAlert || initializedForRef.current === alertId) return;
+        initializedForRef.current = alertId;
+        const fd = alertTriggerToFormData(existingAlert);
+        setName(fd.name);
+        setDescription(fd.description);
+        setSeverity(fd.severity);
+        setEnabled(fd.enabled);
+        setRuleId(sourceTypeToRuleId(fd.source, fd.type));
+        setConditions(fd.conditions);
+        setFilters(fd.filters);
+        setNotifications(fd.notifications);
+        setTimeframes(fd.timeframes);
+        setDampening(fd.dampening ?? { mode: 'STRICT_COUNT', trueEvaluations: 1 });
+    }, [existingAlert, alertId]);
+
+    const {
+        data: historyPage,
+        refetch: refetchHistory,
+        isFetching: isRefreshingHistory,
+    } = useQuery({
+        queryKey: platformAlertKeys.history(environmentId, alertId ?? ''),
+        queryFn: () => listPlatformAlertEvents(environmentId, alertId!),
+        enabled: isUpdate && activeTab === 'history' && !!environmentId && !!alertId,
+    });
+
+    const mutation = useMutation({
+        mutationFn: (data: AlertFormData) =>
+            isUpdate && alertId ? updatePlatformAlertFromForm(environmentId, alertId, data) : createPlatformAlert(environmentId, data),
+        onSuccess: saved => {
+            queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
+            notify.success(isUpdate ? `Alert "${saved.name}" updated.` : `Alert "${saved.name}" created.`);
+            navigate('..');
+        },
+        onError: (e: Error) => {
+            setSaveError(e.message || 'Failed to save alert.');
+            notify.error(e, 'Failed to save alert.');
+        },
+    });
+
+    const validate = (): boolean => {
+        const errs: Record<string, string> = {};
+        if (!name.trim()) errs.name = 'Name is required.';
+        else if (name.length < 3) errs.name = 'Name has to be at least 3 characters long.';
+        else if (name.length > 50) errs.name = 'Name length must not exceed 50 characters.';
+        setErrors(errs);
+        return Object.keys(errs).length === 0;
+    };
+
+    const handleSave = () => {
+        if (!validate()) {
+            setActiveTab('alerts');
+            return;
+        }
+        const { source, type } = ruleIdToSourceType(ruleId);
+        mutation.mutate({ name, description, severity, enabled, source, type, conditions, filters, notifications, timeframes, dampening });
+    };
+
+    const handleCancel = () => navigate('..');
+
+    const handleRuleChange = (newRuleId: AlertRuleId) => {
+        setRuleId(newRuleId);
+        setConditions(getDefaultCondition(newRuleId));
+        setFilters([]);
+        markDirty();
+    };
+
+    const metricsForRule = useMemo(() => getMetricsForRuleId(ruleId), [ruleId]);
+    const selectedRule = useMemo(() => ALERT_RULES.find(r => r.id === ruleId), [ruleId]);
+
+    const updateCondition = useCallback(
+        (index: number, c: AlertFormCondition) => {
+            setConditions(prev => prev.map((item, i) => (i === index ? c : item)));
+            markDirty();
+        },
+        [markDirty],
+    );
+
+    const addFilter = () => {
+        const defaultProperty = metricsForRule[0]?.key ?? 'response.response_time';
+        const defaultOperator = isStringMetric(defaultProperty) ? 'EQUALS' : 'GT';
+        setFilters(prev => [...prev, { type: 'THRESHOLD', property: defaultProperty, operator: defaultOperator }]);
+        markDirty();
+    };
+    const updateFilter = useCallback(
+        (index: number, f: AlertFormCondition) => {
+            setFilters(prev => prev.map((item, i) => (i === index ? f : item)));
+            markDirty();
+        },
+        [markDirty],
+    );
+    const removeFilter = useCallback(
+        (index: number) => {
+            setFilters(prev => prev.filter((_, i) => i !== index));
+            markDirty();
+        },
+        [markDirty],
+    );
+
+    const addNotification = (channel: AlertNotificationChannel) => {
+        setNotifications(prev => [...prev, { channel, target: '' }]);
+        markDirty();
+    };
+    const removeNotification = (index: number) => {
+        setNotifications(prev => prev.filter((_, i) => i !== index));
+        markDirty();
+    };
+    const updateNotificationTarget = (index: number, target: string) => {
+        setNotifications(prev => prev.map((n, i) => (i === index ? { ...n, target } : n)));
+        markDirty();
+    };
+
+    const addTimeframe = () => {
+        setTimeframes(prev => [...prev, { days: [1, 2, 3, 4, 5], startHour: 9 * 3600, endHour: 18 * 3600 }]);
+        markDirty();
+    };
+    const removeTimeframe = (index: number) => {
+        setTimeframes(prev => prev.filter((_, i) => i !== index));
+        markDirty();
+    };
+    const toggleTimeframeDay = useCallback(
+        (index: number, dayNum: number) => {
+            setTimeframes(prev =>
+                prev.map((t, i) =>
+                    i === index ? { ...t, days: t.days.includes(dayNum) ? t.days.filter(d => d !== dayNum) : [...t.days, dayNum] } : t,
+                ),
+            );
+            markDirty();
+        },
+        [markDirty],
+    );
+    const updateTimeframeHour = useCallback(
+        (index: number, field: 'startHour' | 'endHour', value: number) => {
+            setTimeframes(prev => prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)));
+            markDirty();
+        },
+        [markDirty],
+    );
+    const setTimeframeDays = useCallback(
+        (index: number, days: number[]) => {
+            setTimeframes(prev => prev.map((t, i) => (i === index ? { ...t, days } : t)));
+            markDirty();
+        },
+        [markDirty],
+    );
+    const updateTimeframeHours = useCallback(
+        (index: number, startHour: number, endHour: number) => {
+            setTimeframes(prev => prev.map((t, i) => (i === index ? { ...t, startHour, endHour } : t)));
+            markDirty();
+        },
+        [markDirty],
+    );
+
+    return {
+        alertId,
+        isUpdate,
+        canEdit,
+        name,
+        description,
+        severity,
+        enabled,
+        ruleId,
+        conditions,
+        filters,
+        notifications,
+        timeframes,
+        dampening,
+        errors,
+        activeTab,
+        isDirty,
+        saveError,
+        historyPage,
+        isRefreshingHistory,
+        isLoadingAlert,
+        isPending: mutation.isPending,
+        selectedRule,
+        metricsForRule,
+        setName,
+        setDescription,
+        setSeverity,
+        setEnabled,
+        setDampening,
+        setErrors,
+        setActiveTab,
+        handleSave,
+        handleCancel,
+        handleRuleChange,
+        refreshHistory: () => {
+            void refetchHistory();
+        },
+        markDirty,
+        updateCondition,
+        addFilter,
+        updateFilter,
+        removeFilter,
+        addNotification,
+        removeNotification,
+        updateNotificationTarget,
+        addTimeframe,
+        removeTimeframe,
+        toggleTimeframeDay,
+        updateTimeframeHour,
+        setTimeframeDays,
+        updateTimeframeHours,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.spec.tsx
@@ -48,6 +48,9 @@ jest.mock('@tanstack/react-query', () => ({
         }),
         isPending: false,
     })),
+    useQueries: jest.fn(({ queries = [] }: { queries?: unknown[] }) =>
+        queries.map(() => ({ data: undefined, isLoading: false, isFetching: false, isError: false })),
+    ),
     useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
 }));
 
@@ -153,6 +156,7 @@ it('calls createPlatformAlert with correct payload when form is valid and submit
     renderCreatePage();
 
     await user.type(screen.getByLabelText(/name/i), 'My Alert');
+    await user.type(screen.getByPlaceholderText('e.g. 500'), '500');
     await user.click(screen.getByRole('button', { name: /^create$/i }));
 
     await waitFor(() => expect(mockCreatePlatformAlert).toHaveBeenCalledTimes(1));
@@ -161,6 +165,32 @@ it('calls createPlatformAlert with correct payload when form is valid and submit
     expect(sentData.name).toBe('My Alert');
     expect(sentData.source).toBe('REQUEST');
     expect(sentData.type).toBe('METRICS_SIMPLE_CONDITION');
+    expect(sentData.conditions[0].threshold).toBe(500);
+    expect(sentData.notifications).toEqual([]);
+});
+
+it('does not create when the threshold is empty', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.type(screen.getByLabelText(/name/i), 'My Alert');
+    await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+    expect(screen.getByText(/required condition fields/i)).not.toBeNull();
+    expect(mockCreatePlatformAlert).not.toHaveBeenCalled();
+});
+
+it('disables Create after a notification is added until a channel and required schema fields are set', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.type(screen.getByLabelText(/name/i), 'My Alert');
+    await user.click(screen.getByRole('tab', { name: /notifications/i }));
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+    expect(screen.getByRole('button', { name: /^create$/i })).toHaveProperty('disabled', true);
+    expect(screen.getByText(/select a channel for each notification/i)).not.toBeNull();
+    expect(mockCreatePlatformAlert).not.toHaveBeenCalled();
 });
 
 it('populates form with existing alert data in edit mode', () => {
@@ -168,6 +198,38 @@ it('populates form with existing alert data in edit mode', () => {
 
     expect(screen.getByRole('heading', { name: /update alert/i })).not.toBeNull();
     expect((screen.getByLabelText(/name/i) as HTMLInputElement).value).toBe('High Response Time');
+});
+
+it('keeps classic group-by projections when saving an existing alert', async () => {
+    const user = userEvent.setup();
+    const grouped = [{ type: 'PROPERTY', property: 'api' }];
+    renderEditPage({
+        ...EXISTING_ALERT,
+        projections: grouped,
+        conditions: [{ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT', threshold: 500, projections: grouped }],
+    });
+
+    await user.type(screen.getByLabelText(/name/i), '!');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(mockUpdatePlatformAlertFromForm).toHaveBeenCalledTimes(1));
+    const [, , sentData, preserved] = mockUpdatePlatformAlertFromForm.mock.calls[0];
+    expect(preserved.projections).toEqual(grouped);
+    expect(sentData.conditions[0].projections).toEqual(grouped);
+});
+
+it('stays on the Alerts tab in edit mode after save instead of returning to the list', async () => {
+    const user = userEvent.setup();
+    renderEditPage();
+
+    await user.type(screen.getByLabelText(/name/i), '!');
+    await user.click(screen.getByRole('tab', { name: /notifications/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(mockUpdatePlatformAlertFromForm).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('heading', { name: /update alert/i })).not.toBeNull();
+    expect(screen.getByRole('tab', { name: /alerts/i }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.queryByRole('button', { name: /^save$/i })).toBeNull();
 });
 
 it('hides Create button for read-only users', () => {
@@ -217,4 +279,84 @@ it('shows History tab in edit mode', () => {
     renderEditPage();
 
     expect(screen.getByRole('tab', { name: /history/i })).not.toBeNull();
+});
+
+it('shows a not-found state for an unknown alert id', () => {
+    mockUseQuery.mockImplementation(config => {
+        if (config.enabled === false) {
+            return { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+        }
+        return { data: [], isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+    });
+
+    render(
+        <MemoryRouter initialEntries={['/alerts/missing-id']}>
+            <Routes>
+                <Route path="alerts/:alertId" element={<AlertFormPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /alert not found/i })).not.toBeNull();
+    expect(screen.queryByRole('heading', { name: /update alert/i })).toBeNull();
+});
+
+it('does not allow saving a template alert opened by id', () => {
+    renderEditPage({ ...EXISTING_ALERT, template: true, event_rules: [{ event: 'API_CREATE' }] });
+
+    expect(screen.getByRole('heading', { name: /update alert/i })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /^save$/i })).toBeNull();
+});
+
+it('keeps the original source and type when the rule is unrecognized', async () => {
+    const user = userEvent.setup();
+    renderEditPage({ ...EXISTING_ALERT, source: 'CUSTOM', type: 'UNKNOWN_TYPE' });
+
+    await user.type(screen.getByLabelText(/name/i), '!');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(mockUpdatePlatformAlertFromForm).toHaveBeenCalledTimes(1));
+    const [, , sentData] = mockUpdatePlatformAlertFromForm.mock.calls[0];
+    expect(sentData.source).toBe('CUSTOM');
+    expect(sentData.type).toBe('UNKNOWN_TYPE');
+});
+
+it('falls back to the Alerts tab when creating with ?tab=history', () => {
+    render(
+        <MemoryRouter initialEntries={['/alerts/new?tab=history']}>
+            <Routes>
+                <Route path="alerts/new" element={<AlertFormPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /create new alert/i })).not.toBeNull();
+    expect(screen.getByRole('tab', { name: /alerts/i }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.queryByRole('tab', { name: /history/i })).toBeNull();
+});
+
+it('keeps Save enabled when notifier schema fetch failed', async () => {
+    const user = userEvent.setup();
+    const { useQueries } = jest.requireMock('@tanstack/react-query') as { useQueries: jest.Mock };
+    useQueries.mockImplementation(({ queries = [] }: { queries?: unknown[] }) =>
+        queries.map(() => ({ data: undefined, isLoading: false, isFetching: false, isError: true })),
+    );
+
+    renderEditPage({
+        ...EXISTING_ALERT,
+        notifications: [{ type: 'webhook-notifier', configuration: { url: 'https://example.com' } }],
+    });
+
+    await user.type(screen.getByLabelText(/name/i), '!');
+    expect(screen.getByRole('button', { name: /^save$/i })).toHaveProperty('disabled', false);
+});
+
+it('shows failed-to-load when notification configuration JSON is invalid', () => {
+    renderEditPage({
+        ...EXISTING_ALERT,
+        notifications: [{ type: 'webhook-notifier', configuration: 'not-json' }],
+    });
+
+    expect(screen.getByText(/failed to load this alert/i)).not.toBeNull();
+    expect(screen.queryByRole('heading', { name: /update alert/i })).toBeNull();
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.spec.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { AlertFormPage } from './AlertFormPage';
+import { createPlatformAlert, listPlatformAlerts, updatePlatformAlertFromForm } from '../services/alerts';
+import type { AlertTrigger } from '../types';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+    useQuery: jest.fn(config => {
+        if (config.enabled === false) {
+            return { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+        }
+        return { data: config.queryFnResult, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+    }),
+    useMutation: jest.fn(config => ({
+        mutate: jest.fn(async args => {
+            const result = await config.mutationFn(args);
+            config.onSuccess?.(result);
+        }),
+        isPending: false,
+    })),
+    useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
+}));
+
+jest.mock('../services/alerts', () => ({
+    listPlatformAlerts: jest.fn(() => Promise.resolve([])),
+    listPlatformAlertEvents: jest.fn(() => Promise.resolve({ content: [], totalElements: 0 })),
+    createPlatformAlert: jest.fn(() => Promise.resolve({ id: 'new-id', name: 'My Alert' })),
+    updatePlatformAlertFromForm: jest.fn(() => Promise.resolve({ id: 'alert-1', name: 'High Response Time' })),
+    alertTriggerToFormData: jest.requireActual('../services/alerts').alertTriggerToFormData,
+}));
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseQuery = useQuery as jest.Mock;
+const mockListPlatformAlerts = listPlatformAlerts as jest.Mock;
+const mockCreatePlatformAlert = createPlatformAlert as jest.Mock;
+const mockUpdatePlatformAlertFromForm = updatePlatformAlertFromForm as jest.Mock;
+
+const EXISTING_ALERT: AlertTrigger = {
+    id: 'alert-1',
+    name: 'High Response Time',
+    description: 'Alert on slow responses',
+    severity: 'WARNING',
+    enabled: true,
+    source: 'REQUEST',
+    type: 'METRICS_SIMPLE_CONDITION',
+    conditions: [{ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT', threshold: 500 }],
+    filters: [],
+    notifications: [],
+    notificationPeriods: [],
+    dampening: { mode: 'STRICT_COUNT', trueEvaluations: 1 },
+};
+
+function renderCreatePage() {
+    render(
+        <MemoryRouter initialEntries={['/alerts/new']}>
+            <Routes>
+                <Route path="alerts/new" element={<AlertFormPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+function renderEditPage(alert: AlertTrigger = EXISTING_ALERT) {
+    mockListPlatformAlerts.mockResolvedValue([alert]);
+    mockUseQuery.mockImplementation(config => {
+        if (config.enabled === false) {
+            return { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+        }
+        return { data: [alert], isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+    });
+
+    render(
+        <MemoryRouter initialEntries={['/alerts/alert-1']}>
+            <Routes>
+                <Route path="alerts/:alertId" element={<AlertFormPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+    mockCreatePlatformAlert.mockResolvedValue({ id: 'new-id', name: 'My Alert' });
+    mockUpdatePlatformAlertFromForm.mockResolvedValue({ id: 'alert-1', name: 'High Response Time' });
+    mockUseQuery.mockImplementation(config => {
+        if (config.enabled === false) {
+            return { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+        }
+        return { data: undefined, isLoading: false, isError: false, isFetching: false, refetch: jest.fn() };
+    });
+});
+
+it('renders create form with name field and Create button', () => {
+    renderCreatePage();
+
+    expect(screen.getByRole('heading', { name: /create new alert/i })).not.toBeNull();
+    expect(screen.getByLabelText(/name/i)).not.toBeNull();
+    expect(screen.getByRole('button', { name: /^create$/i })).not.toBeNull();
+});
+
+it('shows name validation error when saving without a name', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+    expect(screen.getByText(/name is required/i)).not.toBeNull();
+});
+
+it('shows validation error when name is too short', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.type(screen.getByLabelText(/name/i), 'AB');
+    await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+    expect(screen.getByText(/at least 3 characters/i)).not.toBeNull();
+});
+
+it('calls createPlatformAlert with correct payload when form is valid and submitted', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.type(screen.getByLabelText(/name/i), 'My Alert');
+    await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+    await waitFor(() => expect(mockCreatePlatformAlert).toHaveBeenCalledTimes(1));
+
+    const [, sentData] = mockCreatePlatformAlert.mock.calls[0];
+    expect(sentData.name).toBe('My Alert');
+    expect(sentData.source).toBe('REQUEST');
+    expect(sentData.type).toBe('METRICS_SIMPLE_CONDITION');
+});
+
+it('populates form with existing alert data in edit mode', () => {
+    renderEditPage();
+
+    expect(screen.getByRole('heading', { name: /update alert/i })).not.toBeNull();
+    expect((screen.getByLabelText(/name/i) as HTMLInputElement).value).toBe('High Response Time');
+});
+
+it('hides Create button for read-only users', () => {
+    mockUseHasPermission.mockReturnValue(false);
+    renderCreatePage();
+
+    expect(screen.queryByRole('button', { name: /^create$/i })).toBeNull();
+});
+
+it('renders Notifications and Alerts tabs', () => {
+    renderCreatePage();
+
+    expect(screen.getByRole('tab', { name: /alerts/i })).not.toBeNull();
+    expect(screen.getByRole('tab', { name: /notifications/i })).not.toBeNull();
+});
+
+it('adds a timeframe with start and end times including seconds', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.click(screen.getByRole('button', { name: /add timeframe/i }));
+
+    const start = screen.getByLabelText(/start time/i) as HTMLInputElement;
+    const end = screen.getByLabelText(/end time/i) as HTMLInputElement;
+    expect(start.type).toBe('time');
+    expect(start.step).toBe('1');
+    expect(start.value).toBe('09:00:00');
+    expect(end.value).toBe('18:00:00');
+});
+
+it('opens the native time picker when any part of the time field is clicked', async () => {
+    const user = userEvent.setup();
+    renderCreatePage();
+
+    await user.click(screen.getByRole('button', { name: /add timeframe/i }));
+
+    const start = screen.getByLabelText(/start time/i) as HTMLInputElement;
+    const showPicker = jest.fn();
+    start.showPicker = showPicker;
+
+    await user.click(start);
+
+    expect(showPicker).toHaveBeenCalled();
+});
+
+it('shows History tab in edit mode', () => {
+    renderEditPage();
+
+    expect(screen.getByRole('tab', { name: /history/i })).not.toBeNull();
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, cn, PageFocused, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+
+import { AlertsTab } from '../components/AlertsTab';
+import { HistoryTab } from '../components/HistoryTab';
+import { NotificationsTab } from '../components/NotificationsTab';
+import { useAlertForm } from '../hooks/useAlertForm';
+
+export function AlertFormPage() {
+    const {
+        isUpdate,
+        canEdit,
+        name,
+        setName,
+        description,
+        setDescription,
+        severity,
+        setSeverity,
+        enabled,
+        setEnabled,
+        ruleId,
+        handleRuleChange,
+        conditions,
+        updateCondition,
+        filters,
+        addFilter,
+        updateFilter,
+        removeFilter,
+        notifications,
+        addNotification,
+        removeNotification,
+        updateNotificationTarget,
+        timeframes,
+        addTimeframe,
+        removeTimeframe,
+        toggleTimeframeDay,
+        updateTimeframeHour,
+        setTimeframeDays,
+        updateTimeframeHours,
+        dampening,
+        setDampening,
+        errors,
+        setErrors,
+        activeTab,
+        setActiveTab,
+        isDirty,
+        saveError,
+        historyPage,
+        isRefreshingHistory,
+        isLoadingAlert,
+        isPending,
+        selectedRule,
+        metricsForRule,
+        handleSave,
+        handleCancel,
+        markDirty,
+        refreshHistory,
+    } = useAlertForm();
+
+    if (isUpdate && isLoadingAlert) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-8 w-48 rounded" />
+                <Skeleton className="h-10 w-full rounded" />
+                <Skeleton className="h-64 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    return (
+        <PageFocused>
+            <div className="space-y-6">
+                {/* ─── Header ─────────────────────────────────────────────────── */}
+                <div>
+                    <Button variant="ghost" size="sm" className="-ml-2 mb-3 text-muted-foreground" onClick={handleCancel}>
+                        <ArrowLeftIcon className="size-4" />
+                        Back to alerts
+                    </Button>
+                    <h1 className="text-2xl font-semibold">{isUpdate ? 'Update alert' : 'Create new alert'}</h1>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Configure your own alerts. Get notified when a metric condition is met, when data is missing, or when an endpoint
+                        health check status changes.
+                    </p>
+                </div>
+
+                {/* ─── Save error ──────────────────────────────────────────────── */}
+                {saveError && (
+                    <div
+                        className="rounded-lg p-3"
+                        style={{ background: 'hsl(var(--destructive) / 0.08)', border: '1px solid hsl(var(--destructive) / 0.3)' }}
+                    >
+                        <p className="text-xs text-destructive">{saveError}</p>
+                    </div>
+                )}
+
+                <div>
+                    {/* ── Tab bar ──────────────────────────────────────────────── */}
+                    <div role="tablist" className="flex gap-1 border-b">
+                        {(isUpdate ? (['alerts', 'notifications', 'history'] as const) : (['alerts', 'notifications'] as const)).map(
+                            tab => (
+                                <button
+                                    key={tab}
+                                    role="tab"
+                                    type="button"
+                                    aria-selected={activeTab === tab}
+                                    onClick={() => setActiveTab(tab)}
+                                    className={cn(
+                                        '-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors',
+                                        activeTab === tab
+                                            ? 'border-primary text-foreground'
+                                            : 'border-transparent text-muted-foreground hover:border-muted-foreground hover:text-foreground',
+                                    )}
+                                >
+                                    {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                                </button>
+                            ),
+                        )}
+                    </div>
+
+                    {/* ── Tab panels ───────────────────────────────────────────── */}
+                    {activeTab === 'alerts' && (
+                        <AlertsTab
+                            name={name}
+                            setName={setName}
+                            description={description}
+                            setDescription={setDescription}
+                            severity={severity}
+                            setSeverity={setSeverity}
+                            enabled={enabled}
+                            setEnabled={setEnabled}
+                            ruleId={ruleId}
+                            handleRuleChange={handleRuleChange}
+                            isUpdate={isUpdate}
+                            canEdit={canEdit}
+                            errors={errors}
+                            setErrors={setErrors}
+                            markDirty={markDirty}
+                            timeframes={timeframes}
+                            addTimeframe={addTimeframe}
+                            removeTimeframe={removeTimeframe}
+                            toggleTimeframeDay={toggleTimeframeDay}
+                            updateTimeframeHour={updateTimeframeHour}
+                            setTimeframeDays={setTimeframeDays}
+                            updateTimeframeHours={updateTimeframeHours}
+                            conditions={conditions}
+                            updateCondition={updateCondition}
+                            metricsForRule={metricsForRule}
+                            filters={filters}
+                            addFilter={addFilter}
+                            updateFilter={updateFilter}
+                            removeFilter={removeFilter}
+                            selectedRule={selectedRule}
+                        />
+                    )}
+
+                    {activeTab === 'notifications' && (
+                        <NotificationsTab
+                            dampening={dampening}
+                            setDampening={setDampening}
+                            notifications={notifications}
+                            addNotification={addNotification}
+                            removeNotification={removeNotification}
+                            updateNotificationTarget={updateNotificationTarget}
+                            canEdit={canEdit}
+                            markDirty={markDirty}
+                        />
+                    )}
+
+                    {isUpdate && activeTab === 'history' && (
+                        <HistoryTab historyPage={historyPage} onRefresh={refreshHistory} isRefreshing={isRefreshingHistory} />
+                    )}
+                </div>
+
+                {/* ─── Save bar ────────────────────────────────────────────────── */}
+                {canEdit && isDirty && (
+                    <div className="sticky bottom-0 z-10 -mx-6 flex items-center justify-end gap-3 border-t bg-background px-6 py-3">
+                        <Button variant="outline" onClick={handleCancel}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleSave} disabled={isPending}>
+                            {isPending ? 'Saving…' : isUpdate ? 'Save' : 'Create'}
+                        </Button>
+                    </div>
+                )}
+
+                {canEdit && !isDirty && !isUpdate && (
+                    <div className="flex items-center justify-end gap-3 pt-2">
+                        <Button variant="outline" onClick={handleCancel}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleSave} disabled={isPending}>
+                            {isPending ? 'Creating…' : 'Create'}
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </PageFocused>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertFormPage.tsx
@@ -33,7 +33,6 @@ export function AlertFormPage() {
         setSeverity,
         enabled,
         setEnabled,
-        ruleId,
         handleRuleChange,
         conditions,
         updateCondition,
@@ -44,7 +43,8 @@ export function AlertFormPage() {
         notifications,
         addNotification,
         removeNotification,
-        updateNotificationTarget,
+        setNotificationType,
+        updateNotification,
         timeframes,
         addTimeframe,
         removeTimeframe,
@@ -63,13 +63,19 @@ export function AlertFormPage() {
         historyPage,
         isRefreshingHistory,
         isLoadingAlert,
+        isAlertListError,
+        hydrateError,
+        alertNotFound,
         isPending,
+        notificationsComplete,
+        notificationsIncompleteReason,
         selectedRule,
         metricsForRule,
         handleSave,
         handleCancel,
         markDirty,
         refreshHistory,
+        ruleLabel,
     } = useAlertForm();
 
     if (isUpdate && isLoadingAlert) {
@@ -78,6 +84,31 @@ export function AlertFormPage() {
                 <Skeleton className="h-8 w-48 rounded" />
                 <Skeleton className="h-10 w-full rounded" />
                 <Skeleton className="h-64 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    if (isUpdate && (isAlertListError || hydrateError)) {
+        return (
+            <div className="space-y-4">
+                <Button variant="ghost" size="sm" className="-ml-2 text-muted-foreground" onClick={handleCancel}>
+                    <ArrowLeftIcon className="size-4" />
+                    Back to alerts
+                </Button>
+                <p className="text-sm text-destructive">Failed to load this alert. Please try again.</p>
+            </div>
+        );
+    }
+
+    if (alertNotFound) {
+        return (
+            <div className="space-y-4">
+                <Button variant="ghost" size="sm" className="-ml-2 text-muted-foreground" onClick={handleCancel}>
+                    <ArrowLeftIcon className="size-4" />
+                    Back to alerts
+                </Button>
+                <h1 className="text-2xl font-semibold">Alert not found</h1>
+                <p className="text-sm text-muted-foreground">This alert does not exist or was deleted.</p>
             </div>
         );
     }
@@ -143,7 +174,6 @@ export function AlertFormPage() {
                             setSeverity={setSeverity}
                             enabled={enabled}
                             setEnabled={setEnabled}
-                            ruleId={ruleId}
                             handleRuleChange={handleRuleChange}
                             isUpdate={isUpdate}
                             canEdit={canEdit}
@@ -165,6 +195,7 @@ export function AlertFormPage() {
                             updateFilter={updateFilter}
                             removeFilter={removeFilter}
                             selectedRule={selectedRule}
+                            ruleLabel={ruleLabel}
                         />
                     )}
 
@@ -175,9 +206,12 @@ export function AlertFormPage() {
                             notifications={notifications}
                             addNotification={addNotification}
                             removeNotification={removeNotification}
-                            updateNotificationTarget={updateNotificationTarget}
+                            setNotificationType={setNotificationType}
+                            updateNotification={updateNotification}
                             canEdit={canEdit}
                             markDirty={markDirty}
+                            channelError={errors.notifications}
+                            dampeningError={errors.dampening}
                         />
                     )}
 
@@ -189,10 +223,13 @@ export function AlertFormPage() {
                 {/* ─── Save bar ────────────────────────────────────────────────── */}
                 {canEdit && isDirty && (
                     <div className="sticky bottom-0 z-10 -mx-6 flex items-center justify-end gap-3 border-t bg-background px-6 py-3">
+                        {notificationsIncompleteReason && (
+                            <p className="mr-auto text-xs text-destructive">{notificationsIncompleteReason}</p>
+                        )}
                         <Button variant="outline" onClick={handleCancel}>
                             Cancel
                         </Button>
-                        <Button onClick={handleSave} disabled={isPending}>
+                        <Button onClick={handleSave} disabled={isPending || !notificationsComplete}>
                             {isPending ? 'Saving…' : isUpdate ? 'Save' : 'Create'}
                         </Button>
                     </div>
@@ -200,10 +237,13 @@ export function AlertFormPage() {
 
                 {canEdit && !isDirty && !isUpdate && (
                     <div className="flex items-center justify-end gap-3 pt-2">
+                        {notificationsIncompleteReason && (
+                            <p className="mr-auto text-xs text-destructive">{notificationsIncompleteReason}</p>
+                        )}
                         <Button variant="outline" onClick={handleCancel}>
                             Cancel
                         </Button>
-                        <Button onClick={handleSave} disabled={isPending}>
+                        <Button onClick={handleSave} disabled={isPending || !notificationsComplete}>
                             {isPending ? 'Creating…' : 'Create'}
                         </Button>
                     </div>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import {
+    apiNotifToForm,
     createPlatformAlert,
     deletePlatformAlert,
     formConditionToApi,
+    formNotifToApi,
     listPlatformAlertEvents,
     listPlatformAlerts,
+    parseNotificationConfiguration,
     updatePlatformAlert,
     updatePlatformAlertFromForm,
 } from './alerts';
@@ -93,6 +96,20 @@ describe('platform alerts service', () => {
             expect(body.template).toBe(false);
         });
 
+        it('omits notifications that have no channel type', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ ...ALERT, id: 'created' });
+            await createPlatformAlert('env-1', {
+                ...FORM_DATA,
+                notifications: [
+                    { type: '', configuration: {} },
+                    { type: 'webhook-notifier', configuration: { url: 'https://example.com' } },
+                ],
+            });
+
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.notifications).toEqual([{ type: 'webhook-notifier', configuration: { url: 'https://example.com' } }]);
+        });
+
         it('maps timeframe start/end as seconds since midnight (classic beginHour/endHour)', async () => {
             mockApimFetchJsonV1Env.mockResolvedValue({ ...ALERT, id: 'created' });
             await createPlatformAlert('env-1', {
@@ -142,6 +159,26 @@ describe('platform alerts service', () => {
             expect(body.id).toBe('alert-1');
             expect(body.name).toBe('High CPU');
         });
+
+        it('preserves template and event_rules from the existing trigger', async () => {
+            await updatePlatformAlertFromForm('env-1', 'tpl-1', FORM_DATA, {
+                template: true,
+                event_rules: [{ event: 'API_CREATE' }],
+            });
+
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.template).toBe(true);
+            expect(body.event_rules).toEqual([{ event: 'API_CREATE' }]);
+        });
+
+        it('preserves classic group-by projections from the existing trigger', async () => {
+            await updatePlatformAlertFromForm('env-1', 'alert-1', FORM_DATA, {
+                projections: [{ type: 'PROPERTY', property: 'api' }],
+            });
+
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.projections).toEqual([{ type: 'PROPERTY', property: 'api' }]);
+        });
     });
 
     describe('deletePlatformAlert', () => {
@@ -183,6 +220,24 @@ describe('platform alerts service', () => {
             });
         });
 
+        it('round-trips group-by projections on a THRESHOLD condition', () => {
+            expect(
+                formConditionToApi({
+                    type: 'THRESHOLD',
+                    property: 'response.response_time',
+                    operator: 'GT',
+                    threshold: 500,
+                    projections: [{ type: 'PROPERTY', property: 'api' }],
+                }),
+            ).toEqual({
+                type: 'THRESHOLD',
+                property: 'response.response_time',
+                operator: 'GT',
+                threshold: 500,
+                projections: [{ type: 'PROPERTY', property: 'api' }],
+            });
+        });
+
         it('defaults THRESHOLD operator to GT when missing (classic requires operator)', () => {
             expect(
                 formConditionToApi({
@@ -214,6 +269,54 @@ describe('platform alerts service', () => {
                 thresholdLow: 200,
                 operatorHigh: 'INCLUSIVE',
                 thresholdHigh: 488,
+            });
+        });
+    });
+
+    describe('parseNotificationConfiguration', () => {
+        it('returns an object as-is', () => {
+            expect(parseNotificationConfiguration({ to: 'ops@example.com' })).toEqual({ to: 'ops@example.com' });
+        });
+
+        it('parses a JSON string from the API', () => {
+            expect(parseNotificationConfiguration('{"url":"https://hooks.example.com","method":"POST"}')).toEqual({
+                url: 'https://hooks.example.com',
+                method: 'POST',
+            });
+        });
+
+        it('returns {} for empty values', () => {
+            expect(parseNotificationConfiguration(undefined)).toEqual({});
+            expect(parseNotificationConfiguration('')).toEqual({});
+        });
+
+        it('throws when the JSON string is malformed or not an object', () => {
+            expect(() => parseNotificationConfiguration('not-json')).toThrow(/not valid JSON/i);
+            expect(() => parseNotificationConfiguration('[]')).toThrow(/JSON object/i);
+        });
+    });
+
+    describe('formNotifToApi / apiNotifToForm', () => {
+        it('passes through type and full configuration', () => {
+            const form = {
+                type: 'slack-notifier',
+                configuration: { channel: '#ops', token: 'xoxb-test' },
+            };
+            expect(formNotifToApi(form)).toEqual({
+                type: 'slack-notifier',
+                configuration: { channel: '#ops', token: 'xoxb-test' },
+            });
+        });
+
+        it('parses string configuration when loading an alert', () => {
+            expect(
+                apiNotifToForm({
+                    type: 'webhook-notifier',
+                    configuration: '{"method":"POST","url":"https://example.com"}',
+                }),
+            ).toEqual({
+                type: 'webhook-notifier',
+                configuration: { method: 'POST', url: 'https://example.com' },
             });
         });
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
@@ -13,9 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { listPlatformAlerts, updatePlatformAlert } from './alerts';
+import {
+    createPlatformAlert,
+    deletePlatformAlert,
+    formConditionToApi,
+    listPlatformAlertEvents,
+    listPlatformAlerts,
+    updatePlatformAlert,
+    updatePlatformAlertFromForm,
+} from './alerts';
 import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { AlertTrigger } from '../types/alert';
+import type { AlertFormCondition, AlertTrigger } from '../types/alert';
 
 jest.mock('../../../shared/api/apimClient', () => ({
     apimFetchJsonV1Env: jest.fn(),
@@ -38,6 +46,20 @@ const ALERT: AlertTrigger = {
     dampening: { mode: 'STRICT_COUNT', trueEvaluations: 1 },
 };
 
+const FORM_DATA = {
+    name: 'High CPU',
+    description: 'Node CPU',
+    severity: 'WARNING' as const,
+    enabled: true,
+    source: 'NODE_HEARTBEAT',
+    type: 'METRICS_SIMPLE_CONDITION',
+    conditions: [{ type: 'THRESHOLD' as const, property: 'os.cpu.percent', operator: 'GT' as const, threshold: 80 }],
+    filters: [],
+    notifications: [],
+    timeframes: [],
+    dampening: { mode: 'STRICT_COUNT' as const, trueEvaluations: 1 },
+};
+
 describe('platform alerts service', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -49,6 +71,43 @@ describe('platform alerts service', () => {
             await listPlatformAlerts('env-1');
 
             expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts?event_counts=true');
+        });
+    });
+
+    describe('createPlatformAlert', () => {
+        it('POSTs to /platform/alerts with ENVIRONMENT reference', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ ...ALERT, id: 'created' });
+            await createPlatformAlert('env-1', FORM_DATA);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith(
+                'env-1',
+                '/platform/alerts',
+                expect.objectContaining({
+                    method: 'POST',
+                    body: expect.stringContaining('"reference_type":"ENVIRONMENT"'),
+                }),
+            );
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.reference_id).toBe('env-1');
+            expect(body.name).toBe('High CPU');
+            expect(body.template).toBe(false);
+        });
+
+        it('maps timeframe start/end as seconds since midnight (classic beginHour/endHour)', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ ...ALERT, id: 'created' });
+            await createPlatformAlert('env-1', {
+                ...FORM_DATA,
+                timeframes: [{ days: [1, 2, 3, 4, 5], startHour: 9 * 3600, endHour: 18 * 3600 }],
+            });
+
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.notificationPeriods[0]).toEqual(
+                expect.objectContaining({
+                    days: [1, 2, 3, 4, 5],
+                    beginHour: 32400,
+                    endHour: 64800,
+                }),
+            );
         });
     });
 
@@ -67,6 +126,95 @@ describe('platform alerts service', () => {
             await updatePlatformAlert('env-1', { ...ALERT, id: 'a/b' });
 
             expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/a%2Fb', expect.any(Object));
+        });
+    });
+
+    describe('updatePlatformAlertFromForm', () => {
+        it('PUTs converted form data to /platform/alerts/{id}', async () => {
+            await updatePlatformAlertFromForm('env-1', 'alert-1', FORM_DATA);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith(
+                'env-1',
+                '/platform/alerts/alert-1',
+                expect.objectContaining({ method: 'PUT' }),
+            );
+            const body = JSON.parse((mockApimFetchJsonV1Env.mock.calls[0][2] as { body: string }).body);
+            expect(body.id).toBe('alert-1');
+            expect(body.name).toBe('High CPU');
+        });
+    });
+
+    describe('deletePlatformAlert', () => {
+        it('DELETEs /platform/alerts/{id}', async () => {
+            await deletePlatformAlert('env-1', 'alert-1');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/alert-1', { method: 'DELETE' });
+        });
+    });
+
+    describe('listPlatformAlertEvents', () => {
+        it('GETs /platform/alerts/{id}/events with pagination', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ content: [], totalElements: 0 });
+            await listPlatformAlertEvents('env-1', 'alert-1', 2, 20);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/alert-1/events?page=2&size=20');
+        });
+    });
+
+    describe('formConditionToApi', () => {
+        it('maps RATE conditions with nested comparison', () => {
+            const condition: AlertFormCondition = {
+                type: 'RATE',
+                property: 'os.cpu.percent',
+                operator: 'GT',
+                threshold: 50,
+                rateOperator: 'GTE',
+                rateThreshold: 10,
+                duration: 5,
+                timeUnit: 'MINUTES',
+            };
+            expect(formConditionToApi(condition)).toEqual({
+                type: 'RATE',
+                operator: 'GTE',
+                threshold: 10,
+                comparison: { type: 'THRESHOLD', property: 'os.cpu.percent', operator: 'GT', threshold: 50 },
+                duration: 5,
+                timeUnit: 'MINUTES',
+            });
+        });
+
+        it('defaults THRESHOLD operator to GT when missing (classic requires operator)', () => {
+            expect(
+                formConditionToApi({
+                    type: 'THRESHOLD',
+                    property: 'response.response_time',
+                    threshold: 10,
+                }),
+            ).toEqual({
+                type: 'THRESHOLD',
+                property: 'response.response_time',
+                operator: 'GT',
+                threshold: 10,
+            });
+        });
+
+        it('maps THRESHOLD_RANGE with classic BETWEEN operator', () => {
+            expect(
+                formConditionToApi({
+                    type: 'THRESHOLD_RANGE',
+                    property: 'response.response_time',
+                    thresholdLow: 200,
+                    thresholdHigh: 488,
+                }),
+            ).toEqual({
+                type: 'THRESHOLD_RANGE',
+                property: 'response.response_time',
+                operator: 'BETWEEN',
+                operatorLow: 'INCLUSIVE',
+                thresholdLow: 200,
+                operatorHigh: 'INCLUSIVE',
+                thresholdHigh: 488,
+            });
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
@@ -14,14 +14,243 @@
  * limitations under the License.
  */
 import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { AlertTrigger } from '../types/alert';
+import { isStringMetric } from '../constants/alertConstants';
+import type {
+    AlertApiCondition,
+    AlertApiNotification,
+    AlertApiPeriod,
+    AlertFormCondition,
+    AlertFormNotification,
+    AlertFormTimeframe,
+    AlertHistoryPage,
+    AlertOperator,
+    AlertStringOperator,
+    AlertTrigger,
+} from '../types';
 
-/** Lists environment / platform alerts. Mirrors classic `AlertService.listAlerts(Scope.ENVIRONMENT, true)`. */
+export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
+    if (c.type === 'RATE') {
+        const isStr = isStringMetric(c.property ?? '');
+        const comparison: AlertApiCondition = isStr
+            ? {
+                  type: 'STRING',
+                  property: c.property,
+                  operator: (c.operator as AlertStringOperator) || 'EQUALS',
+                  pattern: c.pattern,
+              }
+            : {
+                  type: 'THRESHOLD',
+                  property: c.property,
+                  operator: (c.operator as AlertOperator) || 'GT',
+                  threshold: c.threshold,
+              };
+        return {
+            type: 'RATE',
+            operator: c.rateOperator || 'GT',
+            threshold: c.rateThreshold,
+            comparison,
+            duration: c.duration,
+            timeUnit: c.timeUnit,
+        };
+    }
+    if (c.type === 'AGGREGATION') {
+        return {
+            type: 'AGGREGATION',
+            property: c.property,
+            function: c.aggregationFunction,
+            operator: (c.operator as AlertOperator) || 'GT',
+            threshold: c.threshold,
+            duration: c.duration,
+            timeUnit: c.timeUnit,
+        };
+    }
+    if (c.type === 'THRESHOLD_RANGE') {
+        // Classic env payload always includes operator: BETWEEN on threshold-range conditions.
+        return {
+            type: 'THRESHOLD_RANGE',
+            property: c.property,
+            operator: 'BETWEEN',
+            operatorLow: 'INCLUSIVE',
+            thresholdLow: c.thresholdLow,
+            operatorHigh: 'INCLUSIVE',
+            thresholdHigh: c.thresholdHigh,
+        };
+    }
+    if (c.type === 'STRING') {
+        return {
+            type: 'STRING',
+            property: c.property,
+            operator: (c.operator as AlertStringOperator) || 'EQUALS',
+            pattern: c.pattern,
+        };
+    }
+    if (c.type === 'THRESHOLD') {
+        return {
+            type: 'THRESHOLD',
+            property: c.property,
+            operator: (c.operator as AlertOperator) || 'GT',
+            threshold: c.threshold,
+        };
+    }
+    return {
+        type: c.type,
+        property: c.property,
+        operator: c.operator,
+        threshold: c.threshold,
+        pattern: c.pattern,
+        property2: c.property2,
+        multiplier: c.multiplier,
+        duration: c.duration,
+        timeUnit: c.timeUnit,
+    };
+}
+
+function apiOperatorToForm(operator: AlertApiCondition['operator']): AlertOperator | AlertStringOperator | undefined {
+    if (!operator || operator === 'BETWEEN') return undefined;
+    return operator;
+}
+
+export function apiConditionToForm(c: AlertApiCondition): AlertFormCondition {
+    if (c.type === 'RATE') {
+        const cmp = (c.comparison ?? {}) as AlertApiCondition;
+        return {
+            type: 'RATE',
+            property: cmp.property,
+            operator: apiOperatorToForm(cmp.operator),
+            threshold: cmp.threshold,
+            pattern: cmp.pattern,
+            rateOperator: apiOperatorToForm(c.operator) as AlertOperator | undefined,
+            rateThreshold: c.threshold,
+            duration: c.duration,
+            timeUnit: c.timeUnit,
+        };
+    }
+    if (c.type === 'AGGREGATION') {
+        return {
+            type: 'AGGREGATION',
+            property: c.property,
+            aggregationFunction: c.function,
+            operator: apiOperatorToForm(c.operator),
+            threshold: c.threshold,
+            duration: c.duration,
+            timeUnit: c.timeUnit,
+        };
+    }
+    if (c.type === 'THRESHOLD_RANGE') {
+        return {
+            type: 'THRESHOLD_RANGE',
+            property: c.property,
+            thresholdLow: c.thresholdLow,
+            thresholdHigh: c.thresholdHigh,
+        };
+    }
+    return {
+        type: c.type,
+        property: c.property,
+        operator: apiOperatorToForm(c.operator),
+        threshold: c.threshold,
+        thresholdLow: c.thresholdLow,
+        thresholdHigh: c.thresholdHigh,
+        pattern: c.pattern,
+        property2: c.property2,
+        multiplier: c.multiplier,
+        duration: c.duration,
+        timeUnit: c.timeUnit,
+    };
+}
+
+export function formNotifToApi(n: AlertFormNotification): AlertApiNotification {
+    const isEmail = n.channel === 'email-notifier' || n.channel === 'default-email';
+    return {
+        type: n.channel,
+        configuration: isEmail ? { to: n.target, subject: 'Alert notification' } : { url: n.target },
+    };
+}
+
+export function apiNotifToForm(n: AlertApiNotification): AlertFormNotification {
+    const cfg = (n.configuration ?? {}) as Record<string, unknown>;
+    return {
+        channel: n.type as AlertFormNotification['channel'],
+        target: (cfg['to'] as string) || (cfg['url'] as string) || '',
+    };
+}
+
+function formTimeframeToApi(tf: AlertFormTimeframe): AlertApiPeriod {
+    return {
+        days: tf.days,
+        beginHour: tf.startHour,
+        endHour: tf.endHour,
+        zoneId: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+}
+
+function apiTimeframeToForm(np: AlertApiPeriod): AlertFormTimeframe {
+    return { days: np.days, startHour: np.beginHour, endHour: np.endHour };
+}
+
+export interface AlertFormData {
+    name: string;
+    description: string;
+    severity: AlertTrigger['severity'];
+    enabled: boolean;
+    source: string;
+    type: string;
+    conditions: AlertFormCondition[];
+    filters: AlertFormCondition[];
+    notifications: AlertFormNotification[];
+    timeframes: AlertFormTimeframe[];
+    dampening: AlertTrigger['dampening'];
+}
+
+export function alertTriggerToFormData(alert: AlertTrigger): AlertFormData {
+    return {
+        name: alert.name,
+        description: alert.description ?? '',
+        severity: alert.severity,
+        enabled: alert.enabled,
+        source: alert.source,
+        type: alert.type,
+        conditions: (alert.conditions ?? []).map(apiConditionToForm),
+        filters: (alert.filters ?? []).map(apiConditionToForm),
+        notifications: (alert.notifications ?? []).map(apiNotifToForm),
+        timeframes: (alert.notificationPeriods ?? []).map(apiTimeframeToForm),
+        dampening: alert.dampening ?? { mode: 'STRICT_COUNT', trueEvaluations: 1 },
+    };
+}
+
+export function formDataToAlertTrigger(data: AlertFormData): Omit<AlertTrigger, 'id'> {
+    return {
+        name: data.name,
+        description: data.description || undefined,
+        severity: data.severity,
+        enabled: data.enabled,
+        source: data.source,
+        type: data.type,
+        conditions: data.conditions.map(formConditionToApi),
+        filters: data.filters.map(formConditionToApi),
+        notifications: data.notifications.map(formNotifToApi),
+        notificationPeriods: data.timeframes.map(formTimeframeToApi),
+        dampening: data.dampening,
+    };
+}
+
 export async function listPlatformAlerts(environmentId: string): Promise<AlertTrigger[]> {
     return apimFetchJsonV1Env<AlertTrigger[]>(environmentId, '/platform/alerts?event_counts=true');
 }
 
-/** Updates a platform alert (used for enable/disable toggles on the list page). */
+export async function createPlatformAlert(environmentId: string, data: AlertFormData): Promise<AlertTrigger> {
+    const payload = {
+        ...formDataToAlertTrigger(data),
+        reference_type: 'ENVIRONMENT',
+        reference_id: environmentId,
+        template: false,
+    };
+    return apimFetchJsonV1Env<AlertTrigger>(environmentId, '/platform/alerts', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
 export async function updatePlatformAlert(environmentId: string, alert: AlertTrigger): Promise<AlertTrigger> {
     if (!alert.id) {
         throw new Error('Cannot update a platform alert without an id');
@@ -30,4 +259,25 @@ export async function updatePlatformAlert(environmentId: string, alert: AlertTri
         method: 'PUT',
         body: JSON.stringify(alert),
     });
+}
+
+export async function updatePlatformAlertFromForm(environmentId: string, alertId: string, data: AlertFormData): Promise<AlertTrigger> {
+    const payload = { ...formDataToAlertTrigger(data), id: alertId };
+    return apimFetchJsonV1Env<AlertTrigger>(environmentId, `/platform/alerts/${encodeURIComponent(alertId)}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function deletePlatformAlert(environmentId: string, alertId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(environmentId, `/platform/alerts/${encodeURIComponent(alertId)}`, {
+        method: 'DELETE',
+    });
+}
+
+export async function listPlatformAlertEvents(environmentId: string, alertId: string, page = 1, size = 10): Promise<AlertHistoryPage> {
+    return apimFetchJsonV1Env<AlertHistoryPage>(
+        environmentId,
+        `/platform/alerts/${encodeURIComponent(alertId)}/events?page=${page}&size=${size}`,
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
@@ -28,6 +28,10 @@ import type {
     AlertTrigger,
 } from '../types';
 
+function withProjections(form: AlertFormCondition, api: AlertApiCondition): AlertApiCondition {
+    return form.projections !== undefined ? { ...api, projections: form.projections } : api;
+}
+
 export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
     if (c.type === 'RATE') {
         const isStr = isStringMetric(c.property ?? '');
@@ -44,17 +48,17 @@ export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
                   operator: (c.operator as AlertOperator) || 'GT',
                   threshold: c.threshold,
               };
-        return {
+        return withProjections(c, {
             type: 'RATE',
             operator: c.rateOperator || 'GT',
             threshold: c.rateThreshold,
             comparison,
             duration: c.duration,
             timeUnit: c.timeUnit,
-        };
+        });
     }
     if (c.type === 'AGGREGATION') {
-        return {
+        return withProjections(c, {
             type: 'AGGREGATION',
             property: c.property,
             function: c.aggregationFunction,
@@ -62,11 +66,11 @@ export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
             threshold: c.threshold,
             duration: c.duration,
             timeUnit: c.timeUnit,
-        };
+        });
     }
     if (c.type === 'THRESHOLD_RANGE') {
         // Classic env payload always includes operator: BETWEEN on threshold-range conditions.
-        return {
+        return withProjections(c, {
             type: 'THRESHOLD_RANGE',
             property: c.property,
             operator: 'BETWEEN',
@@ -74,25 +78,25 @@ export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
             thresholdLow: c.thresholdLow,
             operatorHigh: 'INCLUSIVE',
             thresholdHigh: c.thresholdHigh,
-        };
+        });
     }
     if (c.type === 'STRING') {
-        return {
+        return withProjections(c, {
             type: 'STRING',
             property: c.property,
             operator: (c.operator as AlertStringOperator) || 'EQUALS',
             pattern: c.pattern,
-        };
+        });
     }
     if (c.type === 'THRESHOLD') {
-        return {
+        return withProjections(c, {
             type: 'THRESHOLD',
             property: c.property,
             operator: (c.operator as AlertOperator) || 'GT',
             threshold: c.threshold,
-        };
+        });
     }
-    return {
+    return withProjections(c, {
         type: c.type,
         property: c.property,
         operator: c.operator,
@@ -102,7 +106,7 @@ export function formConditionToApi(c: AlertFormCondition): AlertApiCondition {
         multiplier: c.multiplier,
         duration: c.duration,
         timeUnit: c.timeUnit,
-    };
+    });
 }
 
 function apiOperatorToForm(operator: AlertApiCondition['operator']): AlertOperator | AlertStringOperator | undefined {
@@ -123,6 +127,7 @@ export function apiConditionToForm(c: AlertApiCondition): AlertFormCondition {
             rateThreshold: c.threshold,
             duration: c.duration,
             timeUnit: c.timeUnit,
+            projections: c.projections,
         };
     }
     if (c.type === 'AGGREGATION') {
@@ -134,6 +139,7 @@ export function apiConditionToForm(c: AlertApiCondition): AlertFormCondition {
             threshold: c.threshold,
             duration: c.duration,
             timeUnit: c.timeUnit,
+            projections: c.projections,
         };
     }
     if (c.type === 'THRESHOLD_RANGE') {
@@ -142,6 +148,7 @@ export function apiConditionToForm(c: AlertApiCondition): AlertFormCondition {
             property: c.property,
             thresholdLow: c.thresholdLow,
             thresholdHigh: c.thresholdHigh,
+            projections: c.projections,
         };
     }
     return {
@@ -156,22 +163,40 @@ export function apiConditionToForm(c: AlertApiCondition): AlertFormCondition {
         multiplier: c.multiplier,
         duration: c.duration,
         timeUnit: c.timeUnit,
+        projections: c.projections,
     };
 }
 
+export function parseNotificationConfiguration(raw: unknown): Record<string, unknown> {
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+        return raw as Record<string, unknown>;
+    }
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(raw);
+        } catch {
+            throw new Error('Notification configuration is not valid JSON');
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('Notification configuration must be a JSON object');
+        }
+        return parsed as Record<string, unknown>;
+    }
+    return {};
+}
+
 export function formNotifToApi(n: AlertFormNotification): AlertApiNotification {
-    const isEmail = n.channel === 'email-notifier' || n.channel === 'default-email';
     return {
-        type: n.channel,
-        configuration: isEmail ? { to: n.target, subject: 'Alert notification' } : { url: n.target },
+        type: n.type,
+        configuration: n.configuration,
     };
 }
 
 export function apiNotifToForm(n: AlertApiNotification): AlertFormNotification {
-    const cfg = (n.configuration ?? {}) as Record<string, unknown>;
     return {
-        channel: n.type as AlertFormNotification['channel'],
-        target: (cfg['to'] as string) || (cfg['url'] as string) || '',
+        type: n.type,
+        configuration: parseNotificationConfiguration(n.configuration),
     };
 }
 
@@ -228,7 +253,7 @@ export function formDataToAlertTrigger(data: AlertFormData): Omit<AlertTrigger, 
         type: data.type,
         conditions: data.conditions.map(formConditionToApi),
         filters: data.filters.map(formConditionToApi),
-        notifications: data.notifications.map(formNotifToApi),
+        notifications: data.notifications.filter(n => n.type).map(formNotifToApi),
         notificationPeriods: data.timeframes.map(formTimeframeToApi),
         dampening: data.dampening,
     };
@@ -261,8 +286,22 @@ export async function updatePlatformAlert(environmentId: string, alert: AlertTri
     });
 }
 
-export async function updatePlatformAlertFromForm(environmentId: string, alertId: string, data: AlertFormData): Promise<AlertTrigger> {
-    const payload = { ...formDataToAlertTrigger(data), id: alertId };
+export async function updatePlatformAlertFromForm(
+    environmentId: string,
+    alertId: string,
+    data: AlertFormData,
+    preserved?: Pick<AlertTrigger, 'template' | 'event_rules' | 'projections'>,
+): Promise<AlertTrigger> {
+    const payload: Omit<AlertTrigger, 'id'> & { id: string } = { ...formDataToAlertTrigger(data), id: alertId };
+    if (preserved?.template) {
+        payload.template = true;
+    }
+    if (preserved?.event_rules) {
+        payload.event_rules = preserved.event_rules;
+    }
+    if (preserved?.projections) {
+        payload.projections = preserved.projections;
+    }
     return apimFetchJsonV1Env<AlertTrigger>(environmentId, `/platform/alerts/${encodeURIComponent(alertId)}`, {
         method: 'PUT',
         body: JSON.stringify(payload),

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/notifiers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/notifiers.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getNotifierSchema, listNotifiers } from './notifiers';
+import { ApimApiError, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    ...jest.requireActual('../../../shared/api/apimClient'),
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('notifiers service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('lists notifiers from GET /notifiers/', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue([{ id: 'default-email', name: 'System e-mail' }]);
+
+        await listNotifiers('env-1');
+
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/notifiers/');
+    });
+
+    it('loads a notifier schema from GET /notifiers/{id}/schema', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue({ type: 'object', properties: { to: { type: 'string' } } });
+
+        const schema = await getNotifierSchema('env-1', 'default-email');
+
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/notifiers/default-email/schema');
+        expect(schema).toEqual({ type: 'object', properties: { to: { type: 'string' } } });
+    });
+
+    it('parses a double-encoded schema string', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue(JSON.stringify({ type: 'object' }));
+
+        const schema = await getNotifierSchema('env-1', 'webhook-notifier');
+
+        expect(schema).toEqual({ type: 'object' });
+    });
+
+    it('URL-encodes the notifier id', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue({});
+
+        await getNotifierSchema('env-1', 'email/notifier');
+
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/notifiers/email%2Fnotifier/schema');
+    });
+
+    it('returns an empty schema when the notifier schema is missing (404)', async () => {
+        mockApimFetchJsonV1Env.mockRejectedValue(new ApimApiError(404, 'Not found'));
+
+        await expect(getNotifierSchema('env-1', 'missing-notifier')).resolves.toEqual({});
+    });
+
+    it('rethrows non-404 schema errors', async () => {
+        mockApimFetchJsonV1Env.mockRejectedValue(new ApimApiError(500, 'Internal Server Error'));
+
+        await expect(getNotifierSchema('env-1', 'default-email')).rejects.toBeInstanceOf(ApimApiError);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/notifiers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/notifiers.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApimApiError, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+export interface NotifierListItem {
+    id: string;
+    name: string;
+    description?: string;
+    version?: string;
+}
+
+export async function listNotifiers(environmentId: string): Promise<NotifierListItem[]> {
+    return apimFetchJsonV1Env<NotifierListItem[]>(environmentId, '/notifiers/');
+}
+
+export async function getNotifierSchema(environmentId: string, notifierId: string): Promise<Record<string, unknown>> {
+    let raw: unknown;
+    try {
+        raw = await apimFetchJsonV1Env<unknown>(environmentId, `/notifiers/${encodeURIComponent(notifierId)}/schema`);
+    } catch (error) {
+        // Classic Console treats a missing schema as an empty form rather than blocking the alert.
+        if (error instanceof ApimApiError && error.status === 404) {
+            return {};
+        }
+        throw error;
+    }
+    if (typeof raw === 'string') {
+        try {
+            return JSON.parse(raw) as Record<string, unknown>;
+        } catch (cause) {
+            throw new Error(`Malformed JSON schema returned for notifier "${notifierId}"`, { cause });
+        }
+    }
+    return (raw ?? {}) as Record<string, unknown>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
@@ -35,7 +35,6 @@ export type AlertStringOperator = 'EQUALS' | 'NOT_EQUALS' | 'STARTS_WITH' | 'END
 export type AlertAggregationFunction = 'COUNT' | 'AVG' | 'MIN' | 'MAX' | 'P50' | 'P90' | 'P95' | 'P99';
 export type AlertTimeUnit = 'SECONDS' | 'MINUTES' | 'HOURS';
 export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
-export type AlertNotificationChannel = 'email-notifier' | 'slack-notifier' | 'default-email' | 'webhook-notifier';
 
 export interface AlertFormCondition {
     type: AlertConditionType;
@@ -52,11 +51,12 @@ export interface AlertFormCondition {
     aggregationFunction?: AlertAggregationFunction;
     rateOperator?: AlertOperator;
     rateThreshold?: number;
+    projections?: unknown[];
 }
 
 export interface AlertFormNotification {
-    channel: AlertNotificationChannel;
-    target: string;
+    type: string;
+    configuration: Record<string, unknown>;
 }
 
 export interface AlertFormTimeframe {
@@ -92,11 +92,12 @@ export interface AlertApiCondition {
     timeUnit?: AlertTimeUnit;
     function?: AlertAggregationFunction;
     comparison?: AlertApiCondition;
+    projections?: unknown[];
 }
 
 export interface AlertApiNotification {
     type: string;
-    configuration?: Record<string, unknown>;
+    configuration?: Record<string, unknown> | string;
 }
 
 export interface AlertApiPeriod {
@@ -132,9 +133,8 @@ export interface AlertTrigger {
 }
 
 export interface AlertHistoryEvent {
-    id: string;
     message: string;
-    createdAt: string;
+    created_at: number;
 }
 
 export interface AlertHistoryPage {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
@@ -16,8 +16,56 @@
 
 export type AlertSeverity = 'INFO' | 'WARNING' | 'CRITICAL';
 
-export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
+export type AlertRuleId =
+    | 'REQUEST@METRICS_SIMPLE_CONDITION'
+    | 'REQUEST@MISSING_DATA'
+    | 'REQUEST@METRICS_AGGREGATION'
+    | 'REQUEST@METRICS_RATE'
+    | 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED'
+    | 'NODE_LIFECYCLE@NODE_LIFECYCLE_CHANGED'
+    | 'NODE_HEARTBEAT@METRICS_SIMPLE_CONDITION'
+    | 'NODE_HEARTBEAT@METRICS_AGGREGATION'
+    | 'NODE_HEARTBEAT@METRICS_RATE'
+    | 'NODE_HEALTHCHECK@NODE_HEALTHCHECK';
+
+export type AlertConditionType = 'STRING' | 'THRESHOLD' | 'THRESHOLD_RANGE' | 'COMPARE' | 'AGGREGATION' | 'RATE' | 'MISSING_DATA';
+
+export type AlertOperator = 'LT' | 'LTE' | 'GTE' | 'GT';
+export type AlertStringOperator = 'EQUALS' | 'NOT_EQUALS' | 'STARTS_WITH' | 'ENDS_WITH' | 'CONTAINS' | 'MATCHES';
+export type AlertAggregationFunction = 'COUNT' | 'AVG' | 'MIN' | 'MAX' | 'P50' | 'P90' | 'P95' | 'P99';
 export type AlertTimeUnit = 'SECONDS' | 'MINUTES' | 'HOURS';
+export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
+export type AlertNotificationChannel = 'email-notifier' | 'slack-notifier' | 'default-email' | 'webhook-notifier';
+
+export interface AlertFormCondition {
+    type: AlertConditionType;
+    property?: string;
+    operator?: AlertOperator | AlertStringOperator;
+    threshold?: number;
+    thresholdLow?: number;
+    thresholdHigh?: number;
+    pattern?: string;
+    property2?: string;
+    multiplier?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+    aggregationFunction?: AlertAggregationFunction;
+    rateOperator?: AlertOperator;
+    rateThreshold?: number;
+}
+
+export interface AlertFormNotification {
+    channel: AlertNotificationChannel;
+    target: string;
+}
+
+export interface AlertFormTimeframe {
+    days: number[];
+    /** Seconds since midnight — classic API `beginHour`. */
+    startHour: number;
+    /** Seconds since midnight — classic API `endHour`. */
+    endHour: number;
+}
 
 export interface AlertDampening {
     mode: AlertDampeningMode;
@@ -27,8 +75,24 @@ export interface AlertDampening {
     timeUnit?: AlertTimeUnit;
 }
 
-/** Condition shape returned by the management API (opaque to the list page). */
-export type AlertApiCondition = Record<string, unknown>;
+export interface AlertApiCondition {
+    type: AlertConditionType;
+    property?: string;
+    /** THRESHOLD / STRING / AGGREGATION / RATE; THRESHOLD_RANGE uses classic `BETWEEN`. */
+    operator?: AlertOperator | AlertStringOperator | 'BETWEEN';
+    threshold?: number;
+    thresholdLow?: number;
+    thresholdHigh?: number;
+    operatorLow?: 'INCLUSIVE' | 'EXCLUSIVE';
+    operatorHigh?: 'INCLUSIVE' | 'EXCLUSIVE';
+    pattern?: string;
+    property2?: string;
+    multiplier?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+    function?: AlertAggregationFunction;
+    comparison?: AlertApiCondition;
+}
 
 export interface AlertApiNotification {
     type: string;
@@ -42,7 +106,6 @@ export interface AlertApiPeriod {
     zoneId?: string;
 }
 
-/** Platform / environment alert trigger entity from `/platform/alerts`. */
 export interface AlertTrigger {
     id?: string;
     name: string;
@@ -66,4 +129,15 @@ export interface AlertTrigger {
     last_alert_message?: string | null;
     created_at?: string;
     updated_at?: string;
+}
+
+export interface AlertHistoryEvent {
+    id: string;
+    message: string;
+    createdAt: string;
+}
+
+export interface AlertHistoryPage {
+    content: AlertHistoryEvent[];
+    totalElements: number;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { ALERT_RULES, getAlertRuleLabel, type AlertRuleCategory, type AlertRuleDefinition } from './alertConstants';
+export * from './alert';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertConditionComplete.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertConditionComplete.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { conditionWithType, defaultFilterCondition, isAlertConditionComplete, isAlertDampeningComplete } from './alertConditionComplete';
+
+describe('defaultFilterCondition', () => {
+    it('uses STRING for node hostname instead of THRESHOLD', () => {
+        expect(defaultFilterCondition('node.hostname')).toEqual({
+            type: 'STRING',
+            property: 'node.hostname',
+            operator: 'EQUALS',
+        });
+    });
+
+    it('uses THRESHOLD for numeric metrics', () => {
+        expect(defaultFilterCondition('response.response_time')).toEqual({
+            type: 'THRESHOLD',
+            property: 'response.response_time',
+            operator: 'GT',
+        });
+    });
+});
+
+describe('conditionWithType', () => {
+    it('resets THRESHOLD operator and values when switching to STRING', () => {
+        expect(conditionWithType({ type: 'THRESHOLD', property: 'error.key', operator: 'GT', threshold: 500 }, 'STRING')).toEqual({
+            type: 'STRING',
+            property: 'error.key',
+            operator: 'EQUALS',
+            threshold: undefined,
+            thresholdLow: undefined,
+            thresholdHigh: undefined,
+            pattern: undefined,
+            property2: undefined,
+            multiplier: undefined,
+        });
+    });
+
+    it('seeds property2 when switching to COMPARE', () => {
+        expect(
+            conditionWithType({ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT', threshold: 500 }, 'COMPARE', 'api'),
+        ).toEqual({
+            type: 'COMPARE',
+            property: 'response.response_time',
+            operator: 'GT',
+            threshold: undefined,
+            thresholdLow: undefined,
+            thresholdHigh: undefined,
+            pattern: undefined,
+            property2: 'api',
+            multiplier: undefined,
+        });
+    });
+});
+
+describe('isAlertConditionComplete', () => {
+    it('rejects a THRESHOLD condition with no threshold', () => {
+        expect(isAlertConditionComplete({ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT' })).toBe(false);
+    });
+
+    it('rejects MISSING_DATA with no duration', () => {
+        expect(isAlertConditionComplete({ type: 'MISSING_DATA', timeUnit: 'MINUTES' })).toBe(false);
+    });
+
+    it('rejects a range where low is greater than high', () => {
+        expect(
+            isAlertConditionComplete({
+                type: 'THRESHOLD_RANGE',
+                property: 'response.response_time',
+                thresholdLow: 500,
+                thresholdHigh: 300,
+            }),
+        ).toBe(false);
+    });
+
+    it('accepts a filled THRESHOLD condition', () => {
+        expect(isAlertConditionComplete({ type: 'THRESHOLD', property: 'response.response_time', operator: 'GT', threshold: 500 })).toBe(
+            true,
+        );
+    });
+});
+
+describe('isAlertDampeningComplete', () => {
+    it('requires trueEvaluations for STRICT_COUNT', () => {
+        expect(isAlertDampeningComplete({ mode: 'STRICT_COUNT' })).toBe(false);
+        expect(isAlertDampeningComplete({ mode: 'STRICT_COUNT', trueEvaluations: 1 })).toBe(true);
+    });
+
+    it('requires totalEvaluations for RELAXED_COUNT', () => {
+        expect(isAlertDampeningComplete({ mode: 'RELAXED_COUNT', trueEvaluations: 1 })).toBe(false);
+        expect(isAlertDampeningComplete({ mode: 'RELAXED_COUNT', trueEvaluations: 1, totalEvaluations: 5 })).toBe(true);
+    });
+
+    it('requires duration for time-based modes', () => {
+        expect(isAlertDampeningComplete({ mode: 'STRICT_TIME', timeUnit: 'MINUTES' })).toBe(false);
+        expect(isAlertDampeningComplete({ mode: 'STRICT_TIME', duration: 1, timeUnit: 'MINUTES' })).toBe(true);
+        expect(isAlertDampeningComplete({ mode: 'RELAXED_TIME', trueEvaluations: 1, timeUnit: 'MINUTES' })).toBe(false);
+        expect(isAlertDampeningComplete({ mode: 'RELAXED_TIME', trueEvaluations: 1, duration: 2, timeUnit: 'MINUTES' })).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertConditionComplete.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertConditionComplete.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isStringMetric } from '../constants/alertConstants';
+import type { AlertConditionType, AlertDampening, AlertFormCondition } from '../types';
+
+/** Default filter for the given metric — string metrics must not start as THRESHOLD. */
+export function defaultFilterCondition(property: string): AlertFormCondition {
+    if (isStringMetric(property)) {
+        return { type: 'STRING', property, operator: 'EQUALS' };
+    }
+    return { type: 'THRESHOLD', property, operator: 'GT' };
+}
+
+/** Reset value fields when the condition type changes (FilterRow / SimpleConditionForm). */
+export function conditionWithType(condition: AlertFormCondition, type: AlertConditionType, seededProperty2?: string): AlertFormCondition {
+    return {
+        ...condition,
+        type,
+        operator: type === 'STRING' ? 'EQUALS' : type === 'THRESHOLD' || type === 'COMPARE' ? 'GT' : undefined,
+        threshold: undefined,
+        thresholdLow: undefined,
+        thresholdHigh: undefined,
+        pattern: undefined,
+        property2: type === 'COMPARE' ? (condition.property2 ?? seededProperty2) : undefined,
+        multiplier: undefined,
+    };
+}
+
+function hasPositiveNumber(value: number | undefined): value is number {
+    return typeof value === 'number' && value >= 1;
+}
+
+export function isAlertConditionComplete(condition: AlertFormCondition): boolean {
+    switch (condition.type) {
+        case 'THRESHOLD':
+            return hasPositiveNumber(condition.threshold) && !!condition.operator;
+        case 'THRESHOLD_RANGE':
+            return (
+                hasPositiveNumber(condition.thresholdLow) &&
+                hasPositiveNumber(condition.thresholdHigh) &&
+                condition.thresholdLow <= condition.thresholdHigh
+            );
+        case 'STRING':
+            return !!condition.operator && !!condition.pattern?.trim();
+        case 'COMPARE':
+            return !!condition.operator && hasPositiveNumber(condition.multiplier) && !!condition.property2;
+        case 'AGGREGATION':
+            return !!condition.operator && hasPositiveNumber(condition.threshold) && hasPositiveNumber(condition.duration);
+        case 'RATE': {
+            const comparisonFilled = isStringMetric(condition.property ?? '')
+                ? !!condition.pattern?.trim()
+                : hasPositiveNumber(condition.threshold);
+            return (
+                comparisonFilled &&
+                !!condition.operator &&
+                hasPositiveNumber(condition.rateThreshold) &&
+                !!condition.rateOperator &&
+                hasPositiveNumber(condition.duration)
+            );
+        }
+        case 'MISSING_DATA':
+            return hasPositiveNumber(condition.duration);
+        default:
+            return true;
+    }
+}
+
+export function isAlertDampeningComplete(dampening: AlertDampening | undefined): boolean {
+    if (!dampening) {
+        return false;
+    }
+    switch (dampening.mode) {
+        case 'STRICT_COUNT':
+            return hasPositiveNumber(dampening.trueEvaluations);
+        case 'RELAXED_COUNT':
+            return hasPositiveNumber(dampening.trueEvaluations) && hasPositiveNumber(dampening.totalEvaluations);
+        case 'RELAXED_TIME':
+            return hasPositiveNumber(dampening.trueEvaluations) && hasPositiveNumber(dampening.duration) && !!dampening.timeUnit;
+        case 'STRICT_TIME':
+            return hasPositiveNumber(dampening.duration) && !!dampening.timeUnit;
+        default:
+            return false;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPositiveNumber.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPositiveNumber.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { nextAlertPositiveNumber } from './alertPositiveNumber';
+
+describe('nextAlertPositiveNumber', () => {
+    it('clears when the field is emptied', () => {
+        expect(nextAlertPositiveNumber('', 10)).toBeUndefined();
+    });
+
+    it('accepts values of 1 or more', () => {
+        expect(nextAlertPositiveNumber('1', undefined)).toBe(1);
+        expect(nextAlertPositiveNumber('500', 10)).toBe(500);
+    });
+
+    it('keeps the current value for negatives, zero, and non-numeric input (classic min=1)', () => {
+        expect(nextAlertPositiveNumber('-8', 10)).toBe(10);
+        expect(nextAlertPositiveNumber('0', 10)).toBe(10);
+        expect(nextAlertPositiveNumber('-', 10)).toBe(10);
+    });
+
+    it('rejects values above max when a max is set (classic rate threshold 1–99)', () => {
+        expect(nextAlertPositiveNumber('50', 10, { max: 99 })).toBe(50);
+        expect(nextAlertPositiveNumber('100', 50, { max: 99 })).toBe(50);
+    });
+
+    it('rejects values below a custom min (classic high threshold >= low)', () => {
+        expect(nextAlertPositiveNumber('150', 500, { min: 200 })).toBe(500);
+        expect(nextAlertPositiveNumber('250', 500, { min: 200 })).toBe(250);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPositiveNumber.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/alertPositiveNumber.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classic platform alert number fields: `min="1"` (“must be higher than 0”). */
+export const ALERT_POSITIVE_NUMBER_MIN = 1;
+
+/** Classic rate threshold (%) is `min="1"` `max="99"`. */
+export const ALERT_RATE_PERCENT_MAX = 99;
+
+export function nextAlertPositiveNumber(
+    raw: string,
+    current: number | undefined,
+    bounds?: { min?: number; max?: number },
+): number | undefined {
+    if (raw === '') {
+        return undefined;
+    }
+    const min = bounds?.min ?? ALERT_POSITIVE_NUMBER_MIN;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < min) {
+        return current;
+    }
+    if (bounds?.max !== undefined && n > bounds.max) {
+        return current;
+    }
+    return n;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/notifierSchema.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/notifierSchema.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    adaptNotifierSchemaForForm,
+    alertNotificationsIncompleteReason,
+    areAlertNotificationsComplete,
+    isNotifierConfigurationComplete,
+} from './notifierSchema';
+
+describe('adaptNotifierSchemaForForm', () => {
+    it('marks enum arrays as unique so Graphene renders a multi-select (classic checkboxes)', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                authMethods: {
+                    title: 'Allowed authentication methods',
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                        enum: ['XOAUTH2', 'NTLM', 'PLAIN'],
+                    },
+                },
+            },
+        };
+
+        const adapted = adaptNotifierSchemaForForm(schema);
+
+        expect(adapted.properties?.authMethods).toEqual(
+            expect.objectContaining({
+                type: 'array',
+                uniqueItems: true,
+                items: { type: 'string', enum: ['XOAUTH2', 'NTLM', 'PLAIN'] },
+            }),
+        );
+        expect(schema.properties.authMethods).not.toHaveProperty('uniqueItems');
+    });
+
+    it('does not treat object-item arrays as a multi-select', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                headers: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: { key: { type: 'string' }, value: { type: 'string' } },
+                    },
+                },
+            },
+        };
+
+        const adapted = adaptNotifierSchemaForForm(schema);
+
+        expect(adapted.properties?.headers).not.toHaveProperty('uniqueItems');
+    });
+});
+
+const EMAIL_SCHEMA = {
+    type: 'object',
+    properties: {
+        host: { type: 'string' },
+        port: { type: 'integer' },
+        username: { type: 'string' },
+        from: { type: 'string' },
+        to: { type: 'string' },
+        subject: { type: 'string' },
+        body: { type: 'string' },
+        method: { type: 'string', default: 'POST' },
+        url: { type: 'string' },
+    },
+    required: ['host', 'port', 'from', 'to', 'subject', 'body'],
+};
+
+describe('isNotifierConfigurationComplete', () => {
+    it('is false until classic email required fields are filled (username is optional)', () => {
+        expect(isNotifierConfigurationComplete(EMAIL_SCHEMA, { host: 'smtp.example.com' })).toBe(false);
+        expect(
+            isNotifierConfigurationComplete(EMAIL_SCHEMA, {
+                host: 'smtp.example.com',
+                port: 587,
+                from: 'alerts@example.com',
+                to: 'ops@example.com',
+                subject: 'Alert',
+                body: '${alert}',
+            }),
+        ).toBe(true);
+    });
+
+    it('treats blank strings as missing required values', () => {
+        expect(
+            isNotifierConfigurationComplete(EMAIL_SCHEMA, {
+                host: 'smtp.example.com',
+                port: 587,
+                from: 'alerts@example.com',
+                to: '   ',
+                subject: 'Alert',
+                body: '${alert}',
+            }),
+        ).toBe(false);
+    });
+
+    it('applies schema defaults so webhook method need not be re-entered', () => {
+        const webhook = {
+            type: 'object',
+            properties: {
+                method: { type: 'string', default: 'POST' },
+                url: { type: 'string' },
+            },
+            required: ['url', 'method'],
+        };
+        expect(isNotifierConfigurationComplete(webhook, {})).toBe(false);
+        expect(isNotifierConfigurationComplete(webhook, { url: 'https://example.com' })).toBe(true);
+    });
+});
+
+describe('areAlertNotificationsComplete', () => {
+    it('is true when there are no notifications', () => {
+        expect(areAlertNotificationsComplete([], {}, false)).toBe(true);
+    });
+
+    it('is false when a notification has no channel', () => {
+        expect(areAlertNotificationsComplete([{ type: '', configuration: {} }], {}, false)).toBe(false);
+    });
+
+    it('is false while the notifier schema is loading', () => {
+        expect(areAlertNotificationsComplete([{ type: 'email-notifier', configuration: {} }], {}, true)).toBe(false);
+    });
+
+    it('does not block save when the notifier schema request failed and errors are treated as complete', () => {
+        expect(
+            areAlertNotificationsComplete(
+                [{ type: 'email-notifier', configuration: { to: 'ops@example.com' } }],
+                {},
+                false,
+                new Set(['email-notifier']),
+                { treatSchemaErrorAsComplete: true },
+            ),
+        ).toBe(true);
+    });
+
+    it('fails closed on create when the notifier schema request failed', () => {
+        expect(
+            areAlertNotificationsComplete(
+                [{ type: 'email-notifier', configuration: { to: 'ops@example.com' } }],
+                {},
+                false,
+                new Set(['email-notifier']),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('alertNotificationsIncompleteReason', () => {
+    it('explains a missing channel', () => {
+        expect(alertNotificationsIncompleteReason([{ type: '', configuration: {} }], {}, false)).toBe(
+            'Select a channel for each notification.',
+        );
+    });
+
+    it('explains a schema load failure on create', () => {
+        expect(
+            alertNotificationsIncompleteReason([{ type: 'email-notifier', configuration: {} }], {}, false, new Set(['email-notifier'])),
+        ).toBe('Notification settings could not be loaded.');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/notifierSchema.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/notifierSchema.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { JsonSchema } from '@gravitee/graphene-core';
+
+/**
+ * Graphene only renders a multi-select when `type: array` has `uniqueItems: true` and
+ * `items.enum`. Classic Angular schema-form treats the same enum array as checkboxes without
+ * that flag, so plugin notifier schemas otherwise become an "Item 1 / Item 2" list.
+ */
+export function adaptNotifierSchemaForForm(schema: Record<string, unknown>): JsonSchema {
+    return adaptNode(schema) as JsonSchema;
+}
+
+function adaptNode(node: unknown): unknown {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+        return node;
+    }
+    const obj: Record<string, unknown> = { ...(node as Record<string, unknown>) };
+    if (obj.type === 'array' && isEnumItems(obj.items)) {
+        obj.uniqueItems = true;
+    }
+    if (obj.properties && typeof obj.properties === 'object' && !Array.isArray(obj.properties)) {
+        obj.properties = Object.fromEntries(
+            Object.entries(obj.properties as Record<string, unknown>).map(([key, value]) => [key, adaptNode(value)]),
+        );
+    }
+    if (obj.items !== undefined) {
+        obj.items = Array.isArray(obj.items) ? obj.items.map(adaptNode) : adaptNode(obj.items);
+    }
+    for (const key of ['oneOf', 'anyOf', 'allOf'] as const) {
+        const branch = obj[key];
+        if (Array.isArray(branch)) {
+            obj[key] = branch.map(adaptNode);
+        }
+    }
+    return obj;
+}
+
+function isEnumItems(items: unknown): boolean {
+    if (!items || typeof items !== 'object' || Array.isArray(items)) {
+        return false;
+    }
+    const enumValues = (items as { enum?: unknown }).enum;
+    return Array.isArray(enumValues) && enumValues.length > 0;
+}
+
+export function isNotifierConfigurationComplete(schema: Record<string, unknown>, configuration: Record<string, unknown>): boolean {
+    return !hasMissingRequired(schema, applyPropertyDefaults(schema, configuration));
+}
+
+export function areAlertNotificationsComplete(
+    notifications: ReadonlyArray<{ type: string; configuration: Record<string, unknown> }>,
+    schemas: Record<string, Record<string, unknown> | undefined>,
+    schemasLoading: boolean,
+    failedNotifierIds: ReadonlySet<string> = new Set(),
+    options?: { treatSchemaErrorAsComplete?: boolean },
+): boolean {
+    if (notifications.length === 0) {
+        return true;
+    }
+    if (notifications.some(n => !n.type) || schemasLoading) {
+        return false;
+    }
+    return notifications.every(n => {
+        if (failedNotifierIds.has(n.type)) {
+            return options?.treatSchemaErrorAsComplete === true;
+        }
+        const schema = schemas[n.type];
+        return !!schema && isNotifierConfigurationComplete(schema, n.configuration ?? {});
+    });
+}
+
+export function alertNotificationsIncompleteReason(
+    notifications: ReadonlyArray<{ type: string; configuration: Record<string, unknown> }>,
+    schemas: Record<string, Record<string, unknown> | undefined>,
+    schemasLoading: boolean,
+    failedNotifierIds: ReadonlySet<string> = new Set(),
+    options?: { treatSchemaErrorAsComplete?: boolean },
+): string | null {
+    if (areAlertNotificationsComplete(notifications, schemas, schemasLoading, failedNotifierIds, options)) {
+        return null;
+    }
+    if (notifications.some(n => !n.type)) {
+        return 'Select a channel for each notification.';
+    }
+    if (schemasLoading) {
+        return 'Loading notification fields…';
+    }
+    if (notifications.some(n => failedNotifierIds.has(n.type))) {
+        return 'Notification settings could not be loaded.';
+    }
+    return 'Fill in the required fields for each notification.';
+}
+
+function applyPropertyDefaults(schema: Record<string, unknown>, data: Record<string, unknown>): Record<string, unknown> {
+    const properties = schema.properties;
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+        return { ...data };
+    }
+    const merged: Record<string, unknown> = { ...data };
+    for (const [key, prop] of Object.entries(properties as Record<string, unknown>)) {
+        if (merged[key] !== undefined || !prop || typeof prop !== 'object' || Array.isArray(prop)) {
+            continue;
+        }
+        if ('default' in prop) {
+            merged[key] = (prop as { default: unknown }).default;
+        }
+    }
+    return merged;
+}
+
+function hasMissingRequired(schema: Record<string, unknown>, data: unknown): boolean {
+    const obj = isPlainObject(data) ? data : {};
+    const required = schema.required;
+    const properties = isPlainObject(schema.properties) ? (schema.properties as Record<string, Record<string, unknown>>) : undefined;
+    if (Array.isArray(required)) {
+        for (const key of required) {
+            if (typeof key !== 'string' || !isFilled(obj[key])) {
+                return true;
+            }
+        }
+    }
+    if (properties) {
+        for (const [key, prop] of Object.entries(properties)) {
+            if (prop?.type === 'object' && isPlainObject(obj[key]) && hasMissingRequired(prop, obj[key])) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function isFilled(value: unknown): boolean {
+    if (value === undefined || value === null) {
+        return false;
+    }
+    if (typeof value === 'string') {
+        return value.trim().length > 0;
+    }
+    if (typeof value === 'number') {
+        return !Number.isNaN(value);
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
@@ -18,4 +18,6 @@ export const platformAlertKeys = {
     all: ['platform-alerts'] as const,
     list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
     history: (envId: string, alertId: string) => [...platformAlertKeys.all, 'history', envId, alertId] as const,
+    notifiers: (envId: string) => [...platformAlertKeys.all, 'notifiers', envId] as const,
+    notifierSchema: (envId: string, notifierId: string) => [...platformAlertKeys.all, 'notifier-schema', envId, notifierId] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/queryKeys.ts
@@ -17,4 +17,5 @@
 export const platformAlertKeys = {
     all: ['platform-alerts'] as const,
     list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
+    history: (envId: string, alertId: string) => [...platformAlertKeys.all, 'history', envId, alertId] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/timeframeTime.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/timeframeTime.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    END_OF_DAY_SECONDS,
+    OFFICE_END_SECONDS,
+    OFFICE_START_SECONDS,
+    isOfficeHours,
+    secondsSinceMidnightToTimeInput,
+    timeInputToSecondsSinceMidnight,
+} from './timeframeTime';
+
+describe('timeframeTime', () => {
+    it('formats seconds since midnight as HH:mm:ss', () => {
+        expect(secondsSinceMidnightToTimeInput(0)).toBe('00:00:00');
+        expect(secondsSinceMidnightToTimeInput(OFFICE_START_SECONDS)).toBe('09:00:00');
+        expect(secondsSinceMidnightToTimeInput(OFFICE_END_SECONDS)).toBe('18:00:00');
+        expect(secondsSinceMidnightToTimeInput(END_OF_DAY_SECONDS)).toBe('23:59:59');
+        expect(secondsSinceMidnightToTimeInput(9 * 3600 + 15 * 60 + 30)).toBe('09:15:30');
+    });
+
+    it('parses HH:mm:ss (and HH:mm) into seconds since midnight', () => {
+        expect(timeInputToSecondsSinceMidnight('09:00:00')).toBe(OFFICE_START_SECONDS);
+        expect(timeInputToSecondsSinceMidnight('18:00:00')).toBe(OFFICE_END_SECONDS);
+        expect(timeInputToSecondsSinceMidnight('09:15:30')).toBe(9 * 3600 + 15 * 60 + 30);
+        expect(timeInputToSecondsSinceMidnight('09:00')).toBe(OFFICE_START_SECONDS);
+    });
+
+    it('treats 09:00:00–18:00:00 as office hours', () => {
+        expect(isOfficeHours(OFFICE_START_SECONDS, OFFICE_END_SECONDS)).toBe(true);
+        expect(isOfficeHours(0, END_OF_DAY_SECONDS)).toBe(false);
+        expect(isOfficeHours(9, 18)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/timeframeTime.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/timeframeTime.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classic API `beginHour` / `endHour`: seconds since midnight. */
+export const OFFICE_START_SECONDS = 9 * 3600;
+export const OFFICE_END_SECONDS = 18 * 3600;
+export const END_OF_DAY_SECONDS = 24 * 3600 - 1;
+
+function pad2(n: number): string {
+    return String(n).padStart(2, '0');
+}
+
+export function secondsSinceMidnightToTimeInput(seconds: number): string {
+    const clamped = Number.isFinite(seconds) ? Math.max(0, Math.min(END_OF_DAY_SECONDS, Math.floor(seconds))) : 0;
+    const hours = Math.floor(clamped / 3600);
+    const minutes = Math.floor((clamped % 3600) / 60);
+    const secs = clamped % 60;
+    return `${pad2(hours)}:${pad2(minutes)}:${pad2(secs)}`;
+}
+
+export function timeInputToSecondsSinceMidnight(value: string): number {
+    const [hoursPart = '0', minutesPart = '0', secondsPart = '0'] = value.split(':');
+    const hours = Number(hoursPart);
+    const minutes = Number(minutesPart);
+    const seconds = Number(secondsPart);
+    if (![hours, minutes, seconds].every(n => Number.isFinite(n))) {
+        return 0;
+    }
+    return Math.min(END_OF_DAY_SECONDS, hours * 3600 + minutes * 60 + seconds);
+}
+
+export function isOfficeHours(beginSeconds: number, endSeconds: number): boolean {
+    return beginSeconds === OFFICE_START_SECONDS && endSeconds === OFFICE_END_SECONDS;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
@@ -86,9 +86,9 @@ describe('AlertsPage', () => {
         mockUseNavigate.mockReturnValue(mockNavigate);
         mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
         mockUseHasPermission.mockReturnValue(true);
-        mockListPlatformAlerts.mockResolvedValue([]);
-        mockUpdatePlatformAlert.mockResolvedValue(ALERT);
-        mockDeletePlatformAlert.mockResolvedValue(undefined);
+        mockListPlatformAlerts.mockReset().mockResolvedValue([]);
+        mockUpdatePlatformAlert.mockReset().mockResolvedValue(ALERT);
+        mockDeletePlatformAlert.mockReset().mockResolvedValue(undefined);
     });
 
     it('renders the page header', async () => {
@@ -188,6 +188,55 @@ describe('AlertsPage', () => {
         await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Alert "Node stopped" disabled.'));
     });
 
+    it('does not flip the switch until PUT succeeds', async () => {
+        mockListPlatformAlerts.mockResolvedValueOnce([ALERT]);
+        mockUpdatePlatformAlert.mockImplementation(() => new Promise(() => undefined));
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        const toggle = screen.getByRole('switch');
+        expect(toggle.getAttribute('aria-checked')).toBe('true');
+        fireEvent.click(toggle);
+
+        await waitFor(() => expect(mockUpdatePlatformAlert).toHaveBeenCalled());
+        expect(toggle.getAttribute('aria-checked')).toBe('true');
+        expect(notify.success).not.toHaveBeenCalled();
+        expect(mockListPlatformAlerts).toHaveBeenCalledTimes(1);
+    });
+
+    it('flips the switch from the PUT response, then shows the toast and refetches the list', async () => {
+        mockListPlatformAlerts.mockResolvedValueOnce([ALERT]).mockImplementationOnce(() => new Promise(() => undefined));
+        mockUpdatePlatformAlert.mockResolvedValue({ ...ALERT, enabled: false });
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        const toggle = screen.getByRole('switch');
+        fireEvent.click(toggle);
+
+        await waitFor(() => expect(toggle.getAttribute('aria-checked')).toBe('false'));
+        expect(notify.success).toHaveBeenCalledWith('Alert "Node stopped" disabled.');
+        await waitFor(() => expect(mockListPlatformAlerts).toHaveBeenCalledTimes(2));
+    });
+
+    it('refetches the list with event counts after enable/disable', async () => {
+        mockListPlatformAlerts.mockResolvedValueOnce([ALERT]).mockResolvedValueOnce([
+            {
+                ...ALERT,
+                enabled: false,
+                counters: { '5m': 9, '1h': 9, '1d': 9, '1M': 9 },
+            },
+        ]);
+        mockUpdatePlatformAlert.mockResolvedValue({ ...ALERT, enabled: false });
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('1 / 2 / 3 / 4')).not.toBeNull());
+        fireEvent.click(screen.getByRole('switch'));
+
+        await waitFor(() => expect(screen.getByText('9 / 9 / 9 / 9')).not.toBeNull());
+        expect(mockListPlatformAlerts).toHaveBeenCalledTimes(2);
+        expect(mockListPlatformAlerts).toHaveBeenNthCalledWith(2, 'env-1');
+    });
+
     it('does not allow enabling or disabling a template alert', async () => {
         mockListPlatformAlerts.mockResolvedValue([{ ...ALERT, id: 'tpl-1', name: 'API template', template: true }]);
         renderPage();
@@ -199,6 +248,18 @@ describe('AlertsPage', () => {
         expect(mockUpdatePlatformAlert).not.toHaveBeenCalled();
     });
 
+    it('does not offer Edit or Delete for a template alert', async () => {
+        const user = userEvent.setup();
+        mockListPlatformAlerts.mockResolvedValue([{ ...ALERT, id: 'tpl-1', name: 'API template', template: true }, ALERT]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('API template')).not.toBeNull());
+        expect(screen.queryByRole('button', { name: 'Actions for API template' })).toBeNull();
+
+        await user.click(screen.getByRole('button', { name: 'Actions for Node stopped' }));
+        expect(await screen.findByRole('menuitem', { name: 'Edit' })).not.toBeNull();
+    });
+
     it('shows an error toast when enable/disable fails', async () => {
         const failure = new Error('toggle failed');
         mockListPlatformAlerts.mockResolvedValue([ALERT]);
@@ -206,10 +267,12 @@ describe('AlertsPage', () => {
         renderPage();
 
         await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
-        fireEvent.click(screen.getByRole('switch'));
+        const toggle = screen.getByRole('switch');
+        fireEvent.click(toggle);
 
         await waitFor(() => expect(notify.error).toHaveBeenCalledWith(failure, 'Failed to update alert.'));
         expect(notify.success).not.toHaveBeenCalled();
+        await waitFor(() => expect(toggle.getAttribute('aria-checked')).toBe('true'));
     });
 
     it('hides the actions column when the user cannot update or delete', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.spec.tsx
@@ -20,7 +20,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 
 import { AlertsPage } from './AlertsPage';
-import { listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
+import { deletePlatformAlert, listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
 import type { AlertTrigger } from '../features/alerts/types/alert';
 import { notify } from '../shared/notify';
 
@@ -37,6 +37,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('../features/alerts/services/alerts', () => ({
     listPlatformAlerts: jest.fn(),
     updatePlatformAlert: jest.fn(),
+    deletePlatformAlert: jest.fn(),
 }));
 
 jest.mock('../features/alerts/components/AlertsEducationalEmptyState', () => ({
@@ -53,6 +54,7 @@ const mockUseNavigate = jest.mocked(useNavigate);
 const mockNavigate = jest.fn();
 const mockListPlatformAlerts = jest.mocked(listPlatformAlerts);
 const mockUpdatePlatformAlert = jest.mocked(updatePlatformAlert);
+const mockDeletePlatformAlert = jest.mocked(deletePlatformAlert);
 
 const ALERT: AlertTrigger = {
     id: 'alert-1',
@@ -86,6 +88,7 @@ describe('AlertsPage', () => {
         mockUseHasPermission.mockReturnValue(true);
         mockListPlatformAlerts.mockResolvedValue([]);
         mockUpdatePlatformAlert.mockResolvedValue(ALERT);
+        mockDeletePlatformAlert.mockResolvedValue(undefined);
     });
 
     it('renders the page header', async () => {
@@ -135,19 +138,32 @@ describe('AlertsPage', () => {
         expect(screen.queryByText('When a gateway node stops')).toBeNull();
     });
 
-    it('shows Edit and Delete as disabled actions', async () => {
+    it('navigates to the alert id when Edit is clicked', async () => {
         const user = userEvent.setup();
         mockListPlatformAlerts.mockResolvedValue([ALERT]);
         renderPage();
 
         await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
         await user.click(screen.getByRole('button', { name: 'Actions for Node stopped' }));
+        await user.click(await screen.findByRole('menuitem', { name: 'Edit' }));
 
-        const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
-        const deleteItem = screen.getByRole('menuitem', { name: 'Delete alert' });
-        expect(editItem.getAttribute('aria-disabled') ?? editItem.getAttribute('data-disabled')).toBeTruthy();
-        expect(deleteItem.getAttribute('aria-disabled') ?? deleteItem.getAttribute('data-disabled')).toBeTruthy();
-        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('alert-1');
+    });
+
+    it('deletes an alert after ConfirmDialog confirmation', async () => {
+        const user = userEvent.setup();
+        mockListPlatformAlerts.mockResolvedValue([ALERT]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Node stopped')).not.toBeNull());
+        await user.click(screen.getByRole('button', { name: 'Actions for Node stopped' }));
+        await user.click(await screen.findByRole('menuitem', { name: 'Delete alert' }));
+
+        expect(screen.getByRole('heading', { name: 'Delete alert' })).not.toBeNull();
+        await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+
+        await waitFor(() => expect(mockDeletePlatformAlert).toHaveBeenCalledWith('env-1', 'alert-1'));
+        await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Alert "Node stopped" deleted.'));
     });
 
     it('shows an error message when the list request fails', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
@@ -109,11 +109,16 @@ export function AlertsPage() {
         enabled: !!environmentId,
     });
 
+    const listKey = platformAlertKeys.list(environmentId);
+
     const toggleMutation = useMutation({
         mutationFn: (alert: AlertTrigger) => updatePlatformAlert(environmentId, { ...alert, enabled: !alert.enabled }),
         onSuccess: updated => {
-            queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
+            queryClient.setQueryData<AlertTrigger[]>(listKey, previous =>
+                previous?.map(alert => (alert.id === updated.id ? { ...alert, enabled: updated.enabled } : alert)),
+            );
             notify.success(updated.enabled ? `Alert "${updated.name}" enabled.` : `Alert "${updated.name}" disabled.`);
+            void queryClient.invalidateQueries({ queryKey: listKey });
         },
         onError: error => {
             notify.error(error, 'Failed to update alert.');
@@ -121,7 +126,12 @@ export function AlertsPage() {
     });
 
     const deleteMutation = useMutation({
-        mutationFn: (alert: AlertTrigger) => deletePlatformAlert(environmentId, alert.id!),
+        mutationFn: (alert: AlertTrigger) => {
+            if (!alert.id) {
+                throw new Error('Cannot delete a platform alert without an id');
+            }
+            return deletePlatformAlert(environmentId, alert.id);
+        },
         onSuccess: (_void, alert) => {
             queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
             notify.success(`Alert "${alert.name}" deleted.`);
@@ -187,73 +197,84 @@ export function AlertsPage() {
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
-                                {alerts.map(alert => (
-                                    <TableRow key={alert.id}>
-                                        <TableCell>
-                                            <p className="text-sm font-medium">{alert.name}</p>
-                                        </TableCell>
-                                        <TableCell>
-                                            <span className="text-sm text-muted-foreground">
-                                                {getAlertRuleLabel(alert.source, alert.type)}
-                                            </span>
-                                        </TableCell>
-                                        <TableCell>
-                                            <AlertCountersCell counters={alert.counters} />
-                                        </TableCell>
-                                        <TableCell>
-                                            <span className="text-sm text-muted-foreground">{formatLastAlertAt(alert.last_alert_at)}</span>
-                                        </TableCell>
-                                        <TableCell>
-                                            <span className="text-sm text-muted-foreground line-clamp-1">
-                                                {formatLastAlertMessage(alert.last_alert_message)}
-                                            </span>
-                                        </TableCell>
-                                        <TableCell>
-                                            <SeverityBadge severity={alert.severity} />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Switch
-                                                checked={alert.enabled}
-                                                disabled={
-                                                    !canUpdate ||
-                                                    !!alert.template ||
-                                                    (toggleMutation.isPending && toggleMutation.variables?.id === alert.id)
-                                                }
-                                                onCheckedChange={() => toggleMutation.mutate(alert)}
-                                            />
-                                        </TableCell>
-                                        {showActions && (
+                                {alerts.map(alert => {
+                                    const canEditAlert = canUpdate && !!alert.id && !alert.template;
+                                    const canDeleteAlert = canDelete && !!alert.id && !alert.template;
+                                    const rowHasActions = canEditAlert || canDeleteAlert;
+                                    return (
+                                        <TableRow key={alert.id}>
                                             <TableCell>
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="size-8"
-                                                            aria-label={`Actions for ${alert.name}`}
-                                                        >
-                                                            <MoreHorizontalIcon className="size-4" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align="end">
-                                                        {canUpdate && alert.id && (
-                                                            <DropdownMenuItem onClick={() => handleEdit(alert.id!)}>Edit</DropdownMenuItem>
-                                                        )}
-                                                        {canUpdate && canDelete && <DropdownMenuSeparator />}
-                                                        {canDelete && (
-                                                            <DropdownMenuItem
-                                                                className="text-destructive focus:text-destructive"
-                                                                onClick={() => setAlertToDelete(alert)}
-                                                            >
-                                                                Delete alert
-                                                            </DropdownMenuItem>
-                                                        )}
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
+                                                <p className="text-sm font-medium">{alert.name}</p>
                                             </TableCell>
-                                        )}
-                                    </TableRow>
-                                ))}
+                                            <TableCell>
+                                                <span className="text-sm text-muted-foreground">
+                                                    {getAlertRuleLabel(alert.source, alert.type)}
+                                                </span>
+                                            </TableCell>
+                                            <TableCell>
+                                                <AlertCountersCell counters={alert.counters} />
+                                            </TableCell>
+                                            <TableCell>
+                                                <span className="text-sm text-muted-foreground">
+                                                    {formatLastAlertAt(alert.last_alert_at)}
+                                                </span>
+                                            </TableCell>
+                                            <TableCell>
+                                                <span className="text-sm text-muted-foreground line-clamp-1">
+                                                    {formatLastAlertMessage(alert.last_alert_message)}
+                                                </span>
+                                            </TableCell>
+                                            <TableCell>
+                                                <SeverityBadge severity={alert.severity} />
+                                            </TableCell>
+                                            <TableCell>
+                                                <Switch
+                                                    checked={alert.enabled}
+                                                    disabled={
+                                                        !canUpdate ||
+                                                        !!alert.template ||
+                                                        (toggleMutation.isPending && toggleMutation.variables?.id === alert.id)
+                                                    }
+                                                    onCheckedChange={() => toggleMutation.mutate(alert)}
+                                                />
+                                            </TableCell>
+                                            {showActions && (
+                                                <TableCell>
+                                                    {rowHasActions ? (
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger asChild>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    className="size-8"
+                                                                    aria-label={`Actions for ${alert.name}`}
+                                                                >
+                                                                    <MoreHorizontalIcon className="size-4" />
+                                                                </Button>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent align="end">
+                                                                {canEditAlert && (
+                                                                    <DropdownMenuItem onClick={() => handleEdit(alert.id!)}>
+                                                                        Edit
+                                                                    </DropdownMenuItem>
+                                                                )}
+                                                                {canEditAlert && canDeleteAlert && <DropdownMenuSeparator />}
+                                                                {canDeleteAlert && (
+                                                                    <DropdownMenuItem
+                                                                        className="text-destructive focus:text-destructive"
+                                                                        onClick={() => setAlertToDelete(alert)}
+                                                                    >
+                                                                        Delete alert
+                                                                    </DropdownMenuItem>
+                                                                )}
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    ) : null}
+                                                </TableCell>
+                                            )}
+                                        </TableRow>
+                                    );
+                                })}
                             </TableBody>
                         </Table>
                     </TooltipProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AlertsPage.tsx
@@ -38,12 +38,13 @@ import {
 } from '@gravitee/graphene-core';
 import { MoreHorizontalIcon, PlusIcon } from '@gravitee/graphene-core/icons';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AlertsEducationalEmptyState } from '../features/alerts/components/AlertsEducationalEmptyState';
 import { SeverityBadge } from '../features/alerts/components/SeverityBadge';
 import { getAlertRuleLabel } from '../features/alerts/constants/alertRules';
-import { listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
+import { deletePlatformAlert, listPlatformAlerts, updatePlatformAlert } from '../features/alerts/services/alerts';
 import type { AlertTrigger } from '../features/alerts/types/alert';
 import {
     formatAlertCounters,
@@ -57,6 +58,7 @@ import {
     ENVIRONMENT_ALERT_UPDATE_PERMISSION,
 } from '../features/alerts/utils/alertPermissions';
 import { platformAlertKeys } from '../features/alerts/utils/queryKeys';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { notify } from '../shared/notify';
 
 /** Classic `md-tooltip` on the counters cell: `N during the last 5 minutes / …`. */
@@ -79,12 +81,10 @@ function AlertCountersCell({ counters }: { counters: AlertTrigger['counters'] })
 }
 
 /**
- * Environment-level Alerts landing page (APIM-14911).
+ * Environment-level Alerts landing page (APIM-14911 / APIM-14912).
  *
  * Loads `/platform/alerts`, shows the educational empty state when none exist,
- * and otherwise lists alerts with enable/disable.
- * Edit / delete stay in the actions menu but disabled until follow-up tickets
- * (create/edit form + delete confirm modal).
+ * and otherwise lists alerts with enable/disable, edit, and delete.
  */
 export function AlertsPage() {
     const navigate = useNavigate();
@@ -96,6 +96,8 @@ export function AlertsPage() {
     const canUpdate = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_UPDATE_PERMISSION] });
     const canDelete = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_DELETE_PERMISSION] });
     const showActions = canUpdate || canDelete;
+
+    const [alertToDelete, setAlertToDelete] = useState<AlertTrigger | null>(null);
 
     const {
         data: alerts,
@@ -118,7 +120,20 @@ export function AlertsPage() {
         },
     });
 
+    const deleteMutation = useMutation({
+        mutationFn: (alert: AlertTrigger) => deletePlatformAlert(environmentId, alert.id!),
+        onSuccess: (_void, alert) => {
+            queryClient.invalidateQueries({ queryKey: platformAlertKeys.list(environmentId) });
+            notify.success(`Alert "${alert.name}" deleted.`);
+            setAlertToDelete(null);
+        },
+        onError: error => {
+            notify.error(error, 'Failed to delete alert.');
+        },
+    });
+
     const handleAdd = () => navigate('new');
+    const handleEdit = (alertId: string) => navigate(alertId);
 
     return (
         <div className="space-y-6">
@@ -221,10 +236,15 @@ export function AlertsPage() {
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent align="end">
-                                                        {canUpdate && <DropdownMenuItem disabled>Edit</DropdownMenuItem>}
+                                                        {canUpdate && alert.id && (
+                                                            <DropdownMenuItem onClick={() => handleEdit(alert.id!)}>Edit</DropdownMenuItem>
+                                                        )}
                                                         {canUpdate && canDelete && <DropdownMenuSeparator />}
                                                         {canDelete && (
-                                                            <DropdownMenuItem disabled className="text-destructive focus:text-destructive">
+                                                            <DropdownMenuItem
+                                                                className="text-destructive focus:text-destructive"
+                                                                onClick={() => setAlertToDelete(alert)}
+                                                            >
                                                                 Delete alert
                                                             </DropdownMenuItem>
                                                         )}
@@ -239,6 +259,24 @@ export function AlertsPage() {
                     </TooltipProvider>
                 </div>
             )}
+
+            {alertToDelete ? (
+                <ConfirmDialog
+                    open
+                    onOpenChange={open => !open && !deleteMutation.isPending && setAlertToDelete(null)}
+                    title="Delete alert"
+                    description={
+                        <>
+                            Are you sure you want to delete the alert <strong>{alertToDelete.name}</strong>?
+                        </>
+                    }
+                    confirmLabel="Delete"
+                    pendingLabel="Deleting…"
+                    destructive
+                    isPending={deleteMutation.isPending}
+                    onConfirm={() => deleteMutation.mutate(alertToDelete)}
+                />
+            ) : null}
         </div>
     );
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14912

## Description

Implements environment alerts CRUD in Gamma Platform Create/edit follows classic `/platform/alerts` and Gamma API alerts: **Alerts** + **Notifications** on create; **History** on edit.

**List (unlocks 14911 placeholders)**
- Edit navigates to `/alerts/:alertId`
- Delete uses a confirm dialog, then `DELETE /platform/alerts/{id}`
- Template alerts still cannot be toggled (same as classic)

**Form**
- Create: `POST /platform/alerts` with `reference_type: ENVIRONMENT`
- Edit: `PUT /platform/alerts/{id}`; after save, stay on the alert and switch back to the Alerts tab
- Env rules including Node (simple / rate / aggregation / missing-data)
- Timeframes: business days + office hours, sent as seconds since midnight
- Permissions: `environment-alert-c` / `environment-alert-u` / `environment-alert-d`

**Notifications**
- Channel from `GET /notifiers/` + JSON Schema from `GET /notifiers/{id}/schema`
- Saved as `{ type, configuration }` (classic platform shape, not the collapsed API-alert `{channel,target}` model)
- Save/Create stays disabled until required notifier fields are filled

**History (edit only)**
- Loads alert events for the selected trigger


## Additional context




https://github.com/user-attachments/assets/c6ff4f61-a2a9-4d6f-bcf2-53b44da0199a





---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[APIM-14912]: https://gravitee.atlassian.net/browse/APIM-14912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ