### PR TITLE
feat(portal-next): add nullable Portal.activeThemeId column

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
@@ -36,4 +36,5 @@ public class Portal {
     private String organizationId;
     private String name;
     private String portalNavigation;
+    private String activeThemeId;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
@@ -45,6 +45,7 @@ public class JdbcPortalRepository extends JdbcAbstractCrudRepository<Portal, Str
             .addColumn("organization_id", Types.NVARCHAR, String.class)
             .addColumn("name", Types.NVARCHAR, String.class)
             .addColumn("portal_navigation", Types.NVARCHAR, String.class)
+            .addColumn("active_theme_id", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/16_add_active_theme_id_to_portals.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/16_add_active_theme_id_to_portals.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_16_add_active_theme_id_to_portals
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}portals
+            columns:
+              - column: {name: active_theme_id, type: nvarchar(64), constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -417,3 +417,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/14_add_reference_columns_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/15_add_automation_metadata_to_portal_navigation_items.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/16_add_active_theme_id_to_portals.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
@@ -35,4 +35,5 @@ public class PortalMongo {
     private String organizationId;
     private String name;
     private String portalNavigation;
+    private String activeThemeId;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
@@ -40,6 +40,51 @@ public class PortalRepositoryTest extends AbstractManagementRepositoryTest {
         assertThat(portal).isPresent();
         assertThat(portal.get().getName()).isEqualTo("Default Portal");
         assertThat(portal.get().getOrganizationId()).isEqualTo("organization1");
+        assertThat(portal.get().getActiveThemeId()).isNull();
+    }
+
+    @Test
+    public void should_read_active_theme_id_from_fixture() throws Exception {
+        Optional<Portal> portal = portalRepository.findByIdAndEnvironmentId("portal2", "environment1");
+
+        assertThat(portal).isPresent();
+        assertThat(portal.get().getActiveThemeId()).isEqualTo("theme-portal2");
+    }
+
+    @Test
+    public void should_round_trip_active_theme_id_on_create() throws Exception {
+        Portal toCreate = Portal.builder()
+            .id("themed-portal")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Themed Portal")
+            .activeThemeId("theme-xyz")
+            .build();
+
+        Portal created = portalRepository.create(toCreate);
+
+        assertThat(created.getActiveThemeId()).isEqualTo("theme-xyz");
+        assertThat(portalRepository.findById("themed-portal")).hasValueSatisfying(found ->
+            assertThat(found.getActiveThemeId()).isEqualTo("theme-xyz")
+        );
+    }
+
+    @Test
+    public void should_round_trip_active_theme_id_on_update() throws Exception {
+        Portal toUpdate = Portal.builder()
+            .id("portal1")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Default Portal")
+            .activeThemeId("theme-abc")
+            .build();
+
+        Portal updated = portalRepository.update(toUpdate);
+
+        assertThat(updated.getActiveThemeId()).isEqualTo("theme-abc");
+        assertThat(portalRepository.findById("portal1")).hasValueSatisfying(found ->
+            assertThat(found.getActiveThemeId()).isEqualTo("theme-abc")
+        );
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
@@ -9,7 +9,8 @@
     "id": "portal2",
     "environmentId": "environment1",
     "organizationId": "organization1",
-    "name": "Secondary Portal"
+    "name": "Secondary Portal",
+    "activeThemeId": "theme-portal2"
   },
   {
     "id": "portal3",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
@@ -36,22 +36,32 @@ public class Portal {
     @Nonnull
     private final PortalNavigationStructure navigationStructure;
 
-    private Portal(PortalId id, String environmentId, String organizationId, String name, PortalNavigationStructure navigationStructure) {
+    private final String activeThemeId;
+
+    private Portal(
+        PortalId id,
+        String environmentId,
+        String organizationId,
+        String name,
+        PortalNavigationStructure navigationStructure,
+        String activeThemeId
+    ) {
         this.id = id;
         this.environmentId = environmentId;
         this.organizationId = organizationId;
         this.name = name;
         this.navigationStructure = navigationStructure == null ? PortalNavigationStructure.empty() : navigationStructure;
+        this.activeThemeId = activeThemeId;
     }
 
     /** New portal with a random id and no navigation. */
     public static Portal create(String environmentId, String organizationId, String name) {
-        return new Portal(PortalId.random(), environmentId, organizationId, name, PortalNavigationStructure.empty());
+        return new Portal(PortalId.random(), environmentId, organizationId, name, PortalNavigationStructure.empty(), null);
     }
 
     /** Reconstitute a portal from a known id (HRID-derived, persistence, etc.). */
     public static Portal of(PortalId id, String environmentId, String organizationId, String name) {
-        return new Portal(id, environmentId, organizationId, name, PortalNavigationStructure.empty());
+        return new Portal(id, environmentId, organizationId, name, PortalNavigationStructure.empty(), null);
     }
 
     /** Reconstitute a portal with a persisted navigation structure. */
@@ -62,11 +72,15 @@ public class Portal {
         String name,
         PortalNavigationStructure navigationStructure
     ) {
-        return new Portal(id, environmentId, organizationId, name, navigationStructure);
+        return new Portal(id, environmentId, organizationId, name, navigationStructure, null);
     }
 
     public Portal withNavigationStructure(PortalNavigationStructure navigationStructure) {
-        return new Portal(this.id, this.environmentId, this.organizationId, this.name, navigationStructure);
+        return new Portal(this.id, this.environmentId, this.organizationId, this.name, navigationStructure, this.activeThemeId);
+    }
+
+    public Portal withActiveThemeId(String activeThemeId) {
+        return new Portal(this.id, this.environmentId, this.organizationId, this.name, this.navigationStructure, activeThemeId);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
@@ -43,7 +43,7 @@ public interface PortalAdapter {
             portal.getOrganizationId(),
             portal.getName(),
             deserializePortalNavigation(portal.getPortalNavigation())
-        );
+        ).withActiveThemeId(portal.getActiveThemeId());
     }
 
     default io.gravitee.repository.management.model.Portal toRepository(Portal portal) {
@@ -56,6 +56,7 @@ public interface PortalAdapter {
             .organizationId(portal.getOrganizationId())
             .name(portal.getName())
             .portalNavigation(serializePortalNavigation(portal.getNavigationStructure()))
+            .activeThemeId(portal.getActiveThemeId())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
@@ -140,6 +140,33 @@ class PortalAdapterTest {
             assertThat(repo.getOrganizationId()).isEqualTo("org");
             assertThat(repo.getName()).isEqualTo("Portal");
             assertThat(repo.getPortalNavigation()).isNull();
+            assertThat(repo.getActiveThemeId()).isNull();
+        }
+
+        @Test
+        void to_repository_forwards_active_theme_id() {
+            var portal = Portal.of(PortalId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "env", "org", "Portal").withActiveThemeId(
+                "theme-1"
+            );
+
+            var repo = adapter.toRepository(portal);
+
+            assertThat(repo.getActiveThemeId()).isEqualTo("theme-1");
+        }
+
+        @Test
+        void to_entity_forwards_active_theme_id() {
+            var repo = io.gravitee.repository.management.model.Portal.builder()
+                .id("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                .environmentId("env")
+                .organizationId("org")
+                .name("Portal")
+                .activeThemeId("theme-1")
+                .build();
+
+            var entity = adapter.toEntity(repo);
+
+            assertThat(entity.getActiveThemeId()).isEqualTo("theme-1");
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-175

## Description

Adds a nullable `Portal.activeThemeId` column and the matching immutable field with `withActiveThemeId(...)` on the core `Portal` domain model. Adapter round-trips the field in both directions.

No consumer reads or writes it yet, requires follow-up PRs to use it within automation api.

## Why nullable

Existing Portal rows can't be safely backfilled with initial theme,  because theme is currently lazily created on first read.

**Alternative**: create and enable a default theme on env spin-up so `activeThemeId` could be NOT NULL. Also create upgrader that will populate default theme for envs with missing themes.

## Multiportal note

Current column `Theme.enabled` is the wrong long-term model - it's one boolean on a shared Theme row, so it can't represent association to multiple Portals. `Portal.activeThemeId` carries that invariant instead (one slot per Portal). We keep `Theme.enabled` as a fallback currently used by `GetCurrentThemeUseCase` that will be synced, but may eventually get dropped with the multiportal effort.
