### PR TITLE
fix(console): group Top Paths widget on the request uri

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsGroupBy.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/analytics/analyticsGroupBy.ts
@@ -26,5 +26,5 @@ export type GroupByField =
   | 'status'
   | 'application-id'
   | 'plan-id'
-  | 'path-info.keyword'
+  | 'uri'
   | 'additional-metrics.long_mcp-proxy_response-error-code';

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
@@ -84,6 +84,19 @@ describe('ApiAnalyticsProxyComponent', () => {
     });
   });
 
+  describe('Top Paths widget', () => {
+    it('should group on the request uri', async () => {
+      await initComponent();
+
+      const groupByRequests = httpTestingController.match(req => req.url.includes('type=GROUP_BY'));
+      const groupByFields = groupByRequests.map(req => new URL(req.request.urlWithParams).searchParams.get('field'));
+      groupByRequests.forEach(req => req.flush(fakeGroupByResponse()));
+      handleAllRequests();
+
+      expect(groupByFields).toContain('uri');
+    });
+  });
+
   describe('Query parameters', () => {
     const plan1 = fakePlanV4({ id: '1', name: 'plan 1' });
     const plan2 = fakePlanV4({ id: '2', name: 'plan 2' });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
@@ -84,6 +84,20 @@ describe('ApiAnalyticsProxyComponent', () => {
     });
   });
 
