### PR TITLE
fix(gateway): use stable route name for OpenTelemetry transaction.name

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -254,7 +254,15 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
     }
 
     private void markTracingRoute(final Context vertxContext, final String route) {
-        vertxContext.putLocal(TRACING_ROUTE_CONTEXT_KEY, route);
+        // Vert.x 4 exposes String-keyed Context#putLocal directly; on Vert.x 5 (master, 4.12.x) it moved to
+        // io.vertx.core.internal.ContextInternal and requires a cast, so this line needs adjusting on cherry-pick.
+        vertxContext.putLocal(TRACING_ROUTE_CONTEXT_KEY, withoutTrailingSlash(route));
+    }
+
+    // httpAcceptor.path() always has a trailing slash; strip it so http.route matches url.path (both for
+    // correlation in APM tooling and so pre-existing transaction.name-based searches keep matching).
+    private static String withoutTrailingSlash(final String path) {
+        return path.length() > 1 && path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
     }
 
     private MutableExecutionContext prepareExecutionContext(final HttpServerRequest httpServerRequest) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -156,6 +156,9 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             mutableCtx.tracer(
                 new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, gatewayTracingContext.opentelemetryTracer())
             );
+            // No route matched: bucket all of it under "/" rather than the unbounded raw request URI
+            // (scanner/probe traffic on internet-facing gateways is otherwise the largest source of cardinality).
+            markTracingRoute(vertxContext, "/");
             ProcessorChain preProcessorChain = platformProcessorChainFactory.preProcessorChain();
             List<ProcessorHook> processHooks = gatewayTracingContext.isVerbose() ? List.of(tracingHook) : List.of();
             Completable handleNotFoundCompletable = HookHelper.hook(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -83,6 +83,8 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
 
     private static final String ATTR_INTERNAL_VERTX_TIMER_ID = ContextAttributes.ATTR_PREFIX + "vertx-timer-id";
     public static final String ATTR_ENTRYPOINT = ContextAttributes.ATTR_PREFIX + "entrypoint";
+    // Key checked by gravitee-node's RouteGetter (OTel span naming) before falling back to the raw request URI.
+    private static final String TRACING_ROUTE_CONTEXT_KEY = "VertxRoute";
     private final GatewayConfiguration gatewayConfiguration;
     private final HttpAcceptorResolver httpAcceptorResolver;
     private final IdGenerator idGenerator;
@@ -190,6 +192,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest);
             mutableCtx.request().contextPath(httpAcceptor.path());
+            markTracingRoute(vertxContext, httpAcceptor.path());
             TracingContext tracingContext = apiReactor.tracingContext();
             mutableCtx.tracer(new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, tracingContext.opentelemetryTracer()));
             mutableCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, apiReactor.api());
@@ -250,6 +253,10 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         return handleV3Request(httpServerRequest, httpAcceptor, vertxContext);
     }
 
