### PR TITLE
feat(automation): api-referenced links automation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryService.java
@@ -20,7 +20,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -61,11 +60,11 @@ public class AutomationManagedNavigationItemsQueryService {
             .collect(Collectors.toSet());
     }
 
-    public Set<PortalNavigationItemId> automationManagedApiDocPages(AuditInfo auditInfo, PortalNavigationApi navApi, String apiId) {
+    public Set<PortalNavigationItemId> automationManagedApiDocPages(AuditInfo auditInfo, String apiId) {
         return portalPageContentQueryService
             .findByReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
             .stream()
-            .map(pc -> PortalNavigationItemId.forApiDocumentation(auditInfo, navApi.getId(), pc.getId()))
+            .map(pc -> PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, pc.getId()))
             .collect(Collectors.toSet());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -56,22 +56,16 @@ class ApiFolderSubtreeReconciler {
         List<PortalNavigationItem> currentFolders
     ) {
         var desired = desiredPaths(apiId);
-        var ownership = ownership(auditInfo, navApi, apiId, desired);
+        var ownership = ownership(auditInfo, apiId, desired);
         var plan = NavigationSyncPlanner.plan(desired, currentFolders, previousPaths, ownership);
-        Function<String, PortalNavigationItemId> idMapper = path -> apiFolderId(auditInfo, navApi.getId(), path);
+        Function<String, PortalNavigationItemId> idMapper = path -> apiFolderId(auditInfo, apiId, path);
         var deleteStrategy = ownership.asDeleteStrategy();
         planExecutor.execute(plan, auditInfo, navApi.getArea(), navApi, idMapper, deleteStrategy);
     }
 
-    void validateConflicts(
-        AuditInfo auditInfo,
-        PortalNavigationApi navApi,
-        String apiId,
-        List<NavigationPath> desired,
-        List<PortalNavigationItem> currentFolders
-    ) {
+    void validateConflicts(AuditInfo auditInfo, String apiId, List<NavigationPath> desired, List<PortalNavigationItem> currentFolders) {
         var safeDesired = desired == null ? List.<NavigationPath>of() : desired;
-        var ownership = ownership(auditInfo, navApi, apiId, safeDesired);
+        var ownership = ownership(auditInfo, apiId, safeDesired);
         NavigationSyncPlanner.plan(safeDesired, currentFolders, safeDesired, ownership);
     }
 
@@ -109,18 +103,18 @@ class ApiFolderSubtreeReconciler {
             .orElseGet(List::of);
     }
 
-    private NavigationOwnership ownership(AuditInfo auditInfo, PortalNavigationApi navApi, String apiId, List<NavigationPath> paths) {
+    private NavigationOwnership ownership(AuditInfo auditInfo, String apiId, List<NavigationPath> paths) {
         return new NavigationOwnership(
             NavigationSyncPlanner.expandToFullPaths(paths),
-            path -> apiFolderId(auditInfo, navApi.getId(), path),
-            automationManagedNavigationItemsQueryService.automationManagedApiDocPages(auditInfo, navApi, apiId),
+            path -> apiFolderId(auditInfo, apiId, path),
+            automationManagedNavigationItemsQueryService.automationManagedApiDocPages(auditInfo, apiId),
             Set.of(),
             Set.of()
         );
     }
 
-    private PortalNavigationItemId apiFolderId(AuditInfo auditInfo, PortalNavigationItemId navApiId, String path) {
-        return PortalNavigationItemId.forApiFolder(auditInfo, navApiId, path);
+    private PortalNavigationItemId apiFolderId(AuditInfo auditInfo, String apiId, String path) {
+        return PortalNavigationItemId.forApiFolder(auditInfo, apiId, path);
     }
 
     private static final class FolderCollector implements PortalNavigationVisitor {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -102,7 +102,7 @@ public class PortalListingSyncDomainService {
             if (existing instanceof PortalNavigationApi navApi) {
                 var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
                 var desired = apiFolderSubtreeReconciler.desiredPaths(apiId);
-                apiFolderSubtreeReconciler.validateConflicts(auditInfo, navApi, apiId, desired, currentFolders);
+                apiFolderSubtreeReconciler.validateConflicts(auditInfo, apiId, desired, currentFolders);
             }
         }
     }
@@ -113,7 +113,7 @@ public class PortalListingSyncDomainService {
         var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
         for (var navApi : navApis) {
             var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-            apiFolderSubtreeReconciler.validateConflicts(auditInfo, navApi, apiId, desired, currentFolders);
+            apiFolderSubtreeReconciler.validateConflicts(auditInfo, apiId, desired, currentFolders);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
@@ -75,20 +75,25 @@ public class ApiDocumentationSyncDomainService {
         var meta = pageContent.getAutomationMetadata();
         var apiId = meta.referenceId();
         var contentId = pageContent.getId();
-        for (var navApi : findNavApiRows(auditInfo.environmentId(), apiId)) {
-            var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, navApi.getId(), contentId);
+        var navApiRows = findNavApiRows(auditInfo.environmentId(), apiId);
+        if (navApiRows.isEmpty()) {
+            return;
+        }
+        for (var navApi : navApiRows) {
+            var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, contentId);
             var parent = resolveParent(auditInfo, navApi, meta.location().orElse(null));
             upsertNavPage(auditInfo, pageId, contentId, parent, meta);
         }
     }
 
     public void dematerialize(AuditInfo auditInfo, String apiId, PortalPageContentId contentId) {
-        for (var navApi : findNavApiRows(auditInfo.environmentId(), apiId)) {
-            var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, navApi.getId(), contentId);
-            var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId);
-            if (existing != null) {
-                navigationItemCrudService.delete(pageId);
-            }
+        if (findNavApiRows(auditInfo.environmentId(), apiId).isEmpty()) {
+            return;
+        }
+        var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, contentId);
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId);
+        if (existing != null) {
+            navigationItemCrudService.delete(pageId);
         }
     }
 
@@ -119,7 +124,7 @@ public class ApiDocumentationSyncDomainService {
         portalPageContentQueryService
             .findByReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
             .forEach(pc -> {
-                var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, navApiId, pc.getId());
+                var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, pc.getId());
                 if (navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId) != null) {
                     navigationItemCrudService.delete(pageId);
                 }
@@ -148,7 +153,7 @@ public class ApiDocumentationSyncDomainService {
         if (location == null || location.isBlank() || "/".equals(location)) {
             return navApi;
         }
-        var folderId = PortalNavigationItemId.forApiFolder(auditInfo, navApi.getId(), location);
+        var folderId = PortalNavigationItemId.forApiFolder(auditInfo, navApi.getApiId(), location);
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), folderId);
         if (existing instanceof PortalNavigationItemContainer container) {
             return container;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
@@ -61,19 +61,34 @@ public class PortalLinkSyncDomainService {
         String location,
         Integer order
     ) {
-        var linkId = linkId(auditInfo, portalId, linkHrid);
+        return upsert(
+            auditInfo,
+            PortalNavigationItemId.forPortalLink(auditInfo, portalId, linkHrid),
+            resolveParent(auditInfo, location, portalId),
+            linkHrid,
+            name,
+            href,
+            location,
+            order,
+            new AutomationMetadata(AutomationMetadata.ReferenceType.PORTAL, portalId, null, Optional.ofNullable(location), Optional.empty())
+        );
+    }
+
+    private PortalNavigationLink upsert(
+        AuditInfo auditInfo,
+        PortalNavigationItemId linkId,
+        PortalNavigationItemContainer parent,
+        String linkHrid,
+        String name,
+        String href,
+        String location,
+        Integer order,
+        AutomationMetadata automationMetadata
+    ) {
         var segment = Slug.from(linkHrid).value();
-        var parent = resolveParent(auditInfo, location, portalId);
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), linkId);
         var existingLink = existing instanceof PortalNavigationLink link ? link : null;
         var parentId = parent == null ? null : parent.getId();
-        var automationMetadata = new AutomationMetadata(
-            AutomationMetadata.ReferenceType.PORTAL,
-            portalId,
-            null,
-            Optional.ofNullable(location),
-            Optional.empty()
-        );
 
         // Segment is derived from the stable linkHrid, never from the mutable name — so a conflict can
         // only newly arise on create or on an actual relocation. Skipping the check on an in-place update
@@ -109,6 +124,7 @@ public class PortalLinkSyncDomainService {
             .type(PortalNavigationItemType.LINK)
             .order(order != null ? order : 0)
             .url(href)
+            .reference(automationMetadata.reference())
             .automationMetadata(automationMetadata)
             .visibility(PortalVisibility.PUBLIC)
             .published(true)
@@ -120,13 +136,48 @@ public class PortalLinkSyncDomainService {
     }
 
     public void validateForConflicts(AuditInfo auditInfo, String portalId, String linkHrid, String location) {
-        var linkId = linkId(auditInfo, portalId, linkHrid);
-
         rejectIfSegmentTakenByForeignItem(
             auditInfo,
             resolveParent(auditInfo, location, portalId),
             Slug.from(linkHrid).value(),
-            linkId,
+            PortalNavigationItemId.forPortalLink(auditInfo, portalId, linkHrid),
+            location
+        );
+    }
+
+    /**
+     * The API-attached counterpart of {@link #materialize}. {@code location} resolves against the
+     * API's own {@code portalNavigation} folder subtree — the same tree API-attached documentation
+     * uses — so the parent is derived from the API rather than from a portal folder.
+     */
+    public PortalNavigationLink materializeForApi(
+        AuditInfo auditInfo,
+        String apiId,
+        String linkHrid,
+        String name,
+        String href,
+        String location,
+        Integer order
+    ) {
+        return upsert(
+            auditInfo,
+            PortalNavigationItemId.forApiLink(auditInfo, apiId, linkHrid),
+            resolveApiParent(auditInfo, location, apiId),
+            linkHrid,
+            name,
+            href,
+            location,
+            order,
+            new AutomationMetadata(AutomationMetadata.ReferenceType.API, apiId, null, Optional.ofNullable(location), Optional.empty())
+        );
+    }
+
+    public void validateForConflictsForApi(AuditInfo auditInfo, String apiId, String linkHrid, String location) {
+        rejectIfSegmentTakenByForeignItem(
+            auditInfo,
+            resolveApiParent(auditInfo, location, apiId),
+            Slug.from(linkHrid).value(),
+            PortalNavigationItemId.forApiLink(auditInfo, apiId, linkHrid),
             location
         );
     }
@@ -137,8 +188,21 @@ public class PortalLinkSyncDomainService {
         }
     }
 
-    private static PortalNavigationItemId linkId(AuditInfo auditInfo, String portalId, String linkHrid) {
-        return PortalNavigationItemId.forPortalLink(auditInfo, portalId, linkHrid);
+    /**
+     * An API-attached link lives in the API's own navigation subtree, so its location resolves in the
+     * API's key space and an absent location makes the link a root of that subtree. Rendering splices
+     * the subtree in under every portal row that lists the API; nothing here needs to know about portals.
+     */
+    private PortalNavigationItemContainer resolveApiParent(AuditInfo auditInfo, String location, String apiId) {
+        if (location == null || location.isBlank() || "/".equals(location)) {
+            return null;
+        }
+        var folderId = PortalNavigationItemId.forApiFolder(auditInfo, apiId, location);
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), folderId);
+        if (existing instanceof PortalNavigationItemContainer container) {
+            return container;
+        }
+        return PortalNavigationItemContainer.phantom(folderId);
     }
 
     private PortalNavigationItemContainer resolveParent(AuditInfo auditInfo, String location, String portalId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluator.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service;
 
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
@@ -27,8 +28,10 @@ import java.util.function.Predicate;
 public class PortalNavigationItemVisibilityEvaluator {
 
     private final String environmentId;
+    private final PortalNavigationItemViewerContext viewerContext;
     private final PortalNavigationItemsQueryService queryService;
     private final List<PreparedVisibilityService> visibilityServices;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
 
     public PortalNavigationItemVisibilityEvaluator(
         String environmentId,
@@ -37,11 +40,18 @@ public class PortalNavigationItemVisibilityEvaluator {
         List<PortalNavigationItemVisibilityService> visibilityServices
     ) {
         this.environmentId = environmentId;
+        this.viewerContext = viewerContext;
         this.queryService = queryService;
         this.visibilityServices = visibilityServices
             .stream()
             .map(service -> new PreparedVisibilityService(service, service.prepareVisibilityPredicate(environmentId, viewerContext)))
             .toList();
+        this.apiVisibilityDomainService = visibilityServices
+            .stream()
+            .filter(PortalNavigationApiVisibilityDomainService.class::isInstance)
+            .map(PortalNavigationApiVisibilityDomainService.class::cast)
+            .findFirst()
+            .orElse(null);
     }
 
     public boolean isVisible(PortalNavigationItem item) {
@@ -62,7 +72,22 @@ public class PortalNavigationItemVisibilityEvaluator {
                 return true;
             }
         }
+        if (current != null && current.isRoot() && current.getReference() instanceof NavigationItemReference.ApiReference apiReference) {
+            return isEnclosingApiHidden(apiReference.apiId());
+        }
         return false;
+    }
+
+    /**
+     * PortalNavigationApiVisibilityDomainService judges an API by API + viewer only, independent of
+     * which portal is rendering it, so it is safe to call here without knowing the current portal.
+     * If that assumption changes (API visibility becomes portal-dependent), this decision must be revisited.
+     */
+    private boolean isEnclosingApiHidden(String apiId) {
+        if (apiVisibilityDomainService == null) {
+            return false;
+        }
+        return !apiVisibilityDomainService.isApiVisibleToUser(environmentId, apiId, viewerContext.userId().orElse(null));
     }
 
     private record PreparedVisibilityService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemId.java
@@ -73,16 +73,20 @@ public class PortalNavigationItemId implements Comparable<PortalNavigationItemId
         return of(HRIDToUUID.portalLink().context(auditInfo).portal(portalId).hrid(linkHrid).id());
     }
 
-    public static PortalNavigationItemId forApiDocumentation(
-        AuditInfo auditInfo,
-        PortalNavigationItemId navApiRowId,
-        PortalPageContentId contentId
-    ) {
-        return of(HRIDToUUID.navigation().context(auditInfo).api(navApiRowId.toString()).documentation(contentId.toString()).id());
+    /**
+     * The API-attached sibling of {@link #forPortalLink}. Keyed on the API rather than on a
+     * {@code PortalNavigationApi} row, so the id survives listings being added or removed.
+     */
+    public static PortalNavigationItemId forApiLink(AuditInfo auditInfo, String apiId, String linkHrid) {
+        return of(HRIDToUUID.apiLink().context(auditInfo).api(apiId).hrid(linkHrid).id());
     }
 
-    public static PortalNavigationItemId forApiFolder(AuditInfo auditInfo, PortalNavigationItemId navApiRowId, @Nullable String location) {
-        return of(HRIDToUUID.navigation().context(auditInfo).api(navApiRowId.toString()).folder(normalizeLocation(location)).id());
+    public static PortalNavigationItemId forApiDocumentation(AuditInfo auditInfo, String apiId, PortalPageContentId contentId) {
+        return of(HRIDToUUID.navigation().context(auditInfo).api(apiId).documentation(contentId.toString()).id());
+    }
+
+    public static PortalNavigationItemId forApiFolder(AuditInfo auditInfo, String apiId, @Nullable String location) {
+        return of(HRIDToUUID.navigation().context(auditInfo).api(apiId).folder(normalizeLocation(location)).id());
     }
 
     private static String normalizeLocation(@Nullable String location) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiLinkUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiLinkUseCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.AbstractDomainException;
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import io.gravitee.apim.core.portal_page.domain_service.PortalLinkSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateOrUpdateApiLinkUseCase {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+    private final PortalNavigationItemValidatorService navigationItemValidatorService;
+    private final PortalLinkSyncDomainService syncDomainService;
+
+    public record Input(AuditInfo auditInfo, String apiId, String linkHrid, String name, String href, String location, Integer order) {}
+
+    public record Output(PortalNavigationLink link, List<Validator.Error> errors) {}
+
+    /**
+     * Severe errors are reported in {@link Output#errors()} rather than thrown, so the caller can emit
+     * the structured {@code errors.severe[]} array. Nothing is materialized when any severe error is
+     * present.
+     */
+    public Output execute(Input input) {
+        var sanitizedName = input.name() != null ? input.name().trim() : null;
+        var sanitizedHref = input.href() != null ? input.href().trim() : null;
+
+        var errors = new ArrayList<Validator.Error>();
+        if (input.location() != null) {
+            errors.addAll(NavigationPathValidator.validate(input.location(), "location"));
+        }
+
+        if (errors.stream().anyMatch(Validator.Error::isSevere)) {
+            return new Output(null, errors);
+        }
+
+        var linkId = PortalNavigationItemId.forApiLink(input.auditInfo(), input.apiId(), input.linkHrid());
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(input.auditInfo().environmentId(), linkId);
+
+        // The shared validator throws on its first failing rule, so at most one error surfaces here.
+        try {
+            if (existing instanceof PortalNavigationLink existingLink) {
+                var toUpdate = UpdatePortalNavigationItem.builder()
+                    .type(PortalNavigationItemType.LINK)
+                    .title(sanitizedName)
+                    .url(sanitizedHref)
+                    .build();
+                navigationItemValidatorService.validateToUpdate(toUpdate, existingLink);
+            } else {
+                var toCreate = CreatePortalNavigationItem.builder()
+                    .id(linkId)
+                    .type(PortalNavigationItemType.LINK)
+                    .title(sanitizedName)
+                    .url(sanitizedHref)
+                    .build();
+                navigationItemValidatorService.validateOne(toCreate, input.auditInfo().environmentId());
+            }
+            syncDomainService.validateForConflictsForApi(input.auditInfo(), input.apiId(), input.linkHrid(), input.location());
+        } catch (AbstractDomainException e) {
+            errors.add(Validator.Error.severe("%s", e.getMessage()));
+        }
+
+        if (errors.stream().anyMatch(Validator.Error::isSevere)) {
+            return new Output(null, errors);
+        }
+
+        var link = syncDomainService.materializeForApi(
+            input.auditInfo(),
+            input.apiId(),
+            input.linkHrid(),
+            sanitizedName,
+            sanitizedHref,
+            input.location(),
+            input.order()
+        );
+
+        return new Output(link, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiLinkUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiLinkUseCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_page.domain_service.PortalLinkSyncDomainService;
+import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteApiLinkUseCase {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+    private final PortalLinkSyncDomainService syncDomainService;
+
+    public record Input(AuditInfo auditInfo, PortalNavigationItemId linkId) {}
+
+    public void execute(Input input) {
+        var item = navigationItemsQueryService.findByIdAndEnvironmentId(input.auditInfo().environmentId(), input.linkId());
+        if (
+            !(item instanceof PortalNavigationLink link) ||
+            link.getAutomationMetadata() == null ||
+            link.getAutomationMetadata().referenceType() != AutomationMetadata.ReferenceType.API
+        ) {
+            throw new PortalLinkNotFoundException(input.linkId().toString());
+        }
+        syncDomainService.dematerialize(input.auditInfo(), input.linkId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetApiLinkUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetApiLinkUseCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetApiLinkUseCase {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    public record Input(AuditInfo auditInfo, PortalNavigationItemId linkId) {}
+
+    public record Output(PortalNavigationLink link) {}
+
+    public Output execute(Input input) {
+        var item = navigationItemsQueryService.findByIdAndEnvironmentId(input.auditInfo().environmentId(), input.linkId());
+        if (!(item instanceof PortalNavigationLink link) || !isApiAttached(link)) {
+            throw new PortalLinkNotFoundException(input.linkId().toString());
+        }
+        return new Output(link);
+    }
+
+    // Scopes the read to API-attached links so an /apis/{apiHrid}/links path cannot reach a
+    // portal-attached one, mirroring GetApiDocumentationUseCase's referenceType filter.
+    private static boolean isApiAttached(PortalNavigationLink link) {
+        return link.getAutomationMetadata() != null && link.getAutomationMetadata().referenceType() == AutomationMetadata.ReferenceType.API;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -22,13 +22,17 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityEvaluator;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemVisibilityService;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemComparator;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
@@ -61,20 +65,16 @@ public class ListPortalNavigationItemsUseCase {
             visibilityServices
         );
 
-        PortalNavigationItem parentItem;
+        List<PortalNavigationItem> rootItems;
         if (input.parentId().isPresent()) {
-            parentItem = findAndValidateParent(input, visibilityEvaluator);
+            var parentItem = findAndValidateParent(input, visibilityEvaluator);
             if (parentItem == null) {
                 return new Output(List.of(), Map.of());
             }
+            rootItems = childrenOf(parentItem, input, visibilityEvaluator);
+        } else {
+            rootItems = searchItems(input, null, true, visibilityEvaluator);
         }
-
-        List<PortalNavigationItem> rootItems = searchItems(
-            input,
-            input.parentId().orElse(null),
-            input.parentId().isEmpty(),
-            visibilityEvaluator
-        );
 
         List<PortalNavigationItem> allItems = new ArrayList<>(rootItems);
 
@@ -154,7 +154,7 @@ public class ListPortalNavigationItemsUseCase {
         while (!queue.isEmpty()) {
             var currentFolder = queue.removeFirst();
 
-            var foundChildren = searchItems(input, currentFolder.getId(), false, visibilityEvaluator);
+            var foundChildren = childrenOf(currentFolder, input, visibilityEvaluator);
 
             if (!foundChildren.isEmpty()) {
                 childrenAccumulator.addAll(foundChildren);
@@ -186,7 +186,133 @@ public class ListPortalNavigationItemsUseCase {
         }
 
         List<PortalNavigationItem> items = queryService.search(builder.build());
+        if (isRootSearch) {
+            // An API's subtree is materialized once, as a root, and spliced in under every portal's
+            // nav-api row by childrenOf(...) — it must never also surface at the portal's own top level.
+            items = items
+                .stream()
+                .filter(item -> !(item.getReference() instanceof NavigationItemReference.ApiReference))
+                .toList();
+        }
         return filterHiddenItems(items, input.viewerContext(), visibilityEvaluator);
+    }
+
+    /**
+     * A {@link PortalNavigationApi} row can have two kinds of children: ordinary console-authored
+     * sub-navigation, still physically parented under the row and found the usual way, and the API's
+     * own automation-owned subtree — materialized once, keyed on the API — reached here by reference
+     * rather than by the row's own parentId, so it renders identically under every portal row that
+     * lists the API. Both are real; this returns their union.
+     */
+    private List<PortalNavigationItem> childrenOf(
+        PortalNavigationItem parent,
+        Input input,
+        PortalNavigationItemVisibilityEvaluator visibilityEvaluator
+    ) {
+        if (parent instanceof PortalNavigationApi navApi) {
+            var physicalChildren = searchItems(input, navApi.getId(), false, visibilityEvaluator);
+            var splicedRoots = queryService.findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(
+                input.environmentId(),
+                input.portalArea(),
+                new NavigationItemReference.ApiReference(navApi.getApiId())
+            );
+            var combined = new ArrayList<>(physicalChildren);
+            combined.addAll(renderUnder(navApi, filterForViewer(splicedRoots, input, visibilityEvaluator)));
+            return combined;
+        }
+        return searchItems(input, parent.getId(), false, visibilityEvaluator);
+    }
+
+    /**
+     * {@code findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference} has no published/visibility
+     * criteria of its own — unlike {@code searchItems}'s query builder — so portal-mode narrowing is
+     * applied here in Java before the shared {@link #filterHiddenItems} pass.
+     */
+    private List<PortalNavigationItem> filterForViewer(
+        List<PortalNavigationItem> items,
+        Input input,
+        PortalNavigationItemVisibilityEvaluator visibilityEvaluator
+    ) {
+        var viewerContext = input.viewerContext();
+        var narrowed = items;
+        if (viewerContext.isPortalMode()) {
+            narrowed = narrowed
+                .stream()
+                .filter(item -> Boolean.TRUE.equals(item.getPublished()))
+                .toList();
+            if (!viewerContext.isAuthenticated()) {
+                narrowed = narrowed
+                    .stream()
+                    .filter(item -> item.getVisibility() == PortalVisibility.PUBLIC)
+                    .toList();
+            }
+        }
+        return filterHiddenItems(narrowed, viewerContext, visibilityEvaluator);
+    }
+
+    /**
+     * The returned model deliberately does not mirror storage: each spliced root is a copy with its
+     * {@code parentId} rewritten to the nav-api row it renders under here, so every client keeps
+     * rebuilding the tree from {@code parentId} unchanged. The original stored item — root, with no
+     * parent — is never mutated; the same root renders differently under each portal that lists the API.
+     */
+    private List<PortalNavigationItem> renderUnder(PortalNavigationItemContainer navApiRow, List<PortalNavigationItem> roots) {
+        return roots
+            .stream()
+            .map(root -> renderedCopy(root, navApiRow))
+            .toList();
+    }
+
+    private PortalNavigationItem renderedCopy(PortalNavigationItem item, PortalNavigationItemContainer parent) {
+        PortalNavigationItem copy = switch (item) {
+            case PortalNavigationPage page -> PortalNavigationPage.builder()
+                .id(page.getId())
+                .organizationId(page.getOrganizationId())
+                .environmentId(page.getEnvironmentId())
+                .reference(page.getReference())
+                .title(page.getTitle())
+                .segment(page.getSegment())
+                .area(page.getArea())
+                .order(page.getOrder())
+                .published(page.getPublished())
+                .visibility(page.getVisibility())
+                .source(page.getSource())
+                .automationMetadata(page.getAutomationMetadata())
+                .portalPageContentId(page.getPortalPageContentId())
+                .build();
+            case PortalNavigationFolder folder -> PortalNavigationFolder.builder()
+                .id(folder.getId())
+                .organizationId(folder.getOrganizationId())
+                .environmentId(folder.getEnvironmentId())
+                .reference(folder.getReference())
+                .title(folder.getTitle())
+                .segment(folder.getSegment())
+                .area(folder.getArea())
+                .order(folder.getOrder())
+                .published(folder.getPublished())
+                .visibility(folder.getVisibility())
+                .source(folder.getSource())
+                .automationMetadata(folder.getAutomationMetadata())
+                .build();
+            case PortalNavigationLink link -> PortalNavigationLink.builder()
+                .id(link.getId())
+                .organizationId(link.getOrganizationId())
+                .environmentId(link.getEnvironmentId())
+                .reference(link.getReference())
+                .title(link.getTitle())
+                .segment(link.getSegment())
+                .area(link.getArea())
+                .order(link.getOrder())
+                .published(link.getPublished())
+                .visibility(link.getVisibility())
+                .source(link.getSource())
+                .automationMetadata(link.getAutomationMetadata())
+                .url(link.getUrl())
+                .build();
+            default -> throw new IllegalStateException("Unexpected API subtree root type: " + item.getClass().getSimpleName());
+        };
+        copy.updateParent(parent);
+        return copy;
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ValidateApiLinkUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ValidateApiLinkUseCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.AbstractDomainException;
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import io.gravitee.apim.core.portal_page.domain_service.PortalLinkSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ValidateApiLinkUseCase {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+    private final PortalNavigationItemValidatorService navigationItemValidatorService;
+    private final PortalLinkSyncDomainService syncDomainService;
+
+    public CreateOrUpdateApiLinkUseCase.Output execute(CreateOrUpdateApiLinkUseCase.Input input) {
+        var sanitizedName = input.name() != null ? input.name().trim() : null;
+        var sanitizedHref = input.href() != null ? input.href().trim() : null;
+
+        var errors = new ArrayList<Validator.Error>();
+        if (input.location() != null) {
+            errors.addAll(NavigationPathValidator.validate(input.location(), "location"));
+        }
+
+        var linkId = PortalNavigationItemId.forApiLink(input.auditInfo(), input.apiId(), input.linkHrid());
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(input.auditInfo().environmentId(), linkId);
+
+        try {
+            if (existing instanceof PortalNavigationLink existingLink) {
+                var toUpdate = UpdatePortalNavigationItem.builder()
+                    .type(PortalNavigationItemType.LINK)
+                    .title(sanitizedName)
+                    .url(sanitizedHref)
+                    .build();
+                navigationItemValidatorService.validateToUpdate(toUpdate, existingLink);
+            } else {
+                var toCreate = CreatePortalNavigationItem.builder()
+                    .id(linkId)
+                    .type(PortalNavigationItemType.LINK)
+                    .title(sanitizedName)
+                    .url(sanitizedHref)
+                    .build();
+                navigationItemValidatorService.validateOne(toCreate, input.auditInfo().environmentId());
+            }
+            syncDomainService.validateForConflictsForApi(input.auditInfo(), input.apiId(), input.linkHrid(), input.location());
+        } catch (AbstractDomainException e) {
+            errors.add(Validator.Error.severe("%s", e.getMessage()));
+        }
+
+        return new CreateOrUpdateApiLinkUseCase.Output(null, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -106,6 +106,10 @@ public final class HRIDToUUID {
         return new ApiSubResourceBuilder();
     }
 
+    public static ApiSubResourceBuilder apiLink() {
+        return new ApiSubResourceBuilder();
+    }
+
     public static GammaBuilder gamma() {
         return new GammaBuilder();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryServiceTest.java
@@ -30,7 +30,6 @@ import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_listing.model.PortalListingId;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
@@ -137,11 +136,9 @@ class AutomationManagedNavigationItemsQueryServiceTest {
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api("pets-api").hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(apiDoc(contentId, apiId)));
-        var navApi = navApiRow(PortalNavigationItemId.forListingApi(AUDIT_INFO, PORTAL_ID.toString(), apiId), apiId);
+        var result = queryService.automationManagedApiDocPages(AUDIT_INFO, apiId);
 
-        var result = queryService.automationManagedApiDocPages(AUDIT_INFO, navApi, apiId);
-
-        assertThat(result).containsExactly(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, navApi.getId(), contentId));
+        assertThat(result).containsExactly(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, apiId, contentId));
     }
 
     @Test
@@ -220,20 +217,5 @@ class AutomationManagedNavigationItemsQueryServiceTest {
 
     private static AutomationMetadata automationMetadata(AutomationMetadata.ReferenceType type, String refId) {
         return new AutomationMetadata(type, refId, "name", Optional.of("/x"), Optional.of(0));
-    }
-
-    private static PortalNavigationApi navApiRow(PortalNavigationItemId id, String apiId) {
-        return PortalNavigationApi.builder()
-            .id(id)
-            .organizationId(AUDIT_INFO.organizationId())
-            .environmentId(AUDIT_INFO.environmentId())
-            .title("api")
-            .segment("api")
-            .area(PortalArea.TOP_NAVBAR)
-            .order(0)
-            .apiId(apiId)
-            .published(true)
-            .visibility(PortalVisibility.PUBLIC)
-            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -140,10 +140,7 @@ class PortalListingSyncDomainServiceTest {
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
 
-        var expectedNavApiId = PortalNavigationItemId.of(
-            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).listingApi(apiId).id()
-        );
-        var expectedPageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, expectedNavApiId, docContentId);
+        var expectedPageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, apiId, docContentId);
         assertThat(navItemCrud.storage())
             .filteredOn(PortalNavigationPage.class::isInstance)
             .extracting(PortalNavigationItem::getId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
@@ -81,31 +81,30 @@ class ApiDocumentationSyncDomainServiceTest {
     }
 
     @Test
-    void should_create_one_page_per_nav_api_row_for_the_api() {
-        var navApiA = seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
-        var navApiB = seedNavApi(PortalNavigationItemId.of("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+    void should_create_one_page_for_the_api_however_many_nav_api_rows_exist() {
+        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        seedNavApi(PortalNavigationItemId.of("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
 
         syncService.materialize(AUDIT_INFO, aDocumentation());
 
-        var pageIdA = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, navApiA.getId(), DOC_ID);
-        var pageIdB = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, navApiB.getId(), DOC_ID);
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
         assertThat(
             navItemCrud.storage().stream().filter(PortalNavigationPage.class::isInstance).map(PortalNavigationItem::getId)
-        ).containsExactlyInAnyOrder(pageIdA, pageIdB);
+        ).containsExactly(pageId);
 
-        var pageA = (PortalNavigationPage) navItemCrud
+        var page = (PortalNavigationPage) navItemCrud
             .storage()
             .stream()
-            .filter(item -> item.getId().equals(pageIdA))
+            .filter(item -> item.getId().equals(pageId))
             .findFirst()
             .orElseThrow();
-        assertThat(pageA.getAutomationMetadata()).isNotNull();
-        assertThat(pageA.getAutomationMetadata().referenceType()).isEqualTo(AutomationMetadata.ReferenceType.API);
-        assertThat(pageA.getAutomationMetadata().referenceId()).isEqualTo(API_ID);
-        assertThat(pageA.getAutomationMetadata().location()).isEqualTo(Optional.of("/getting-started"));
+        assertThat(page.getAutomationMetadata()).isNotNull();
+        assertThat(page.getAutomationMetadata().referenceType()).isEqualTo(AutomationMetadata.ReferenceType.API);
+        assertThat(page.getAutomationMetadata().referenceId()).isEqualTo(API_ID);
+        assertThat(page.getAutomationMetadata().location()).isEqualTo(Optional.of("/getting-started"));
         // trimmed: name/order already live natively on the nav item as title/order
-        assertThat(pageA.getAutomationMetadata().name()).isNull();
-        assertThat(pageA.getAutomationMetadata().order()).isEmpty();
+        assertThat(page.getAutomationMetadata().name()).isNull();
+        assertThat(page.getAutomationMetadata().order()).isEmpty();
     }
 
     @Test
@@ -115,8 +114,8 @@ class ApiDocumentationSyncDomainServiceTest {
 
         syncService.materialize(AUDIT_INFO, aDocumentation());
 
-        var pageIdOurs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, ours.getId(), DOC_ID);
-        var pageIdTheirs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, theirs.getId(), DOC_ID);
+        var pageIdOurs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
+        var pageIdTheirs = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, "another-api-id", DOC_ID);
         assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).contains(pageIdOurs).doesNotContain(pageIdTheirs);
     }
 
@@ -152,12 +151,12 @@ class ApiDocumentationSyncDomainServiceTest {
 
     @Test
     void should_remove_pages_on_dematerialize() {
-        var navApi = seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
         syncService.materialize(AUDIT_INFO, aDocumentation());
 
         syncService.dematerialize(AUDIT_INFO, API_ID, DOC_ID);
 
-        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, navApi.getId(), DOC_ID);
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
         assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(pageId);
     }
 
@@ -199,7 +198,7 @@ class ApiDocumentationSyncDomainServiceTest {
     }
 
     @Test
-    void cleanupNavApi_removes_single_nav_api_and_its_pages() {
+    void cleanupNavApi_removes_the_nav_api_row_and_the_api_page_it_still_owns() {
         var keptNavApiId = PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var removedNavApiId = PortalNavigationItemId.of("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         seedNavApi(keptNavApiId);
@@ -210,12 +209,11 @@ class ApiDocumentationSyncDomainServiceTest {
 
         syncService.cleanupNavApi(AUDIT_INFO, removedNavApiId);
 
-        var keptPageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, keptNavApiId, DOC_ID);
-        var removedPageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, removedNavApiId, DOC_ID);
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
         assertThat(navItemCrud.storage())
             .extracting(PortalNavigationItem::getId)
-            .containsExactlyInAnyOrder(keptNavApiId, keptPageId)
-            .doesNotContain(removedNavApiId, removedPageId);
+            .containsExactly(keptNavApiId)
+            .doesNotContain(removedNavApiId, pageId);
     }
 
     private PortalNavigationApi seedNavApi(PortalNavigationItemId id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -24,9 +25,13 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.List;
@@ -45,6 +50,7 @@ class PortalLinkSyncDomainServiceTest {
         .actor(AuditActor.builder().userId("user-id").build())
         .build();
     private static final String PORTAL_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
 
     private final PortalNavigationItemsCrudServiceInMemory navItemCrud = new PortalNavigationItemsCrudServiceInMemory();
     private final PortalNavigationItemsQueryServiceInMemory navItemQuery = new PortalNavigationItemsQueryServiceInMemory(
@@ -222,11 +228,101 @@ class PortalLinkSyncDomainServiceTest {
         assertThat(navItemCrud.storage()).isEmpty();
     }
 
+    @Test
+    void materialize_for_api_creates_a_link_under_the_api_folder() {
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides");
+
+        var link = syncService.materializeForApi(
+            AUDIT_INFO,
+            API_ID,
+            "external-docs",
+            "External Docs",
+            "https://docs.example.com",
+            "/guides",
+            3
+        );
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+        assertThat(link.getId()).isEqualTo(PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs"));
+        assertThat(link.getParentId()).isEqualTo(folderId);
+        assertThat(link.getOrder()).isEqualTo(3);
+        assertThat(link.getAutomationMetadata().referenceType()).isEqualTo(AutomationMetadata.ReferenceType.API);
+        assertThat(link.getAutomationMetadata().referenceId()).isEqualTo(API_ID);
+    }
+
+    @Test
+    void materialize_for_api_makes_the_link_a_root_of_the_api_subtree_when_no_location_is_given() {
+        var link = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", null, 0);
+
+        assertThat(link.isRoot()).isTrue();
+    }
+
+    @Test
+    void materialize_for_api_persists_the_link_even_when_the_api_is_not_listed_anywhere() {
+        // No folder exists yet: the parent is a phantom, and the link still lands (D5).
+        var link = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", "/guides", 0);
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+        assertThat(link.getParentId()).isEqualTo(PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides"));
+    }
+
+    @Test
+    void materialize_for_api_is_idempotent() {
+        var first = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", "/guides", 1);
+        var second = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", "/guides", 1);
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+        assertThat(second.getId()).isEqualTo(first.getId());
+    }
+
+    @Test
+    void materialize_for_api_rejects_a_segment_already_taken_by_a_foreign_item() {
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides");
+        var squatter = linkRow("external-docs", folderId, 0);
+        navItemCrud.create(squatter);
+
+        var throwable = catchThrowable(() ->
+            syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", "/guides", 0)
+        );
+
+        assertThat(throwable).isInstanceOf(PathConflictException.class);
+    }
+
+    @Test
+    void materialize_for_api_stamps_an_api_reference_on_the_nav_item() {
+        var link = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", null, 0);
+
+        assertThat(link.getReference()).isEqualTo(new NavigationItemReference.ApiReference(API_ID));
+    }
+
+    @Test
+    void materialize_stamps_a_portal_reference_on_a_portal_attached_link() {
+        var link = syncService.materialize(AUDIT_INFO, PORTAL_ID, "docs", "Docs", "https://d.example", null, 0);
+
+        assertThat(link.getReference()).isEqualTo(new NavigationItemReference.PortalReference(PortalId.of(PORTAL_ID)));
+    }
+
     private static PortalNavigationItemId expectedLinkId() {
         return PortalNavigationItemId.of(HRIDToUUID.portalLink().context(AUDIT_INFO).portal(PORTAL_ID).hrid("external-docs").id());
     }
 
     private static PortalNavigationItemId expectedFolderId(String path) {
         return PortalNavigationItemId.forPortalFolder(AUDIT_INFO, PORTAL_ID, path);
+    }
+
+    private PortalNavigationLink linkRow(String title, PortalNavigationItemId parentId, int order) {
+        return PortalNavigationLink.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .url("https://example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemVisibilityEvaluatorTest.java
@@ -18,10 +18,20 @@ package io.gravitee.apim.core.portal_page.domain_service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +84,45 @@ class PortalNavigationItemVisibilityEvaluatorTest {
         var evaluator = evaluatorWith(new HiddenApiProductVisibilityService());
 
         assertThat(evaluator.hasHiddenAncestor(page)).isTrue();
+    }
+
+    @Test
+    void should_detect_hidden_ancestor_when_the_enclosing_api_of_a_spliced_subtree_root_is_hidden() {
+        var privateApiRow = PortalNavigationItemFixtures.anApi("00000000-0000-0000-0000-00000000b001", "Private API", null, "api-x");
+        privateApiRow.markAsRoot();
+        privateApiRow.setVisibility(PortalVisibility.PRIVATE);
+        queryService.initWith(List.of(privateApiRow));
+
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            new MembershipQueryServiceInMemory(),
+            new SubscriptionQueryServiceInMemory(),
+            new ApiQueryServiceInMemory()
+        );
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(queryService, apiMembershipDomainService);
+
+        var splicedRoot = PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(PortalNavigationItemFixtures.ORG_ID)
+            .environmentId(PortalNavigationItemFixtures.ENV_ID)
+            .title("Doc")
+            .segment("doc")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.random())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .reference(new NavigationItemReference.ApiReference("api-x"))
+            .build();
+        splicedRoot.markAsRoot();
+
+        var evaluator = new PortalNavigationItemVisibilityEvaluator(
+            PortalNavigationItemFixtures.ENV_ID,
+            PortalNavigationItemViewerContext.forPortal(false),
+            queryService,
+            List.of(apiVisibilityDomainService)
+        );
+
+        assertThat(evaluator.hasHiddenAncestor(splicedRoot)).isTrue();
     }
 
     private PortalNavigationItemVisibilityEvaluator evaluatorWith(PortalNavigationItemVisibilityService visibilityService) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemIdTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemIdTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .build();
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
+
+    @Test
+    void forApiLink_is_deterministic_and_independent_of_any_portal() {
+        var first = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs");
+        var second = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs");
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void forApiLink_differs_per_api_and_per_link_hrid() {
+        var link = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs");
+        var otherLink = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "support");
+        var otherApi = PortalNavigationItemId.forApiLink(AUDIT_INFO, "other-api-id", "external-docs");
+
+        assertThat(link).isNotEqualTo(otherLink);
+        assertThat(link).isNotEqualTo(otherApi);
+    }
+
+    @Test
+    void forApiFolder_is_the_same_id_regardless_of_which_portal_lists_the_api() {
+        var folder = PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides");
+
+        assertThat(folder).isEqualTo(PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides"));
+        assertThat(folder).isNotEqualTo(PortalNavigationItemId.forApiFolder(AUDIT_INFO, "other-api-id", "/guides"));
+    }
+
+    @Test
+    void forApiDocumentation_is_keyed_on_the_api_not_on_a_listing_row() {
+        var contentId = PortalPageContentId.random();
+
+        assertThat(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, contentId)).isEqualTo(
+            PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, contentId)
+        );
+        assertThat(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, contentId)).isNotEqualTo(
+            PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, "other-api-id", contentId)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiLinkUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiLinkUseCaseTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_page.domain_service.PortalLinkSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdateApiLinkUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
+
+    private final PortalNavigationItemsCrudServiceInMemory navItemCrud = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navItemQuery = new PortalNavigationItemsQueryServiceInMemory(
+        navItemCrud.storage()
+    );
+
+    private CreateOrUpdateApiLinkUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        navItemCrud.reset();
+        useCase = new CreateOrUpdateApiLinkUseCase(
+            navItemQuery,
+            navigationItemValidatorService(),
+            new PortalLinkSyncDomainService(navItemCrud, navItemQuery)
+        );
+    }
+
+    @Test
+    void materializes_an_api_attached_link_with_no_portal_in_the_environment() {
+        // An API-attached link belongs to its API, so it needs no portal to exist. It renders as soon
+        // as some portal's listing places the API (spec §11).
+        var output = useCase.execute(input("/guides"));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(output.link().getId()).isEqualTo(PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs"));
+        assertThat(navItemCrud.storage()).hasSize(1);
+    }
+
+    @Test
+    void reports_a_severe_error_for_a_malformed_location() {
+        var output = useCase.execute(input("not-absolute"));
+
+        assertThat(output.link()).isNull();
+        assertThat(output.errors()).anyMatch(Validator.Error::isSevere);
+        assertThat(navItemCrud.storage()).isEmpty();
+    }
+
+    @Test
+    void dry_run_validates_without_persisting() {
+        var validateUseCase = new ValidateApiLinkUseCase(
+            navItemQuery,
+            navigationItemValidatorService(),
+            new PortalLinkSyncDomainService(navItemCrud, navItemQuery)
+        );
+
+        var output = validateUseCase.execute(input("/guides"));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(output.link()).isNull();
+        assertThat(navItemCrud.storage()).isEmpty();
+    }
+
+    private PortalNavigationItemValidatorService navigationItemValidatorService() {
+        return new PortalNavigationItemValidatorService(
+            navItemQuery,
+            new PortalPageContentQueryServiceInMemory(),
+            new ApiProductQueryServiceInMemory(),
+            new PortalNavigationItemSourceDomainServiceInMemory()
+        );
+    }
+
+    private CreateOrUpdateApiLinkUseCase.Input input(String location) {
+        return new CreateOrUpdateApiLinkUseCase.Input(
+            AUDIT_INFO,
+            API_ID,
+            "external-docs",
+            "External Docs",
+            "https://docs.example.com",
+            location,
+            0
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetApiLinkUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetApiLinkUseCaseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetApiLinkUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
+
+    private final PortalNavigationItemsCrudServiceInMemory navItemCrud = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navItemQuery = new PortalNavigationItemsQueryServiceInMemory(
+        navItemCrud.storage()
+    );
+
+    private GetApiLinkUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        navItemCrud.reset();
+        useCase = new GetApiLinkUseCase(navItemQuery);
+    }
+
+    @Test
+    void returns_an_api_attached_link() {
+        var linkId = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs");
+        navItemCrud.create(apiLinkRow(linkId));
+
+        var output = useCase.execute(new GetApiLinkUseCase.Input(AUDIT_INFO, linkId));
+
+        assertThat(output.link().getId()).isEqualTo(linkId);
+    }
+
+    @Test
+    void throws_when_the_link_does_not_exist() {
+        var linkId = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "missing");
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetApiLinkUseCase.Input(AUDIT_INFO, linkId)));
+
+        assertThat(throwable).isInstanceOf(PortalLinkNotFoundException.class);
+    }
+
+    @Test
+    void throws_when_the_link_is_attached_to_a_portal_rather_than_an_api() {
+        var linkId = PortalNavigationItemId.forApiLink(AUDIT_INFO, API_ID, "external-docs");
+        navItemCrud.create(portalLinkRow(linkId));
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetApiLinkUseCase.Input(AUDIT_INFO, linkId)));
+
+        assertThat(throwable).isInstanceOf(PortalLinkNotFoundException.class);
+    }
+
+    private PortalNavigationLink apiLinkRow(PortalNavigationItemId id) {
+        return linkRow(id, new AutomationMetadata(AutomationMetadata.ReferenceType.API, API_ID, null, Optional.empty(), Optional.empty()));
+    }
+
+    private PortalNavigationLink portalLinkRow(PortalNavigationItemId id) {
+        return linkRow(
+            id,
+            new AutomationMetadata(AutomationMetadata.ReferenceType.PORTAL, "some-portal-id", null, Optional.empty(), Optional.empty())
+        );
+    }
+
+    private PortalNavigationLink linkRow(PortalNavigationItemId id, AutomationMetadata automationMetadata) {
+        return PortalNavigationLink.builder()
+            .id(id)
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("external-docs")
+            .segment("external-docs")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .url("https://example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .automationMetadata(automationMetadata)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -36,9 +36,15 @@ import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -871,5 +877,236 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.apis()).containsExactly(java.util.Map.entry(apiNavItem.getId(), api));
+    }
+
+    private PortalNavigationItemId navApiRowA;
+    private PortalNavigationItemId navApiRowB;
+    private PortalNavigationItemId apiPageId;
+    private PortalNavigationItemId apiLinkId;
+
+    /**
+     * Simulates two portals listing the same API: two nav-api rows, and the API's own subtree —
+     * materialized once, as a root, keyed on the API by reference — that both rows should render.
+     * The link has no location (Part 1 left it unrendered on purpose; the splice is what closes it).
+     */
+    private void seedApiSubtreeListedByTwoPortals() {
+        var apiId = "spliced-api-id";
+        navApiRowA = PortalNavigationItemId.random();
+        navApiRowB = PortalNavigationItemId.random();
+        apiPageId = PortalNavigationItemId.random();
+        apiLinkId = PortalNavigationItemId.random();
+
+        var rowA = PortalNavigationItemFixtures.anApi(navApiRowA.toString(), "API (portal A)", null, apiId);
+        var rowB = PortalNavigationItemFixtures.anApi(navApiRowB.toString(), "API (portal B)", null, apiId);
+        var apiPage = PortalNavigationPage.builder()
+            .id(apiPageId)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("API Overview")
+            .segment("api-overview")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.random())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .reference(new NavigationItemReference.ApiReference(apiId))
+            .build();
+        var apiLink = PortalNavigationLink.builder()
+            .id(apiLinkId)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("External Docs")
+            .segment("external-docs")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .url("https://docs.example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .reference(new NavigationItemReference.ApiReference(apiId))
+            .build();
+
+        queryService.initWith(List.of(rowA, rowB, apiPage, apiLink));
+    }
+
+    @Test
+    void renders_the_api_subtree_under_every_portal_row_that_lists_the_api() {
+        seedApiSubtreeListedByTwoPortals();
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(result.items())
+            .filteredOn(i -> i.getId().equals(apiPageId))
+            .hasSize(2);
+        assertThat(result.items()).extracting(PortalNavigationItem::getParentId).contains(navApiRowA, navApiRowB);
+    }
+
+    @Test
+    void does_not_expose_api_subtree_roots_at_the_portal_top_level() {
+        seedApiSubtreeListedByTwoPortals();
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(result.items())
+            .filteredOn(PortalNavigationItem::isRoot)
+            .noneMatch(i -> i.getReference() instanceof NavigationItemReference.ApiReference);
+    }
+
+    @Test
+    void returns_the_api_subtree_when_children_are_requested_lazily_for_the_nav_api_row() {
+        seedApiSubtreeListedByTwoPortals();
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.of(navApiRowA),
+                false,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(result.items()).extracting(PortalNavigationItem::getId).contains(apiPageId);
+    }
+
+    @Test
+    void the_rewritten_parent_id_is_not_persisted() {
+        seedApiSubtreeListedByTwoPortals();
+
+        useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(queryService.storage())
+            .filteredOn(i -> i.getId().equals(apiPageId))
+            .allMatch(PortalNavigationItem::isRoot);
+    }
+
+    @Test
+    void renders_an_api_attached_link_under_every_portal_that_lists_the_api() {
+        seedApiSubtreeListedByTwoPortals();
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(result.items())
+            .filteredOn(i -> i.getId().equals(apiLinkId))
+            .hasSize(2)
+            .extracting(PortalNavigationItem::getParentId)
+            .containsExactlyInAnyOrder(navApiRowA, navApiRowB);
+    }
+
+    @Test
+    void renders_an_api_attached_link_that_has_no_location() {
+        seedApiSubtreeListedByTwoPortals();
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forConsole(),
+                false
+            )
+        );
+
+        assertThat(result.items()).extracting(PortalNavigationItem::getId).contains(apiLinkId);
+    }
+
+    @Test
+    void a_hidden_portal_folder_hides_the_api_subtree_spliced_under_its_nav_api_row() {
+        var apiId = "hidden-folder-api-id";
+        var hiddenFolder = PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Hidden Folder")
+            .segment("hidden-folder")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .published(false)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        hiddenFolder.markAsRoot();
+
+        var navApiRow = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "API under hidden folder",
+            hiddenFolder.getId(),
+            apiId
+        );
+
+        var apiPage = PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Spliced Doc")
+            .segment("spliced-doc")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.random())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .reference(new NavigationItemReference.ApiReference(apiId))
+            .build();
+        apiPage.markAsRoot();
+
+        queryService.initWith(List.of(hiddenFolder, navApiRow, apiPage));
+
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal(false),
+                false
+            )
+        );
+
+        assertThat(result.items())
+            .extracting(PortalNavigationItem::getId)
+            .doesNotContain(hiddenFolder.getId(), navApiRow.getId(), apiPage.getId());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-180

## Description

### What this branch does

This branch introduces the core building blocks for **API-referenced** portal navigation links: pages, folders and links that belong to a specific API rather than to a fixed spot in a portal's navigation tree. Instead of an operator manually placing a link under one portal, it is declared once against the API, and Gravitee takes care of showing it everywhere that API is listed.

### Core use cases

Four new use cases give the Automation API a way to manage an API's own link:

- **Create or update** it
- **Read** it back
- **Validate** it
- **Delete** it

These sit at the domain layer and encapsulate the rules around what a valid API-referenced link looks like (e.g. how it resolves an optional location within the API's own subtree).

### Materialization / sync pipeline

The domain services responsible for turning declared automation config into actual stored navigation items were extended so that an API-referenced link is materialized correctly: as a **root item tagged with a reference back to its owning API**, rather than as an item physically parented somewhere in a portal's tree.

The reconciliation and sync services — subtree reconciliation, documentation sync, listing sync, and the query service that finds automation-managed items — were adjusted to understand and preserve this new kind of reference.

### Rendering: splicing the API's subtree into portal navigation

The most significant behavioural change is in how the portal navigation tree is assembled for display.

Previously, an API-referenced link/page would either be invisible or would incorrectly leak out at the very top level of a portal's navigation, because the query that fetches "root" items had no way to distinguish a genuine portal-level root from an API's own subtree root.

Now, whenever the navigation tree walk reaches a row that represents an API being listed in a portal, the API's own materialized subtree is looked up by its API reference and **spliced in underneath that row** — with a freshly rendered copy of each item whose parent is rewritten to point at that row. The original stored item is never mutated, so the same API subtree renders correctly and identically no matter how many different portals list that API. At the same time, those subtree roots are explicitly excluded from ever appearing as standalone top-level items, closing the leak described above.

Visibility was extended to match: if the API itself is hidden from a given viewer, its subtree is treated as hidden too — even if someone tries to reach it directly by its own item id rather than through the portal row that lists the API. This closes a gap where a client could otherwise bypass the "can this viewer see this API" check by asking for the subtree root directly.

### Outcome

Together, these changes let an API's links, pages and folders be declared once and consistently surfaced wherever the API appears across all portals, with correct visibility and no duplication or leakage — laying the groundwork the follow-up branch (`part2`) builds on to expose this through the Automation REST API and OpenAPI contract.


