### PR TITLE
fix(gamma): add environment switching handling in `ShellLayout` and `RemoteModuleRoute` with updated navigation logic

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
@@ -18,18 +18,23 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { useEnvironmentStore } from './environment.store';
 import { EnvironmentGuard } from './EnvironmentGuard';
+import { EnvironmentRenderProbe } from '../../testing/EnvironmentRenderProbe';
 import { buildEnvironment, TEST_ENVIRONMENTS } from '../../testing/factories';
 import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
 import { PathnameProbe } from '../../testing/PathnameProbe';
 
 describe('EnvironmentGuard', () => {
     let lastPath = '';
+    const realSetCurrentEnvironment = useEnvironmentStore.getState().setCurrentEnvironment;
 
     beforeEach(() => {
         resetAllStores();
         seedBootstrap();
         lastPath = '';
     });
+
+    // `reset()` restores state, not actions, so a stubbed action would leak into the next test.
+    afterEach(() => useEnvironmentStore.setState({ setCurrentEnvironment: realSetCurrentEnvironment }));
 
     function renderGuard(initialPath: string) {
         return render(
@@ -123,6 +128,43 @@ describe('EnvironmentGuard', () => {
         await waitFor(() => {
             expect(lastPath).toBe('/environments/env-1/home');
         });
+    });
+
+    it('should never render children while the URL environment and the store disagree', async () => {
+        seedEnvironments();
+        const seen: string[] = [];
+
+        render(
+            <MemoryRouter initialEntries={['/environments/env-2/home']}>
+                <Routes>
+                    <Route path="/environments/:envHrid" element={<EnvironmentGuard />}>
+                        <Route
+                            path="home"
+                            element={
+                                <EnvironmentRenderProbe onRender={(_, environmentId) => seen.push(environmentId)}>
+                                    <div>Child</div>
+                                </EnvironmentRenderProbe>
+                            }
+                        />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => expect(screen.getByText('Child')).toBeTruthy());
+        expect(seen).not.toHaveLength(0);
+        expect(seen.filter(id => id !== 'env-2-id')).toEqual([]);
+    });
+
+    it('should show the loading skeleton, not a blank area, while the store has not caught up', () => {
+        seedEnvironments();
+        // Freezes the pending state the browser paints before the sync effect heals it.
+        useEnvironmentStore.setState({ setCurrentEnvironment: () => undefined });
+
+        renderGuard('/environments/env-2/home');
+
+        expect(screen.getByLabelText('Loading content')).toBeTruthy();
+        expect(screen.queryByText('Child')).toBeNull();
     });
 
     it('should render nothing when environments list is empty', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.tsx
@@ -19,6 +19,7 @@ import { type NavigateFunction, Outlet, useLocation, useNavigate } from 'react-r
 import { useEnvironmentStore } from './environment.store';
 import type { Environment } from './environment.types';
 import { getPrimaryHrid, resolveEnvironmentFromSegment, shouldRewriteIdToHrid, useEnvHrid } from './environment.utils';
+import { ContentSkeleton } from '../../shared/components/ContentSkeleton';
 
 function redirectToFirst(env: Environment, navigate: NavigateFunction, search: string, hash: string) {
     navigate({ pathname: `/environments/${getPrimaryHrid(env)}/home`, search, hash }, { replace: true });
@@ -42,6 +43,7 @@ export function EnvironmentGuard() {
     locationRef.current = location;
 
     const environments = useEnvironmentStore(s => s.environments);
+    const environmentId = useEnvironmentStore(s => s.environmentId);
     const setCurrentEnvironment = useEnvironmentStore(s => s.setCurrentEnvironment);
     const lastSyncedId = useRef<string | null>(null);
 
@@ -72,6 +74,10 @@ export function EnvironmentGuard() {
 
     if (!environments.length) {
         return null;
+    }
+
+    if (resolveEnvironmentFromSegment(environments, envHrid)?.id !== environmentId) {
+        return <ContentSkeleton />;
     }
 
     return <Outlet />;

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/components/RemoteModuleRoute.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/components/RemoteModuleRoute.spec.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { RemoteModuleRoute } from './RemoteModuleRoute';
+import { EnvironmentGuard } from '../../../features/environment';
+import { resetAllStores, seedEnvironments } from '../../../testing/helpers';
+import type { GammaModule } from '../modules.types';
+
+const mockMounts = { count: 0 };
+
+function MockRemoteModule() {
+    useEffect(() => {
+        mockMounts.count += 1;
+    }, []);
+    return <div>Remote module</div>;
+}
+
+const mockRemoteExport = { default: MockRemoteModule };
+
+jest.mock('@module-federation/runtime', () => ({
+    loadRemote: jest.fn(() => Promise.resolve(mockRemoteExport)),
+}));
+
+const MODULE: GammaModule = {
+    id: 'apim',
+    name: 'API Management',
+    version: '1.0.0',
+    remoteName: 'apim',
+    exposedModule: 'Module',
+};
+
+describe('RemoteModuleRoute', () => {
+    beforeEach(() => {
+        resetAllStores();
+        mockMounts.count = 0;
+    });
+
+    /** Resolves the lazy remote; only the first mount is genuinely asynchronous. */
+    async function renderMounted() {
+        const result = render(<RemoteModuleRoute module={MODULE} />);
+        await waitFor(() => expect(mockMounts.count).toBe(1));
+        return result;
+    }
+
+    /** Mirrors AppRoutes: the module is only ever reached through EnvironmentGuard. */
+    async function renderUnderGuard() {
+        const router = createMemoryRouter(
+            [
+                {
+                    path: '/environments/:envHrid',
+                    element: <EnvironmentGuard />,
+                    children: [{ path: 'apim/*', element: <RemoteModuleRoute module={MODULE} /> }],
+                },
+            ],
+            { initialEntries: ['/environments/env-1/apim'] },
+        );
+        render(<RouterProvider router={router} />);
+        await waitFor(() => expect(mockMounts.count).toBe(1));
+        return router;
+    }
+
+    it('should remount the remote module when the environment changes in the real route tree', async () => {
+        seedEnvironments();
+        const router = await renderUnderGuard();
+
+        await act(async () => {
+            await router.navigate('/environments/env-2/apim');
+        });
+
+        await waitFor(() => expect(mockMounts.count).toBe(2));
+    });
+
+    it('should not remount on a re-render that leaves the environment unchanged', async () => {
+        seedEnvironments();
+        const { rerender } = await renderMounted();
+
+        await act(async () => {
+            rerender(<RemoteModuleRoute module={MODULE} />);
+        });
+
+        expect(mockMounts.count).toBe(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/components/RemoteModuleRoute.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/components/RemoteModuleRoute.tsx
@@ -16,6 +16,7 @@
 import { loadRemote } from '@module-federation/runtime';
 import { lazy, type LazyExoticComponent, type ComponentType } from 'react';
 
+import { useEnvironmentStore } from '../../environment/environment.store';
 import type { GammaModule } from '../modules.types';
 
 const lazyComponentCache = new Map<string, LazyExoticComponent<ComponentType>>();
@@ -34,7 +35,21 @@ export function getOrCreateLazyModule(remoteName: string, exposedModule: string)
     return cached;
 }
 
+/**
+ * Mounts a federated module, keyed by environment so that switching environments remounts it.
+ *
+ * Everything a module holds below the SDK -- component state, stores, caches -- is scoped to the
+ * environment it was loaded for. Remounting drops it without asking module authors for teardown
+ * logic, which matters because modules ship from their own repositories. The technical id is the
+ * key rather than the URL segment, so canonicalizing an id to its hrid does not remount.
+ * The lazy component itself is cached, so this re-renders the remote without re-fetching it.
+ *
+ * EnvironmentGuard only renders this once the store environment matches the URL, so the key is
+ * always the environment the URL addresses.
+ */
 export function RemoteModuleRoute({ module }: { readonly module: GammaModule }) {
+    const environmentId = useEnvironmentStore(s => s.environmentId);
     const LazyModule = getOrCreateLazyModule(module.remoteName, module.exposedModule);
-    return <LazyModule />;
+
+    return <LazyModule key={environmentId} />;
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.spec.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useNavigate, type NavigateFunction } from 'react-router-dom';
+
+import { ShellLayout } from './ShellLayout';
+import { EnvironmentGuard } from '../../features/environment';
+import { useEnvironmentStore } from '../../features/environment/environment.store';
+import type { GammaModule } from '../../features/modules';
+import { EnvironmentRenderProbe } from '../../testing/EnvironmentRenderProbe';
+import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
+
+const MODULES: GammaModule[] = [{ id: 'apim', name: 'API Management', version: '1.0.0', remoteName: 'apim', exposedModule: 'Module' }];
+
+function NavigateHandle({ onReady }: { readonly onReady: (navigate: NavigateFunction) => void }) {
+    onReady(useNavigate());
+    return null;
+}
+
+describe('ShellLayout environment switching', () => {
+    let renders: Array<{ pathname: string; environmentId: string }> = [];
+    let navigate: NavigateFunction;
+
+    beforeEach(() => {
+        resetAllStores();
+        seedBootstrap();
+        seedEnvironments();
+        renders = [];
+    });
+
+    /** Mirrors AppRoutes: the guard sits between the shell and the module area. */
+    function renderShell(initialPath: string) {
+        return render(
+            <MemoryRouter initialEntries={[initialPath]}>
+                <NavigateHandle onReady={n => (navigate = n)} />
+                <Routes>
+                    <Route path="/environments/:envHrid" element={<ShellLayout modules={MODULES} />}>
+                        <Route element={<EnvironmentGuard />}>
+                            <Route
+                                path="*"
+                                element={
+                                    <EnvironmentRenderProbe
+                                        onRender={(pathname, environmentId) => renders.push({ pathname, environmentId })}
+                                    />
+                                }
+                            />
+                        </Route>
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+    }
+
+    function mismatchedRenders() {
+        return renders.filter(r => {
+            const hrid = /^\/environments\/([^/]+)/.exec(r.pathname)?.[1];
+            return hrid === 'env-1' ? r.environmentId !== 'env-1-id' : hrid === 'env-2' && r.environmentId !== 'env-2-id';
+        });
+    }
+
+    async function switchToEnvironment2() {
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: /Switch environment/ }));
+        await user.click(await screen.findByText('Environment 2'));
+    }
+
+    it('should land on the module root when switching from a deep module page', async () => {
+        renderShell('/environments/env-1/apim/apis/api-1/endpoints');
+
+        await switchToEnvironment2();
+
+        await waitFor(() => expect(renders.at(-1)?.pathname).toBe('/environments/env-2/apim'));
+    });
+
+    it('should land on the host area root when switching from a deep host page', async () => {
+        renderShell('/environments/env-1/tasks/task-1');
+
+        await switchToEnvironment2();
+
+        await waitFor(() => expect(renders.at(-1)?.pathname).toBe('/environments/env-2/tasks'));
+    });
+
+    it('should never render the new environment path while the store still holds the previous environment', async () => {
+        renderShell('/environments/env-1/apim/apis/api-1/endpoints');
+
+        await switchToEnvironment2();
+
+        await waitFor(() => expect(renders.at(-1)?.pathname).toBe('/environments/env-2/apim'));
+        expect(mismatchedRenders()).toEqual([]);
+    });
+
+    it('should never pair a restored environment path with the environment left behind, on back navigation', async () => {
+        renderShell('/environments/env-1/apim/apis/api-1/endpoints');
+        await switchToEnvironment2();
+        await waitFor(() => expect(renders.at(-1)?.pathname).toBe('/environments/env-2/apim'));
+
+        await act(async () => {
+            navigate(-1);
+        });
+
+        await waitFor(() => expect(useEnvironmentStore.getState().environmentId).toBe('env-1-id'));
+        expect(mismatchedRenders()).toEqual([]);
+    });
+
+    it('should never pair a deep-linked environment path with the environment seeded at startup', async () => {
+        renderShell('/environments/env-2/apim/apis/api-1/endpoints');
+
+        await waitFor(() => expect(useEnvironmentStore.getState().environmentId).toBe('env-2-id'));
+        expect(mismatchedRenders()).toEqual([]);
+    });
+
+    it('should update the environment store when switching', async () => {
+        renderShell('/environments/env-1/apim/apis/api-1/endpoints');
+
+        await switchToEnvironment2();
+
+        await waitFor(() => expect(useEnvironmentStore.getState().currentEnvironment?.id).toBe('env-2-id'));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
@@ -92,8 +92,7 @@ function ShellLayoutInner({ modules }: { readonly modules: readonly GammaModule[
     const logout = useLogout();
     const navigate = useNavigate();
     const envHrid = useEnvHrid();
-    const location = useLocation();
-    const pathname = location.pathname;
+    const { pathname } = useLocation();
     const { slots } = useLayoutSlots();
 
     const environments = useEnvironmentStore(s => s.environments);
@@ -117,12 +116,13 @@ function ShellLayoutInner({ modules }: { readonly modules: readonly GammaModule[
         [envHrid, navigate],
     );
 
+    // `search` and `hash` are dropped along with the sub-path -- they carry filters and tabs that
+    // are just as environment-scoped. EnvironmentGuard owns adopting the new environment.
     const handleEnvironmentChange = useCallback(
         (newEnvHrid: string) => {
-            const newPathname = buildPathnameAfterEnvironmentChange(pathname, envHrid, newEnvHrid);
-            navigate({ pathname: newPathname, search: location.search, hash: location.hash });
+            navigate({ pathname: buildPathnameAfterEnvironmentChange(pathname, envHrid, newEnvHrid) });
         },
-        [envHrid, location.hash, location.search, navigate, pathname],
+        [envHrid, navigate, pathname],
     );
 
     const handleSignOut = useCallback(() => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.spec.ts
@@ -46,17 +46,35 @@ describe('pathSegmentsAfterEnvironment', () => {
 });
 
 describe('buildPathnameAfterEnvironmentChange', () => {
-    it('should keep path after the environment when switching to another', () => {
+    it('should drop the module sub-path and land on the module root', () => {
         expect(buildPathnameAfterEnvironmentChange('/environments/env-1/some-module/apis/list', 'env-1', 'env-2')).toBe(
-            '/environments/env-2/some-module/apis/list',
+            '/environments/env-2/some-module',
         );
+    });
+
+    it('should keep the module root for any module id, including unknown ones', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/env-1/aim/catalog/models/m-1', 'env-1', 'env-2')).toBe(
+            '/environments/env-2/aim',
+        );
+    });
+
+    it('should drop the sub-path of host areas too', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/a/tasks/task-1', 'a', 'b')).toBe('/environments/b/tasks');
     });
 
     it('should use home when the URL is only the environment base', () => {
         expect(buildPathnameAfterEnvironmentChange('/environments/env-1', 'env-1', 'env-2')).toBe('/environments/env-2/home');
     });
 
+    it('should use home when the pathname is not under the current environment', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/other/apim/apis', 'env-1', 'env-2')).toBe('/environments/env-2/home');
+    });
+
     it('should keep host home when switching', () => {
         expect(buildPathnameAfterEnvironmentChange('/environments/a/home', 'a', 'b')).toBe('/environments/b/home');
+    });
+
+    it('should keep the module root when already on it', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/a/apim', 'a', 'b')).toBe('/environments/b/apim');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.ts
@@ -71,14 +71,17 @@ export function pathSegmentsAfterEnvironment(pathname: string, envHrid: string):
 }
 
 /**
- * New pathname when changing the environment segment while keeping the same page
- * (host area, module path, or nested route). If there is no path under the current
- * environment, returns /environments/{new}/home.
+ * New pathname when changing the environment segment. Only the first segment after the
+ * environment is kept -- the module id, or a host area such as `home`/`tasks`.
+ *
+ * Modules are registered per organization, so every environment exposes the same ones and that
+ * root always resolves. Everything below it addresses environment-scoped data (an api id, a task
+ * id), which carries no meaning in the target environment. Falls back to home when the pathname
+ * holds no such segment.
  */
 export function buildPathnameAfterEnvironmentChange(pathname: string, currentEnvHrid: string, newEnvHrid: string): string {
-    const rest = pathSegmentsAfterEnvironment(pathname, currentEnvHrid);
-    const base = `/environments/${newEnvHrid}`;
-    return rest.length > 0 ? `${base}/${rest.join('/')}` : `${base}/home`;
+    const [root] = pathSegmentsAfterEnvironment(pathname, currentEnvHrid);
+    return `/environments/${newEnvHrid}/${root ?? HOME_NAV_KEY}`;
 }
 
 function extractSubPath(pathname: string, envHrid: string): string | null {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/test-setup.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/test-setup.ts
@@ -18,6 +18,19 @@ import { act } from '@testing-library/react';
 import { resetAllStores, seedBootstrap } from './testing/helpers';
 import { server } from './testing/server';
 
+// jsdom ships no matchMedia; graphene's AppLayout needs it to resolve the "system" theme.
+window.matchMedia ??= (query: string): MediaQueryList =>
+    ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+    }) as MediaQueryList;
+
 beforeAll(() => {
     server.listen({ onUnhandledRequest: 'error' });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/EnvironmentRenderProbe.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/EnvironmentRenderProbe.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { useEnvironmentStore } from '../features/environment/environment.store';
+
+/**
+ * Records the (pathname, store environment) pair on *every* render, for tests asserting that the
+ * two never disagree where children can observe them.
+ *
+ * Deliberately not built on {@link PathnameProbe}: that one reports from an effect keyed on the
+ * pathname, so a render whose pathname is unchanged never reaches it. The renders this probe exists
+ * to catch are exactly those, a mismatched pair immediately corrected under the same pathname, so
+ * recording has to happen during render.
+ */
+export function EnvironmentRenderProbe({
+    onRender,
+    children,
+}: {
+    readonly onRender: (pathname: string, environmentId: string) => void;
+    readonly children?: ReactNode;
+}) {
+    const { pathname } = useLocation();
+    const environmentId = useEnvironmentStore(s => s.environmentId);
+
+    onRender(pathname, environmentId);
+
+    return <>{children}</>;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-162

## Problem

Switching environment kept the whole path. From an API detail page, `/environments/env-1/apim/apis/{apiId}` became `/environments/env-2/apim/apis/{apiId}`, with an `apiId` that does not exist in `env-2`.

The Gateway Endpoint repainted immediately (it is keyed on the environment id), then the API detail query refetched and 404'd. Two symptoms, one cause.

## Changes

All host side. No module repository is touched, and graphene is unchanged.

* `shared/config/routes.ts`: on environment change, keep only the first segment after the environment (the module id, or a host area such as `home`/`tasks`). Modules are registered per organization, so every environment exposes the same ones and that root always resolves. This is what makes the fix generic across `apim`, `aim`, `authz`,
  `edge`, `esm`, and any module added later, without those repos participating.
* `features/environment/EnvironmentGuard.tsx`: withhold children until the environment in the URL and the one in the store agree. Children resolve ids from the URL but fetch with the store's environment, so any render where the two disagree issues a request for an entity of one environment against another. The store is synced from a passive effect, so the browser paints that state before it heals, and back/forward plus deep links reach it the same way. While withholding, the guard renders the same `ContentSkeleton` the shell uses as its Suspense fallback for that area, rather than blanking it.
* `features/modules/components/RemoteModuleRoute.tsx`: key the lazy remote on the environment's technical id so the federated subtree remounts, dropping any environment scoped state a module holds. The technical id rather than the URL segment, so canonicalizing an id to its hrid does not remount. The bundle stays cached, so this
  re-renders the remote without re-fetching it.
* `shared/components/ShellLayout.tsx`: the environment selector now only navigates. `EnvironmentGuard` owns adopting the new environment.

## Behaviour change

`/environments/{a}/apim/apis/{apiId}/endpoints` now goes to `/environments/{b}/apim`, not the equivalent deep path. Query string and hash are dropped with the sub-path. In apim nothing is lost by that: query params are only used there as transient deep links into a form on API detail pages (`?editGroup`/`?step`, which the page clears once consumed, and `?tab` on the alert form), all of them under the sub-path being discarded anyway. Back
still returns to the source environment's page.

`EnvironmentGuard`'s id to hrid canonicalization and its unknown-environment redirect are left alone: both rewrite the URL at constant environment, and both still preserve query string and hash.

## Why the module root, and not one level up

Considered: from an API detail page, land on the API list rather than the module home.
Rejected for now, because it cannot be done correctly from the host alone.

The host only sees opaque segments. Keeping "module id plus one segment" works for flat sections but breaks on nested ones: `/aim/catalog/models/{id}` would give `/aim/catalog`, which is neither the intended target (`/aim/catalog/models` is) nor a page at all, that route being a permission guard with no index.

Detecting the id by UUID shape works today but dies with the planned move to hrids everywhere: nothing would match, and every switch would fall back to the module root anyway.

Doing it properly means modules declaring their route paths to the host through the SDK. That is format agnostic, so it survives the hrid migration, but it is a cross-repo contract. The truncation in this PR is its correct fallback for any module that has not adopted it, so this work is not thrown away.

## Out of scope

`permission-sync` clears environment permissions and reloads them asynchronously, so a module can still render briefly without them. The remount makes this less visible but does not close it.

Before:

https://github.com/user-attachments/assets/a68fc0ab-e635-46e5-8d87-9f5c578ebd21

After:

https://github.com/user-attachments/assets/d0ac5555-d22e-4f7c-8231-19f1f91b4f01




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

