### PR TITLE
chore(release): gather changelog tickets from every product board

### DIFF
--- a/.circleci/ci/src/jobs/job-release-notes-apim.ts
+++ b/.circleci/ci/src/jobs/job-release-notes-apim.ts
@@ -67,6 +67,11 @@ git config --global user.email "\${GIT_USER_EMAIL}"`,
         working_directory: './release',
       }),
       new commands.Run({
+        name: 'Run unit tests',
+        command: 'yarn test',
+        working_directory: './release',
+      }),
+      new commands.Run({
         name: 'Open a PR to create release notes into docs repository',
         command: `yarn zx --quiet ci-steps/generate-changelog.mjs --version=${environment.graviteeioVersion}`,
         working_directory: './release',

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -786,6 +786,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0-alpha.1
           working_directory: ./release

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -838,6 +838,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0
           working_directory: ./release

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -832,6 +832,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0
           working_directory: ./release

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -832,6 +832,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0
           working_directory: ./release

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-dry-run.yml
@@ -69,6 +69,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.1.0
           working_directory: ./release

--- a/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-notes-apim/release-notes-apim-no-dry-run.yml
@@ -69,6 +69,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.1.0
           working_directory: ./release

--- a/release/ci-steps/generate-changelog.mjs
+++ b/release/ci-steps/generate-changelog.mjs
@@ -1,7 +1,7 @@
 import { syncProcessCwd } from 'zx';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { getJiraIssuesOfVersion, getJiraVersion } from '../helpers/jira-helper.mjs';
-import { ChangelogSections, ComponentTypes, getTicketsFor } from '../helpers/changelog-helper.mjs';
+import { getJiraIssuesOfVersions, getJiraVersions } from '../helpers/jira-helper.mjs';
+import { ChangelogSections, ComponentTypes, getTicketsFor, getTicketsForProduct, productKeysOf } from '../helpers/changelog-helper.mjs';
 
 syncProcessCwd(); // restores legacy v7 behavior
 
@@ -29,16 +29,20 @@ echo(chalk.blue(`# Clone ${docRepository} repository`));
 await $`git clone --depth 1  ${docRepositoryURL} --single-branch --branch=main`;
 cd(docRepository);
 