+  describe('Top Paths widget', () => {
+    it('should group Top Paths on the request uri', async () => {
+      await initComponent();
+
+      const groupByRequests = httpTestingController.match(req => req.url.includes('type=GROUP_BY'));
+      const topPathsRequest = groupByRequests.find(req => new URL(req.request.urlWithParams).searchParams.get('field') === 'uri');
+      groupByRequests.forEach(req => req.flush(fakeGroupByResponse()));
+      handleAllRequests();
+
+      expect(topPathsRequest).toBeDefined();
+      expect(new URL(topPathsRequest!.request.urlWithParams).searchParams.get('order')).toBe('-count:_count');
+    });
+  });
+
   describe('Query parameters', () => {
     const plan1 = fakePlanV4({ id: '1', name: 'plan 1' });
     const plan2 = fakePlanV4({ id: '2', name: 'plan 2' });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -299,7 +299,7 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       title: 'Top Paths',
       tooltip: 'Most frequently hit API paths',
       shouldSortBuckets: false,
-      groupByField: 'path-info.keyword',
+      groupByField: 'uri',
       analyticsType: 'GROUP_BY',
       orderBy: '-count:_count',
       isClickable: false,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.ts
@@ -81,6 +81,7 @@ type WidgetDataConfig = {
   statsField?: StatsField;
   ranges?: Range[];
   orderBy?: string;
+  mergeGroupByUriPath?: boolean;
   filterQueryParams?: (queryParams: ApiAnalyticsWidgetUrlParamsData) => ApiAnalyticsWidgetUrlParamsData;
   mapQueryParams?: (queryParams: ApiAnalyticsWidgetUrlParamsData) => UrlQueryParamsData;
   tableData?: {
@@ -299,7 +300,8 @@ export class ApiAnalyticsProxyComponent implements OnInit, OnDestroy {
       title: 'Top Paths',
       tooltip: 'Most frequently hit API paths',
       shouldSortBuckets: false,
-      groupByField: 'path-info.keyword',
+      groupByField: 'uri',
+      mergeGroupByUriPath: true,
       analyticsType: 'GROUP_BY',
       orderBy: '-count:_count',
       isClickable: false,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
@@ -637,6 +637,58 @@ describe('ApiAnalyticsWidgetService', () => {
           expectGroupByRequest('application-id', mockGroupByResponse);
         });
 
+        it('should merge uri buckets that differ only by query string and rank by merged count', done => {
+          const widgetConfig: ApiAnalyticsDashboardWidgetConfig = {
+            type: 'table',
+            apiId: API_ID,
+            title: 'Top Paths',
+            tooltip: 'Most frequently hit API paths',
+            analyticsType: 'GROUP_BY',
+            groupByField: 'uri',
+            mergeGroupByUriPath: true,
+            shouldSortBuckets: false,
+            orderBy: '-count:_count',
+            tableData: {
+              columns: [
+                { label: 'Path', dataType: 'string' },
+                { label: 'Hits', dataType: 'number' },
+              ],
+            },
+          };
+
+          const mockGroupByResponse: GroupByResponse = fakeGroupByResponse({
+            values: {
+              '/health': 50,
+              '/orders?id=1': 40,
+              '/orders?id=2': 39,
+              '/orders?id=3': 221,
+            },
+            metadata: {
+              '/health': { name: '/health', order: 0 },
+              '/orders?id=1': { name: '/orders?id=1', order: 1 },
+              '/orders?id=2': { name: '/orders?id=2', order: 2 },
+              '/orders?id=3': { name: '/orders?id=3', order: 3 },
+            },
+          });
+
+          service.getApiAnalyticsWidgetConfig$(widgetConfig).subscribe(result => {
+            if (result.state === 'loading') {
+              return;
+            }
+
+            expect(result.state).toBe('success');
+            expect(result.widgetType).toBe('table');
+            if (result.widgetType === 'table') {
+              expect(result.widgetData.data).toHaveLength(2);
+              expect(result.widgetData.data[0]).toEqual(expect.objectContaining({ 'col-0': '/orders', 'col-1': 300, __key: '/orders' }));
+              expect(result.widgetData.data[1]).toEqual(expect.objectContaining({ 'col-0': '/health', 'col-1': 50, __key: '/health' }));
+            }
+            done();
+          });
+
+          expectGroupByRequest('uri', mockGroupByResponse, { order: '-count:_count' });
+        });
+
         it('should use default column names when no columns are provided for table widget', done => {
           const widgetConfig: ApiAnalyticsDashboardWidgetConfig = {
             type: 'table',

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -230,16 +230,50 @@ export class ApiAnalyticsWidgetService {
     groupByResponse: GroupByResponse,
     widgetConfig: ApiAnalyticsDashboardWidgetConfig,
   ): ApiAnalyticsWidgetConfig {
+    const normalizedGroupByResponse = this.normalizeGroupByResponse(groupByResponse, widgetConfig);
+
     if (widgetConfig.type === 'pie') {
-      return this.transformGroupByResponseToPieConfig(groupByResponse, widgetConfig);
+      return this.transformGroupByResponseToPieConfig(normalizedGroupByResponse, widgetConfig);
     }
 
     if (widgetConfig.type === 'table') {
-      return this.transformGroupByResponseToTableConfig(groupByResponse, widgetConfig);
+      return this.transformGroupByResponseToTableConfig(normalizedGroupByResponse, widgetConfig);
     }
 
     // Default fallback for unsupported widget types
     return this.createErrorConfig(widgetConfig, 'Unsupported widget type for GROUP_BY analytics');
+  }
+
+  private normalizeGroupByResponse(groupByResponse: GroupByResponse, widgetConfig: ApiAnalyticsDashboardWidgetConfig): GroupByResponse {
+    // Opt-in per widget so a future uri-based widget can still show raw per-URI buckets.
+    if (!widgetConfig.mergeGroupByUriPath) {
+      return groupByResponse;
+    }
+
+    const values: Record<string, number> = {};
+
+    Object.entries(groupByResponse.values).forEach(([uri, count]) => {
+      const path = this.pathWithoutQueryString(uri);
+      values[path] = (values[path] ?? 0) + count;
+    });
+
+    const metadata = Object.entries(values)
+      .sort(([, countA], [, countB]) => countB - countA)
+      .reduce<GroupByResponse['metadata']>((acc, [path], index) => {
+        acc[path] = { name: path, order: index };
+        return acc;
+      }, {});
+
+    return {
+      ...groupByResponse,
+      values,
+      metadata,
+    };
+  }
+
+  private pathWithoutQueryString(uri: string): string {
+    const queryIndex = uri.indexOf('?');
+    return queryIndex === -1 ? uri : uri.slice(0, queryIndex);
   }
 
   private transformGroupByResponseToPieConfig(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11063

## Description

## Summary

The **Top Paths** widget on the v4 API Traffic screen showed a single `(empty)` row instead of the paths being hit.

It grouped on `path-info`, which is the sub-path *after* the API's context path. A request to the API root — the normal case for a simple proxy API — records `path-info: ""`, so Elasticsearch returned one bucket with an empty key, which the table renders via `{{ element || '(empty)' }}`.

The widget now groups on `uri`, the actual called URI.


## Changes

- `api-analytics-proxy.component.ts` — Top Paths `groupByField`: `path-info.keyword` → `uri`
- `analyticsGroupBy.ts` — same swap in the `GroupByField` union
- `api-analytics-proxy.component.spec.ts` — new spec

With Fix: 
<img width="1920" height="1022" alt="image" src="https://github.com/user-attachments/assets/068875cd-8ea8-49a5-960e-7857026b3449" />

Without Fix:
<img width="1920" height="1035" alt="image" src="https://github.com/user-attachments/assets/04a89af7-d2c9-4654-9915-db92f77d7a9f" />


## Related

Closes the remaining gap found while verifying [APIM-11063](https://gravitee.atlassian.net/browse/APIM-11063). The ticket's original ask — the URI column in the v4 Logs list — already shipped in `b60ec975a9` and is covered by an existing Jest test.




[APIM-11063]: https://gravitee.atlassian.net/browse/APIM-11063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