### PR TITLE
fix(ci): build and scan the chainguard images on a branch push, not on the nightly

### DIFF
--- a/.circleci/ci/src/jobs/job-aikido-scan-docker-images.ts
+++ b/.circleci/ci/src/jobs/job-aikido-scan-docker-images.ts
@@ -118,13 +118,15 @@ export class AikidoScanDockerImagesJob {
     environment: CircleCIEnvironment,
     isProd: boolean,
     nameSuffix: string,
-    withChainguardVariants: boolean,
+    // The chainguard variants this workflow builds, and therefore scans. A workflow scans what it
+    // builds: the images to pull and the jobs to wait for are both derived from this list, so the
+    // two cannot drift apart.
+    chainguardVariants: Variant[],
   ): workflow.WorkflowJob[] {
     if (isProd && environment.isDryRun) {
       return [];
     }
 
-    const chainguardVariants: Variant[] = withChainguardVariants ? ['chainguard', 'chainguard-fips'] : [];
     const components = [
       { label: 'APIM Portal', image: config.components.portal.image, variants: [undefined, ...chainguardVariants] },
       { label: 'APIM Console', image: config.components.console.image, variants: [undefined, ...chainguardVariants] },
@@ -151,9 +153,7 @@ export class AikidoScanDockerImagesJob {
         name: `Scan docker images with Aikido${nameSuffix}`,
         requires: components.flatMap(({ label }) => [
           `Build ${label} docker image${nameSuffix}`,
-          ...(withChainguardVariants
-            ? [`Build ${label} chainguard docker image${nameSuffix}`, `Build ${label} chainguard-fips docker image${nameSuffix}`]
-            : []),
+          ...chainguardVariants.map((variant) => `Build ${label} ${variant} docker image${nameSuffix}`),
         ]),
       }),
     ];

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -510,43 +510,6 @@ jobs:
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
-  job-build-docker-chainguard-image:
-    parameters:
-      apim-project:
-        type: string
-        default: ""
-        description: the name of the project to build
-      apim-project-workdir:
-        type: string
-        default: ""
-        description: the directory of the project to build
-      docker-context:
-        type: string
-        default: ""
-        description: the name of context folder for docker build
-      docker-image-name:
-        type: string
-        default: ""
-        description: the name of the image
-    docker:
-      - image: cimg/base:stable
-    resource_class: medium
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - setup_remote_docker:
-          version: default
-      - cmd-create-docker-context
-      - cmd-docker-login
-      - run:
-          name: Build Chainguard docker image for << parameters.apim-project >>
-          command: |-
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
-            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard \
-            << parameters.docker-context >>
-          working_directory: << parameters.apim-project-workdir >>
-      - cmd-docker-logout
   job-build-docker-chainguard-fips-image:
     parameters:
       apim-project:
@@ -740,21 +703,16 @@ jobs:
           command: |-
             IMAGES="
             graviteeio.azurecr.io/apim-portal-ui:master-latest
-            graviteeio.azurecr.io/apim-portal-ui:master-latest-chainguard
             graviteeio.azurecr.io/apim-portal-ui:master-latest-chainguard-fips
             graviteeio.azurecr.io/apim-management-ui:master-latest
-            graviteeio.azurecr.io/apim-management-ui:master-latest-chainguard
             graviteeio.azurecr.io/apim-management-ui:master-latest-chainguard-fips
             graviteeio.azurecr.io/gamma-ui:master-latest
-            graviteeio.azurecr.io/gamma-ui:master-latest-chainguard
             graviteeio.azurecr.io/gamma-ui:master-latest-chainguard-fips
             graviteeio.azurecr.io/apim-management-api:master-latest
             graviteeio.azurecr.io/apim-management-api:master-latest-debian
-            graviteeio.azurecr.io/apim-management-api:master-latest-chainguard
             graviteeio.azurecr.io/apim-management-api:master-latest-chainguard-fips
             graviteeio.azurecr.io/apim-gateway:master-latest
             graviteeio.azurecr.io/apim-gateway:master-latest-debian
-            graviteeio.azurecr.io/apim-gateway:master-latest-chainguard
             graviteeio.azurecr.io/apim-gateway:master-latest-chainguard-fips
             "
             : > /tmp/aikido-images.txt
@@ -848,56 +806,6 @@ workflows:
           apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
           docker-context: target
           docker-image-name: apim-gateway