+    private void markTracingRoute(final Context vertxContext, final String route) {
+        vertxContext.putLocal(TRACING_ROUTE_CONTEXT_KEY, route);
+    }
+
     private MutableExecutionContext prepareExecutionContext(final HttpServerRequest httpServerRequest) {
         VertxHttpServerRequest request = new VertxHttpServerRequest(
             httpServerRequest,
@@ -288,6 +295,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         final Context vertxContext
     ) {
         final ReactorHandler reactorHandler = handlerEntrypoint.reactor();
+        markTracingRoute(vertxContext, handlerEntrypoint.path());
 
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(httpServerRequest, idGenerator);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -96,6 +96,8 @@ class DefaultHttpRequestDispatcherTest {
 
     protected static final String HOST = "gravitee.io";
     protected static final String PATH = "/path";
+    // AbstractHttpAcceptor always appends a trailing slash; the real acceptor never returns PATH as-is.
+    protected static final String ACCEPTOR_PATH = "/path/";
     protected static final String MOCK_ERROR_MESSAGE = "Mock error";
     public static final String SERVER_ID = null;
 
@@ -242,7 +244,7 @@ class DefaultHttpRequestDispatcherTest {
         @BeforeEach
         public void prepareV4EmulationMock() {
             when(httpAcceptorResolver.resolve(HOST, PATH, SERVER_ID)).thenReturn(handlerEntrypoint);
-            when(handlerEntrypoint.path()).thenReturn(PATH);
+            when(handlerEntrypoint.path()).thenReturn(ACCEPTOR_PATH);
             when(handlerEntrypoint.reactor()).thenReturn(apiReactor);
             when(apiReactor.tracingContext()).thenReturn(tracingContext);
         }
@@ -325,7 +327,7 @@ class DefaultHttpRequestDispatcherTest {
         @BeforeEach
         public void prepareV2ApiReactor() {
             when(httpAcceptorResolver.resolve(HOST, PATH, SERVER_ID)).thenReturn(handlerEntrypoint);
-            when(handlerEntrypoint.path()).thenReturn(PATH);
+            when(handlerEntrypoint.path()).thenReturn(ACCEPTOR_PATH);
             when(handlerEntrypoint.reactor()).thenReturn(apiReactor);
             when(apiReactor.tracingContext()).thenReturn(tracingContext);
             mockConnectionCreationTimestamp();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -64,6 +64,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
@@ -284,6 +285,17 @@ class DefaultHttpRequestDispatcherTest {
         }
 
         @Test
+        void shouldUseStableRouteAsTracingSpanNameOnV4EmulationRequest() {
+            when(apiReactor.handle(any(MutableExecutionContext.class))).thenReturn(Completable.complete());
+            ArgumentCaptor<Context> vertxContextCaptor = ArgumentCaptor.forClass(Context.class);
+
+            cut.dispatch(rxRequest, SERVER_ID).test().assertComplete();
+
+            verify(spyNoopTracer).startRootSpanFrom(vertxContextCaptor.capture(), any());
+            assertThat(vertxContextCaptor.getValue().<String>getLocal("VertxRoute")).isEqualTo(PATH);
+        }
+
+        @Test
         void shouldEndTracingSpanInErrorWhenExceptionOnV4EmulationRequest() {
             when(
                 apiReactor.handle(
@@ -313,6 +325,7 @@ class DefaultHttpRequestDispatcherTest {
         @BeforeEach
         public void prepareV2ApiReactor() {
             when(httpAcceptorResolver.resolve(HOST, PATH, SERVER_ID)).thenReturn(handlerEntrypoint);
+            when(handlerEntrypoint.path()).thenReturn(PATH);
             when(handlerEntrypoint.reactor()).thenReturn(apiReactor);
             when(apiReactor.tracingContext()).thenReturn(tracingContext);
             mockConnectionCreationTimestamp();
@@ -464,6 +477,25 @@ class DefaultHttpRequestDispatcherTest {
             cut.dispatch(rxRequest, SERVER_ID).test().assertComplete();
             verify(spyNoopTracer).startRootSpanFrom(any(), any());
             verify(spyNoopTracer, timeout(1000)).endWithResponse(any(), any(), any());
+        }
+
+        @Test
+        void shouldUseStableRouteAsTracingSpanNameOnV3Request() {
+            when(response.ended()).thenReturn(true);
+
+            doAnswer(i -> {
+                simulateEndHandlerCall(i);
+                return null;
+            })
+                .when(apiReactor)
+                .handle(any(ExecutionContext.class), any(Handler.class));
+
+            ArgumentCaptor<Context> vertxContextCaptor = ArgumentCaptor.forClass(Context.class);
+
+            cut.dispatch(rxRequest, SERVER_ID).test().assertComplete();
+
+            verify(spyNoopTracer).startRootSpanFrom(vertxContextCaptor.capture(), any());
+            assertThat(vertxContextCaptor.getValue().<String>getLocal("VertxRoute")).isEqualTo(PATH);
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -551,6 +551,19 @@ class DefaultHttpRequestDispatcherTest {
             verify(spyNoopTracer).startRootSpanFrom(any(), any());
             verify(spyNoopTracer, timeout(1000)).endWithResponseAndError(any(), any(), any(), eq((Throwable) null));
         }
+
+        @Test
+        void shouldUseStableRouteAsTracingSpanNameOnNotFoundRequest() {
+            ProcessorChain processorChain = spy(new ProcessorChain("id", List.of()));
+            when(notFoundProcessorChainFactory.processorChain()).thenReturn(processorChain);
+            when(httpAcceptorResolver.resolve(HOST, PATH, SERVER_ID)).thenReturn(null);
+            ArgumentCaptor<Context> vertxContextCaptor = ArgumentCaptor.forClass(Context.class);
+
+            cut.dispatch(rxRequest, SERVER_ID).test().assertComplete();
+
+            verify(spyNoopTracer).startRootSpanFrom(vertxContextCaptor.capture(), any());
+            assertThat(vertxContextCaptor.getValue().<String>getLocal("VertxRoute")).isEqualTo("/");
+        }
     }
 
     private void simulateEndHandlerCall(InvocationOnMock i) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -145,7 +145,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .assertNoErrors();
 
         Set<String> expectedOperationNames = Set.of(
-            "POST /test",
+            "POST /test/",
             "Request phase",
             "REQUEST Processor (processor-metrics)",
             "REQUEST Processor (pre-processor-transaction)",
@@ -178,7 +178,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 assertThat(response.statusCode()).isEqualTo(200);
                 JsonObject body = response.bodyAsJsonObject();
                 assertData(body, expectedOperationNames);
-                assertExactlyOneSpanWithKind(body, "POST /test", "server");
+                assertExactlyOneSpanWithKind(body, "POST /test/", "server");
             });
     }
 
@@ -205,7 +205,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
         httpClient.close().blockingAwait();
 
         Set<String> expectedOperationNames = Set.of(
-            "GET /test",
+            "GET /test/",
             "REQUEST Processor (processor-metrics)",
             "REQUEST Processor (pre-processor-transaction)",
             "REQUEST Processor (processor-x-forward-for)",
@@ -239,7 +239,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 assertThat(response.statusCode()).isEqualTo(200);
                 JsonObject body = response.bodyAsJsonObject();
                 assertData(body, expectedOperationNames);
-                assertExactlyOneSpanWithKind(body, "GET /test", "server");
+                assertExactlyOneSpanWithKind(body, "GET /test/", "server");
             });
     }
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -145,7 +145,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .assertNoErrors();
 
         Set<String> expectedOperationNames = Set.of(
-            "POST /test/",
+            "POST /test",
             "Request phase",
             "REQUEST Processor (processor-metrics)",
             "REQUEST Processor (pre-processor-transaction)",
@@ -178,7 +178,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 assertThat(response.statusCode()).isEqualTo(200);
                 JsonObject body = response.bodyAsJsonObject();
                 assertData(body, expectedOperationNames);
-                assertExactlyOneSpanWithKind(body, "POST /test/", "server");
+                assertExactlyOneSpanWithKind(body, "POST /test", "server");
             });
     }
 
@@ -205,7 +205,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
         httpClient.close().blockingAwait();
 
         Set<String> expectedOperationNames = Set.of(
-            "GET /test/",
+            "GET /test",
             "REQUEST Processor (processor-metrics)",
             "REQUEST Processor (pre-processor-transaction)",
             "REQUEST Processor (processor-x-forward-for)",
@@ -239,7 +239,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 assertThat(response.statusCode()).isEqualTo(200);
                 JsonObject body = response.bodyAsJsonObject();
                 assertData(body, expectedOperationNames);
-                assertExactlyOneSpanWithKind(body, "GET /test/", "server");
+                assertExactlyOneSpanWithKind(body, "GET /test", "server");
             });
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14819

**Purpose**

Stop the Gateway's OpenTelemetry root span (transaction.name in Elastic APM / Jaeger) from including the concrete request path and query string, which was producing one distinct transaction name per unique ID/query combination and triggering high-cardinality warnings.

**Summary of changes**

`DefaultHttpRequestDispatcher` now sets the Vert.x context local `"VertxRoute"` to the API's stable acceptor path (`httpAcceptor.path()`) before the root span starts, for both the V4 and V3 request-handling branches. `gravitee-node`'s `RouteGetter` already prefers this context local over the raw request URI when naming the span — it just was never populated. No `gravitee-node` change required.

**Out of scope**

The "not found" branch (no acceptor resolved) still falls back to the raw URI — there's no real route to report there by definition.

**Testing**

- Unit: two new tests in `DefaultHttpRequestDispatcherTest` (V4 and V3 paths) assert the `"VertxRoute"` context local passed to `startRootSpanFrom` equals the API's configured path. Written RED-first, confirmed failing before the fix, passing after. Full module suite green (232/232).
- Manual/docker: built this branch's Gateway into a local Docker image, ran it with Jaeger via `docker/quick-setup/opentelemetry-jaeger`, deployed a v4 HTTP proxy API with a keyless plan and tracing enabled, and called it 10+ times with different resource IDs and query strings. Every trace produced the identical span name (the API's route), with no query string — confirmed via the Jaeger HTTP API against each trace's raw `url.path` attribute, which was genuinely different every time.

**Additional context**

No screenshot/video included — this is an internal tracing behavior fix with no UI surface; verification was done via the Jaeger HTTP API (see Testing). Happy to capture a Jaeger UI screenshot as a follow-up if useful.