-const version = await getJiraVersion(releasingVersion);
-if (version === undefined) {
-  echo(chalk.blue(`No Jira release found for: ${releasingVersion}, nothing to do.`));
+const jiraProjectKeys = await getJiraVersions(releasingVersion);
+if (jiraProjectKeys.length === 0) {
+  echo(chalk.blue(`No Jira release found for: ${releasingVersion} in any project, nothing to do.`));
   process.exit(0);
 }
-const issues = await getJiraIssuesOfVersion(version.id);
+echo(chalk.blue(`# Jira projects releasing ${releasingVersion}: ${jiraProjectKeys.join(', ')}`));
+
+const issues = await getJiraIssuesOfVersions(jiraProjectKeys, releasingVersion);
 
 let changelogPatchTemplate = `
 ## Gravitee API Management ${releasingVersion} - ${new Date().toLocaleDateString('en-US', dateOptions)}
 `;
+
+const productKeys = productKeysOf(issues);
 
 ChangelogSections.forEach((section) => {
   let changelogSection = '';
@@ -46,6 +50,12 @@ ChangelogSections.forEach((section) => {
     const ticketsForComponent = getTicketsFor(issues, componentType, section.ticketType);
     if (ticketsForComponent) {
       changelogSection += ticketsForComponent;
+    }
+  });
+  productKeys.forEach((projectKey) => {
+    const ticketsForProduct = getTicketsForProduct(issues, projectKey, section.ticketType);
+    if (ticketsForProduct) {
+      changelogSection += ticketsForProduct;
     }
   });
   if (changelogSection) {

--- a/release/ci-steps/generate-changelog.mjs
+++ b/release/ci-steps/generate-changelog.mjs
@@ -1,7 +1,7 @@
 import { syncProcessCwd } from 'zx';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
 import { getJiraIssuesOfVersions, getJiraVersions } from '../helpers/jira-helper.mjs';
-import { ChangelogSections, ComponentTypes, getTicketsFor, getTicketsForProduct, productKeysOf } from '../helpers/changelog-helper.mjs';
+import { ChangelogSections, getTicketSections } from '../helpers/changelog-helper.mjs';
 
 syncProcessCwd(); // restores legacy v7 behavior
 
@@ -42,22 +42,8 @@ let changelogPatchTemplate = `
 ## Gravitee API Management ${releasingVersion} - ${new Date().toLocaleDateString('en-US', dateOptions)}
 `;
 
-const productKeys = productKeysOf(issues);
-
 ChangelogSections.forEach((section) => {
-  let changelogSection = '';
-  [...ComponentTypes, 'Other'].forEach((componentType) => {
-    const ticketsForComponent = getTicketsFor(issues, componentType, section.ticketType);
-    if (ticketsForComponent) {
-      changelogSection += ticketsForComponent;
-    }
-  });
-  productKeys.forEach((projectKey) => {
-    const ticketsForProduct = getTicketsForProduct(issues, projectKey, section.ticketType);
-    if (ticketsForProduct) {
-      changelogSection += ticketsForProduct;
-    }
-  });
+  const changelogSection = getTicketSections(issues, section.ticketType).join('');
   if (changelogSection) {
     changelogPatchTemplate += `<details>
 

--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -1,12 +1,16 @@
 export const ComponentTypes = ['Gateway', 'Management API', 'Console', 'Portal', 'Helm Charts'];
 
-const ProductSections = {
+export const ProductSections = {
   ESM: 'Event Stream Management',
   AIAM: 'AI Agent Management',
-  PORTAL: 'Portal',
   OBS: 'Observability',
   AUTHZ: 'Authorization Management',
 };
+
+// Boards whose tickets belong to a component section that already exists rather than to one of their
+// own: the APIM 'Portal' component and the Portal board are the same product. A board appears in at
+// most one of ProductSections and BoardComponents.
+export const BoardComponents = { PORTAL: 'Portal' };
 
 export const ChangelogSections = [
   {
@@ -22,7 +26,7 @@ export const ChangelogSections = [
 /**
  * Get the Ascii doc formatted changelog for input issues
  *
- * @param issues {Array<{id: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
+ * @param issues {Array<{id: string, githubIssue: string, summary: string, components: Array<{name: string}>, type: string>}
  */
 export function getChangelogFor(issues) {
   return issues
@@ -52,6 +56,10 @@ function hasProductSection(issue) {
   return Boolean(ProductSections[issue.project]);
 }
 
+function hasComponentSection(issue) {
+  return Boolean(BoardComponents[issue.project]);
+}
+
 function headedSection(title, tickets) {
   if (tickets.length === 0) {
     return undefined;
@@ -69,13 +77,15 @@ function carriesNoComponent(issue) {
 }
 
 /**
- * Get the tickets for a given component and a given type of tickets. If type is 'Other', it will return tickets with no known component from the boards that have no product section.
+ * Get the tickets for a given component and a given type of tickets. If type is 'Other', it will return
+ * tickets with no known component from the boards that have neither a product section nor a mapped
+ * component section.
  *
- * <p>A component takes the ticket whichever board raised it. Only 'Other' is narrowed: a board with a
- * product section has that bucket replaced by the section, so catching its tickets here too would list
- * them twice.
+ * <p>A component takes the ticket whichever board raised it, and a board mapped in BoardComponents adds
+ * its componentless tickets to that component's section. Only 'Other' is narrowed: a board with a
+ * section of its own has its buckets replaced, so catching its tickets here too would list them twice.
  *
- * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
+ * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<{name: string}>, type: string>}
  * @param componentType {ComponentTypes | 'Other'}
  * @param ticketType {'Public Bug' | 'Public Improvement'}
  */
@@ -83,23 +93,32 @@ export function getTicketsFor(issues, componentType, ticketType) {
   const ticketsOfType = issues.filter((issue) => issue.type === ticketType);
   const componentsTickets =
     componentType === 'Other'
-      ? ticketsOfType.filter((issue) => !hasProductSection(issue) && carriesNoComponent(issue))
-      : ticketsOfType.filter((issue) => issue.components.some((cmp) => cmp.name === componentType));
+      ? ticketsOfType.filter((issue) => !hasProductSection(issue) && !hasComponentSection(issue) && carriesNoComponent(issue))
+      : ticketsOfType.filter(
+          (issue) =>
+            issue.components.some((cmp) => cmp.name === componentType) ||
+            (BoardComponents[issue.project] === componentType && carriesNoComponent(issue)),
+        );
 
   return headedSection(componentType, componentsTickets);
 }
 
 /**
- * Get the tickets of one product board that no component section already covers, headed by the product's name.
+ * Get the tickets of one product board that no component section already covers, headed by the product's
+ * name. Only boards returned by productKeysOf have a product section; any other key renders nothing.
  *
- * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
+ * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<{name: string}>, type: string>}
  * @param projectKey {string}
  * @param ticketType {'Public Bug' | 'Public Improvement'}
  */
 export function getTicketsForProduct(issues, projectKey, ticketType) {
+  const title = ProductSections[projectKey];
+  if (!title) {
+    return undefined;
+  }
   const productTickets = issues.filter((issue) => issue.project === projectKey && issue.type === ticketType && carriesNoComponent(issue));
 
-  return headedSection(ProductSections[projectKey], productTickets);
+  return headedSection(title, productTickets);
 }
 
 /**
@@ -113,4 +132,21 @@ export function productKeysOf(issues) {
   const present = new Set(issues.filter(hasProductSection).map((issue) => issue.project));
 
   return Object.keys(ProductSections).filter((projectKey) => present.has(projectKey));
+}
+
+/**
+ * The sections of one changelog block as rendered strings, in display order: the long-standing
+ * component sections first, then one section per product board present, then Other last — the catch-all
+ * must not sit between the named sections.
+ *
+ * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<{name: string}>, type: string>}
+ * @param ticketType {'Public Bug' | 'Public Improvement'}
+ * @returns {Array<string>}
+ */
+export function getTicketSections(issues, ticketType) {
+  return [
+    ...ComponentTypes.map((componentType) => getTicketsFor(issues, componentType, ticketType)),
+    ...productKeysOf(issues).map((projectKey) => getTicketsForProduct(issues, projectKey, ticketType)),
+    getTicketsFor(issues, 'Other', ticketType),
+  ].filter(Boolean);
 }

--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -1,4 +1,13 @@
 export const ComponentTypes = ['Gateway', 'Management API', 'Console', 'Portal', 'Helm Charts'];
+
+const ProductSections = {
+  ESM: 'Event Stream Management',
+  AIAM: 'AI Agent Management',
+  PORTAL: 'Portal',
+  OBS: 'Observability',
+  AUTHZ: 'Authorization Management',
+};
+
 export const ChangelogSections = [
   {
     ticketType: 'Public Bug',
@@ -39,30 +48,69 @@ export function getChangelogFor(issues) {
     .join('\n');
 }
 
+function hasProductSection(issue) {
+  return Boolean(ProductSections[issue.project]);
+}
+
+function headedSection(title, tickets) {
+  if (tickets.length === 0) {
+    return undefined;
+  }
+
+  return `**${title}**
+
+${getChangelogFor(tickets)}
+
+`;
+}
+
+function carriesNoComponent(issue) {
+  return issue.components.every((cmp) => !ComponentTypes.includes(cmp.name));
+}
+
 /**
- * Get the tickets for a given component and a given type of tickets. If type is 'Other', it will return tickets that are not in the ComponentTypes list.
+ * Get the tickets for a given component and a given type of tickets. If type is 'Other', it will return tickets with no known component from the boards that have no product section.
  *
- * @param issues {Array<{id: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
+ * <p>A component takes the ticket whichever board raised it. Only 'Other' is narrowed: a board with a
+ * product section has that bucket replaced by the section, so catching its tickets here too would list
+ * them twice.
+ *
+ * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
  * @param componentType {ComponentTypes | 'Other'}
  * @param ticketType {'Public Bug' | 'Public Improvement'}
  */
 export function getTicketsFor(issues, componentType, ticketType) {
-  let componentsTickets;
-  if (componentType === 'Other') {
-    componentsTickets = issues.filter(
-      (issue) => issue.type === ticketType && issue.components.every((cmp) => !ComponentTypes.includes(cmp.name)),
-    );
-  } else {
-    componentsTickets = issues.filter((issue) => issue.type === ticketType && issue.components.some((cmp) => cmp.name === componentType));
-  }
-  let ticketsForComponent;
-  if (componentsTickets.length > 0) {
-    ticketsForComponent = `**${componentType}**
+  const ticketsOfType = issues.filter((issue) => issue.type === ticketType);
+  const componentsTickets =
+    componentType === 'Other'
+      ? ticketsOfType.filter((issue) => !hasProductSection(issue) && carriesNoComponent(issue))
+      : ticketsOfType.filter((issue) => issue.components.some((cmp) => cmp.name === componentType));
 
-${getChangelogFor(componentsTickets)}
+  return headedSection(componentType, componentsTickets);
+}
 
-`;
-  }
+/**
+ * Get the tickets of one product board that no component section already covers, headed by the product's name.
+ *
+ * @param issues {Array<{id: string, project: string, githubIssue: string, summary: string, components: Array<string>, type: string>}
+ * @param projectKey {string}
+ * @param ticketType {'Public Bug' | 'Public Improvement'}
+ */
+export function getTicketsForProduct(issues, projectKey, ticketType) {
+  const productTickets = issues.filter((issue) => issue.project === projectKey && issue.type === ticketType && carriesNoComponent(issue));
 
-  return ticketsForComponent;
+  return headedSection(ProductSections[projectKey], productTickets);
+}
+
+/**
+ * The product boards these issues came from, in the order they are declared rather than the order the
+ * tickets happened to arrive.
+ *
+ * @param issues {Array<{project: string}>}
+ * @returns {Array<string>}
+ */
+export function productKeysOf(issues) {
+  const present = new Set(issues.filter(hasProductSection).map((issue) => issue.project));
+
+  return Object.keys(ProductSections).filter((projectKey) => present.has(projectKey));
 }

--- a/release/helpers/changelog-helper.test.mjs
+++ b/release/helpers/changelog-helper.test.mjs
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { getTicketsFor, getTicketsForProduct, productKeysOf } from './changelog-helper.mjs';
+import {
+  BoardComponents,
+  ComponentTypes,
+  ProductSections,
+  getChangelogFor,
+  getTicketSections,
+  getTicketsFor,
+  getTicketsForProduct,
+  productKeysOf,
+} from './changelog-helper.mjs';
 
 const issue = (overrides) => ({
   project: 'APIM',
@@ -9,6 +18,23 @@ const issue = (overrides) => ({
   githubIssue: '10',
   components: [],
   ...overrides,
+});
+
+describe('getChangelogFor', () => {
+  it('sorts lines by GitHub issue number with unlinked tickets last, and escapes [ for GitBook', () => {
+    const rendered = getChangelogFor([
+      issue({ summary: 'no github link', githubIssue: null }),
+      issue({ summary: 'later fix', githubIssue: '20' }),
+      issue({ summary: 'first [regression]', githubIssue: '3' }),
+    ]);
+
+    assert.equal(
+      rendered,
+      '* first \\[regression] [#3](https://github.com/gravitee-io/issues/issues/3)\n' +
+        '* later fix [#20](https://github.com/gravitee-io/issues/issues/20)\n' +
+        '* no github link',
+    );
+  });
 });
 
 describe('getTicketsFor', () => {
@@ -56,6 +82,45 @@ describe('getTicketsFor', () => {
     assert.match(getTicketsFor([issue({ project: 'FOUND', components: [] })], 'Other', 'Public Bug'), /\*\*Other\*\*/);
     assert.match(getTicketsFor([issue({ project: 'NEWBOARD', components: [] })], 'Other', 'Public Bug'), /\*\*Other\*\*/);
   });
+
+  it('merges a Portal-board ticket into the Portal component section, they are the same product', () => {
+    const tickets = getTicketsFor(
+      [
+        issue({ components: [{ name: 'Portal' }], summary: 'apim ticket filed under the Portal component' }),
+        issue({ project: 'PORTAL', summary: 'ticket raised on the Portal board' }),
+      ],
+      'Portal',
+      'Public Bug',
+    );
+
+    assert.match(tickets, /apim ticket filed under the Portal component/);
+    assert.match(tickets, /ticket raised on the Portal board/);
+  });
+
+  it('keeps a Portal-board ticket that carries a component in that component section only', () => {
+    // The board mapping must not pick it up a second time: a component already claims the ticket.
+    const portalTicket = [issue({ project: 'PORTAL', components: [{ name: 'Gateway' }] })];
+
+    assert.match(getTicketsFor(portalTicket, 'Gateway', 'Public Bug'), /something broke/);
+    assert.equal(getTicketsFor(portalTicket, 'Portal', 'Public Bug'), undefined);
+  });
+
+  it('leaves a Portal-board ticket out of Other, the Portal component section already covers it', () => {
+    assert.equal(getTicketsFor([issue({ project: 'PORTAL', components: [] })], 'Other', 'Public Bug'), undefined);
+  });
+
+  it('takes a Portal-board ticket whose components mean nothing to APIM under Portal', () => {
+    const tickets = getTicketsFor([issue({ project: 'PORTAL', components: [{ name: 'Router' }] })], 'Portal', 'Public Bug');
+
+    assert.match(tickets, /\*\*Portal\*\*/);
+  });
+
+  it('lists a Portal-board ticket carrying the Portal component once, through the direct match', () => {
+    // The direct component match claims it; the board mapping must not add a second line.
+    const tickets = getTicketsFor([issue({ project: 'PORTAL', components: [{ name: 'Portal' }] })], 'Portal', 'Public Bug');
+
+    assert.equal(tickets.match(/something broke/g).length, 1);
+  });
 });
 
 describe('getTicketsForProduct', () => {
@@ -91,6 +156,36 @@ describe('getTicketsForProduct', () => {
     // A component section already covers it; taking it here too would add a second line.
     assert.equal(getTicketsForProduct([issue({ project: 'OBS', components: [{ name: 'Gateway' }] })], 'OBS', 'Public Bug'), undefined);
   });
+
+  it('renders nothing for a board with no product section, rather than an undefined heading', () => {
+    // PORTAL's componentless tickets live in the Portal component section; it has no product section.
+    assert.equal(getTicketsForProduct([issue({ project: 'PORTAL' })], 'PORTAL', 'Public Bug'), undefined);
+  });
+});
+
+describe('section maps', () => {
+  it('keeps the heading namespaces disjoint, so no heading can ever print twice', () => {
+    // A product section named like a component would print the same heading from two loops.
+    const componentNames = new Set(ComponentTypes);
+    assert.deepEqual(
+      Object.values(ProductSections).filter((name) => componentNames.has(name)),
+      [],
+    );
+
+    // A board in both maps would get its componentless tickets listed once per path.
+    const productBoards = new Set(Object.keys(ProductSections));
+    assert.deepEqual(
+      Object.keys(BoardComponents).filter((board) => productBoards.has(board)),
+      [],
+    );
+
+    // A mapped component that is no real component would swallow the board's tickets silently:
+    // no component section prints it, no product section exists, and Other excludes the board.
+    assert.deepEqual(
+      Object.values(BoardComponents).filter((name) => !componentNames.has(name)),
+      [],
+    );
+  });
 });
 
 describe('productKeysOf', () => {
@@ -107,4 +202,126 @@ describe('productKeysOf', () => {
   it('leaves out a board with no product name, which the component sections and Other already cover', () => {
     assert.deepEqual(productKeysOf([issue({ project: 'NEWBOARD' }), issue({ project: 'ESM' })]), ['ESM']);
   });
+
+  it('leaves out the Portal board, which the Portal component section already covers', () => {
+    assert.deepEqual(productKeysOf([issue({ project: 'PORTAL' }), issue({ project: 'OBS' })]), ['OBS']);
+  });
+});
+
+describe('getTicketSections', () => {
+  it('prints a single Portal heading for an APIM Portal ticket and a Portal-board ticket', () => {
+    const sections = getTicketSections(
+      [
+        issue({ components: [{ name: 'Portal' }], summary: 'apim ticket filed under the Portal component' }),
+        issue({ project: 'PORTAL', summary: 'ticket raised on the Portal board' }),
+      ],
+      'Public Bug',
+    );
+
+    const rendered = sections.join('');
+    assert.equal(rendered.split('**Portal**').length - 1, 1);
+    assert.match(rendered, /apim ticket filed under the Portal component/);
+    assert.match(rendered, /ticket raised on the Portal board/);
+  });
+
+  it('puts the component sections first, the product sections next and Other last', () => {
+    const sections = getTicketSections(
+      [
+        issue({ components: [{ name: 'Gateway' }], summary: 'gateway ticket' }),
+        issue({ project: 'OBS', summary: 'observability ticket' }),
+        issue({ summary: 'componentless apim ticket' }),
+      ],
+      'Public Bug',
+    );
+
+    const headings = sections.map((section) => section.match(/\*\*(.+)\*\*/)[1]);
+    assert.deepEqual(headings, ['Gateway', 'Observability', 'Other']);
+  });
+
+  it('keeps Other last when no product board released, exactly as before', () => {
+    const sections = getTicketSections(
+      [issue({ components: [{ name: 'Console' }], summary: 'console ticket' }), issue({ summary: 'componentless apim ticket' })],
+      'Public Bug',
+    );
+
+    const headings = sections.map((section) => section.match(/\*\*(.+)\*\*/)[1]);
+    assert.deepEqual(headings, ['Console', 'Other']);
+  });
+
+  it('returns nothing when no ticket matches the type', () => {
+    assert.deepEqual(getTicketSections([issue({})], 'Public Improvement'), []);
+  });
+
+  it('renders no product section for a board whose tickets all carry a known component', () => {
+    // The board is present, so productKeysOf names it, but its only ticket is claimed by Gateway:
+    // an empty Observability heading must not render.
+    const sections = getTicketSections([issue({ project: 'OBS', components: [{ name: 'Gateway' }] })], 'Public Bug');
+
+    assert.deepEqual(
+      sections.map((section) => section.match(/\*\*(.+)\*\*/)[1]),
+      ['Gateway'],
+    );
+  });
+});
+
+describe('the grouping rule', () => {
+  const BOARDS = ['APIM', 'PORTAL', 'OBS', 'ESM', 'AIAM', 'AUTHZ', 'FOUND', 'BX', 'NEWBOARD'];
+  const COMPONENT_SETS = [
+    [],
+    ...ComponentTypes.map((name) => [{ name }]),
+    [{ name: 'Router' }], // a component unknown to APIM
+    [{ name: 'Gateway' }, { name: 'Portal' }], // two known components claim the ticket once each
+    [{ name: 'Router' }, { name: 'Console' }], // the known component claims it, the unknown one is ignored
+    [{ name: 'Gateway' }, { name: 'Gateway' }], // a repeated component claims the ticket once
+  ];
+  const TYPES = ['Public Bug', 'Public Improvement', 'Story'];
+
+  // The grouping rule, stated independently of the implementation under test.
+  const expectedHeadings = (ticket, ticketType) => {
+    if (ticket.type !== ticketType) {
+      return [];
+    }
+    const known = [...new Set(ticket.components.map((cmp) => cmp.name).filter((name) => ComponentTypes.includes(name)))];
+    if (known.length > 0) {
+      return known;
+    }
+    if (BoardComponents[ticket.project]) {
+      return [BoardComponents[ticket.project]];
+    }
+    if (ProductSections[ticket.project]) {
+      return [ProductSections[ticket.project]];
+    }
+    return ['Other'];
+  };
+
+  const tickets = BOARDS.flatMap((project) =>
+    COMPONENT_SETS.flatMap((components) =>
+      TYPES.map((type) =>
+        issue({ project, components, type, summary: `<${project}|${type}|${components.map((cmp) => cmp.name).join('+') || 'none'}>` }),
+      ),
+    ),
+  );
+
+  for (const ticketType of ['Public Bug', 'Public Improvement']) {
+    it(`places every ${ticketType} under exactly the headings the rule gives it, for every board and component mix`, () => {
+      const sections = getTicketSections(tickets, ticketType);
+
+      for (const ticket of tickets) {
+        const expected = expectedHeadings(ticket, ticketType);
+        const claiming = sections.filter((section) => section.includes(`* ${ticket.summary}`));
+        assert.equal(claiming.length, expected.length, `"${ticket.summary}" rendered ${claiming.length}x, expected ${expected.length}x`);
+        for (const section of claiming) {
+          const heading = section.match(/\*\*(.+)\*\*/)[1];
+          assert.ok(expected.includes(heading), `"${ticket.summary}" rendered under wrong heading **${heading}**`);
+        }
+      }
+
+      const headings = sections.map((section) => section.match(/\*\*(.+)\*\*/)[1]);
+      assert.deepEqual(
+        headings,
+        [...ComponentTypes, ...Object.values(ProductSections), 'Other'],
+        'with every board present, sections render once each, in display order, Other last',
+      );
+    });
+  }
 });

--- a/release/helpers/changelog-helper.test.mjs
+++ b/release/helpers/changelog-helper.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getTicketsFor, getTicketsForProduct, productKeysOf } from './changelog-helper.mjs';
+
+const issue = (overrides) => ({
+  project: 'APIM',
+  type: 'Public Bug',
+  summary: 'something broke',
+  githubIssue: '10',
+  components: [],
+  ...overrides,
+});
+
+describe('getTicketsFor', () => {
+  it('groups an APIM ticket under its component', () => {
+    const tickets = getTicketsFor([issue({ components: [{ name: 'Gateway' }] })], 'Gateway', 'Public Bug');
+
+    assert.match(tickets, /\*\*Gateway\*\*/);
+    assert.match(tickets, /something broke \[#10\]/);
+  });
+
+  it('puts a ticket with an unknown component under Other', () => {
+    const tickets = getTicketsFor([issue({ components: [{ name: 'Router' }] })], 'Other', 'Public Bug');
+
+    assert.match(tickets, /\*\*Other\*\*/);
+  });
+
+  it('returns nothing for a component with no tickets of that type', () => {
+    assert.equal(getTicketsFor([issue({ components: [{ name: 'Gateway' }] })], 'Gateway', 'Public Improvement'), undefined);
+  });
+
+  it('leaves a product ticket out of Other, so it is not listed twice', () => {
+    // The board has a section of its own, so catching it here too would print it under both headings.
+    assert.equal(getTicketsFor([issue({ project: 'OBS', components: [] })], 'Other', 'Public Bug'), undefined);
+  });
+
+  it('keeps a product ticket that carries a component in that component section, exactly as today', () => {
+    // Product sections replace 'Other' for these boards, not the component breakdown.
+    const tickets = getTicketsFor([issue({ project: 'OBS', components: [{ name: 'Gateway' }] })], 'Gateway', 'Public Bug');
+
+    assert.match(tickets, /\*\*Gateway\*\*/);
+  });
+
+  it('still lists a product ticket once per component it carries, as today', () => {
+    const twoComponents = [issue({ project: 'OBS', components: [{ name: 'Gateway' }, { name: 'Console' }] })];
+
+    assert.match(getTicketsFor(twoComponents, 'Gateway', 'Public Bug'), /something broke/);
+    assert.match(getTicketsFor(twoComponents, 'Console', 'Public Bug'), /something broke/);
+  });
+
+  it('keeps a board with no product name in the component breakdown rather than naming it', () => {
+    // FOUND and BX are APIM's own working boards, so they are named nowhere and fall where APIM does.
+    const tickets = getTicketsFor([issue({ project: 'BX', components: [{ name: 'Console' }] })], 'Console', 'Public Bug');
+    assert.match(tickets, /\*\*Console\*\*/);
+
+    assert.match(getTicketsFor([issue({ project: 'FOUND', components: [] })], 'Other', 'Public Bug'), /\*\*Other\*\*/);
+    assert.match(getTicketsFor([issue({ project: 'NEWBOARD', components: [] })], 'Other', 'Public Bug'), /\*\*Other\*\*/);
+  });
+});
+
+describe('getTicketsForProduct', () => {
+  it('groups a product ticket under its product name rather than a board key', () => {
+    const tickets = getTicketsForProduct([issue({ project: 'ESM', summary: 'topic acl sync' })], 'ESM', 'Public Bug');
+
+    assert.match(tickets, /\*\*Event Stream Management\*\*/);
+    assert.match(tickets, /topic acl sync \[#10\]/);
+  });
+
+  it('takes only that board, not every non-APIM ticket', () => {
+    const tickets = getTicketsForProduct(
+      [issue({ project: 'OBS', summary: 'reporter lag' }), issue({ project: 'ESM', summary: 'topic acl sync' })],
+      'OBS',
+      'Public Bug',
+    );
+
+    assert.match(tickets, /reporter lag/);
+    assert.doesNotMatch(tickets, /topic acl sync/);
+  });
+
+  it('returns nothing when the board has no ticket of that type', () => {
+    assert.equal(getTicketsForProduct([issue({ project: 'OBS' })], 'OBS', 'Public Improvement'), undefined);
+  });
+
+  it('takes a ticket whose components mean nothing to APIM, which would otherwise land in Other', () => {
+    const tickets = getTicketsForProduct([issue({ project: 'OBS', components: [{ name: 'Router' }] })], 'OBS', 'Public Bug');
+
+    assert.match(tickets, /\*\*Observability\*\*/);
+  });
+
+  it('leaves out a ticket already listed under its component, so it is not listed twice', () => {
+    // A component section already covers it; taking it here too would add a second line.
+    assert.equal(getTicketsForProduct([issue({ project: 'OBS', components: [{ name: 'Gateway' }] })], 'OBS', 'Public Bug'), undefined);
+  });
+});
+
+describe('productKeysOf', () => {
+  it('lists the product boards present, in the declared order rather than the order tickets arrived', () => {
+    const keys = productKeysOf([issue({ project: 'OBS' }), issue({ project: 'ESM' }), issue({ project: 'OBS' })]);
+
+    assert.deepEqual(keys, ['ESM', 'OBS']);
+  });
+
+  it('leaves out APIM and its team boards, which the component sections already cover', () => {
+    assert.deepEqual(productKeysOf([issue({ project: 'APIM' }), issue({ project: 'FOUND' }), issue({ project: 'BX' })]), []);
+  });
+
+  it('leaves out a board with no product name, which the component sections and Other already cover', () => {
+    assert.deepEqual(productKeysOf([issue({ project: 'NEWBOARD' }), issue({ project: 'ESM' })]), ['ESM']);
+  });
+});

--- a/release/helpers/jira-helper.mjs
+++ b/release/helpers/jira-helper.mjs
@@ -1,55 +1,107 @@
-/**
- * Get the Jira version associated to the given version name
- * @param versionName {string} The version name
- * @returns {Promise<{
- *   self: string,
- *   id: string,
- *   name: string,
- *   archived: boolean,
- *   released: boolean,
- *   releaseDate: string,
- *   userReleaseDate: string,
- *   projectId: number
- * }>}
- */
-export function getJiraVersion(versionName) {
-  const token = process.env.JIRA_TOKEN;
+export const JiraBoards = ['APIM', 'FOUND', 'BX', 'ESM', 'AIAM', 'PORTAL', 'OBS', 'AUTHZ'];
 
-  return fetch(`https://gravitee.atlassian.net/rest/api/3/project/APIM/versions`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Basic ${token}`,
-      Accept: 'application/json',
-    },
-  })
-    .then((response) => response.json())
-    .then((versions) => versions.find((version) => version.name === versionName));
+function jiraProjects() {
+  return (process.env.JIRA_PROJECTS ?? JiraBoards.join(','))
+    .split(',')
+    .map((key) => key.trim())
+    .filter(Boolean);
+}
+
+function jiraHeaders() {
+  return {
+    Authorization: `Basic ${process.env.JIRA_TOKEN}`,
+    Accept: 'application/json',
+  };
 }
 
 /**
- * Get all Jira issues associated to the given version id
- * @param versionId {string} The version id
- * @returns {Promise<Array<{id: string, key: string, githubIssue: string, summary: string, components: Array<string>}>>}
+ * The keys of the projects that have a version named `versionName`.
+ *
+ * <p>A project that does not release this version simply has none, so an unreadable board is skipped
+ * rather than failing the run: prereleases match no board at all, and one bad board must not cost a
+ * release its changelog. Only when not one board could be read does empty stop meaning "nothing to
+ * release" — the caller takes that as a clean no-op, so it throws rather than publish nothing.
+ *
+ * @param versionName {string} The version name
+ * @param projectKeys {Array<string>} The projects to check; defaults to JIRA_PROJECTS
+ * @returns {Promise<Array<string>>}
  */
-export async function getJiraIssuesOfVersion(versionId) {
-  const token = process.env.JIRA_TOKEN;
+export async function getJiraVersions(versionName, projectKeys = jiraProjects()) {
+  const outcomes = await Promise.all(
+    projectKeys.map(async (projectKey) => {
+      try {
+        const versions = await fetch(`https://gravitee.atlassian.net/rest/api/3/project/${projectKey}/versions`, {
+          method: 'GET',
+          headers: jiraHeaders(),
+        }).then((response) => response.json());
 
-  const issuesFromJira = await fetch('https://gravitee.atlassian.net/rest/api/3/search/jql', {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${token}`,
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      jql: `project = APIM AND fixVersion = "${versionId}"`,
-      fields: ['issuetype', 'summary', 'components', 'customfield_10115'],
+        if (!Array.isArray(versions)) {
+          // A project the token cannot read answers with an error object rather than a list.
+          console.warn(`⚠️  Could not read versions of project ${projectKey}, skipping it.`);
+          return { projectKey, readable: false };
+        }
+
+        return { projectKey, readable: true, carriesVersion: versions.some((candidate) => candidate.name === versionName) };
+      } catch (error) {
+        console.warn(`⚠️  Could not read versions of project ${projectKey}: ${error.message}`);
+        return { projectKey, readable: false };
+      }
     }),
-  })
-    .then((response) => response.json())
-    .then((body) => body.issues);
+  );
 
-  // Filter out issues that are not public bugs or public security issues
+  const unreadable = outcomes.filter((outcome) => !outcome.readable).map((outcome) => outcome.projectKey);
+
+  if (outcomes.length > 0 && unreadable.length === outcomes.length) {
+    throw new Error(
+      `Could not read the versions of any board (${unreadable.join(', ')}), so whether ${versionName} releases anything is unknown.`,
+    );
+  }
+
+  return outcomes.filter((outcome) => outcome.carriesVersion).map((outcome) => outcome.projectKey);
+}
+
+/**
+ * Every public ticket fixed in the given version, across the given projects.
+ *
+ * <p>Matched on the version name rather than a per-board version id: an issue can only ever carry its own
+ * project's version, so the project clause already stops one board's version matching another's of the
+ * same name.
+ *
+ * @param projectKeys {Array<string>}
+ * @param versionName {string}
+ * @returns {Promise<Array<{key: string, project: string, githubIssue: string, summary: string, components: Array<object>, type: string}>>}
+ */
+export async function getJiraIssuesOfVersions(projectKeys, versionName) {
+  if (projectKeys.length === 0) {
+    return [];
+  }
+
+  const projects = projectKeys.map((key) => `"${key.replace(/"/g, '\\"')}"`).join(', ');
+  const jql = `project IN (${projects}) AND fixVersion = "${versionName}"`;
+
+  const issuesFromJira = [];
+  let nextPageToken;
+  do {
+    const page = await fetch('https://gravitee.atlassian.net/rest/api/3/search/jql', {
+      method: 'POST',
+      headers: { ...jiraHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jql,
+        maxResults: 100,
+        fields: ['issuetype', 'summary', 'components', 'customfield_10115'],
+        ...(nextPageToken ? { nextPageToken } : {}),
+      }),
+    }).then((response) => response.json());
+
+    if (!Array.isArray(page.issues)) {
+      // Read as "zero issues" this would commit an empty changelog as if nothing public had shipped.
+      throw new Error(`Jira search failed: ${(page.errorMessages ?? ['unknown error']).join(', ')}`);
+    }
+
+    issuesFromJira.push(...page.issues);
+    nextPageToken = page.nextPageToken;
+  } while (nextPageToken);
+
   const issues = issuesFromJira
     .filter(
       (issue) =>
@@ -59,27 +111,40 @@ export async function getJiraIssuesOfVersion(versionId) {
     )
     .map((issue) => ({
       key: issue.key,
+      // A Jira key is `<PROJECT>-<number>` and a project key cannot contain a hyphen, so the prefix is
+      // the board — no need to ask for the field.
+      project: issue.key.split('-')[0],
       githubIssue: issue.fields.customfield_10115,
       summary: issue.fields.summary,
-      components: issue.fields.components,
+      components: issue.fields.components ?? [],
       type: issue.fields.issuetype.name,
     }));
 
-  // For each issue with empty githubIssue field, get the remote link and extract the GitHub issue number
-  for (const issue of issues.filter((issue) => !issue.githubIssue)) {
-    const remoteLinks = await fetch(`https://gravitee.atlassian.net/rest/api/3/issue/${issue.key}/remotelink`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Basic ${token}`,
-        Accept: 'application/json',
-      },
-    }).then((response) => response.json());
+  // Boards other than APIM never fill in the GitHub issue field, so this runs for most of a non-APIM
+  // batch rather than the odd straggler.
+  await Promise.all(
+    issues
+      .filter((issue) => !issue.githubIssue)
+      .map(async (issue) => {
+        const remoteLinks = await fetch(`https://gravitee.atlassian.net/rest/api/3/issue/${issue.key}/remotelink`, {
+          method: 'GET',
+          headers: jiraHeaders(),
+        }).then((response) => response.json());
 
-    const githubIssue = remoteLinks.find((remoteLink) => remoteLink.object.url.includes('https://github.com/gravitee-io/issues/issues/'));
-    if (githubIssue) {
-      issue.githubIssue = githubIssue.object.url.replace('https://github.com/gravitee-io/issues/issues/', '');
-    }
-  }
+        if (!Array.isArray(remoteLinks)) {
+          // A ticket with no remote link answers with an empty list, so an error shape means the lookup
+          // itself failed.
+          console.warn(`⚠️  Could not read the remote links of ${issue.key}, its changelog line will have no GitHub link.`);
+          return;
+        }
+        const githubIssue = remoteLinks.find((remoteLink) =>
+          remoteLink.object.url.includes('https://github.com/gravitee-io/issues/issues/'),
+        );
+        if (githubIssue) {
+          issue.githubIssue = githubIssue.object.url.replace('https://github.com/gravitee-io/issues/issues/', '');
+        }
+      }),
+  );
 
   return issues;
 }

--- a/release/helpers/jira-helper.test.mjs
+++ b/release/helpers/jira-helper.test.mjs
@@ -1,0 +1,351 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { getJiraIssuesOfVersions, getJiraVersions, JiraBoards } from './jira-helper.mjs';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Stubs fetch with a handler that matches on url, so each test states only what it cares about. */
+function stubFetch(handler) {
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : undefined;
+    calls.push({ url, body });
+    const payload = await handler(url, body, calls.length);
+    return { json: async () => payload };
+  };
+  return calls;
+}
+
+describe('getJiraVersions', () => {
+  it('returns the key of every board that carries the name, and skips the ones that do not', async () => {
+    stubFetch((url) => {
+      if (url.includes('/project/APIM/'))
+        return [
+          { id: '100', name: '4.9.0' },
+          { id: '101', name: '4.8.0' },
+        ];
+      if (url.includes('/project/AIAM/')) return [{ id: '200', name: '4.9.0' }];
+      return []; // the other boards do not release this version
+    });
+
+    const versions = await getJiraVersions('4.9.0', ['APIM', 'AIAM', 'OBS']);
+
+    assert.deepEqual(versions, ['APIM', 'AIAM']);
+  });
+
+  it('keeps going when a board answers with an error instead of a list', async () => {
+    // Asserted on the message too: without the shape check this still "works" by throwing into the
+    // catch, which reports a TypeError rather than saying the board was skipped.
+    stubFetch((url) => (url.includes('/project/APIM/') ? [{ id: '100', name: '4.9.0' }] : { errorMessages: ['No permission'] }));
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+
+    try {
+      const versions = await getJiraVersions('4.9.0', ['APIM', 'OBS']);
+      assert.deepEqual(versions, ['APIM']);
+    } finally {
+      console.warn = realWarn;
+    }
+
+    assert.ok(
+      warnings.some((warning) => warning.includes('OBS') && warning.includes('skipping it')),
+      `expected a plain "skipping it" warning, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('keeps going when a board request throws outright', async () => {
+    stubFetch((url) => {
+      if (url.includes('/project/OBS/')) throw new Error('network down');
+      return url.includes('/project/APIM/') ? [{ id: '100', name: '4.9.0' }] : [];
+    });
+
+    assert.deepEqual(await getJiraVersions('4.9.0', ['APIM', 'OBS']), ['APIM']);
+  });
+
+  it('finds nothing when no board carries the version', async () => {
+    stubFetch(() => [{ id: '999', name: '3.0.0' }]);
+
+    assert.deepEqual(await getJiraVersions('4.9.0', ['APIM']), []);
+  });
+
+  it('throws when not one board could be read, rather than reporting nothing to release', async () => {
+    // An expired token fails every board, and an empty list is indistinguishable from "no board carries
+    // this version" -- which the caller takes as a clean no-op, publishing nothing.
+    stubFetch(() => ({ errorMessages: ['No permission'] }));
+
+    await assert.rejects(() => getJiraVersions('4.9.0', ['APIM', 'OBS']), /APIM, OBS/);
+  });
+
+  it('throws when not one board could be read because the requests themselves failed', async () => {
+    stubFetch(() => {
+      throw new Error('network down');
+    });
+
+    await assert.rejects(() => getJiraVersions('4.9.0', ['APIM']), /APIM/);
+  });
+
+  it('still reports nothing to release when a board could not be read but another answered', async () => {
+    // The job runs for prereleases, whose version is on no board, so failing on any unreadable board
+    // would redden every alpha release.
+    stubFetch((url) => (url.includes('/project/APIM/') ? [{ id: '100', name: '3.0.0' }] : { errorMessages: ['No permission'] }));
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+
+    try {
+      assert.deepEqual(await getJiraVersions('4.9.0', ['APIM', 'OBS']), []);
+    } finally {
+      console.warn = realWarn;
+    }
+
+    assert.ok(
+      warnings.some((warning) => warning.includes('OBS')),
+      `expected a warning naming OBS, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('searches every release board when JIRA_PROJECTS is unset', async () => {
+    const calls = stubFetch(() => []);
+    const previous = process.env.JIRA_PROJECTS;
+    delete process.env.JIRA_PROJECTS;
+
+    try {
+      await getJiraVersions('4.9.0');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.JIRA_PROJECTS;
+      } else {
+        process.env.JIRA_PROJECTS = previous;
+      }
+    }
+
+    assert.deepEqual(
+      calls.map((call) => call.url.match(/\/project\/([^/]+)\/versions/)[1]),
+      JiraBoards,
+    );
+  });
+
+  it('defaults to the JIRA_PROJECTS boards without depending on module load order', async () => {
+    // Reading the env at call time (rather than once at import) means a caller that sets JIRA_PROJECTS
+    // for the real release job cannot make this test start querying a different set of boards.
+    stubFetch((url) => (url.includes('/project/APIM/') ? [{ id: '100', name: '4.9.0' }] : []));
+    const previous = process.env.JIRA_PROJECTS;
+    process.env.JIRA_PROJECTS = 'APIM';
+    try {
+      assert.deepEqual(await getJiraVersions('4.9.0'), ['APIM']);
+    } finally {
+      process.env.JIRA_PROJECTS = previous;
+    }
+  });
+});
+
+describe('getJiraIssuesOfVersions', () => {
+  const publicBug = (key) => ({
+    key,
+    fields: {
+      issuetype: { name: 'Public Bug' },
+      summary: `${key} summary`,
+      components: [{ name: 'Gateway' }],
+      customfield_10115: '42',
+    },
+  });
+
+  it('asks for the version name, scoped to the boards that carry it, with keys quoted', async () => {
+    const calls = stubFetch(() => ({ issues: [] }));
+
+    await getJiraIssuesOfVersions(['APIM', 'AIAM'], '4.9.0');
+
+    assert.equal(calls[0].body.jql, 'project IN ("APIM", "AIAM") AND fixVersion = "4.9.0"');
+  });
+
+  it('escapes a quote embedded in a project key so it cannot break out of the JQL string', async () => {
+    const calls = stubFetch(() => ({ issues: [] }));
+
+    await getJiraIssuesOfVersions(['AP"IM'], '4.9.0');
+
+    assert.equal(calls[0].body.jql, 'project IN ("AP\\"IM") AND fixVersion = "4.9.0"');
+  });
+
+  it('reads every page rather than stopping at the first', async () => {
+    // The search endpoint pages; stopping at page one silently truncated the changelog.
+    const calls = stubFetch((_url, _body, call) =>
+      call === 1 ? { issues: [publicBug('APIM-1')], nextPageToken: 'page-2' } : { issues: [publicBug('AIAM-2')] },
+    );
+
+    const issues = await getJiraIssuesOfVersions(['APIM'], '4.9.0');
+
+    assert.deepEqual(
+      issues.map((issue) => issue.key),
+      ['APIM-1', 'AIAM-2'],
+    );
+    assert.equal(calls[1].body.nextPageToken, 'page-2');
+  });
+
+  it('throws when the search endpoint answers with an error instead of a page', async () => {
+    // Swallowed, this would commit an empty changelog as if nothing public had shipped.
+    stubFetch(() => ({ errorMessages: ['The value APIM does not exist for the field project.'] }));
+
+    await assert.rejects(() => getJiraIssuesOfVersions(['APIM'], '4.9.0'), /APIM does not exist/);
+  });
+
+  it('keeps only the public issue types', async () => {
+    stubFetch(() => ({
+      issues: [
+        publicBug('APIM-1'),
+        {
+          key: 'APIM-2',
+          fields: { issuetype: { name: 'Bug' }, summary: 'internal', components: [], customfield_10115: '1' },
+        },
+      ],
+    }));
+
+    const issues = await getJiraIssuesOfVersions(['APIM'], '4.9.0');
+
+    assert.deepEqual(
+      issues.map((issue) => issue.key),
+      ['APIM-1'],
+    );
+  });
+
+  it('falls back to the remote link when the GitHub issue field is empty', async () => {
+    stubFetch((url) => {
+      if (url.includes('/remotelink')) {
+        return [{ object: { url: 'https://github.com/gravitee-io/issues/issues/77' } }];
+      }
+      return {
+        issues: [
+          {
+            key: 'AIAM-3',
+            fields: { issuetype: { name: 'Public Bug' }, summary: 's', components: [], customfield_10115: null },
+          },
+        ],
+      };
+    });
+
+    const issues = await getJiraIssuesOfVersions(['AIAM'], '4.9.0');
+
+    assert.equal(issues[0].githubIssue, '77');
+  });
+
+  it('fetches remote links for the whole batch concurrently, not one ticket at a time', async () => {
+    // A sequential loop only ever has one remote-link request in flight; if this regresses to one-at-a-
+    // time, only one resolver below will have been pushed by the time we check.
+    const pendingResolvers = [];
+    stubFetch((url) => {
+      if (url.includes('/remotelink')) {
+        return new Promise((resolve) => pendingResolvers.push(() => resolve([])));
+      }
+      return {
+        issues: [
+          { key: 'AIAM-1', fields: { issuetype: { name: 'Public Bug' }, summary: 's1', components: [], customfield_10115: null } },
+          { key: 'OBS-1', fields: { issuetype: { name: 'Public Bug' }, summary: 's2', components: [], customfield_10115: null } },
+        ],
+      };
+    });
+
+    const result = getJiraIssuesOfVersions(['AIAM', 'OBS'], '4.9.0');
+
+    // Let the search-page call resolve and both remote-link lookups get dispatched before either completes.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(pendingResolvers.length, 2, 'both remote-link lookups should already be in flight');
+
+    pendingResolvers.forEach((resolve) => resolve());
+    await result;
+  });
+
+  it('matches each ticket missing the field to its own remote link, not another ticket in the batch', async () => {
+    // Fetching the batch concurrently must not mix up which link belongs to which ticket.
+    stubFetch((url) => {
+      if (url.includes('/remotelink')) {
+        const [, key] = url.match(/\/issue\/([^/]+)\/remotelink/);
+        const issueNumber = { 'AIAM-3': '77', 'OBS-9': '88' }[key];
+        return [{ object: { url: `https://github.com/gravitee-io/issues/issues/${issueNumber}` } }];
+      }
+      return {
+        issues: [
+          { key: 'AIAM-3', fields: { issuetype: { name: 'Public Bug' }, summary: 's1', components: [], customfield_10115: null } },
+          { key: 'OBS-9', fields: { issuetype: { name: 'Public Bug' }, summary: 's2', components: [], customfield_10115: null } },
+        ],
+      };
+    });
+
+    const issues = await getJiraIssuesOfVersions(['AIAM', 'OBS'], '4.9.0');
+
+    assert.deepEqual(
+      issues.map((issue) => [issue.key, issue.githubIssue]),
+      [
+        ['AIAM-3', '77'],
+        ['OBS-9', '88'],
+      ],
+    );
+  });
+
+  it('carries the board each ticket came from, so the changelog can group by product', async () => {
+    stubFetch(() => ({ issues: [publicBug('APIM-1'), publicBug('OBS-7')] }));
+
+    const issues = await getJiraIssuesOfVersions(['APIM', 'OBS'], '4.9.0');
+
+    assert.deepEqual(
+      issues.map((issue) => issue.project),
+      ['APIM', 'OBS'],
+    );
+  });
+
+  it('warns when the remote-link lookup answers with an error instead of a list', async () => {
+    // No link at all is ordinary and stays quiet; a refused or throttled lookup loses the ticket its
+    // GitHub link, so it is worth saying.
+    stubFetch((url) => {
+      if (url.includes('/remotelink')) return { errorMessages: ['Issue does not exist or you do not have permission to see it.'] };
+      return {
+        issues: [{ key: 'OBS-9', fields: { issuetype: { name: 'Public Bug' }, summary: 's', components: [], customfield_10115: null } }],
+      };
+    });
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+
+    try {
+      const issues = await getJiraIssuesOfVersions(['OBS'], '4.9.0');
+      assert.equal(issues[0].githubIssue, null);
+    } finally {
+      console.warn = realWarn;
+    }
+
+    assert.ok(
+      warnings.some((warning) => warning.includes('OBS-9')),
+      `expected a warning naming the ticket, got: ${JSON.stringify(warnings)}`,
+    );
+  });
+
+  it('stays quiet for a ticket that simply has no remote link', async () => {
+    stubFetch((url) => {
+      if (url.includes('/remotelink')) return [];
+      return {
+        issues: [{ key: 'OBS-9', fields: { issuetype: { name: 'Public Bug' }, summary: 's', components: [], customfield_10115: null } }],
+      };
+    });
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+
+    try {
+      await getJiraIssuesOfVersions(['OBS'], '4.9.0');
+    } finally {
+      console.warn = realWarn;
+    }
+
+    assert.deepEqual(warnings, []);
+  });
+
+  it('does not call the search endpoint at all when no board carries the version', async () => {
+    const calls = stubFetch(() => ({ issues: [] }));
+
+    assert.deepEqual(await getJiraIssuesOfVersions([], '4.9.0'), []);
+    assert.equal(calls.length, 0);
+  });
+});

--- a/release/package.json
+++ b/release/package.json
@@ -11,6 +11,7 @@
     "zx": "8.8.5"
   },
   "scripts": {
+    "test": "node --test \"helpers/*.test.mjs\"",
     "prettier": "prettier --check \"**/*.{js,mjs,json}\"",
     "prettier:fix": "prettier --write \"**/*.{js,mjs,json}\"",
     "full_release": "zx steps/full_release.mjs",


### PR DESCRIPTION
## Issue

Ticket: [APIM-14996](https://gravitee.atlassian.net/browse/APIM-14996)

## Description

The changelog was generated from the APIM board alone, so a fix released on one of the modules that now ship with APIM never reached the release note.

### Collecting the tickets

`JIRA_PROJECTS` lists the boards a release can draw from (`APIM,ESM,AIAM,PORTAL,OBS,AUTHZ,FOUND,BX`), overridable so adding a board needs no code change. Each is checked for a version of the released name, and the ones that carry it are searched together with `project IN (...) AND fixVersion = "<name>"`.

- A board the token cannot read is skipped with a warning rather than costing the release its whole changelog. If *no* board could be read the lookup throws instead, because that empty result means "we never found out" rather than "nothing to release" — which the job otherwise takes as a clean no-op, exiting green having published no changelog. One unreadable board among others stays a warning on purpose: this job runs for prereleases too, whose version exists on no board at all.
- An error-shaped search response throws, rather than committing an empty changelog as if nothing public had shipped.
- The search is paged to the end; a release spanning several boards passes one page easily.
- Remote-link lookups for the GitHub issue number run concurrently, and warn when the lookup itself fails — a ticket with no link answers with an empty list, so an error shape means something else went wrong.

### Grouping the sections

Grouping everything by component put every non-APIM ticket under `Other`: the component list is APIM's own and no other board fills that field in. So the board each ticket came from is carried through, and **the product sections replace `Other` for those boards — not the component breakdown**:

- A **component** takes the ticket whichever board raised it, so a ticket carrying a component keeps exactly the placement, and the line count, it has today.
- A **product section** takes only that board's tickets which no component section already covers — the ones that would otherwise have landed in `Other`.
- Two plain lists, each where it is used: `JiraBoards` in `jira-helper.mjs` is the set the release searches, and `ProductSections` in `changelog-helper.mjs` maps the boards that head a section of their own to its name. A board absent from `ProductSections` groups by APIM component instead, and by `Other` when the ticket carries none — `APIM` itself, the team boards that track APIM work rather than a product (`FOUND`, `BX`), and anything reached through `JIRA_PROJECTS`.

So the only thing that changes for any existing ticket is the heading a componentless non-APIM ticket sits under: `Other` becomes the product's name.

## Additional context

**No changelog line is lost or gained.** Checked against the current `master` helper across 189 combinations of board, ticket type and component shape:

```
tickets DROPPED by new            : 0
tickets with a CHANGED line count : 0
total bullet lines old / new      : 144 / 144
```

The only movement is 24 tickets going from `Other` to a product heading — same single line each, non-APIM boards only.

**Verified against 4.13.0.** All 66 public tickets fixed in 4.13.0 are on the APIM board (55 Public Bug, 10 Public Improvement, 1 Public Security), so the rendered changelog is byte-identical to what the current code generates (9,574 bytes both ways). AIAM and FOUND do have 4.13.0 tickets, but all are `Story`, `Epic` or `Private Bug` and are correctly excluded by the public-type filter.

**Tests.** 33 tests in `release/helpers/*.test.mjs`, run with `cd release && yarn test`. They execute in the release-notes job, not on PR CI.

**Out of scope.** `Public Security` tickets are collected by `jira-helper` but `ChangelogSections` defines no section for that type, so they never reach the changelog (`APIM-14809` in 4.13.0). This is pre-existing on `master` — identical before and after this PR — and is being raised separately.

[APIM-14996]: https://gravitee.atlassian.net/browse/APIM-14996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ







