### PR TITLE
feat(observability): filter authz decisions by subject, action, resource and caller

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/authz/AuthzDecisionLogQuery.java
@@ -33,6 +33,10 @@ public class AuthzDecisionLogQuery {
     private Long from;
     private Long to;
     private Set<String> decisions;
+    private Set<String> subjectIds;
+    private Set<String> actions;
+    private Set<String> resourceIds;
+    private Set<String> callers;
 
     @Builder.Default
     private int size = 20;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapter.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.repository.log.v4.model.authz.AuthzDecisionLogQuery;
+import java.util.Set;
 
 /**
  * @author GraviteeSource Team
@@ -48,6 +49,16 @@ public final class SearchAuthzDecisionLogsQueryAdapter {
 
     private SearchAuthzDecisionLogsQueryAdapter() {}
 
+    /** Omitted entirely when nothing is selected: an empty terms clause matches no document. */
+    private static void addTermsIfAny(ArrayNode filters, String field, Set<String> values) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        ArrayNode node = MAPPER.createArrayNode();
+        values.forEach(node::add);
+        filters.add(MAPPER.createObjectNode().set(TERMS, MAPPER.createObjectNode().set(field, node)));
+    }
+
     public static String adapt(AuthzDecisionLogQuery query) {
         ArrayNode filters = MAPPER.createArrayNode();
         // The event-metrics data stream is shared by every BaseEventMetrics subtype (api, application,
@@ -58,11 +69,12 @@ public final class SearchAuthzDecisionLogsQueryAdapter {
         query.getApiIds().forEach(apiIds::add);
         filters.add(MAPPER.createObjectNode().set(TERMS, MAPPER.createObjectNode().set(AuthzDecisionLogFields.API_ID, apiIds)));
 
-        if (query.getDecisions() != null && !query.getDecisions().isEmpty()) {
-            ArrayNode decisions = MAPPER.createArrayNode();
-            query.getDecisions().forEach(decisions::add);
-            filters.add(MAPPER.createObjectNode().set(TERMS, MAPPER.createObjectNode().set(AuthzDecisionLogFields.DECISION, decisions)));
-        }
+        // Every one of these is a keyword field, so an exact terms clause is the whole translation.
+        addTermsIfAny(filters, AuthzDecisionLogFields.DECISION, query.getDecisions());
+        addTermsIfAny(filters, AuthzDecisionLogFields.SUBJECT_ID, query.getSubjectIds());
+        addTermsIfAny(filters, AuthzDecisionLogFields.ACTION, query.getActions());
+        addTermsIfAny(filters, AuthzDecisionLogFields.RESOURCE_ID, query.getResourceIds());
+        addTermsIfAny(filters, AuthzDecisionLogFields.CALLER, query.getCallers());
 
         if (query.getFrom() != null || query.getTo() != null) {
             ObjectNode bounds = MAPPER.createObjectNode();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/authz/SearchAuthzDecisionLogsQueryAdapterTest.java
@@ -124,6 +124,52 @@ class SearchAuthzDecisionLogsQueryAdapterTest {
     }
 
     @Test
+    void narrows_on_subject_action_resource_and_caller() {
+        var query = AuthzDecisionLogQuery.builder()
+            .apiIds(Set.of("api-1"))
+            .subjectIds(Set.of("alice"))
+            .actions(Set.of("read"))
+            .resourceIds(Set.of("doc-1"))
+            .callers(Set.of("pep", "authzen"))
+            .build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        assertThatJson(result)
+            .inPath("$.query.bool.filter[2].terms.subject-id")
+            .isEqualTo(
+                """
+                [ "alice" ]
+                """
+            );
+        assertThatJson(result)
+            .inPath("$.query.bool.filter[3].terms.action")
+            .isEqualTo(
+                """
+                [ "read" ]
+                """
+            );
+        assertThatJson(result)
+            .inPath("$.query.bool.filter[4].terms.resource-id")
+            .isEqualTo(
+                """
+                [ "doc-1" ]
+                """
+            );
+        assertThatJson(result).inPath("$.query.bool.filter[5].terms.caller").isArray().hasSize(2);
+    }
+
+    @Test
+    void omits_every_optional_clause_when_none_is_requested() {
+        var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).build();
+
+        var result = SearchAuthzDecisionLogsQueryAdapter.adapt(query);
+
+        // doc-type + api-id only: an empty terms clause would match nothing and silently empty the table.
+        assertThatJson(result).inPath("$.query.bool.filter").isArray().hasSize(2);
+    }
+
+    @Test
     void omits_the_decision_clause_when_none_is_requested() {
         var query = AuthzDecisionLogQuery.builder().apiIds(Set.of("api-1")).build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/AuthzDecisionLogFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/AuthzDecisionLogFilters.java
@@ -24,4 +24,13 @@ import lombok.Builder;
  * signature again.
  */
 @Builder
-public record AuthzDecisionLogFilters(Set<String> apiIds, Long from, Long to, Set<String> decisions) {}
+public record AuthzDecisionLogFilters(
+    Set<String> apiIds,
+    Long from,
+    Long to,
+    Set<String> decisions,
+    Set<String> subjectIds,
+    Set<String> actions,
+    Set<String> resourceIds,
+    Set<String> callers
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/AuthzDecisionLogsCrudServiceImpl.java
@@ -28,7 +28,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -64,6 +63,10 @@ class AuthzDecisionLogsCrudServiceImpl implements AuthzDecisionLogsCrudService {
                     .from(filters.from())
                     .to(filters.to())
                     .decisions(filters.decisions())
+                    .subjectIds(filters.subjectIds())
+                    .actions(filters.actions())
+                    .resourceIds(filters.resourceIds())
+                    .callers(filters.callers())
                     .page(pageable.getPageNumber())
                     .size(pageable.getPageSize())
                     .build()

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -116,6 +116,13 @@ public enum StaticFilters {
 
     // --- Authz decisions ------------------------------------------------------------------------
     DECISION("Decision", FilterType.ENUM, Defs.EQ_IN, Defs.DECISIONS, null, Defs.LOGS, Defs.DECISION_RECORDS),
+    // STRING, not KEYWORD: these are open sets (any principal, any resource a policy names), so there
+    // is nothing to suggest from and the picker would offer an empty dropdown. The indexed fields are
+    // keyword, so exact match is the honest operator; CONTAINS would need a wildcard query.
+    SUBJECT("Subject", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.LOGS, Defs.DECISION_RECORDS),
+    ACTION("Action", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.LOGS, Defs.DECISION_RECORDS),
+    RESOURCE("Resource", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.LOGS, Defs.DECISION_RECORDS),
+    CALLER_KIND("Caller kind", FilterType.ENUM, Defs.EQ_IN, Defs.AUTHZ_CALLERS, null, Defs.LOGS, Defs.DECISION_RECORDS),
 
     // --- LLM ------------------------------------------------------------------------------------
     LLM_PROXY_MODEL("LLM Model", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Set.of(ApiType.LLM)),
@@ -311,6 +318,18 @@ public enum StaticFilters {
             new EnumValue("CONNECTION_ERROR", "Connection error"),
             new EnumValue("SESSION_ERROR", "Session error"),
             new EnumValue("INTERNAL_ERROR", "Internal error")
+        );
+
+        /**
+         * What produced the decision, as the reporter writes it (lowercase wire values). {@code reactor}
+         * is deliberately absent: it was renamed to {@code gateway} in gravitee-reporter-api 2.7.1, so
+         * only pre-2.7.1 documents carry it and nothing emits it today.
+         */
+        private static final List<EnumValue> AUTHZ_CALLERS = List.of(
+            new EnumValue("pep", "PEP policy"),
+            new EnumValue("gateway", "Gateway"),
+            new EnumValue("authzen", "AuthZEN endpoint"),
+            new EnumValue("unknown", "Unknown")
         );
 
         private static final List<EnumValue> DECISIONS = List.of(

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -181,7 +181,13 @@ public class SearchObservabilityLogsUseCase {
     }
 
     /** Predicates the decision search can express, on top of the api scope and the time range. */
-    private static final Set<String> DECISION_SUPPORTED_FILTERS = Set.of(StaticFilters.DECISION.filterName());
+    private static final Set<String> DECISION_SUPPORTED_FILTERS = Set.of(
+        StaticFilters.DECISION.filterName(),
+        StaticFilters.SUBJECT.filterName(),
+        StaticFilters.ACTION.filterName(),
+        StaticFilters.RESOURCE.filterName(),
+        StaticFilters.CALLER_KIND.filterName()
+    );
 
     /**
      * Anything the decision search cannot express would be accepted and then dropped —
@@ -199,7 +205,7 @@ public class SearchObservabilityLogsUseCase {
             throw new ValidationDomainException(
                 "Filters " +
                     unsupported +
-                    " do not apply to RECORD_TYPE=AUTHZ_DECISION. Supported: API, API_TYPE, DECISION and the time range."
+                    " do not apply to RECORD_TYPE=AUTHZ_DECISION. Supported: API, API_TYPE, DECISION, SUBJECT, ACTION, RESOURCE, CALLER_KIND and the time range."
             );
         }
     }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -423,6 +423,10 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             .from(query.from())
             .to(query.to())
             .decisions(valuesOf(query.conditions(), StaticFilters.DECISION.filterName()))
+            .subjectIds(valuesOf(query.conditions(), StaticFilters.SUBJECT.filterName()))
+            .actions(valuesOf(query.conditions(), StaticFilters.ACTION.filterName()))
+            .resourceIds(valuesOf(query.conditions(), StaticFilters.RESOURCE.filterName()))
+            .callers(valuesOf(query.conditions(), StaticFilters.CALLER_KIND.filterName()))
             .build();
         var result = authzDecisionLogsCrudService.searchDecisionLogs(executionContext, filters, pageable);
         var entries = result

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
@@ -98,7 +98,7 @@ class SpiFilterRegistryTest {
 
         assertThat(result)
             .extracting(FilterSpec::name)
-            .containsExactlyInAnyOrder("API", "DECISION")
+            .containsExactlyInAnyOrder("API", "DECISION", "SUBJECT", "ACTION", "RESOURCE", "CALLER_KIND")
             .doesNotContain("API_TYPE", "RECORD_TYPE", "ENTRYPOINT", "REQUEST_ID", "HTTP_STATUS", "PAYLOAD");
     }
 


### PR DESCRIPTION
## What

The decisions view shipped with one decision-specific filter, the outcome. Four more:

| Filter | Type | Operators | ES field |
|---|---|---|---|
| Subject | string | `=` | `subject-id` |
| Action | string | `=` | `action` |
| Resource | string | `=` | `resource-id` |
| Caller kind | enum | `=`, `in` | `caller` |

All four are keyword fields the decision documents already carry, so each one translates to a
single exact `terms` clause. No new data, no mapping change.

## Why the caller enum has four values and not five

The values come from the PDP contract, not from sampling the data. `normalizeCaller` in
`AuthzDecisionMetricsFactory` checks the incoming caller against `KNOWN_CALLERS`
(`pep`, `gateway`, `authzen`) and maps everything else to `unknown`, so those four are the
complete set a document can carry.

Worth recording because the live data disagrees: a dev environment here holds documents with
`caller: reactor`. All of them predate the normalization (they are from one day, and `reactor`
never appears in that file's history), so they are the output of an older producer. Advertising a
fifth value the current contract cannot emit would be wrong, so the enum stays at four.

## Empty selection omits the clause

```java
/** Omitted entirely when nothing is selected: an empty terms clause matches no document. */
private static void addTermsIfAny(ArrayNode filters, String field, Set<String> values) { … }
```

Emitting `terms: {field: []}` matches nothing, so a filter the user cleared would silently empty
the table rather than widen it.

## Live verification

Driven through the console UI, not curl. Each result checked against an independently computed
Elasticsearch aggregation over the same index, scoped to the environment's api set:

| Filter | UI | Expected |
|---|---|---|
| unfiltered | 36 | 36 |
| Caller kind = PEP policy | 6 | 6 |
| Action = write | 1 | 1 |
| Resource = doc1 | 24 | 24 |
| Subject = alice | 29 | 29 |
| Resource = doc2 | 0 | 0 |

The last row is the interesting one. `doc2` has three documents in the index, and zero is still
correct: all three sit on an api outside this environment, and the query is api-scoped. The
counts confirm it, one api holds 20 documents and the remaining five sum to exactly the 36 the
table shows.

## Tests

`SearchAuthzDecisionLogsQueryAdapterTest` 11 → 13, covering that a selection produces its terms
clause and that an empty one produces no clause at all. `ObservabilityLogsDataPortAdapterTest`,
`SearchObservabilityLogsUseCaseTest` and the `SpiFilterRegistry` tripwire updated for the new
filter names. Full targeted run green on JDK 25 against current master.

## Housekeeping

Drops an unused `java.util.Set` import in `AuthzDecisionLogsCrudServiceImpl`, raised in review on
#19044 after that PR had already merged.