-      - job-build-docker-chainguard-image:
-          context:
-            - cicd-orchestrator
-          name: Build APIM Management API chainguard docker image
-          requires:
-            - Build backend
-          apim-project: gravitee-apim-rest-api
-          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
-          docker-context: target
-          docker-image-name: apim-management-api
-      - job-build-docker-chainguard-image:
-          context:
-            - cicd-orchestrator
-          name: Build APIM Gateway chainguard docker image
-          requires:
-            - Build backend
-          apim-project: gravitee-apim-gateway
-          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
-          docker-context: target
-          docker-image-name: apim-gateway
-      - job-build-docker-chainguard-image:
-          context:
-            - cicd-orchestrator
-          name: Build APIM Console chainguard docker image
-          requires:
-            - Build APIM Console
-          apim-project: gravitee-apim-console-webui
-          apim-project-workdir: gravitee-apim-console-webui
-          docker-context: .
-          docker-image-name: apim-management-ui
-      - job-build-docker-chainguard-image:
-          context:
-            - cicd-orchestrator
-          name: Build APIM Portal chainguard docker image
-          requires:
-            - Build APIM Portal
-          apim-project: gravitee-apim-portal-webui
-          apim-project-workdir: gravitee-apim-portal-webui
-          docker-context: .
-          docker-image-name: apim-portal-ui
-      - job-build-docker-chainguard-image:
-          context:
-            - cicd-orchestrator
-          name: Build Gamma Console chainguard docker image
-          requires:
-            - Build Gamma Console
-          apim-project: gravitee-gamma-control-plane-webui
-          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
-          docker-context: .
-          docker-image-name: gamma-ui
       - job-build-docker-chainguard-fips-image:
           context:
             - cicd-orchestrator
@@ -1011,19 +919,14 @@ workflows:
           name: Scan docker images with Aikido
           requires:
             - Build APIM Portal docker image
-            - Build APIM Portal chainguard docker image
             - Build APIM Portal chainguard-fips docker image
             - Build APIM Console docker image
-            - Build APIM Console chainguard docker image
             - Build APIM Console chainguard-fips docker image
             - Build Gamma Console docker image
-            - Build Gamma Console chainguard docker image
             - Build Gamma Console chainguard-fips docker image
             - Build APIM Management API docker image
-            - Build APIM Management API chainguard docker image
             - Build APIM Management API chainguard-fips docker image
             - Build APIM Gateway docker image
-            - Build APIM Gateway chainguard docker image
             - Build APIM Gateway chainguard-fips docker image
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -351,6 +351,43 @@ jobs:
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
   job-publish-on-artifactory:
     docker:
       - image: cimg/openjdk:25.0.3-node
@@ -552,12 +589,17 @@ jobs:
           command: |-
             IMAGES="
             graviteeio.azurecr.io/apim-portal-ui:4.1.x-latest
+            graviteeio.azurecr.io/apim-portal-ui:4.1.x-latest-chainguard
             graviteeio.azurecr.io/apim-management-ui:4.1.x-latest
+            graviteeio.azurecr.io/apim-management-ui:4.1.x-latest-chainguard
             graviteeio.azurecr.io/gamma-ui:4.1.x-latest
+            graviteeio.azurecr.io/gamma-ui:4.1.x-latest-chainguard
             graviteeio.azurecr.io/apim-management-api:4.1.x-latest
             graviteeio.azurecr.io/apim-management-api:4.1.x-latest-debian
+            graviteeio.azurecr.io/apim-management-api:4.1.x-latest-chainguard
             graviteeio.azurecr.io/apim-gateway:4.1.x-latest
             graviteeio.azurecr.io/apim-gateway:4.1.x-latest-debian
+            graviteeio.azurecr.io/apim-gateway:4.1.x-latest-chainguard
             "
             : > /tmp/aikido-images.txt
             for image in $IMAGES; do
@@ -650,6 +692,56 @@ workflows:
           apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
           docker-context: target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
+          docker-context: target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
+          docker-context: target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
       - job-trigger-saas-docker-images:
           context:
             - cicd-orchestrator
@@ -683,20 +775,26 @@ workflows:
           context:
             - cicd-orchestrator
           requires:
-            - Build APIM Management API docker image
-            - Build APIM Gateway docker image
-            - Build APIM Console docker image
-            - Build APIM Portal docker image
+            - Build APIM Management API chainguard docker image
+            - Build APIM Gateway chainguard docker image
+            - Build APIM Console chainguard docker image
+            - Build APIM Portal chainguard docker image
+            - Build Gamma Console chainguard docker image
       - job-aikido-scan-docker-images:
           context:
             - cicd-orchestrator
           name: Scan docker images with Aikido
           requires:
             - Build APIM Portal docker image
+            - Build APIM Portal chainguard docker image
             - Build APIM Console docker image
+            - Build APIM Console chainguard docker image
             - Build Gamma Console docker image
+            - Build Gamma Console chainguard docker image
             - Build APIM Management API docker image
+            - Build APIM Management API chainguard docker image
             - Build APIM Gateway docker image
+            - Build APIM Gateway chainguard docker image
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -351,6 +351,43 @@ jobs:
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
   job-publish-on-artifactory:
     docker:
       - image: cimg/openjdk:25.0.3-node
@@ -609,12 +646,17 @@ jobs:
           command: |-
             IMAGES="
             graviteeio.azurecr.io/apim-portal-ui:master-latest
+            graviteeio.azurecr.io/apim-portal-ui:master-latest-chainguard
             graviteeio.azurecr.io/apim-management-ui:master-latest
+            graviteeio.azurecr.io/apim-management-ui:master-latest-chainguard
             graviteeio.azurecr.io/gamma-ui:master-latest
+            graviteeio.azurecr.io/gamma-ui:master-latest-chainguard
             graviteeio.azurecr.io/apim-management-api:master-latest
             graviteeio.azurecr.io/apim-management-api:master-latest-debian
+            graviteeio.azurecr.io/apim-management-api:master-latest-chainguard
             graviteeio.azurecr.io/apim-gateway:master-latest
             graviteeio.azurecr.io/apim-gateway:master-latest-debian
+            graviteeio.azurecr.io/apim-gateway:master-latest-chainguard
             "
             : > /tmp/aikido-images.txt
             for image in $IMAGES; do
@@ -707,6 +749,56 @@ workflows:
           apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
           docker-context: target
           docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
+          docker-context: target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image
+          requires:
+            - Build backend
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
+          docker-context: target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
       - job-trigger-saas-docker-images:
           context:
             - cicd-orchestrator
@@ -740,10 +832,11 @@ workflows:
           context:
             - cicd-orchestrator
           requires:
-            - Build APIM Management API docker image
-            - Build APIM Gateway docker image
-            - Build APIM Console docker image
-            - Build APIM Portal docker image
+            - Build APIM Management API chainguard docker image
+            - Build APIM Gateway chainguard docker image
+            - Build APIM Console chainguard docker image
+            - Build APIM Portal chainguard docker image
+            - Build Gamma Console chainguard docker image
       - job-deploy-on-next-gen-integration:
           name: Deploy on NextGen Integration environment
           context:
@@ -757,10 +850,15 @@ workflows:
           name: Scan docker images with Aikido
           requires:
             - Build APIM Portal docker image
+            - Build APIM Portal chainguard docker image
             - Build APIM Console docker image
+            - Build APIM Console chainguard docker image
             - Build Gamma Console docker image
+            - Build Gamma Console chainguard docker image
             - Build APIM Management API docker image
+            - Build APIM Management API chainguard docker image
             - Build APIM Gateway docker image
+            - Build APIM Gateway chainguard docker image
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/groups/chainguard-image-jobs.ts
+++ b/.circleci/ci/src/workflows/groups/chainguard-image-jobs.ts
@@ -20,8 +20,9 @@ import { config } from '../../config';
 
 /**
  * The chainguard component images, published to Docker Hub alongside the alpine and debian
- * variants. The development environment does not run them, so they are not part of refreshing
- * it — but they are shipped, so something has to build and scan them regularly.
+ * variants. The development environment runs them, so refreshing it means building them: the
+ * deployment is a rollout restart, which cannot report a missing image — the pods simply come
+ * back up on the tag's previous content.
  */
 export function chainguardImageJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {
   const buildDockerChainguardImageJob = BuildDockerChainguardImageJob.create(dynamicConfig, environment, false);

--- a/.circleci/ci/src/workflows/groups/publish-and-deploy-jobs.ts
+++ b/.circleci/ci/src/workflows/groups/publish-and-deploy-jobs.ts
@@ -63,6 +63,18 @@ export function publishAndDeployJobs(dynamicConfig: Config, environment: CircleC
     'Build APIM Portal docker image',
   ];
 
+  // What the cluster actually pulls. The deployment is a rollout restart: it never names a tag,
+  // so it cannot fail on an image that was not pushed yet — the pods come back up on whatever
+  // the tag pointed at before. The standard variants are absent on purpose: they are built for
+  // the end-to-end suites and the SaaS trigger, not for this environment.
+  const environmentImages = [
+    'Build APIM Management API chainguard docker image',
+    'Build APIM Gateway chainguard docker image',
+    'Build APIM Console chainguard docker image',
+    'Build APIM Portal chainguard docker image',
+    'Build Gamma Console chainguard docker image',
+  ];
+
   return [
     new workflow.WorkflowJob(runTriggerSaasDockerImagesJob, {
       context: [...config.jobContext, 'keeper-orb-publishing'],
@@ -87,7 +99,7 @@ export function publishAndDeployJobs(dynamicConfig: Config, environment: CircleC
     new workflow.WorkflowJob(deployOnAzureJob, {
       name: 'Deploy on Azure cluster',
       context: config.jobContext,
-      requires: productImages,
+      requires: environmentImages,
     }),
     ...(isMasterBranch(environment.branch)
       ? [
@@ -99,9 +111,8 @@ export function publishAndDeployJobs(dynamicConfig: Config, environment: CircleC
         ]
       : []),
 
-    // Aikido scans the images this path actually pushes. The chainguard variants are built by
-    // their own manually triggered workflows, so asking for them here would leave the scan
-    // waiting on jobs that are not in this workflow.
-    ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', false),
+    // Everything this path pushes. The chainguard-fips variants are not among them: the
+    // environment does not run them, so the scheduled build both builds and scans those.
+    ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', ['chainguard']),
   ];
 }

--- a/.circleci/ci/src/workflows/workflow-build-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-build-docker-images.ts
@@ -226,7 +226,10 @@ export class BuildDockerImagesWorkflow {
       }),
 
       // Aikido image scans, once every variant of a component has been pushed
-      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, true, ` for APIM ${environment.graviteeioVersion}`, true),
+      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, true, ` for APIM ${environment.graviteeioVersion}`, [
+        'chainguard',
+        'chainguard-fips',
+      ]),
     ];
 
     return new Workflow('build-docker-images', jobs);

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -391,7 +391,10 @@ export class FullReleaseWorkflow {
       }),
 
       // Aikido image scans, once every variant of a component has been pushed
-      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, true, ` for APIM ${environment.graviteeioVersion}`, true),
+      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, true, ` for APIM ${environment.graviteeioVersion}`, [
+        'chainguard',
+        'chainguard-fips',
+      ]),
     ]);
   }
 }

--- a/.circleci/ci/src/workflows/workflow-nightly.ts
+++ b/.circleci/ci/src/workflows/workflow-nightly.ts
@@ -19,7 +19,6 @@ import { CircleCIEnvironment } from '../pipelines';
 import { config } from '../config';
 import { devEnvironmentJobs } from './groups/dev-environment-jobs';
 import { e2eJobs } from './groups/e2e-jobs';
-import { chainguardImageJobs } from './groups/chainguard-image-jobs';
 import { chainguardFipsImageJobs } from './groups/chainguard-fips-image-jobs';
 
 /**
@@ -42,10 +41,8 @@ export class NightlyWorkflow {
     return new Workflow('nightly', [
       ...devEnvironmentJobs(dynamicConfig, environment),
 
-      // The chainguard variants are shipped but the environment does not run them, so a branch
-      // push has no reason to build them. They are built here instead, which is also what gives
-      // the Aikido scan below something to look at every night rather than only at release time.
-      ...chainguardImageJobs(dynamicConfig, environment),
+      // Only the FIPS variants. The chainguard images are built — and scanned — by every branch
+      // push, since the environment runs them.
       ...chainguardFipsImageJobs(dynamicConfig, environment),
 
       new workflow.WorkflowJob(testIntegrationJob, {
@@ -68,9 +65,10 @@ export class NightlyWorkflow {
         requires: ['Integration tests', 'Run Cypress UI tests'],
       }),
 
-      // Every variant, standard and chainguard alike. This is the only place they are scanned
-      // between two releases.
-      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', true),
+      // What this workflow builds: the standard images and the FIPS variants. FIPS is scanned
+      // nowhere else between two releases; the chainguard variants are scanned on the branch
+      // push that builds them.
+      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', ['chainguard-fips']),
     ]);
   }
 }

--- a/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
+++ b/.circleci/ci/src/workflows/workflow-publish-docker-images.ts
@@ -134,7 +134,7 @@ export class PublishDockerImagesWorkflow {
       }),
 
       // Aikido image scans. This workflow only builds the alpine and debian variants.
-      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', false),
+      ...AikidoScanDockerImagesJob.workflowJobs(dynamicConfig, environment, false, '', []),
     ];
 
     return new Workflow('publish_docker_images', jobs);

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -23,6 +23,7 @@ import { DangerJsJob, TestApimChartsJob } from '../jobs';
 import { orbs } from '../orbs';
 import { backendImageJobs } from './groups/backend-image-jobs';
 import { e2eJobs } from './groups/e2e-jobs';
+import { chainguardImageJobs } from './groups/chainguard-image-jobs';
 import { publishAndDeployJobs } from './groups/publish-and-deploy-jobs';
 import { devEnvironmentJobs } from './groups/dev-environment-jobs';
 import { backendJobs } from './groups/backend-jobs';
@@ -39,10 +40,18 @@ export class PullRequestsWorkflow {
     // publishes its snapshots. It no longer replays the test battery: a pull request has already
     // run it, on the scope its changes could affect. What nobody would otherwise run — the
     // real-plugin integration tests and the end-to-end suites — is what the scheduled build is
-    // for. The chainguard and chainguard-fips images keep their own manually triggered
-    // workflows, since the environment does not run them.
+    // for.
+    //
+    // The chainguard images are part of refreshing the environment: it runs them, and the
+    // deployment is a rollout restart, so an image left unbuilt is not an error — the pods just
+    // come back up on the previous one. The chainguard-fips variants are a compliance base the
+    // environment does not run; they stay on the scheduled build and their manual workflow.
     if (isSupportBranchOrMaster(environment.branch)) {
-      jobs.push(...devEnvironmentJobs(dynamicConfig, environment), ...publishAndDeployJobs(dynamicConfig, environment));
+      jobs.push(
+        ...devEnvironmentJobs(dynamicConfig, environment),
+        ...chainguardImageJobs(dynamicConfig, environment),
+        ...publishAndDeployJobs(dynamicConfig, environment),
+      );
     } else if (isE2EBranch(environment.branch)) {
       jobs.push(
         ...this.getCommonJobs(dynamicConfig, environment, false, true, shouldBuildDockerImages, true),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-292

## Description

The development environment runs the chainguard images, and #19087 moved their build to the nightly. A merge stopped refreshing them.

Nothing failed. `Deploy on Azure cluster` is a `kubectl rollout restart` on three namespaces — it never names a tag, so it cannot report a missing image. The pods came back up on whatever `master-latest-chainguard` pointed at before, while the standard variants kept moving.

The claim that the environment did not run them was mine, and it was wrong. It came from reading the `requires` of the deployment job, which listed only the four standard images. That list says what the deployment *waits for*, not what the cluster *pulls*, and the two had drifted apart. The same reasoning is now written down in the code, next to the list, so the next reader does not repeat it.

**What changes**

- **The chainguard images are built on every branch push again**, and the nightly stops building them. The branch pipeline goes from 17 jobs to 22, the nightly from 27 to 22.
- **`Deploy on Azure cluster` waits for the five images the cluster pulls** — the four components plus Gamma Console. Building them again is not enough on its own: without this, the rollout races the push it depends on. Gamma Console was never in that list, which is a pre-existing gap of the same nature.
- **Each workflow scans the variants it builds**: chainguard on a branch push, chainguard-fips on the nightly. The 17 images stay covered between the two.
- **The Aikido scan takes its variant list explicitly.** It used to derive both the images to pull and the jobs to wait for from one boolean; they are now one list, so they cannot drift apart.

**Security-sensitive**: this changes CI/CD configuration and where the container image scan runs. Coverage is unchanged — 17 distinct images, verified across both generated pipelines — but the scan is now split across two workflows instead of one.

## Additional context

**How it was verified.** `tsc` and lint clean, 153 tests green, and every `requires` in all 52 generated fixtures checked to resolve to a job present in its own workflow. That last check is what makes a change like this safe: removing a job from a path silently orphans whatever depended on it, and it happened three times on #19087.

**What was deliberately left alone.**

The standard images stay on the branch push even though the cluster does not pull them. They feed `Trigger SaaS Docker images creation`, which POSTs to the `cloud-distributions` pipeline with `branch-version`, `sha1` and `os-distribution: debian` — so that pipeline resolves images we pushed, by tag. `Publish Helm chart` and `Deploy on NextGen Integration` sit behind it. Removing them would change a contract with another repository on an inference.

The nightly's own `Deploy on Azure cluster` has the same gap this PR closes on the branch path: it waits on `Integration tests` and `Run Cypress UI tests`, so it covers the four product images transitively but neither Gamma nor the chainguard variants. It is left as is because that `requires` carries the open question about fanning in on the E2E matrix, and changing it here would settle that question as a side effect.

**Worth a follow-up.** The nightly still builds the standard images, for the end-to-end suites — they pull `<branch>-<sha7>` from the registry. Since the nightly runs at the same commit as the last merge, those tags already exist and could be reused. The saving is smaller than it looks: the frontend builds have to stay either way, because the chainguard-fips images depend on them. And it would make the nightly depend on the merge pipeline having pushed, without anything in the graph saying so.
