### PR TITLE
feat(audit-logs): add organization and environment audit log support

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/browser/index.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/browser/index.ts
@@ -20,8 +20,12 @@ export function downloadBlob(blob: Blob, fileName: string): void {
     const anchor = document.createElement('a');
     anchor.download = fileName;
     anchor.href = url;
+    document.body.appendChild(anchor);
     anchor.click();
-    URL.revokeObjectURL(url);
+    anchor.remove();
+    // Some browsers (older Safari/Edge) start the download asynchronously; revoking in this
+    // turn can cancel it. Yield so the click is processed first.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /** Builds a `Blob` from text content and downloads it as `fileName`. */

--- a/gravitee-gamma/gamma-ui-shared/src/browser/index.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/browser/index.ts
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
-import { SHARDING_TAGS_UPGRADE } from '../license/shardingTagsLicense';
 
-export function ShardingTagsLicenseDialog({
-    open,
-    onOpenChange,
-}: Readonly<{
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}>) {
-    return <FeatureLicenseDialog upgrade={SHARDING_TAGS_UPGRADE} open={open} onOpenChange={onOpenChange} />;
+/** Triggers a browser download of `blob` as `fileName`. */
+export function downloadBlob(blob: Blob, fileName: string): void {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.download = fileName;
+    anchor.href = url;
+    anchor.click();
+    URL.revokeObjectURL(url);
+}
+
+/** Builds a `Blob` from text content and downloads it as `fileName`. */
+export function downloadTextFile(content: string, fileName: string, mimeType: string): void {
+    downloadBlob(new Blob([content], { type: mimeType }), fileName);
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/ApiGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/ApiGeneralPage.tsx
@@ -41,6 +41,7 @@ import { ExportApi } from './ExportApi';
 import { ImagePicker } from './ImagePicker';
 import { ImportApiSheet } from './ImportApiSheet';
 import { PromoteDialog } from './PromoteDialog';
+import { downloadBlob } from '../../../../../shared/browser';
 import { ConfirmDialog } from '../../../../../shared/components';
 import { notify } from '../../../../../shared/notify';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
@@ -49,7 +50,7 @@ import { useEnvCategories } from '../../../hooks/useEnvCategories';
 import { exportApiCrd, exportApiDefinition } from '../../../services/apis';
 import type { ApiDetailDto } from '../../../types';
 import { extractContextPathPlaceholder, extractHostPlaceholder, getDuplicateEntryMode } from '../../../utils/apiGeneralDuplicate';
-import { buildExcludeAdditionalData, buildExportFileName, downloadBlob, type ExportIncludeKey } from '../../../utils/apiGeneralExport';
+import { buildExcludeAdditionalData, buildExportFileName, type ExportIncludeKey } from '../../../utils/apiGeneralExport';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiGeneralExport.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiGeneralExport.ts
@@ -33,12 +33,3 @@ export function buildExportFileName(api: ApiDetailDto | null, suffix?: string): 
 export function buildExcludeAdditionalData(include: Record<ExportIncludeKey, boolean>): string[] {
     return EXPORT_INCLUDE_OPTIONS.filter(option => !include[option.id]).map(option => option.id);
 }
-
-export function downloadBlob(blob: Blob, fileName: string): void {
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.download = fileName;
-    anchor.href = url;
-    anchor.click();
-    URL.revokeObjectURL(url);
-}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/browser/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/browser/index.ts
@@ -13,15 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
-import { SHARDING_TAGS_UPGRADE } from '../license/shardingTagsLicense';
 
-export function ShardingTagsLicenseDialog({
-    open,
-    onOpenChange,
-}: Readonly<{
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}>) {
-    return <FeatureLicenseDialog upgrade={SHARDING_TAGS_UPGRADE} open={open} onOpenChange={onOpenChange} />;
-}
+export * from '../../../../../../gamma-ui-shared/src/browser/index';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -110,6 +110,14 @@ jest.mock('../pages/AlertsPage', () => ({
     AlertsPage: () => <div data-testid="alerts-page" />,
 }));
 
+jest.mock('../pages/OrgAuditLogsPage', () => ({
+    OrgAuditLogsPage: () => <div data-testid="org-audit-logs-page" />,
+}));
+
+jest.mock('../pages/EnvAuditLogsPage', () => ({
+    EnvAuditLogsPage: () => <div data-testid="env-audit-logs-page" />,
+}));
+
 function renderPlatform(path = '/applications') {
     render(
         <MemoryRouter initialEntries={[path]}>
@@ -442,6 +450,140 @@ describe('AppRoutes', () => {
         renderPlatform('/tenants');
 
         expect(screen.queryByTestId('tenants-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('routes to the Organization Audit page under the platform module', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'organization-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/organization-audit');
+
+        expect(screen.getByTestId('org-audit-logs-page')).not.toBeNull();
+    });
+
+    it('shows the Organization Audit nav item when the user has audit read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'organization-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/organization-audit');
+
+        expect(visibleNavKeys()).toContain('organization-audit');
+    });
+
+    it('hides the Organization Audit nav item when the user lacks audit read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'organization-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-audit-r'));
+
+        renderPlatform('/organization-audit');
+
+        expect(visibleNavKeys()).not.toContain('organization-audit');
+    });
+
+    it('redirects away from Organization Audit when the user lacks audit read permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-audit-r'));
+
+        renderPlatform('/organization-audit');
+
+        expect(screen.queryByTestId('org-audit-logs-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('routes to the Environment Audit page under the platform module', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'environment-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/environment-audit');
+
+        expect(screen.getByTestId('env-audit-logs-page')).not.toBeNull();
+    });
+
+    it('shows the Environment Audit nav item when the user has audit read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'environment-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/environment-audit');
+
+        expect(visibleNavKeys()).toContain('environment-audit');
+    });
+
+    it('hides the Environment Audit nav item when the user lacks audit read permission', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'environment-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-audit-r'));
+
+        renderPlatform('/environment-audit');
+
+        expect(visibleNavKeys()).not.toContain('environment-audit');
+    });
+
+    it('redirects away from Environment Audit when the user lacks audit read permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-audit-r'));
+
+        renderPlatform('/environment-audit');
+
+        expect(screen.queryByTestId('env-audit-logs-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('hides the Organization Audit nav item for a user holding only environment audit read', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'environment-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-audit-r'));
+
+        renderPlatform('/environment-audit');
+
+        expect(visibleNavKeys()).not.toContain('organization-audit');
+        expect(visibleNavKeys()).toContain('environment-audit');
+    });
+
+    it('hides the Environment Audit nav item for a user holding only organization audit read', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'organization-audit',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-audit-r'));
+
+        renderPlatform('/organization-audit');
+
+        expect(visibleNavKeys()).not.toContain('environment-audit');
+        expect(visibleNavKeys()).toContain('organization-audit');
+    });
+
+    it('redirects away from Organization Audit for a user holding only environment audit read', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-audit-r'));
+
+        renderPlatform('/organization-audit');
+
+        expect(screen.queryByTestId('org-audit-logs-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('redirects away from Environment Audit for a user holding only organization audit read', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-audit-r'));
+
+        renderPlatform('/environment-audit');
+
+        expect(screen.queryByTestId('env-audit-logs-page')).toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -44,6 +44,7 @@ import {
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { ENVIRONMENT_AUDIT_READ_PERMISSIONS, ORGANIZATION_AUDIT_READ_PERMISSIONS } from '../features/audit-logs/utils/auditPermissions';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { GatewayInstanceDetailLayout } from '../features/gateway-instances/components/GatewayInstanceDetailLayout';
 import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
@@ -57,12 +58,14 @@ import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
+import { EnvAuditLogsPage } from '../pages/EnvAuditLogsPage';
 import { GatewayInstanceEnvironmentPage } from '../pages/GatewayInstanceEnvironmentPage';
 import { GatewayInstanceMonitoringPage } from '../pages/GatewayInstanceMonitoringPage';
 import { GatewayInstancesPage } from '../pages/GatewayInstancesPage';
 import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
 import { MetadataPage } from '../pages/MetadataPage';
+import { OrgAuditLogsPage } from '../pages/OrgAuditLogsPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { TenantsPage } from '../pages/TenantsPage';
 import { UserDetailPage } from '../pages/UserDetailPage';
@@ -117,6 +120,8 @@ function isNavItemVisible(
     canReadGroups: boolean,
     canReadAlerts: boolean,
     canReadTenants: boolean,
+    canReadOrgAudit: boolean,
+    canReadEnvAudit: boolean,
 ): boolean {
     if (itemKey === 'users') {
         return !permissionsReady || canAccessUsers;
@@ -141,6 +146,12 @@ function isNavItemVisible(
     }
     if (itemKey === 'tenants') {
         return !permissionsReady || canReadTenants;
+    }
+    if (itemKey === 'organization-audit') {
+        return !permissionsReady || canReadOrgAudit;
+    }
+    if (itemKey === 'environment-audit') {
+        return !permissionsReady || canReadEnvAudit;
     }
     return true;
 }
@@ -225,6 +236,8 @@ function ModuleLayout() {
     const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
     const canReadAlerts = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_READ_PERMISSION] });
     const canReadTenants = useHasPermission({ anyOf: ['organization-tenant-r', 'environment-tenant-r'] });
+    const canReadOrgAudit = useHasPermission({ anyOf: [...ORGANIZATION_AUDIT_READ_PERMISSIONS] });
+    const canReadEnvAudit = useHasPermission({ anyOf: [...ENVIRONMENT_AUDIT_READ_PERMISSIONS] });
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
@@ -242,6 +255,8 @@ function ModuleLayout() {
                     canReadGroups,
                     canReadAlerts,
                     canReadTenants,
+                    canReadOrgAudit,
+                    canReadEnvAudit,
                 ),
             ),
         [
@@ -254,6 +269,8 @@ function ModuleLayout() {
             canReadGroups,
             canReadAlerts,
             canReadTenants,
+            canReadOrgAudit,
+            canReadEnvAudit,
         ],
     );
 
@@ -458,6 +475,22 @@ export function AppRoutes() {
                                 element={
                                     <PermissionPageGuard permission={ENVIRONMENT_ALERT_READ_PERMISSION} unauthorizedTo="../applications">
                                         <AlertsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path="organization-audit"
+                                element={
+                                    <PermissionPageGuard anyOf={[...ORGANIZATION_AUDIT_READ_PERMISSIONS]} unauthorizedTo="../applications">
+                                        <OrgAuditLogsPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path="environment-audit"
+                                element={
+                                    <PermissionPageGuard anyOf={[...ENVIRONMENT_AUDIT_READ_PERMISSIONS]} unauthorizedTo="../applications">
+                                        <EnvAuditLogsPage />
                                     </PermissionPageGuard>
                                 }
                             />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -41,16 +41,16 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Organization', 'Assets')).toEqual(['tenants', 'entrypoints-and-sharding-tags']);
     });
 
-    it('places Access Management under Organization / System & Security', () => {
-        expect(sectionKeys('Organization', 'System & Security')).toEqual(['access-management']);
+    it('places Access Management then Audit under Organization / System & Security', () => {
+        expect(sectionKeys('Organization', 'System & Security')).toEqual(['access-management', 'organization-audit']);
     });
 
     it('places Applications, Metadata, and Dictionaries under Environment / APIs & Assets', () => {
         expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries']);
     });
 
-    it('places Gateways, Alerts, and Security Plan Types under Environment / System & Security', () => {
-        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'alerts', 'security-plan-types']);
+    it('places Gateways, Alerts, Security Plan Types, and Audit under Environment / System & Security', () => {
+        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'alerts', 'security-plan-types', 'environment-audit']);
     });
 
     it('places Users and Groups under Team', () => {
@@ -74,6 +74,8 @@ describe('platform navigation config', () => {
         expect(findNavSectionKey(NAV_SECTIONS, 'users')).toBe('team');
         expect(findNavSectionKey(NAV_SECTIONS, 'access-management')).toBe('organization');
         expect(findNavSectionKey(NAV_SECTIONS, 'tenants')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'organization-audit')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'environment-audit')).toBe('environment');
         expect(findNavSectionKey(NAV_SECTIONS, 'missing')).toBeUndefined();
     });
 
@@ -108,5 +110,15 @@ describe('platform navigation config', () => {
     it('declares the tenants route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('tenants');
         expect(ROUTES.tenants).toEqual({ path: 'tenants', label: 'Tenants' });
+    });
+
+    it('declares the organization-audit route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('organization-audit');
+        expect(ROUTES['organization-audit']).toEqual({ path: 'organization-audit', label: 'Audit' });
+    });
+
+    it('declares the environment-audit route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('environment-audit');
+        expect(ROUTES['environment-audit']).toEqual({ path: 'environment-audit', label: 'Audit' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -25,6 +25,7 @@ import {
     GroupIcon,
     KeyIcon,
     RadioIcon,
+    ScrollTextIcon,
     ServerIcon,
     ShieldIcon,
     UsersIcon,
@@ -65,7 +66,10 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
             },
             {
                 label: 'System & Security',
-                items: [{ key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon }],
+                items: [
+                    { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
+                    { key: 'organization-audit', title: ROUTES['organization-audit'].label, icon: ScrollTextIcon },
+                ],
             },
         ],
     },
@@ -88,6 +92,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                     { key: 'gateways', title: ROUTES.gateways.label, icon: ServerIcon },
                     { key: 'alerts', title: ROUTES.alerts.label, icon: BellIcon },
                     { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
+                    { key: 'environment-audit', title: ROUTES['environment-audit'].label, icon: ScrollTextIcon },
                 ],
             },
         ],

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -27,6 +27,8 @@ export const ROUTE_KEYS: readonly string[] = [
     'tenants',
     'entrypoints-and-sharding-tags',
     'alerts',
+    'organization-audit',
+    'environment-audit',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
@@ -44,6 +46,8 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     tenants: { path: 'tenants', label: 'Tenants' },
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
     alerts: { path: 'alerts', label: 'Alerts' },
+    'organization-audit': { path: 'organization-audit', label: 'Audit' },
+    'environment-audit': { path: 'environment-audit', label: 'Audit' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.spec.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AuditLogsFilters, ENV_AUDIT_REFERENCE_TYPES, ORG_AUDIT_REFERENCE_TYPES } from './AuditLogsFilters';
+import type { AuditLogsFiltersProps } from './AuditLogsFilters';
+
+function renderFilters(overrides: Partial<AuditLogsFiltersProps> = {}) {
+    const props: AuditLogsFiltersProps = {
+        scope: 'organization',
+        eventTypes: ['API_CREATED', 'USER_UPDATED'],
+        event: '',
+        onEventChange: jest.fn(),
+        referenceType: '',
+        onReferenceTypeChange: jest.fn(),
+        environments: [{ id: 'env-1', name: 'Production' }],
+        environmentId: '',
+        onEnvironmentIdChange: jest.fn(),
+        applications: [],
+        applicationId: '',
+        onApplicationIdChange: jest.fn(),
+        apis: [],
+        apiId: '',
+        onApiIdChange: jest.fn(),
+        datePreset: '',
+        onDatePresetChange: jest.fn(),
+        customRange: undefined,
+        onCustomRangeChange: jest.fn(),
+        onReset: jest.fn(),
+        onExport: jest.fn(),
+        ...overrides,
+    };
+    return { ...render(<AuditLogsFilters {...props} />), props };
+}
+
+describe('AuditLogsFilters', () => {
+    it('renders event, type, date, and export controls', () => {
+        renderFilters();
+        expect(screen.getByLabelText('Filter by event type')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by type')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by time period')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by date range')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Export' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reset' })).toBeNull();
+    });
+
+    it('offers ORGANIZATION and ENVIRONMENT types only on the organization page', () => {
+        expect(ORG_AUDIT_REFERENCE_TYPES).toEqual(['ORGANIZATION', 'ENVIRONMENT', 'APPLICATION', 'API']);
+        expect(ENV_AUDIT_REFERENCE_TYPES).toEqual(['APPLICATION', 'API']);
+    });
+
+    it('shows an environment picker when type is ENVIRONMENT', () => {
+        renderFilters({ referenceType: 'ENVIRONMENT' });
+        expect(screen.getByLabelText('Filter by environment')).not.toBeNull();
+    });
+
+    it('calls onReset and onExport', () => {
+        const { props } = renderFilters({ event: 'API_CREATED' });
+        fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+        expect(props.onReset).toHaveBeenCalled();
+        expect(props.onExport).toHaveBeenCalled();
+    });
+
+    it('emits the selected relative time preset', () => {
+        const { props } = renderFilters();
+        fireEvent.click(screen.getByLabelText('Filter by time period'));
+        fireEvent.click(screen.getByRole('option', { name: 'Last 24 hours' }));
+        expect(props.onDatePresetChange).toHaveBeenCalledWith('24h');
+    });
+
+    it('always shows the date range picker so a calendar range can be applied', () => {
+        renderFilters();
+        expect(document.querySelector('[data-slot="date-range-picker"]')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.tsx
@@ -40,10 +40,11 @@ import type {
     AuditReferenceType,
     AuditScope,
 } from '../types/auditLog';
+import { hasActiveAuditFilters } from '../utils/auditFilters';
 
-const ALL_EVENTS = '__all__';
-const ALL_TYPES = '__all__';
-const ALL_REFS = '__all__';
+// Radix Select cannot hold an empty string as a value, so "no filter" needs a sentinel that the
+// change handlers translate back to ''.
+const ALL_OPTION = '__all__';
 
 export const ORG_AUDIT_REFERENCE_TYPES: AuditReferenceType[] = ['ORGANIZATION', 'ENVIRONMENT', 'APPLICATION', 'API'];
 export const ENV_AUDIT_REFERENCE_TYPES: AuditReferenceType[] = ['APPLICATION', 'API'];
@@ -134,16 +135,16 @@ export function AuditLogsFilters({
     onExport,
 }: AuditLogsFiltersProps) {
     const types = scope === 'organization' ? ORG_AUDIT_REFERENCE_TYPES : ENV_AUDIT_REFERENCE_TYPES;
-    const hasFilters = Boolean(event || referenceType || datePreset || customRange?.from || customRange?.to);
+    const hasFilters = hasActiveAuditFilters({ event, referenceType, environmentId, applicationId, apiId, datePreset, customRange });
 
     return (
         <div className="flex flex-wrap items-center gap-2">
-            <Select value={event || ALL_EVENTS} onValueChange={value => onEventChange(value === ALL_EVENTS ? '' : value)}>
+            <Select value={event || ALL_OPTION} onValueChange={value => onEventChange(value === ALL_OPTION ? '' : value)}>
                 <SelectTrigger className="w-52" aria-label="Filter by event type">
                     <SelectValue placeholder="All events" />
                 </SelectTrigger>
                 <SelectContent position="popper" className="max-h-72 overflow-y-auto">
-                    <SelectItem value={ALL_EVENTS}>All events</SelectItem>
+                    <SelectItem value={ALL_OPTION}>All events</SelectItem>
                     {eventTypes.map(name => (
                         <SelectItem key={name} value={name}>
                             {name}
@@ -153,14 +154,14 @@ export function AuditLogsFilters({
             </Select>
 
             <Select
-                value={referenceType || ALL_TYPES}
-                onValueChange={value => onReferenceTypeChange(value === ALL_TYPES ? '' : (value as AuditReferenceType))}
+                value={referenceType || ALL_OPTION}
+                onValueChange={value => onReferenceTypeChange(value === ALL_OPTION ? '' : (value as AuditReferenceType))}
             >
                 <SelectTrigger className="w-44" aria-label="Filter by type">
                     <SelectValue placeholder="All types" />
                 </SelectTrigger>
                 <SelectContent position="popper">
-                    <SelectItem value={ALL_TYPES}>All types</SelectItem>
+                    <SelectItem value={ALL_OPTION}>All types</SelectItem>
                     {types.map(type => (
                         <SelectItem key={type} value={type}>
                             {type}
@@ -170,12 +171,15 @@ export function AuditLogsFilters({
             </Select>
 
             {scope === 'organization' && referenceType === 'ENVIRONMENT' ? (
-                <Select value={environmentId || ALL_REFS} onValueChange={value => onEnvironmentIdChange(value === ALL_REFS ? '' : value)}>
+                <Select
+                    value={environmentId || ALL_OPTION}
+                    onValueChange={value => onEnvironmentIdChange(value === ALL_OPTION ? '' : value)}
+                >
                     <SelectTrigger className="w-52" aria-label="Filter by environment">
                         <SelectValue placeholder="All environments" />
                     </SelectTrigger>
                     <SelectContent position="popper" className="max-h-72 overflow-y-auto">
-                        <SelectItem value={ALL_REFS}>All environments</SelectItem>
+                        <SelectItem value={ALL_OPTION}>All environments</SelectItem>
                         {environments.map(item => (
                             <SelectItem key={item.id} value={item.id}>
                                 {item.name}
@@ -186,39 +190,42 @@ export function AuditLogsFilters({
             ) : null}
 
             {referenceType === 'APPLICATION' ? (
-                <Select value={applicationId || ALL_REFS} onValueChange={value => onApplicationIdChange(value === ALL_REFS ? '' : value)}>
+                <Select
+                    value={applicationId || ALL_OPTION}
+                    onValueChange={value => onApplicationIdChange(value === ALL_OPTION ? '' : value)}
+                >
                     <SelectTrigger className="w-52" aria-label="Filter by application">
                         <SelectValue placeholder="All applications" />
                     </SelectTrigger>
                     <SelectContent position="popper" className="max-h-72 overflow-y-auto">
-                        <SelectItem value={ALL_REFS}>All applications</SelectItem>
+                        <SelectItem value={ALL_OPTION}>All applications</SelectItem>
                         <RefOptions items={applications} />
                     </SelectContent>
                 </Select>
             ) : null}
 
             {referenceType === 'API' ? (
-                <Select value={apiId || ALL_REFS} onValueChange={value => onApiIdChange(value === ALL_REFS ? '' : value)}>
+                <Select value={apiId || ALL_OPTION} onValueChange={value => onApiIdChange(value === ALL_OPTION ? '' : value)}>
                     <SelectTrigger className="w-52" aria-label="Filter by API">
                         <SelectValue placeholder="All APIs" />
                     </SelectTrigger>
                     <SelectContent position="popper" className="max-h-72 overflow-y-auto">
-                        <SelectItem value={ALL_REFS}>All APIs</SelectItem>
+                        <SelectItem value={ALL_OPTION}>All APIs</SelectItem>
                         <RefOptions items={apis} />
                     </SelectContent>
                 </Select>
             ) : null}
 
             <Select
-                value={datePreset || ALL_EVENTS}
-                onValueChange={value => onDatePresetChange((value === ALL_EVENTS ? '' : value) as AuditDatePreset)}
+                value={datePreset || ALL_OPTION}
+                onValueChange={value => onDatePresetChange((value === ALL_OPTION ? '' : value) as AuditDatePreset)}
             >
                 <SelectTrigger className="w-44" aria-label="Filter by time period">
                     <SelectValue placeholder="Any time" />
                 </SelectTrigger>
                 <SelectContent position="popper">
                     {DATE_PRESETS.map(preset => (
-                        <SelectItem key={preset.value || ALL_EVENTS} value={preset.value || ALL_EVENTS}>
+                        <SelectItem key={preset.value || ALL_OPTION} value={preset.value || ALL_OPTION}>
                             {preset.label}
                         </SelectItem>
                     ))}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsFilters.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DateRangePicker,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { DownloadIcon, XIcon } from '@gravitee/graphene-core/icons';
+import type { DateRange } from 'react-day-picker';
+
+import type {
+    AuditDatePreset,
+    AuditExportFormat,
+    AuditGroupedRefs,
+    AuditNamedRef,
+    AuditReferenceType,
+    AuditScope,
+} from '../types/auditLog';
+
+const ALL_EVENTS = '__all__';
+const ALL_TYPES = '__all__';
+const ALL_REFS = '__all__';
+
+export const ORG_AUDIT_REFERENCE_TYPES: AuditReferenceType[] = ['ORGANIZATION', 'ENVIRONMENT', 'APPLICATION', 'API'];
+export const ENV_AUDIT_REFERENCE_TYPES: AuditReferenceType[] = ['APPLICATION', 'API'];
+
+const DATE_PRESETS: Array<{ value: AuditDatePreset; label: string }> = [
+    { value: '', label: 'Any time' },
+    { value: '24h', label: 'Last 24 hours' },
+    { value: '7d', label: 'Last 7 days' },
+    { value: '30d', label: 'Last 30 days' },
+    { value: '90d', label: 'Last 90 days' },
+    { value: 'custom', label: 'Custom' },
+];
+
+export interface AuditLogsFiltersProps {
+    readonly scope: AuditScope;
+    readonly eventTypes: readonly string[];
+    readonly event: string;
+    readonly onEventChange: (event: string) => void;
+    readonly referenceType: AuditReferenceType | '';
+    readonly onReferenceTypeChange: (type: AuditReferenceType | '') => void;
+    readonly environments?: readonly AuditNamedRef[];
+    readonly environmentId: string;
+    readonly onEnvironmentIdChange: (id: string) => void;
+    readonly applications: readonly AuditNamedRef[] | readonly AuditGroupedRefs[];
+    readonly applicationId: string;
+    readonly onApplicationIdChange: (id: string) => void;
+    readonly apis: readonly AuditNamedRef[] | readonly AuditGroupedRefs[];
+    readonly apiId: string;
+    readonly onApiIdChange: (id: string) => void;
+    readonly datePreset: AuditDatePreset;
+    readonly onDatePresetChange: (preset: AuditDatePreset) => void;
+    readonly customRange: DateRange | undefined;
+    readonly onCustomRangeChange: (range: DateRange | undefined) => void;
+    readonly onReset: () => void;
+    readonly onExport: () => void;
+}
+
+function isGrouped(items: readonly AuditNamedRef[] | readonly AuditGroupedRefs[]): items is readonly AuditGroupedRefs[] {
+    return items.length > 0 && 'group' in items[0];
+}
+
+function RefOptions({ items }: { items: readonly AuditNamedRef[] | readonly AuditGroupedRefs[] }) {
+    if (isGrouped(items)) {
+        return (
+            <>
+                {items.flatMap(group =>
+                    group.items.map(item => (
+                        <SelectItem key={`${group.group}:${item.id}`} value={item.id}>
+                            {group.group} / {item.name}
+                        </SelectItem>
+                    )),
+                )}
+            </>
+        );
+    }
+    return (
+        <>
+            {items.map(item => (
+                <SelectItem key={item.id} value={item.id}>
+                    {item.name}
+                </SelectItem>
+            ))}
+        </>
+    );
+}
+
+export function AuditLogsFilters({
+    scope,
+    eventTypes,
+    event,
+    onEventChange,
+    referenceType,
+    onReferenceTypeChange,
+    environments = [],
+    environmentId,
+    onEnvironmentIdChange,
+    applications,
+    applicationId,
+    onApplicationIdChange,
+    apis,
+    apiId,
+    onApiIdChange,
+    datePreset,
+    onDatePresetChange,
+    customRange,
+    onCustomRangeChange,
+    onReset,
+    onExport,
+}: AuditLogsFiltersProps) {
+    const types = scope === 'organization' ? ORG_AUDIT_REFERENCE_TYPES : ENV_AUDIT_REFERENCE_TYPES;
+    const hasFilters = Boolean(event || referenceType || datePreset || customRange?.from || customRange?.to);
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <Select value={event || ALL_EVENTS} onValueChange={value => onEventChange(value === ALL_EVENTS ? '' : value)}>
+                <SelectTrigger className="w-52" aria-label="Filter by event type">
+                    <SelectValue placeholder="All events" />
+                </SelectTrigger>
+                <SelectContent position="popper" className="max-h-72 overflow-y-auto">
+                    <SelectItem value={ALL_EVENTS}>All events</SelectItem>
+                    {eventTypes.map(name => (
+                        <SelectItem key={name} value={name}>
+                            {name}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <Select
+                value={referenceType || ALL_TYPES}
+                onValueChange={value => onReferenceTypeChange(value === ALL_TYPES ? '' : (value as AuditReferenceType))}
+            >
+                <SelectTrigger className="w-44" aria-label="Filter by type">
+                    <SelectValue placeholder="All types" />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                    <SelectItem value={ALL_TYPES}>All types</SelectItem>
+                    {types.map(type => (
+                        <SelectItem key={type} value={type}>
+                            {type}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            {scope === 'organization' && referenceType === 'ENVIRONMENT' ? (
+                <Select value={environmentId || ALL_REFS} onValueChange={value => onEnvironmentIdChange(value === ALL_REFS ? '' : value)}>
+                    <SelectTrigger className="w-52" aria-label="Filter by environment">
+                        <SelectValue placeholder="All environments" />
+                    </SelectTrigger>
+                    <SelectContent position="popper" className="max-h-72 overflow-y-auto">
+                        <SelectItem value={ALL_REFS}>All environments</SelectItem>
+                        {environments.map(item => (
+                            <SelectItem key={item.id} value={item.id}>
+                                {item.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            ) : null}
+
+            {referenceType === 'APPLICATION' ? (
+                <Select value={applicationId || ALL_REFS} onValueChange={value => onApplicationIdChange(value === ALL_REFS ? '' : value)}>
+                    <SelectTrigger className="w-52" aria-label="Filter by application">
+                        <SelectValue placeholder="All applications" />
+                    </SelectTrigger>
+                    <SelectContent position="popper" className="max-h-72 overflow-y-auto">
+                        <SelectItem value={ALL_REFS}>All applications</SelectItem>
+                        <RefOptions items={applications} />
+                    </SelectContent>
+                </Select>
+            ) : null}
+
+            {referenceType === 'API' ? (
+                <Select value={apiId || ALL_REFS} onValueChange={value => onApiIdChange(value === ALL_REFS ? '' : value)}>
+                    <SelectTrigger className="w-52" aria-label="Filter by API">
+                        <SelectValue placeholder="All APIs" />
+                    </SelectTrigger>
+                    <SelectContent position="popper" className="max-h-72 overflow-y-auto">
+                        <SelectItem value={ALL_REFS}>All APIs</SelectItem>
+                        <RefOptions items={apis} />
+                    </SelectContent>
+                </Select>
+            ) : null}
+
+            <Select
+                value={datePreset || ALL_EVENTS}
+                onValueChange={value => onDatePresetChange((value === ALL_EVENTS ? '' : value) as AuditDatePreset)}
+            >
+                <SelectTrigger className="w-44" aria-label="Filter by time period">
+                    <SelectValue placeholder="Any time" />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                    {DATE_PRESETS.map(preset => (
+                        <SelectItem key={preset.value || ALL_EVENTS} value={preset.value || ALL_EVENTS}>
+                            {preset.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <DateRangePicker
+                value={customRange}
+                onChange={onCustomRangeChange}
+                placeholder="Date range"
+                numberOfMonths={2}
+                aria-label="Filter by date range"
+                className="w-64"
+            />
+
+            {hasFilters ? (
+                <Button type="button" variant="ghost" size="sm" onClick={onReset} className="gap-1">
+                    <XIcon className="size-3.5" aria-hidden />
+                    Reset
+                </Button>
+            ) : null}
+
+            <Button type="button" variant="outline" size="sm" className="ml-auto gap-1" onClick={onExport}>
+                <DownloadIcon className="size-3.5" aria-hidden />
+                Export
+            </Button>
+        </div>
+    );
+}
+
+export function AuditExportDialog({
+    open,
+    exporting,
+    onOpenChange,
+    onConfirm,
+}: Readonly<{
+    open: boolean;
+    exporting: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: (format: AuditExportFormat) => void;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-full max-w-md sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Export audit logs</DialogTitle>
+                    <DialogDescription>Download the current filtered results as CSV or JSON.</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="sm:justify-end">
+                    <Button type="button" variant="outline" disabled={exporting} onClick={() => onConfirm('csv')}>
+                        CSV
+                    </Button>
+                    <Button type="button" disabled={exporting} onClick={() => onConfirm('json')}>
+                        JSON
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import { AuditLogsPageView, type AuditLogsPageViewProps } from './AuditLogsPageView';
+
+function stubState(): AuditLogsPageViewProps['state'] {
+    return {
+        params: { page: 1, size: 10 },
+        page: 1,
+        setPage: jest.fn(),
+        pageSize: 10,
+        setPageSize: jest.fn(),
+        event: '',
+        onEventChange: jest.fn(),
+        referenceType: '',
+        onReferenceTypeChange: jest.fn(),
+        environmentId: '',
+        onEnvironmentIdChange: jest.fn(),
+        applicationId: '',
+        onApplicationIdChange: jest.fn(),
+        apiId: '',
+        onApiIdChange: jest.fn(),
+        datePreset: '',
+        onDatePresetChange: jest.fn(),
+        customRange: undefined,
+        onCustomRangeChange: jest.fn(),
+        selected: null,
+        setSelected: jest.fn(),
+        exportOpen: false,
+        setExportOpen: jest.fn(),
+        exporting: false,
+        handleReset: jest.fn(),
+        handleExport: jest.fn(),
+    };
+}
+
+function renderView(overrides: Partial<AuditLogsPageViewProps> = {}) {
+    return render(
+        <AuditLogsPageView
+            scope="organization"
+            description="Search configuration changes across the organization."
+            state={stubState()}
+            rows={[]}
+            totalCount={0}
+            loading={false}
+            isError={false}
+            eventTypes={['API_UPDATED']}
+            applications={[]}
+            apis={[]}
+            {...overrides}
+        />,
+    );
+}
+
+describe('AuditLogsPageView', () => {
+    it('keeps heading, filters, and table chrome when the query fails', () => {
+        renderView({ isError: true });
+
+        expect(screen.getByRole('heading', { name: 'Audit' })).not.toBeNull();
+        expect(screen.getByText('Search configuration changes across the organization.')).not.toBeNull();
+        expect(screen.getByText('Failed to load audit logs. Please try again.')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by event type')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by type')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by time period')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Export' })).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.spec.tsx
@@ -25,6 +25,7 @@ function stubState(): AuditLogsPageViewProps['state'] {
         setPage: jest.fn(),
         pageSize: 10,
         setPageSize: jest.fn(),
+        onPageSizeChange: jest.fn(),
         event: '',
         onEventChange: jest.fn(),
         referenceType: '',
@@ -46,6 +47,7 @@ function stubState(): AuditLogsPageViewProps['state'] {
         exporting: false,
         handleReset: jest.fn(),
         handleExport: jest.fn(),
+        hasActiveFilters: false,
     };
 }
 
@@ -78,5 +80,7 @@ describe('AuditLogsPageView', () => {
         expect(screen.getByLabelText('Filter by type')).not.toBeNull();
         expect(screen.getByLabelText('Filter by time period')).not.toBeNull();
         expect(screen.getByRole('button', { name: 'Export' })).not.toBeNull();
+        expect(screen.queryByText('No audit logs')).toBeNull();
+        expect(screen.queryByText('Try adjusting or clearing your filters.')).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
@@ -56,20 +56,42 @@ export function AuditLogsPageView({
     applications,
     apis,
 }: AuditLogsPageViewProps) {
-    if (isError) {
-        return <AuditPageHeading description="Failed to load audit logs. Please refresh and try again." />;
-    }
+    const filters = (
+        <AuditLogsFilters
+            scope={scope}
+            eventTypes={eventTypes}
+            event={state.event}
+            onEventChange={state.onEventChange}
+            referenceType={state.referenceType}
+            onReferenceTypeChange={state.onReferenceTypeChange}
+            environments={environments}
+            environmentId={state.environmentId}
+            onEnvironmentIdChange={state.onEnvironmentIdChange}
+            applications={applications}
+            applicationId={state.applicationId}
+            onApplicationIdChange={state.onApplicationIdChange}
+            apis={apis}
+            apiId={state.apiId}
+            onApiIdChange={state.onApiIdChange}
+            datePreset={state.datePreset}
+            onDatePresetChange={state.onDatePresetChange}
+            customRange={state.customRange}
+            onCustomRangeChange={state.onCustomRangeChange}
+            onReset={state.handleReset}
+            onExport={() => state.setExportOpen(true)}
+        />
+    );
 
     return (
         <div className="space-y-4">
             <AuditPageHeading description={description} />
-
+            {isError ? <p className="text-sm text-destructive">Failed to load audit logs. Please try again.</p> : null}
             <AuditLogsTable
-                rows={rows}
-                loading={loading}
+                rows={isError ? [] : rows}
+                loading={!isError && loading}
                 page={state.page}
                 pageSize={state.pageSize}
-                totalCount={totalCount}
+                totalCount={isError ? 0 : totalCount}
                 onPageChange={state.setPage}
                 onPageSizeChange={size => {
                     state.setPageSize(size);
@@ -78,31 +100,7 @@ export function AuditLogsPageView({
                 selected={state.selected}
                 onSelectRow={state.setSelected}
                 onCloseDetail={() => state.setSelected(null)}
-                toolbar={
-                    <AuditLogsFilters
-                        scope={scope}
-                        eventTypes={eventTypes}
-                        event={state.event}
-                        onEventChange={state.onEventChange}
-                        referenceType={state.referenceType}
-                        onReferenceTypeChange={state.onReferenceTypeChange}
-                        environments={environments}
-                        environmentId={state.environmentId}
-                        onEnvironmentIdChange={state.onEnvironmentIdChange}
-                        applications={applications}
-                        applicationId={state.applicationId}
-                        onApplicationIdChange={state.onApplicationIdChange}
-                        apis={apis}
-                        apiId={state.apiId}
-                        onApiIdChange={state.onApiIdChange}
-                        datePreset={state.datePreset}
-                        onDatePresetChange={state.onDatePresetChange}
-                        customRange={state.customRange}
-                        onCustomRangeChange={state.onCustomRangeChange}
-                        onReset={state.handleReset}
-                        onExport={() => state.setExportOpen(true)}
-                    />
-                }
+                toolbar={filters}
             />
             <AuditExportDialog
                 open={state.exportOpen}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AuditExportDialog, AuditLogsFilters } from './AuditLogsFilters';
+import { AuditLogsTable } from './AuditLogsTable';
+import type { useAuditLogsPageState } from '../hooks/useAuditLogsPageState';
+import type { AuditGroupedRefs, AuditLogRow, AuditNamedRef, AuditScope } from '../types/auditLog';
+
+export interface AuditLogsPageViewProps {
+    readonly scope: AuditScope;
+    readonly description: string;
+    readonly state: ReturnType<typeof useAuditLogsPageState>;
+    readonly rows: readonly AuditLogRow[];
+    readonly totalCount: number;
+    readonly loading: boolean;
+    readonly isError: boolean;
+    readonly eventTypes: readonly string[];
+    readonly environments?: readonly AuditNamedRef[];
+    readonly applications: readonly AuditNamedRef[] | readonly AuditGroupedRefs[];
+    readonly apis: readonly AuditNamedRef[] | readonly AuditGroupedRefs[];
+}
+
+function AuditPageHeading({ description }: Readonly<{ description: string }>) {
+    return (
+        <div className="space-y-1">
+            <h1 className="text-2xl font-semibold tracking-tight">Audit</h1>
+            <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+    );
+}
+
+/** Shared chrome for both Audit pages: heading, filter toolbar, results table and export dialog. */
+export function AuditLogsPageView({
+    scope,
+    description,
+    state,
+    rows,
+    totalCount,
+    loading,
+    isError,
+    eventTypes,
+    environments,
+    applications,
+    apis,
+}: AuditLogsPageViewProps) {
+    if (isError) {
+        return <AuditPageHeading description="Failed to load audit logs. Please refresh and try again." />;
+    }
+
+    return (
+        <div className="space-y-4">
+            <AuditPageHeading description={description} />
+
+            <AuditLogsTable
+                rows={rows}
+                loading={loading}
+                page={state.page}
+                pageSize={state.pageSize}
+                totalCount={totalCount}
+                onPageChange={state.setPage}
+                onPageSizeChange={size => {
+                    state.setPageSize(size);
+                    state.setPage(1);
+                }}
+                selected={state.selected}
+                onSelectRow={state.setSelected}
+                onCloseDetail={() => state.setSelected(null)}
+                toolbar={
+                    <AuditLogsFilters
+                        scope={scope}
+                        eventTypes={eventTypes}
+                        event={state.event}
+                        onEventChange={state.onEventChange}
+                        referenceType={state.referenceType}
+                        onReferenceTypeChange={state.onReferenceTypeChange}
+                        environments={environments}
+                        environmentId={state.environmentId}
+                        onEnvironmentIdChange={state.onEnvironmentIdChange}
+                        applications={applications}
+                        applicationId={state.applicationId}
+                        onApplicationIdChange={state.onApplicationIdChange}
+                        apis={apis}
+                        apiId={state.apiId}
+                        onApiIdChange={state.onApiIdChange}
+                        datePreset={state.datePreset}
+                        onDatePresetChange={state.onDatePresetChange}
+                        customRange={state.customRange}
+                        onCustomRangeChange={state.onCustomRangeChange}
+                        onReset={state.handleReset}
+                        onExport={() => state.setExportOpen(true)}
+                    />
+                }
+            />
+            <AuditExportDialog
+                open={state.exportOpen}
+                exporting={state.exporting}
+                onOpenChange={state.setExportOpen}
+                onConfirm={state.handleExport}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsPageView.tsx
@@ -23,7 +23,7 @@ export interface AuditLogsPageViewProps {
     readonly scope: AuditScope;
     readonly description: string;
     readonly state: ReturnType<typeof useAuditLogsPageState>;
-    readonly rows: readonly AuditLogRow[];
+    readonly rows: AuditLogRow[];
     readonly totalCount: number;
     readonly loading: boolean;
     readonly isError: boolean;
@@ -93,14 +93,13 @@ export function AuditLogsPageView({
                 pageSize={state.pageSize}
                 totalCount={isError ? 0 : totalCount}
                 onPageChange={state.setPage}
-                onPageSizeChange={size => {
-                    state.setPageSize(size);
-                    state.setPage(1);
-                }}
+                onPageSizeChange={state.onPageSizeChange}
                 selected={state.selected}
                 onSelectRow={state.setSelected}
                 onCloseDetail={() => state.setSelected(null)}
                 toolbar={filters}
+                hasActiveFilters={state.hasActiveFilters}
+                hideEmptyState={isError}
             />
             <AuditExportDialog
                 open={state.exportOpen}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.spec.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AuditLogsTable } from './AuditLogsTable';
+import type { AuditLogRow } from '../types/auditLog';
+
+const ROW: AuditLogRow = {
+    id: 'a-1',
+    createdAt: Date.parse('2026-08-19T10:00:00.000Z'),
+    user: 'Ada Lovelace',
+    referenceType: 'API',
+    reference: 'Pets',
+    event: 'API_UPDATED',
+    targets: [{ key: 'API', value: 'Pets' }],
+    patch: '[{"op":"replace","path":"/name","value":"Pets"}]',
+};
+
+describe('AuditLogsTable', () => {
+    it('renders audit columns', () => {
+        render(
+            <AuditLogsTable
+                rows={[ROW]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={1}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={jest.fn()}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Ada Lovelace')).not.toBeNull();
+        expect(screen.getByText('API_UPDATED')).not.toBeNull();
+        expect(screen.getByText('Pets')).not.toBeNull();
+        expect(screen.getByText(/API: Pets/)).not.toBeNull();
+    });
+
+    it('shows an empty state when there are no rows', () => {
+        render(
+            <AuditLogsTable
+                rows={[]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={0}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={jest.fn()}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('No audit logs found')).not.toBeNull();
+    });
+
+    it('opens the detail sheet with a pretty-printed patch when the eye is clicked', () => {
+        const onSelectRow = jest.fn();
+        const { rerender } = render(
+            <AuditLogsTable
+                rows={[ROW]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={1}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={onSelectRow}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'View patch' }));
+        expect(onSelectRow).toHaveBeenCalledWith(ROW);
+
+        rerender(
+            <AuditLogsTable
+                rows={[ROW]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={1}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={ROW}
+                onSelectRow={onSelectRow}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Audit event')).not.toBeNull();
+        expect(screen.getByText(/"op": "replace"/)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.spec.tsx
@@ -53,7 +53,28 @@ describe('AuditLogsTable', () => {
         expect(screen.getByText(/API: Pets/)).not.toBeNull();
     });
 
-    it('shows an empty state when there are no rows', () => {
+    it('names the Date and User actions distinctly per row so screen readers can tell them apart', () => {
+        const onSelectRow = jest.fn();
+        render(
+            <AuditLogsTable
+                rows={[ROW]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={1}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={onSelectRow}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getAllByRole('button', { name: /^View audit details for API_UPDATED/ })[0]);
+        expect(onSelectRow).toHaveBeenCalledWith(ROW);
+    });
+
+    it('shows a first-use empty state when there are no rows and no filters', () => {
         render(
             <AuditLogsTable
                 rows={[]}
@@ -69,7 +90,49 @@ describe('AuditLogsTable', () => {
             />,
         );
 
+        expect(screen.getByText('No audit logs')).not.toBeNull();
+        expect(screen.getByText('Configuration changes will appear here.')).not.toBeNull();
+        expect(screen.queryByText('Try adjusting or clearing your filters.')).toBeNull();
+    });
+
+    it('tells the user to clear filters when a filtered search is empty', () => {
+        render(
+            <AuditLogsTable
+                rows={[]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={0}
+                hasActiveFilters
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={jest.fn()}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
         expect(screen.getByText('No audit logs found')).not.toBeNull();
+        expect(screen.getByText('Try adjusting or clearing your filters.')).not.toBeNull();
+    });
+
+    it('renders a dash when a row has no targets', () => {
+        render(
+            <AuditLogsTable
+                rows={[{ ...ROW, targets: [] }]}
+                loading={false}
+                page={1}
+                pageSize={10}
+                totalCount={1}
+                onPageChange={jest.fn()}
+                onPageSizeChange={jest.fn()}
+                selected={null}
+                onSelectRow={jest.fn()}
+                onCloseDetail={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('—')).not.toBeNull();
     });
 
     it('opens the detail sheet with a pretty-printed patch when the eye is clicked', () => {
@@ -89,7 +152,7 @@ describe('AuditLogsTable', () => {
             />,
         );
 
-        fireEvent.click(screen.getByRole('button', { name: 'View patch' }));
+        fireEvent.click(screen.getByRole('button', { name: 'View patch for API_UPDATED' }));
         expect(onSelectRow).toHaveBeenCalledWith(ROW);
 
         rerender(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.tsx
@@ -26,18 +26,18 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@gravitee/graphene-core';
-import { EyeIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import { EyeIcon, ScrollTextIcon, SearchIcon } from '@gravitee/graphene-core/icons';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 
 import type { ColCell } from '../../applications/utils/dataTableTypes';
 import type { AuditLogRow } from '../types/auditLog';
-import { formatAuditTargetText, prettyPrintPatch } from '../utils/auditListFormat';
+import { prettyPrintPatch } from '../utils/auditListFormat';
 
 export const AUDIT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
 
 export interface AuditLogsTableProps {
-    readonly rows: readonly AuditLogRow[];
+    readonly rows: AuditLogRow[];
     readonly loading: boolean;
     readonly page: number;
     readonly pageSize: number;
@@ -48,6 +48,15 @@ export interface AuditLogsTableProps {
     readonly selected: AuditLogRow | null;
     readonly onSelectRow: (row: AuditLogRow) => void;
     readonly onCloseDetail: () => void;
+    readonly hasActiveFilters?: boolean;
+    readonly hideEmptyState?: boolean;
+}
+
+// Every row opens the same sheet, so the labels have to say *which* row — a screen reader reading a
+// page of identical "View audit details" buttons cannot tell them apart. The event is the most
+// identifying field, so it anchors each label.
+function detailLabel(row: AuditLogRow, context: string): string {
+    return `View audit details for ${row.event} ${context}`;
 }
 
 function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<AuditLogRow>['columns'] {
@@ -58,7 +67,13 @@ function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<A
             header: 'Date',
             enableSorting: false,
             cell: ({ row }: ColCell<AuditLogRow>) => (
-                <button type="button" className="text-left" onClick={() => onSelectRow(row.original)}>
+                <button
+                    type="button"
+                    className="text-left"
+                    aria-label={detailLabel(row.original, `at ${new Date(row.original.createdAt).toISOString()}`)}
+                    onClick={() => onSelectRow(row.original)}
+                >
+                    {/* Audit is a forensic log: wall-clock time belongs in the cell, not a relative "2h ago". */}
                     <DateCell value={new Date(row.original.createdAt).toISOString()} format="absolute" />
                 </button>
             ),
@@ -69,7 +84,12 @@ function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<A
             header: 'User',
             enableSorting: false,
             cell: ({ row }: ColCell<AuditLogRow>) => (
-                <button type="button" className="text-left text-sm" onClick={() => onSelectRow(row.original)}>
+                <button
+                    type="button"
+                    className="text-left text-sm"
+                    aria-label={detailLabel(row.original, `by ${row.original.user}`)}
+                    onClick={() => onSelectRow(row.original)}
+                >
                     {row.original.user}
                 </button>
             ),
@@ -97,9 +117,8 @@ function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<A
             id: 'Target',
             header: 'Target',
             enableSorting: false,
-            cell: ({ row }: ColCell<AuditLogRow>) => {
-                const text = formatAuditTargetText(row.original.targets);
-                return text ? (
+            cell: ({ row }: ColCell<AuditLogRow>) =>
+                row.original.targets.length > 0 ? (
                     <div className="text-sm">
                         {row.original.targets.map(target => (
                             <div key={`${target.key}:${target.value}`}>
@@ -109,8 +128,7 @@ function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<A
                     </div>
                 ) : (
                     <span className="text-muted-foreground/40 italic">—</span>
-                );
-            },
+                ),
         },
         {
             id: 'actions',
@@ -128,10 +146,10 @@ function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<A
                             size="icon"
                             className="size-8"
                             onClick={() => onSelectRow(row.original)}
-                            aria-label="View patch"
+                            aria-label={`View patch for ${row.original.event}`}
                             title="View patch"
                         >
-                            <EyeIcon className="size-4" />
+                            <EyeIcon className="size-4" aria-hidden="true" />
                         </Button>
                     </div>
                 );
@@ -152,6 +170,8 @@ export function AuditLogsTable({
     selected,
     onSelectRow,
     onCloseDetail,
+    hasActiveFilters = false,
+    hideEmptyState = false,
 }: AuditLogsTableProps) {
     const columns = useMemo(() => buildColumns(onSelectRow), [onSelectRow]);
 
@@ -160,7 +180,7 @@ export function AuditLogsTable({
             <DataTable
                 aria-label="Audit logs"
                 columns={columns}
-                data={[...rows]}
+                data={rows}
                 loading={loading}
                 skeletonCount={pageSize}
                 serverSide
@@ -172,20 +192,27 @@ export function AuditLogsTable({
                               totalCount,
                               pageSizeOptions: [...AUDIT_PAGE_SIZE_OPTIONS],
                               onPageChange,
-                              onPageSizeChange: (size: number) => {
-                                  onPageSizeChange(size);
-                                  onPageChange(1);
-                              },
+                              // The owner of the page state resets the offset; forward the size as-is.
+                              onPageSizeChange,
                           }
                         : undefined
                 }
                 emptyMessage={
-                    <DataTableEmptyState
-                        variant="no-results"
-                        icon={<SearchIcon />}
-                        title="No audit logs found"
-                        description="Try adjusting or clearing your filters."
-                    />
+                    hideEmptyState ? undefined : hasActiveFilters ? (
+                        <DataTableEmptyState
+                            variant="no-results"
+                            icon={<SearchIcon />}
+                            title="No audit logs found"
+                            description="Try adjusting or clearing your filters."
+                        />
+                    ) : (
+                        <DataTableEmptyState
+                            variant="first-use"
+                            icon={<ScrollTextIcon />}
+                            title="No audit logs"
+                            description="Configuration changes will appear here."
+                        />
+                    )
                 }
                 toolbar={toolbar}
             />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditLogsTable.tsx
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    DataTable,
+    DataTableEmptyState,
+    DateCell,
+    type DataTableProps,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { EyeIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+
+import type { ColCell } from '../../applications/utils/dataTableTypes';
+import type { AuditLogRow } from '../types/auditLog';
+import { formatAuditTargetText, prettyPrintPatch } from '../utils/auditListFormat';
+
+export const AUDIT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export interface AuditLogsTableProps {
+    readonly rows: readonly AuditLogRow[];
+    readonly loading: boolean;
+    readonly page: number;
+    readonly pageSize: number;
+    readonly totalCount: number;
+    readonly onPageChange: (page: number) => void;
+    readonly onPageSizeChange: (size: number) => void;
+    readonly toolbar?: ReactNode;
+    readonly selected: AuditLogRow | null;
+    readonly onSelectRow: (row: AuditLogRow) => void;
+    readonly onCloseDetail: () => void;
+}
+
+function buildColumns(onSelectRow: (row: AuditLogRow) => void): DataTableProps<AuditLogRow>['columns'] {
+    return [
+        {
+            id: 'Date',
+            accessorFn: (row: AuditLogRow) => row.createdAt,
+            header: 'Date',
+            enableSorting: false,
+            cell: ({ row }: ColCell<AuditLogRow>) => (
+                <button type="button" className="text-left" onClick={() => onSelectRow(row.original)}>
+                    <DateCell value={new Date(row.original.createdAt).toISOString()} format="absolute" />
+                </button>
+            ),
+        },
+        {
+            id: 'User',
+            accessorFn: (row: AuditLogRow) => row.user,
+            header: 'User',
+            enableSorting: false,
+            cell: ({ row }: ColCell<AuditLogRow>) => (
+                <button type="button" className="text-left text-sm" onClick={() => onSelectRow(row.original)}>
+                    {row.original.user}
+                </button>
+            ),
+        },
+        {
+            id: 'Type',
+            accessorFn: (row: AuditLogRow) => row.referenceType,
+            header: 'Type',
+            enableSorting: false,
+        },
+        {
+            id: 'Reference',
+            accessorFn: (row: AuditLogRow) => row.reference,
+            header: 'Reference',
+            enableSorting: false,
+        },
+        {
+            id: 'Event',
+            accessorFn: (row: AuditLogRow) => row.event,
+            header: 'Event',
+            enableSorting: false,
+            cell: ({ row }: ColCell<AuditLogRow>) => <span className="font-mono text-sm">{row.original.event}</span>,
+        },
+        {
+            id: 'Target',
+            header: 'Target',
+            enableSorting: false,
+            cell: ({ row }: ColCell<AuditLogRow>) => {
+                const text = formatAuditTargetText(row.original.targets);
+                return text ? (
+                    <div className="text-sm">
+                        {row.original.targets.map(target => (
+                            <div key={`${target.key}:${target.value}`}>
+                                {target.key}: {target.value}
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <span className="text-muted-foreground/40 italic">—</span>
+                );
+            },
+        },
+        {
+            id: 'actions',
+            header: () => <span className="sr-only">Patch</span>,
+            size: 64,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<AuditLogRow>) => {
+                if (!row.original.patch) return null;
+                return (
+                    <div className="flex justify-end">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8"
+                            onClick={() => onSelectRow(row.original)}
+                            aria-label="View patch"
+                            title="View patch"
+                        >
+                            <EyeIcon className="size-4" />
+                        </Button>
+                    </div>
+                );
+            },
+        },
+    ];
+}
+
+export function AuditLogsTable({
+    rows,
+    loading,
+    page,
+    pageSize,
+    totalCount,
+    onPageChange,
+    onPageSizeChange,
+    toolbar,
+    selected,
+    onSelectRow,
+    onCloseDetail,
+}: AuditLogsTableProps) {
+    const columns = useMemo(() => buildColumns(onSelectRow), [onSelectRow]);
+
+    return (
+        <>
+            <DataTable
+                aria-label="Audit logs"
+                columns={columns}
+                data={[...rows]}
+                loading={loading}
+                skeletonCount={pageSize}
+                serverSide
+                pagination={
+                    totalCount > 0
+                        ? {
+                              page,
+                              pageSize,
+                              totalCount,
+                              pageSizeOptions: [...AUDIT_PAGE_SIZE_OPTIONS],
+                              onPageChange,
+                              onPageSizeChange: (size: number) => {
+                                  onPageSizeChange(size);
+                                  onPageChange(1);
+                              },
+                          }
+                        : undefined
+                }
+                emptyMessage={
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon />}
+                        title="No audit logs found"
+                        description="Try adjusting or clearing your filters."
+                    />
+                }
+                toolbar={toolbar}
+            />
+            <AuditDetailSheet row={selected} onClose={onCloseDetail} />
+        </>
+    );
+}
+
+function AuditDetailSheet({ row, onClose }: Readonly<{ row: AuditLogRow | null; onClose: () => void }>) {
+    return (
+        <Sheet open={Boolean(row)} onOpenChange={open => !open && onClose()}>
+            <SheetContent side="right" className="sm:max-w-xl">
+                <SheetHeader>
+                    <SheetTitle>Audit event</SheetTitle>
+                    <SheetDescription>User, resource, and JSON Patch for this configuration change.</SheetDescription>
+                </SheetHeader>
+                {row ? (
+                    <div className="flex-1 space-y-4 overflow-y-auto px-4 pb-4 text-sm">
+                        <DetailField label="User" value={row.user} />
+                        <DetailField label="Type" value={row.referenceType} />
+                        <DetailField label="Reference" value={row.reference} />
+                        <DetailField label="Event" value={row.event} />
+                        <div>
+                            <p className="mb-1 text-xs font-medium text-muted-foreground">Target</p>
+                            {row.targets.length > 0 ? (
+                                row.targets.map(target => (
+                                    <div key={`${target.key}:${target.value}`}>
+                                        {target.key}: {target.value}
+                                    </div>
+                                ))
+                            ) : (
+                                <span className="text-muted-foreground">—</span>
+                            )}
+                        </div>
+                        {row.patch ? (
+                            <div>
+                                <p className="mb-1 text-xs font-medium text-muted-foreground">JSON Patch</p>
+                                <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted p-4 text-xs font-mono text-foreground">
+                                    {prettyPrintPatch(row.patch)}
+                                </pre>
+                            </div>
+                        ) : null}
+                    </div>
+                ) : null}
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+function DetailField({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="mb-1 text-xs font-medium text-muted-foreground">{label}</p>
+            <p>{value}</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditTrailLicenseDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditTrailLicenseDialog.spec.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AuditTrailLicenseDialog } from './AuditTrailLicenseDialog';
+
+describe('AuditTrailLicenseDialog', () => {
+    it('shows upgrade copy and a trial link when open', () => {
+        render(<AuditTrailLicenseDialog open onOpenChange={jest.fn()} />);
+
+        expect(screen.getByText('Audit')).not.toBeNull();
+        expect(screen.getByText(/part of Gravitee Enterprise/i)).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Start a free trial' }).getAttribute('href')).toBe('https://gravitee.io/self-hosted-trial');
+    });
+
+    it('notifies the parent when Close is clicked', () => {
+        const onOpenChange = jest.fn();
+        render(<AuditTrailLicenseDialog open onOpenChange={onOpenChange} />);
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[0]);
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditTrailLicenseDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/components/AuditTrailLicenseDialog.tsx
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
-import { SHARDING_TAGS_UPGRADE } from '../license/shardingTagsLicense';
 
-export function ShardingTagsLicenseDialog({
+import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
+import { AUDIT_TRAIL_UPGRADE } from '../license/auditTrailLicense';
+
+export function AuditTrailLicenseDialog({
     open,
     onOpenChange,
 }: Readonly<{
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }>) {
-    return <FeatureLicenseDialog upgrade={SHARDING_TAGS_UPGRADE} open={open} onOpenChange={onOpenChange} />;
+    return <FeatureLicenseDialog upgrade={AUDIT_TRAIL_UPGRADE} open={open} onOpenChange={onOpenChange} />;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogs.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import {
+    listAuditApis,
+    listAuditApplications,
+    listAuditEnvironments,
+    listEnvAuditEvents,
+    listOrgAuditApisByEnvironment,
+    listOrgAuditApplicationsByEnvironment,
+    listOrgAuditEvents,
+    searchEnvAudits,
+    searchOrgAudits,
+} from '../services/auditLogs';
+import type { AuditScope, AuditSearchParams } from '../types/auditLog';
+import { auditKeys } from '../utils/queryKeys';
+
+export function useAuditLogs(scope: AuditScope, params: AuditSearchParams, environmentId?: string, enabled = true) {
+    return useQuery({
+        queryKey: auditKeys.search(scope, environmentId, params),
+        queryFn: () => (scope === 'organization' ? searchOrgAudits(params) : searchEnvAudits(environmentId ?? '', params)),
+        enabled: enabled && (scope === 'organization' || Boolean(environmentId)),
+        // Keep the current page on screen while the next one loads instead of flashing skeletons.
+        placeholderData: keepPreviousData,
+    });
+}
+
+export function useAuditEvents(scope: AuditScope, environmentId?: string, enabled = true) {
+    return useQuery({
+        queryKey: auditKeys.events(scope, environmentId),
+        queryFn: () => (scope === 'organization' ? listOrgAuditEvents() : listEnvAuditEvents(environmentId ?? '')),
+        enabled: enabled && (scope === 'organization' || Boolean(environmentId)),
+    });
+}
+
+export function useAuditEnvironments(enabled: boolean) {
+    return useQuery({
+        queryKey: auditKeys.environments(),
+        queryFn: listAuditEnvironments,
+        enabled,
+    });
+}
+
+export function useAuditApplications(environmentId: string | undefined, enabled: boolean) {
+    return useQuery({
+        queryKey: auditKeys.applications(environmentId),
+        queryFn: () => listAuditApplications(environmentId ?? ''),
+        enabled: enabled && Boolean(environmentId),
+    });
+}
+
+export function useAuditApis(environmentId: string | undefined, enabled: boolean) {
+    return useQuery({
+        queryKey: auditKeys.apis(environmentId),
+        queryFn: () => listAuditApis(environmentId ?? ''),
+        enabled: enabled && Boolean(environmentId),
+    });
+}
+
+// The org-wide pickers fan out per environment, so they depend on the environments query rather than
+// refetching `/environments` themselves — all three consumers then share one cached response.
+export function useOrgAuditApplications(enabled: boolean) {
+    const { data: environments } = useAuditEnvironments(enabled);
+    return useQuery({
+        queryKey: auditKeys.orgApplications(),
+        queryFn: () => listOrgAuditApplicationsByEnvironment(environments ?? []),
+        enabled: enabled && environments !== undefined,
+    });
+}
+
+export function useOrgAuditApis(enabled: boolean) {
+    const { data: environments } = useAuditEnvironments(enabled);
+    return useQuery({
+        queryKey: auditKeys.orgApis(),
+        queryFn: () => listOrgAuditApisByEnvironment(environments ?? []),
+        enabled: enabled && environments !== undefined,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogs.ts
@@ -27,7 +27,7 @@ import {
     searchEnvAudits,
     searchOrgAudits,
 } from '../services/auditLogs';
-import type { AuditScope, AuditSearchParams } from '../types/auditLog';
+import type { AuditNamedRef, AuditScope, AuditSearchParams } from '../types/auditLog';
 import { auditKeys } from '../utils/queryKeys';
 
 export function useAuditLogs(scope: AuditScope, params: AuditSearchParams, environmentId?: string, enabled = true) {
@@ -72,21 +72,20 @@ export function useAuditApis(environmentId: string | undefined, enabled: boolean
     });
 }
 
-// The org-wide pickers fan out per environment, so they depend on the environments query rather than
-// refetching `/environments` themselves — all three consumers then share one cached response.
-export function useOrgAuditApplications(enabled: boolean) {
-    const { data: environments } = useAuditEnvironments(enabled);
+// Org application/API pickers fan out per environment. The page owns `useAuditEnvironments` so
+// the environment picker and these two queries share one response instead of each hook
+// re-subscribing with its own `enabled` flag.
+export function useOrgAuditApplications(environments: readonly AuditNamedRef[] | undefined, enabled: boolean) {
     return useQuery({
-        queryKey: auditKeys.orgApplications(),
+        queryKey: auditKeys.orgApplications((environments ?? []).map(environment => environment.id)),
         queryFn: () => listOrgAuditApplicationsByEnvironment(environments ?? []),
         enabled: enabled && environments !== undefined,
     });
 }
 
-export function useOrgAuditApis(enabled: boolean) {
-    const { data: environments } = useAuditEnvironments(enabled);
+export function useOrgAuditApis(environments: readonly AuditNamedRef[] | undefined, enabled: boolean) {
     return useQuery({
-        queryKey: auditKeys.orgApis(),
+        queryKey: auditKeys.orgApis((environments ?? []).map(environment => environment.id)),
         queryFn: () => listOrgAuditApisByEnvironment(environments ?? []),
         enabled: enabled && environments !== undefined,
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
@@ -28,6 +28,7 @@ import type {
     AuditSearchParams,
 } from '../types/auditLog';
 import { auditLogsToCsv, auditLogsToJson, buildAuditExportFileName, downloadAuditExport } from '../utils/auditExport';
+import { hasActiveAuditFilters } from '../utils/auditFilters';
 import { toAuditLogRow } from '../utils/auditListFormat';
 
 type ExportAudits = (params: Omit<AuditSearchParams, 'page' | 'size'>) => Promise<AuditMetadataPage>;
@@ -46,12 +47,16 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
     const [applicationId, setApplicationId] = useState('');
     const [apiId, setApiId] = useState('');
     const [datePreset, setDatePreset] = useState<AuditDatePreset>('');
+    // The instant relative presets resolve against, captured when the preset is chosen. It has to be
+    // state, not a memo: a value re-derived during render would move the from/to window and with it
+    // the React Query key. The trade-off is that "Last 24 hours" is frozen until the user reselects it.
+    const [dateAnchor, setDateAnchor] = useState(() => Date.now());
     const [customRange, setCustomRange] = useState<DateRange | undefined>();
     const [selected, setSelected] = useState<AuditLogRow | null>(null);
     const [exportOpen, setExportOpen] = useState(false);
     const [exporting, setExporting] = useState(false);
 
-    const dateRange = useResolvedAuditDateRange(datePreset, customRange);
+    const dateRange = useResolvedAuditDateRange(datePreset, customRange, dateAnchor);
     // `environment` is only ever set on the organization page; the environment page has no such
     // picker, so it stays undefined there and `buildAuditQuery` drops it.
     const params: AuditSearchParams = useMemo(
@@ -74,6 +79,10 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
         setPage(1);
     }, []);
 
+    // A larger or smaller page invalidates the current offset, so the reset lives here rather than
+    // being repeated by every layer that renders the pagination control.
+    const handlePageSizeChange = useCallback((size: number) => resetPage(() => setPageSize(size)), [resetPage]);
+
     const handleReset = useCallback(() => {
         setEvent('');
         setReferenceType('');
@@ -81,6 +90,7 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
         setApplicationId('');
         setApiId('');
         setDatePreset('');
+        setDateAnchor(Date.now());
         setCustomRange(undefined);
         setPage(1);
     }, []);
@@ -133,6 +143,7 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
         (value: AuditDatePreset) =>
             resetPage(() => {
                 setDatePreset(value);
+                setDateAnchor(Date.now());
                 if (value !== 'custom') {
                     setCustomRange(undefined);
                 }
@@ -159,6 +170,7 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
         setPage,
         pageSize,
         setPageSize,
+        onPageSizeChange: handlePageSizeChange,
         event,
         onEventChange: useCallback((value: string) => resetPage(() => setEvent(value)), [resetPage]),
         referenceType,
@@ -180,5 +192,6 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
         exporting,
         handleReset,
         handleExport,
+        hasActiveFilters: hasActiveAuditFilters({ event, referenceType, environmentId, applicationId, apiId, datePreset, customRange }),
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+
+import { useResolvedAuditDateRange } from './useResolvedAuditDateRange';
+import { notify } from '../../../shared/notify';
+import { AuditExportLimitError } from '../services/auditLogs';
+import type {
+    AuditDatePreset,
+    AuditExportFormat,
+    AuditLogRow,
+    AuditMetadataPage,
+    AuditReferenceType,
+    AuditSearchParams,
+} from '../types/auditLog';
+import { auditLogsToCsv, auditLogsToJson, buildAuditExportFileName, downloadAuditExport } from '../utils/auditExport';
+import { toAuditLogRow } from '../utils/auditListFormat';
+
+type ExportAudits = (params: Omit<AuditSearchParams, 'page' | 'size'>) => Promise<AuditMetadataPage>;
+
+/**
+ * Filter, pagination, selection and export state shared by the organization and environment
+ * Audit pages. The pages differ only in which services they hit, so they inject `exportAudits`
+ * and read `params` back to drive their own scope-specific queries.
+ */
+export function useAuditLogsPageState(exportAudits: ExportAudits) {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [event, setEvent] = useState('');
+    const [referenceType, setReferenceType] = useState<AuditReferenceType | ''>('');
+    const [environmentId, setEnvironmentId] = useState('');
+    const [applicationId, setApplicationId] = useState('');
+    const [apiId, setApiId] = useState('');
+    const [datePreset, setDatePreset] = useState<AuditDatePreset>('');
+    const [customRange, setCustomRange] = useState<DateRange | undefined>();
+    const [selected, setSelected] = useState<AuditLogRow | null>(null);
+    const [exportOpen, setExportOpen] = useState(false);
+    const [exporting, setExporting] = useState(false);
+
+    const dateRange = useResolvedAuditDateRange(datePreset, customRange);
+    // `environment` is only ever set on the organization page; the environment page has no such
+    // picker, so it stays undefined there and `buildAuditQuery` drops it.
+    const params: AuditSearchParams = useMemo(
+        () => ({
+            page,
+            size: pageSize,
+            event: event || undefined,
+            type: referenceType || undefined,
+            environment: environmentId || undefined,
+            application: applicationId || undefined,
+            api: apiId || undefined,
+            from: dateRange.from,
+            to: dateRange.to,
+        }),
+        [page, pageSize, event, referenceType, environmentId, applicationId, apiId, dateRange.from, dateRange.to],
+    );
+
+    const resetPage = useCallback((action: () => void) => {
+        action();
+        setPage(1);
+    }, []);
+
+    const handleReset = useCallback(() => {
+        setEvent('');
+        setReferenceType('');
+        setEnvironmentId('');
+        setApplicationId('');
+        setApiId('');
+        setDatePreset('');
+        setCustomRange(undefined);
+        setPage(1);
+    }, []);
+
+    const handleExport = useCallback(
+        async (format: AuditExportFormat) => {
+            setExporting(true);
+            try {
+                const pageResult = await exportAudits({
+                    event: params.event,
+                    type: params.type,
+                    environment: params.environment,
+                    application: params.application,
+                    api: params.api,
+                    from: params.from,
+                    to: params.to,
+                });
+                const exportRows = (pageResult.content ?? []).map(audit => toAuditLogRow(audit, pageResult.metadata ?? {}));
+                const fileName = buildAuditExportFileName(format);
+                if (format === 'csv') {
+                    downloadAuditExport(auditLogsToCsv(exportRows), fileName, 'text/csv;charset=utf-8');
+                } else {
+                    downloadAuditExport(auditLogsToJson(exportRows), fileName, 'application/json');
+                }
+                notify.success('Audit logs exported.');
+                setExportOpen(false);
+            } catch (error) {
+                notify.error(error, error instanceof AuditExportLimitError ? error.message : 'Failed to export audit logs.');
+            } finally {
+                setExporting(false);
+            }
+        },
+        [exportAudits, params],
+    );
+
+    const handleReferenceTypeChange = useCallback(
+        (value: AuditReferenceType | '') =>
+            resetPage(() => {
+                setReferenceType(value);
+                setEnvironmentId('');
+                setApplicationId('');
+                setApiId('');
+            }),
+        [resetPage],
+    );
+
+    const handleDatePresetChange = useCallback(
+        (value: AuditDatePreset) =>
+            resetPage(() => {
+                setDatePreset(value);
+                if (value !== 'custom') {
+                    setCustomRange(undefined);
+                }
+            }),
+        [resetPage],
+    );
+
+    const handleCustomRangeChange = useCallback(
+        (value: DateRange | undefined) =>
+            resetPage(() => {
+                setCustomRange(value);
+                if (value?.from || value?.to) {
+                    setDatePreset('custom');
+                } else {
+                    setDatePreset(current => (current === 'custom' ? '' : current));
+                }
+            }),
+        [resetPage],
+    );
+
+    return {
+        params,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
+        event,
+        onEventChange: useCallback((value: string) => resetPage(() => setEvent(value)), [resetPage]),
+        referenceType,
+        onReferenceTypeChange: handleReferenceTypeChange,
+        environmentId,
+        onEnvironmentIdChange: useCallback((value: string) => resetPage(() => setEnvironmentId(value)), [resetPage]),
+        applicationId,
+        onApplicationIdChange: useCallback((value: string) => resetPage(() => setApplicationId(value)), [resetPage]),
+        apiId,
+        onApiIdChange: useCallback((value: string) => resetPage(() => setApiId(value)), [resetPage]),
+        datePreset,
+        onDatePresetChange: handleDatePresetChange,
+        customRange,
+        onCustomRangeChange: handleCustomRangeChange,
+        selected,
+        setSelected,
+        exportOpen,
+        setExportOpen,
+        exporting,
+        handleReset,
+        handleExport,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useAuditLogsPageState.ts
@@ -19,7 +19,6 @@ import type { DateRange } from 'react-day-picker';
 
 import { useResolvedAuditDateRange } from './useResolvedAuditDateRange';
 import { notify } from '../../../shared/notify';
-import { AuditExportLimitError } from '../services/auditLogs';
 import type {
     AuditDatePreset,
     AuditExportFormat,
@@ -109,7 +108,9 @@ export function useAuditLogsPageState(exportAudits: ExportAudits) {
                 notify.success('Audit logs exported.');
                 setExportOpen(false);
             } catch (error) {
-                notify.error(error, error instanceof AuditExportLimitError ? error.message : 'Failed to export audit logs.');
+                // `notify.error` surfaces `error.message` for any Error, so AuditExportLimitError's own
+                // message reaches the user; the fallback only covers non-Error throws.
+                notify.error(error, 'Failed to export audit logs.');
             } finally {
                 setExporting(false);
             }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.spec.ts
@@ -19,21 +19,30 @@ import { renderHook } from '@testing-library/react';
 import { useResolvedAuditDateRange } from './useResolvedAuditDateRange';
 import type { AuditDatePreset } from '../types/auditLog';
 
+const ANCHOR = 1_800_000_000_000;
+
 describe('useResolvedAuditDateRange', () => {
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('keeps relative from/to stable across rerenders so search keys do not churn', () => {
-        let now = 1_800_000_000_000;
-        jest.spyOn(Date, 'now').mockImplementation(() => {
-            now += 1_000;
-            return now;
+    it('resolves a relative preset from the anchor, never from the wall clock', () => {
+        // Any read of Date.now() inside the hook would let the window drift between renders.
+        const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => {
+            throw new Error('Date.now() must not be read while resolving the range');
         });
 
-        const { result, rerender } = renderHook(({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined), {
-            initialProps: { preset: '24h' },
-        });
+        const { result } = renderHook(() => useResolvedAuditDateRange('24h', undefined, ANCHOR));
+
+        expect(result.current).toEqual({ from: ANCHOR - 24 * 60 * 60 * 1000, to: ANCHOR });
+        expect(nowSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps relative from/to stable across rerenders so search keys do not churn', () => {
+        const { result, rerender } = renderHook(
+            ({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined, ANCHOR),
+            { initialProps: { preset: '24h' as AuditDatePreset } },
+        );
 
         const first = result.current;
         rerender({ preset: '24h' });
@@ -44,15 +53,10 @@ describe('useResolvedAuditDateRange', () => {
     });
 
     it('recomputes when the preset changes', () => {
-        let now = 1_800_000_000_000;
-        jest.spyOn(Date, 'now').mockImplementation(() => {
-            now += 1_000;
-            return now;
-        });
-
-        const { result, rerender } = renderHook(({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined), {
-            initialProps: { preset: '24h' as AuditDatePreset },
-        });
+        const { result, rerender } = renderHook(
+            ({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined, ANCHOR),
+            { initialProps: { preset: '24h' as AuditDatePreset } },
+        );
 
         const last24h = result.current;
         rerender({ preset: '7d' });
@@ -61,11 +65,21 @@ describe('useResolvedAuditDateRange', () => {
         expect(result.current.to! - result.current.from!).toBe(7 * 24 * 60 * 60 * 1000);
     });
 
+    it('moves the window when the anchor is refreshed', () => {
+        const { result, rerender } = renderHook(({ anchor }: { anchor: number }) => useResolvedAuditDateRange('24h', undefined, anchor), {
+            initialProps: { anchor: ANCHOR },
+        });
+
+        rerender({ anchor: ANCHOR + 60_000 });
+
+        expect(result.current).toEqual({ from: ANCHOR + 60_000 - 24 * 60 * 60 * 1000, to: ANCHOR + 60_000 });
+    });
+
     it('keeps custom picker bounds stable when the range object identity changes', () => {
         const from = new Date('2026-08-01T08:00:00');
         const to = new Date('2026-08-03T08:00:00');
         const { result, rerender } = renderHook(
-            ({ range }: { range: { from: Date; to: Date } }) => useResolvedAuditDateRange('custom', range),
+            ({ range }: { range: { from: Date; to: Date } }) => useResolvedAuditDateRange('custom', range, ANCHOR),
             { initialProps: { range: { from, to } } },
         );
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useResolvedAuditDateRange } from './useResolvedAuditDateRange';
+import type { AuditDatePreset } from '../types/auditLog';
+
+describe('useResolvedAuditDateRange', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('keeps relative from/to stable across rerenders so search keys do not churn', () => {
+        let now = 1_800_000_000_000;
+        jest.spyOn(Date, 'now').mockImplementation(() => {
+            now += 1_000;
+            return now;
+        });
+
+        const { result, rerender } = renderHook(({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined), {
+            initialProps: { preset: '24h' },
+        });
+
+        const first = result.current;
+        rerender({ preset: '24h' });
+        rerender({ preset: '24h' });
+
+        expect(result.current).toEqual(first);
+        expect(first.to).toBe(first.from! + 24 * 60 * 60 * 1000);
+    });
+
+    it('recomputes when the preset changes', () => {
+        let now = 1_800_000_000_000;
+        jest.spyOn(Date, 'now').mockImplementation(() => {
+            now += 1_000;
+            return now;
+        });
+
+        const { result, rerender } = renderHook(({ preset }: { preset: AuditDatePreset }) => useResolvedAuditDateRange(preset, undefined), {
+            initialProps: { preset: '24h' as AuditDatePreset },
+        });
+
+        const last24h = result.current;
+        rerender({ preset: '7d' });
+
+        expect(result.current).not.toEqual(last24h);
+        expect(result.current.to! - result.current.from!).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+
+    it('keeps custom picker bounds stable when the range object identity changes', () => {
+        const from = new Date('2026-08-01T08:00:00');
+        const to = new Date('2026-08-03T08:00:00');
+        const { result, rerender } = renderHook(
+            ({ range }: { range: { from: Date; to: Date } }) => useResolvedAuditDateRange('custom', range),
+            { initialProps: { range: { from, to } } },
+        );
+
+        const first = result.current;
+        rerender({ range: { from: new Date(from.getTime()), to: new Date(to.getTime()) } });
+        expect(result.current).toEqual(first);
+        expect(first.from).toBe(from.getTime());
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.ts
@@ -21,11 +21,18 @@ import type { AuditDatePreset } from '../types/auditLog';
 import { resolveAuditDateRange } from '../utils/auditListFormat';
 
 /**
- * Snapshots relative presets (24h / 7d / …) against Date.now() when the filter
- * actually changes. Computing from/to on every render would churn the React Query
- * key and refetch forever.
+ * Resolves relative presets (24h / 7d / …) against `anchor` — the instant the preset was chosen.
+ *
+ * The anchor is a caller-owned value on purpose. Reading Date.now() here and leaning on useMemo to
+ * hold it still is not safe: React documents useMemo as a performance hint it may discard, and a
+ * discarded memo would move from/to, change the React Query key, and refetch. With the anchor passed
+ * in, this hook is pure and the memo is only an optimisation.
  */
-export function useResolvedAuditDateRange(preset: AuditDatePreset, customRange: DateRange | undefined): { from?: number; to?: number } {
+export function useResolvedAuditDateRange(
+    preset: AuditDatePreset,
+    customRange: DateRange | undefined,
+    anchor: number,
+): { from?: number; to?: number } {
     const customFrom = customRange?.from?.getTime();
     const customTo = customRange?.to?.getTime();
     return useMemo(() => {
@@ -36,6 +43,6 @@ export function useResolvedAuditDateRange(preset: AuditDatePreset, customRange: 
                       from: customFrom === undefined ? undefined : new Date(customFrom),
                       to: customTo === undefined ? undefined : new Date(customTo),
                   };
-        return resolveAuditDateRange(preset, range);
-    }, [preset, customFrom, customTo]);
+        return resolveAuditDateRange(preset, range, anchor);
+    }, [preset, customFrom, customTo, anchor]);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/hooks/useResolvedAuditDateRange.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import type { DateRange } from 'react-day-picker';
+
+import type { AuditDatePreset } from '../types/auditLog';
+import { resolveAuditDateRange } from '../utils/auditListFormat';
+
+/**
+ * Snapshots relative presets (24h / 7d / …) against Date.now() when the filter
+ * actually changes. Computing from/to on every render would churn the React Query
+ * key and refetch forever.
+ */
+export function useResolvedAuditDateRange(preset: AuditDatePreset, customRange: DateRange | undefined): { from?: number; to?: number } {
+    const customFrom = customRange?.from?.getTime();
+    const customTo = customRange?.to?.getTime();
+    return useMemo(() => {
+        const range =
+            customFrom === undefined && customTo === undefined
+                ? undefined
+                : {
+                      from: customFrom === undefined ? undefined : new Date(customFrom),
+                      to: customTo === undefined ? undefined : new Date(customTo),
+                  };
+        return resolveAuditDateRange(preset, range);
+    }, [preset, customFrom, customTo]);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/license/auditTrailLicense.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/license/auditTrailLicense.ts
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
-import { SHARDING_TAGS_UPGRADE } from '../license/shardingTagsLicense';
 
-export function ShardingTagsLicenseDialog({
-    open,
-    onOpenChange,
-}: Readonly<{
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}>) {
-    return <FeatureLicenseDialog upgrade={SHARDING_TAGS_UPGRADE} open={open} onOpenChange={onOpenChange} />;
-}
+export const APIM_AUDIT_TRAIL_FEATURE = 'apim-audit-trail';
+
+export const AUDIT_TRAIL_UPGRADE = {
+    title: 'Audit',
+    description:
+        'Audit is part of Gravitee Enterprise. Audit gives you a complete understanding of events and their context to strengthen your security posture.',
+    features: [
+        'Search organization and environment configuration changes',
+        'Inspect JSON Patch diffs for every audited event',
+        'Export filtered audit trails for compliance archives',
+    ],
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
@@ -18,6 +18,7 @@ import {
     AUDIT_EXPORT_MAX_ROWS,
     AUDIT_EXPORT_PAGE_SIZE,
     AuditExportLimitError,
+    ENVIRONMENT_FANOUT_CONCURRENCY,
     buildAuditQuery,
     exportEnvAudits,
     exportOrgAudits,
@@ -135,6 +136,29 @@ describe('auditLogs service', () => {
         ).resolves.toEqual([{ group: 'Production', items: [{ id: 'app-1', name: 'Portal' }] }]);
         // The environments list is supplied by the caller, so no extra `/environments` round-trip.
         expect(mockApimFetchJsonOrg).not.toHaveBeenCalled();
+    });
+
+    it('caps how many environments the org fan-out queries at once', async () => {
+        const environments = Array.from({ length: ENVIRONMENT_FANOUT_CONCURRENCY * 3 }, (_, index) => ({
+            id: `env-${index}`,
+            name: `Env ${index}`,
+        }));
+        let inFlight = 0;
+        let peakInFlight = 0;
+        mockApimFetchJsonV1Env.mockImplementation(async () => {
+            inFlight += 1;
+            peakInFlight = Math.max(peakInFlight, inFlight);
+            await Promise.resolve();
+            inFlight -= 1;
+            return [{ id: 'app-1', name: 'Portal' }];
+        });
+
+        const groups = await listOrgAuditApplicationsByEnvironment(environments);
+
+        expect(groups).toHaveLength(environments.length);
+        // Order follows the environment list, not whichever request happened to settle first.
+        expect(groups.map(group => group.group)).toEqual(environments.map(environment => environment.name));
+        expect(peakInFlight).toBeLessThanOrEqual(ENVIRONMENT_FANOUT_CONCURRENCY);
     });
 
     it('walks pages when exporting and throws when the total exceeds the cap', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
@@ -120,8 +120,8 @@ describe('auditLogs service', () => {
             { id: 'api-1', name: 'Pets' },
             { id: 'api-2', name: 'Orders' },
         ]);
-        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(1, 'env-1', '/apis?page=1&perPage=200');
-        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(2, 'env-1', '/apis?page=2&perPage=200');
+        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(1, 'env-1', '/apis?page=1&perPage=9999');
+        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(2, 'env-1', '/apis?page=2&perPage=9999');
     });
 
     it('groups org application lookups by environment name and drops empty environments', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.spec.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    AUDIT_EXPORT_MAX_ROWS,
+    AUDIT_EXPORT_PAGE_SIZE,
+    AuditExportLimitError,
+    buildAuditQuery,
+    exportEnvAudits,
+    exportOrgAudits,
+    listAuditApis,
+    listAuditApplications,
+    listAuditEnvironments,
+    listEnvAuditEvents,
+    listOrgAuditApplicationsByEnvironment,
+    listOrgAuditEvents,
+    searchEnvAudits,
+    searchOrgAudits,
+} from './auditLogs';
+import { apimFetchJsonOrg, apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { AuditMetadataPage } from '../types/auditLog';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+    apimFetchJsonV1Env: jest.fn(),
+    apimFetchJsonV2: jest.fn(),
+}));
+
+const mockApimFetchJsonOrg = jest.mocked(apimFetchJsonOrg);
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+const mockApimFetchJsonV2 = jest.mocked(apimFetchJsonV2);
+
+const EMPTY_PAGE: AuditMetadataPage = {
+    content: [],
+    pageNumber: 1,
+    pageElements: 0,
+    totalElements: 0,
+    metadata: {},
+};
+
+describe('auditLogs service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonOrg.mockResolvedValue(EMPTY_PAGE);
+        mockApimFetchJsonV1Env.mockResolvedValue(EMPTY_PAGE);
+        mockApimFetchJsonV2.mockResolvedValue({ data: [], pagination: { page: 1, pageCount: 1 } });
+    });
+
+    it('omits empty filters and only sends environment/api/application for the matching type', () => {
+        expect(
+            buildAuditQuery({
+                page: 1,
+                size: 10,
+                event: 'API_UPDATED',
+                type: 'API',
+                environment: 'env-1',
+                application: 'app-1',
+                api: 'api-1',
+                from: 100,
+                to: 200,
+            }),
+        ).toBe('page=1&size=10&event=API_UPDATED&type=API&api=api-1&from=100&to=200');
+
+        expect(buildAuditQuery({ page: 2, size: 25, type: 'ENVIRONMENT', environment: 'env-1' })).toBe(
+            'page=2&size=25&type=ENVIRONMENT&environment=env-1',
+        );
+        expect(buildAuditQuery({ page: 1, size: 10, from: 1_700_000_000_000, to: 1_700_086_400_000 })).toBe(
+            'page=1&size=10&from=1700000000000&to=1700086400000',
+        );
+    });
+
+    it('searches organization audits on GET /audit', async () => {
+        await searchOrgAudits({ page: 1, size: 10, event: 'USER_CREATED' });
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/audit?page=1&size=10&event=USER_CREATED');
+    });
+
+    it('searches environment audits on the env-scoped /audit resource', async () => {
+        await searchEnvAudits('env-1', { page: 1, size: 10 });
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/audit?page=1&size=10');
+    });
+
+    it('lists event types from /audit/events', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue(['API_CREATED']);
+        mockApimFetchJsonV1Env.mockResolvedValue(['APPLICATION_UPDATED']);
+        await expect(listOrgAuditEvents()).resolves.toEqual(['API_CREATED']);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/audit/events');
+        await expect(listEnvAuditEvents('env-1')).resolves.toEqual(['APPLICATION_UPDATED']);
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/audit/events');
+    });
+
+    it('lists environments, applications, and paged APIs for type filters', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue([{ id: 'env-1', name: 'Production' }]);
+        mockApimFetchJsonV1Env.mockResolvedValue([{ id: 'app-1', name: 'Portal' }]);
+        mockApimFetchJsonV2
+            .mockResolvedValueOnce({
+                data: [{ id: 'api-1', name: 'Pets' }],
+                pagination: { page: 1, pageCount: 2 },
+            })
+            .mockResolvedValueOnce({
+                data: [{ id: 'api-2', name: 'Orders' }],
+                pagination: { page: 2, pageCount: 2 },
+            });
+
+        await expect(listAuditEnvironments()).resolves.toEqual([{ id: 'env-1', name: 'Production' }]);
+        await expect(listAuditApplications('env-1')).resolves.toEqual([{ id: 'app-1', name: 'Portal' }]);
+        await expect(listAuditApis('env-1')).resolves.toEqual([
+            { id: 'api-1', name: 'Pets' },
+            { id: 'api-2', name: 'Orders' },
+        ]);
+        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(1, 'env-1', '/apis?page=1&perPage=200');
+        expect(mockApimFetchJsonV2).toHaveBeenNthCalledWith(2, 'env-1', '/apis?page=2&perPage=200');
+    });
+
+    it('groups org application lookups by environment name and drops empty environments', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValueOnce([{ id: 'app-1', name: 'Portal' }]).mockResolvedValueOnce([]);
+
+        await expect(
+            listOrgAuditApplicationsByEnvironment([
+                { id: 'env-1', name: 'Production' },
+                { id: 'env-2', name: 'Staging' },
+            ]),
+        ).resolves.toEqual([{ group: 'Production', items: [{ id: 'app-1', name: 'Portal' }] }]);
+        // The environments list is supplied by the caller, so no extra `/environments` round-trip.
+        expect(mockApimFetchJsonOrg).not.toHaveBeenCalled();
+    });
+
+    it('walks pages when exporting and throws when the total exceeds the cap', async () => {
+        mockApimFetchJsonOrg
+            .mockResolvedValueOnce({
+                content: [{ id: 'a-1' }],
+                pageNumber: 1,
+                pageElements: 1,
+                totalElements: AUDIT_EXPORT_PAGE_SIZE + 1,
+                metadata: { 'USER:u:name': 'Ada' },
+            } as AuditMetadataPage)
+            .mockResolvedValueOnce({
+                content: [{ id: 'a-2' }],
+                pageNumber: 2,
+                pageElements: 1,
+                totalElements: AUDIT_EXPORT_PAGE_SIZE + 1,
+                metadata: { 'API:x:name': 'Pets' },
+            } as AuditMetadataPage);
+
+        const exported = await exportOrgAudits({ event: 'API_UPDATED' });
+        expect(exported.content.map(item => item.id)).toEqual(['a-1', 'a-2']);
+        expect(exported.metadata).toEqual({ 'USER:u:name': 'Ada', 'API:x:name': 'Pets' });
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith(`/audit?page=1&size=${AUDIT_EXPORT_PAGE_SIZE}&event=API_UPDATED`);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith(`/audit?page=2&size=${AUDIT_EXPORT_PAGE_SIZE}&event=API_UPDATED`);
+
+        mockApimFetchJsonV1Env.mockResolvedValueOnce({
+            ...EMPTY_PAGE,
+            totalElements: AUDIT_EXPORT_MAX_ROWS + 1,
+        });
+        await expect(exportEnvAudits('env-1', {})).rejects.toBeInstanceOf(AuditExportLimitError);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
@@ -19,7 +19,9 @@ import type { AuditGroupedRefs, AuditMetadataPage, AuditNamedRef, AuditSearchPar
 
 export const AUDIT_EXPORT_MAX_ROWS = 10_000;
 export const AUDIT_EXPORT_PAGE_SIZE = 1_000;
-const API_LIST_PAGE_SIZE = 200;
+// Large page size on purpose: this only fills a filter dropdown, and on the org page it runs once per
+// environment, so a small page size multiplies into hundreds of round-trips.
+const API_LIST_PAGE_SIZE = 9_999;
 
 export class AuditExportLimitError extends Error {
     constructor(readonly totalElements: number) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonOrg, apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { AuditGroupedRefs, AuditMetadataPage, AuditNamedRef, AuditSearchParams } from '../types/auditLog';
+
+export const AUDIT_EXPORT_MAX_ROWS = 10_000;
+export const AUDIT_EXPORT_PAGE_SIZE = 1_000;
+const API_LIST_PAGE_SIZE = 200;
+
+export class AuditExportLimitError extends Error {
+    constructor(readonly totalElements: number) {
+        super(`Too many audit logs to export (${totalElements}). Narrow the date range or filters.`);
+        this.name = 'AuditExportLimitError';
+    }
+}
+
+export function buildAuditQuery(params: AuditSearchParams): string {
+    const search = new URLSearchParams();
+    search.set('page', String(params.page));
+    search.set('size', String(params.size));
+    if (params.event) {
+        search.set('event', params.event);
+    }
+    if (params.type) {
+        search.set('type', params.type);
+    }
+    if (params.environment && params.type === 'ENVIRONMENT') {
+        search.set('environment', params.environment);
+    }
+    if (params.application && params.type === 'APPLICATION') {
+        search.set('application', params.application);
+    }
+    if (params.api && params.type === 'API') {
+        search.set('api', params.api);
+    }
+    if (params.from !== undefined) {
+        search.set('from', String(params.from));
+    }
+    if (params.to !== undefined) {
+        search.set('to', String(params.to));
+    }
+    return search.toString();
+}
+
+export async function searchOrgAudits(params: AuditSearchParams): Promise<AuditMetadataPage> {
+    return apimFetchJsonOrg<AuditMetadataPage>(`/audit?${buildAuditQuery(params)}`);
+}
+
+export async function searchEnvAudits(environmentId: string, params: AuditSearchParams): Promise<AuditMetadataPage> {
+    return apimFetchJsonV1Env<AuditMetadataPage>(environmentId, `/audit?${buildAuditQuery(params)}`);
+}
+
+export async function listOrgAuditEvents(): Promise<string[]> {
+    return apimFetchJsonOrg<string[]>('/audit/events');
+}
+
+export async function listEnvAuditEvents(environmentId: string): Promise<string[]> {
+    return apimFetchJsonV1Env<string[]>(environmentId, '/audit/events');
+}
+
+export async function listAuditEnvironments(): Promise<AuditNamedRef[]> {
+    const environments = await apimFetchJsonOrg<Array<{ id: string; name?: string }>>('/environments');
+    return (environments ?? []).map(environment => ({
+        id: environment.id,
+        name: environment.name || environment.id,
+    }));
+}
+
+export async function listAuditApplications(environmentId: string): Promise<AuditNamedRef[]> {
+    const applications = await apimFetchJsonV1Env<Array<{ id: string; name?: string }>>(environmentId, '/applications?status=active');
+    return (applications ?? []).map(application => ({
+        id: application.id,
+        name: application.name || application.id,
+    }));
+}
+
+interface ApisPage {
+    data?: Array<{ id: string; name?: string }>;
+    pagination?: { page?: number; pageCount?: number };
+}
+
+export async function listAuditApis(environmentId: string): Promise<AuditNamedRef[]> {
+    const collected: AuditNamedRef[] = [];
+    let page = 1;
+    let pageCount = 1;
+    do {
+        const response = await apimFetchJsonV2<ApisPage>(environmentId, `/apis?page=${page}&perPage=${API_LIST_PAGE_SIZE}`);
+        collected.push(
+            ...(response.data ?? []).map(api => ({
+                id: api.id,
+                name: api.name || api.id,
+            })),
+        );
+        pageCount = response.pagination?.pageCount ?? 1;
+        page += 1;
+    } while (page <= pageCount);
+    return collected;
+}
+
+/**
+ * Fans out `listItems` across every environment and groups the results by environment name.
+ * Callers pass the environment list in so the `/environments` response is fetched and cached once.
+ */
+async function groupByEnvironment(
+    environments: readonly AuditNamedRef[],
+    listItems: (environmentId: string) => Promise<AuditNamedRef[]>,
+): Promise<AuditGroupedRefs[]> {
+    const groups = await Promise.all(
+        environments.map(async environment => ({
+            group: environment.name,
+            items: await listItems(environment.id),
+        })),
+    );
+    return groups.filter(group => group.items.length > 0);
+}
+
+export async function listOrgAuditApplicationsByEnvironment(environments: readonly AuditNamedRef[]): Promise<AuditGroupedRefs[]> {
+    return groupByEnvironment(environments, listAuditApplications);
+}
+
+export async function listOrgAuditApisByEnvironment(environments: readonly AuditNamedRef[]): Promise<AuditGroupedRefs[]> {
+    return groupByEnvironment(environments, listAuditApis);
+}
+
+async function collectAuditPages(fetchPage: (page: number, size: number) => Promise<AuditMetadataPage>): Promise<AuditMetadataPage> {
+    const first = await fetchPage(1, AUDIT_EXPORT_PAGE_SIZE);
+    if (first.totalElements > AUDIT_EXPORT_MAX_ROWS) {
+        throw new AuditExportLimitError(first.totalElements);
+    }
+    const content = [...(first.content ?? [])];
+    const metadata = { ...(first.metadata ?? {}) };
+    const lastPage = Math.max(1, Math.ceil(first.totalElements / AUDIT_EXPORT_PAGE_SIZE));
+    for (let page = 2; page <= lastPage; page += 1) {
+        const next = await fetchPage(page, AUDIT_EXPORT_PAGE_SIZE);
+        content.push(...(next.content ?? []));
+        Object.assign(metadata, next.metadata ?? {});
+    }
+    return {
+        content,
+        metadata,
+        pageNumber: 1,
+        pageElements: content.length,
+        totalElements: first.totalElements,
+    };
+}
+
+export async function exportOrgAudits(params: Omit<AuditSearchParams, 'page' | 'size'>): Promise<AuditMetadataPage> {
+    return collectAuditPages((page, size) => searchOrgAudits({ ...params, page, size }));
+}
+
+export async function exportEnvAudits(environmentId: string, params: Omit<AuditSearchParams, 'page' | 'size'>): Promise<AuditMetadataPage> {
+    return collectAuditPages((page, size) => searchEnvAudits(environmentId, { ...params, page, size }));
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/services/auditLogs.ts
@@ -116,17 +116,35 @@ export async function listAuditApis(environmentId: string): Promise<AuditNamedRe
 /**
  * Fans out `listItems` across every environment and groups the results by environment name.
  * Callers pass the environment list in so the `/environments` response is fetched and cached once.
+ *
+ * The fan-out is capped: this only fills a filter dropdown, and an organization with dozens of
+ * environments would otherwise open one request per environment at once (each of which may itself
+ * paginate), hammering the API for a control the user may never open.
  */
+export const ENVIRONMENT_FANOUT_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(items: readonly T[], limit: number, map: (item: T) => Promise<R>): Promise<R[]> {
+    const results = new Array<R>(items.length);
+    let cursor = 0;
+    const worker = async () => {
+        while (cursor < items.length) {
+            const index = cursor;
+            cursor += 1;
+            results[index] = await map(items[index]);
+        }
+    };
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+    return results;
+}
+
 async function groupByEnvironment(
     environments: readonly AuditNamedRef[],
     listItems: (environmentId: string) => Promise<AuditNamedRef[]>,
 ): Promise<AuditGroupedRefs[]> {
-    const groups = await Promise.all(
-        environments.map(async environment => ({
-            group: environment.name,
-            items: await listItems(environment.id),
-        })),
-    );
+    const groups = await mapWithConcurrency(environments, ENVIRONMENT_FANOUT_CONCURRENCY, async environment => ({
+        group: environment.name,
+        items: await listItems(environment.id),
+    }));
     return groups.filter(group => group.items.length > 0);
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/types/auditLog.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/types/auditLog.ts
@@ -21,7 +21,8 @@ export type AuditScope = 'organization' | 'environment';
 export interface AuditEntity {
     id: string;
     referenceId: string;
-    referenceType: string;
+    // The API tolerates audits with no reference type (AuditServiceImpl skips metadata resolution for them).
+    referenceType: string | null;
     user: string;
     createdAt: number | string;
     event: string;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/types/auditLog.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/types/auditLog.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AuditReferenceType = 'ORGANIZATION' | 'ENVIRONMENT' | 'APPLICATION' | 'API';
+
+export type AuditScope = 'organization' | 'environment';
+
+export interface AuditEntity {
+    id: string;
+    referenceId: string;
+    referenceType: string;
+    user: string;
+    createdAt: number | string;
+    event: string;
+    properties?: Record<string, string>;
+    patch?: string;
+}
+
+export interface AuditMetadataPage {
+    content: AuditEntity[];
+    pageNumber: number;
+    pageElements: number;
+    totalElements: number;
+    metadata: Record<string, unknown>;
+}
+
+export interface AuditSearchParams {
+    page: number;
+    size: number;
+    event?: string;
+    type?: AuditReferenceType;
+    environment?: string;
+    application?: string;
+    api?: string;
+    from?: number;
+    to?: number;
+}
+
+export interface AuditNamedRef {
+    id: string;
+    name: string;
+}
+
+export interface AuditGroupedRefs {
+    group: string;
+    items: AuditNamedRef[];
+}
+
+export interface AuditLogRow {
+    id: string;
+    createdAt: number;
+    user: string;
+    referenceType: string;
+    reference: string;
+    event: string;
+    targets: Array<{ key: string; value: string }>;
+    patch: string;
+}
+
+export type AuditDatePreset = '' | '24h' | '7d' | '30d' | '90d' | 'custom';
+
+export type AuditExportFormat = 'csv' | 'json';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
@@ -88,15 +88,30 @@ describe('auditExport', () => {
     });
 
     it('downloads a blob with the given filename', () => {
+        jest.useFakeTimers();
         const click = jest.fn();
         const revoke = jest.fn();
+        const remove = jest.fn();
         jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:audit');
         jest.spyOn(URL, 'revokeObjectURL').mockImplementation(revoke);
-        jest.spyOn(document, 'createElement').mockReturnValue({ click, download: '', href: '' } as unknown as HTMLAnchorElement);
+        jest.spyOn(document.body, 'appendChild').mockImplementation(node => node);
+        jest.spyOn(document, 'createElement').mockReturnValue({
+            click,
+            download: '',
+            href: '',
+            remove,
+        } as unknown as HTMLAnchorElement);
 
-        downloadAuditExport('csv-body', 'audit-logs-2026-08-19.csv', 'text/csv');
+        try {
+            downloadAuditExport('csv-body', 'audit-logs-2026-08-19.csv', 'text/csv');
 
-        expect(click).toHaveBeenCalled();
-        expect(revoke).toHaveBeenCalledWith('blob:audit');
+            expect(click).toHaveBeenCalled();
+            expect(remove).toHaveBeenCalled();
+            expect(revoke).not.toHaveBeenCalled();
+            jest.runAllTimers();
+            expect(revoke).toHaveBeenCalledWith('blob:audit');
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
@@ -69,6 +69,12 @@ describe('auditExport', () => {
         expect(csv).not.toContain("'Ada");
     });
 
+    it('exports rows whose referenceType the API left unset', () => {
+        const row = { ...ROW, referenceType: null as unknown as string };
+        expect(auditLogsToCsv([row])).toContain('Ada Lovelace,,Pets');
+        expect(JSON.parse(auditLogsToJson([row]))).toEqual([expect.objectContaining({ reference: 'Pets' })]);
+    });
+
     it('serializes table columns to JSON', () => {
         const parsed = JSON.parse(auditLogsToJson([ROW])) as Array<{ event: string; target: string }>;
         expect(parsed).toEqual([

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { auditLogsToCsv, auditLogsToJson, buildAuditExportFileName, downloadAuditExport } from './auditExport';
+import type { AuditLogRow } from '../types/auditLog';
+
+const ROW: AuditLogRow = {
+    id: 'a-1',
+    createdAt: Date.parse('2026-08-19T10:00:00.000Z'),
+    user: 'Ada Lovelace',
+    referenceType: 'API',
+    reference: 'Pets',
+    event: 'API_UPDATED',
+    targets: [{ key: 'API', value: 'Pets' }],
+    patch: '[{"op":"replace","path":"/name","value":"Pets"}]',
+};
+
+describe('auditExport', () => {
+    it('names the file audit-logs-{yyyy-mm-dd}.{format}', () => {
+        expect(buildAuditExportFileName('csv', new Date('2026-08-19T15:00:00'))).toBe('audit-logs-2026-08-19.csv');
+        expect(buildAuditExportFileName('json', new Date('2026-08-19T15:00:00'))).toBe('audit-logs-2026-08-19.json');
+    });
+
+    it('serializes table columns to CSV, quoting commas and quotes', () => {
+        const csv = auditLogsToCsv([{ ...ROW, user: 'Ada, "Countess"' }]);
+        expect(csv).toContain('Date,User,Type,Reference,Event,Target,Patch');
+        expect(csv).toContain('"Ada, ""Countess"""');
+        expect(csv).toContain('API_UPDATED');
+        expect(csv).toContain('API: Pets');
+    });
+
+    it('neutralises spreadsheet formulas in CSV cells', () => {
+        const csv = auditLogsToCsv([
+            {
+                ...ROW,
+                user: '=HYPERLINK("http://evil","click")',
+                reference: '+1234',
+                event: '-cmd',
+                targets: [{ key: 'API', value: '@SUM(A1)' }],
+            },
+        ]);
+        // Each dangerous cell is prefixed with a quote so Excel/Sheets treat it as text.
+        expect(csv).toContain(`"'=HYPERLINK(""http://evil"",""click"")"`);
+        expect(csv).toContain(`'+1234`);
+        expect(csv).toContain(`'-cmd`);
+        expect(csv).not.toContain(',=HYPERLINK');
+        // The guard is per cell: a target renders as `KEY: value`, so a leading `@` in the value is
+        // already inert and is left alone.
+        expect(csv).toContain('API: @SUM(A1)');
+    });
+
+    it('leaves ordinary CSV cells untouched', () => {
+        const csv = auditLogsToCsv([ROW]);
+        expect(csv).toContain('Ada Lovelace');
+        expect(csv).toContain('API_UPDATED');
+        expect(csv).not.toContain("'Ada");
+    });
+
+    it('serializes table columns to JSON', () => {
+        const parsed = JSON.parse(auditLogsToJson([ROW])) as Array<{ event: string; target: string }>;
+        expect(parsed).toEqual([
+            expect.objectContaining({
+                event: 'API_UPDATED',
+                target: 'API: Pets',
+                type: 'API',
+                user: 'Ada Lovelace',
+            }),
+        ]);
+    });
+
+    it('downloads a blob with the given filename', () => {
+        const click = jest.fn();
+        const revoke = jest.fn();
+        jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:audit');
+        jest.spyOn(URL, 'revokeObjectURL').mockImplementation(revoke);
+        jest.spyOn(document, 'createElement').mockReturnValue({ click, download: '', href: '' } as unknown as HTMLAnchorElement);
+
+        downloadAuditExport('csv-body', 'audit-logs-2026-08-19.csv', 'text/csv');
+
+        expect(click).toHaveBeenCalled();
+        expect(revoke).toHaveBeenCalledWith('blob:audit');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.ts
@@ -29,8 +29,9 @@ export function buildAuditExportFileName(format: AuditExportFormat, now = new Da
 // with one of these is executed as a formula by Excel/Sheets, so prefix it with a quote to neutralise it.
 const CSV_FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
 
-export function csvEscape(value: string): string {
-    const safe = CSV_FORMULA_PREFIXES.some(prefix => value.startsWith(prefix)) ? `'${value}` : value;
+export function csvEscape(value: string | null | undefined): string {
+    const text = value ?? '';
+    const safe = CSV_FORMULA_PREFIXES.some(prefix => text.startsWith(prefix)) ? `'${text}` : text;
     if (/[",\n\r]/.test(safe)) {
         return `"${safe.replace(/"/g, '""')}"`;
     }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditExport.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatAuditTargetText } from './auditListFormat';
+import { downloadTextFile } from '../../../shared/browser';
+import type { AuditExportFormat, AuditLogRow } from '../types/auditLog';
+
+export function buildAuditExportFileName(format: AuditExportFormat, now = new Date()): string {
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `audit-logs-${year}-${month}-${day}.${format}`;
+}
+
+// Audit rows carry operator-controlled text (API/application/user names, JSON patches). A cell starting
+// with one of these is executed as a formula by Excel/Sheets, so prefix it with a quote to neutralise it.
+const CSV_FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+
+export function csvEscape(value: string): string {
+    const safe = CSV_FORMULA_PREFIXES.some(prefix => value.startsWith(prefix)) ? `'${value}` : value;
+    if (/[",\n\r]/.test(safe)) {
+        return `"${safe.replace(/"/g, '""')}"`;
+    }
+    return safe;
+}
+
+function exportColumns(row: AuditLogRow): string[] {
+    return [
+        new Date(row.createdAt).toISOString(),
+        row.user,
+        row.referenceType,
+        row.reference,
+        row.event,
+        formatAuditTargetText(row.targets),
+        row.patch,
+    ];
+}
+
+export function auditLogsToCsv(rows: readonly AuditLogRow[]): string {
+    const header = ['Date', 'User', 'Type', 'Reference', 'Event', 'Target', 'Patch'];
+    const lines = [header.map(csvEscape).join(',')];
+    for (const row of rows) {
+        lines.push(exportColumns(row).map(csvEscape).join(','));
+    }
+    return `${lines.join('\n')}\n`;
+}
+
+export function auditLogsToJson(rows: readonly AuditLogRow[]): string {
+    return JSON.stringify(
+        rows.map(row => ({
+            date: new Date(row.createdAt).toISOString(),
+            user: row.user,
+            type: row.referenceType,
+            reference: row.reference,
+            event: row.event,
+            target: formatAuditTargetText(row.targets),
+            patch: row.patch,
+        })),
+        null,
+        2,
+    );
+}
+
+export function downloadAuditExport(content: string, fileName: string, mimeType: string): void {
+    downloadTextFile(content, fileName, mimeType);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditFilters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditFilters.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AuditDatePreset, AuditReferenceType } from '../types/auditLog';
+
+export interface AuditFilterValues {
+    readonly event: string;
+    readonly referenceType: AuditReferenceType | '';
+    readonly environmentId: string;
+    readonly applicationId: string;
+    readonly apiId: string;
+    readonly datePreset: AuditDatePreset;
+    readonly customRange: { from?: Date; to?: Date } | undefined;
+}
+
+/**
+ * Single definition of "the user has narrowed the results", used both by the toolbar (to show Reset)
+ * and by the table (to pick the no-results empty state over the first-use one). Keeping one predicate
+ * stops the two from drifting apart.
+ */
+export function hasActiveAuditFilters(filters: AuditFilterValues): boolean {
+    return Boolean(
+        filters.event ||
+            filters.referenceType ||
+            filters.environmentId ||
+            filters.applicationId ||
+            filters.apiId ||
+            filters.datePreset ||
+            filters.customRange?.from ||
+            filters.customRange?.to,
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    endOfDayMs,
+    formatAuditTargetText,
+    formatAuditTargets,
+    metadataName,
+    resolveAuditDateRange,
+    toAuditLogRow,
+} from './auditListFormat';
+import type { AuditEntity } from '../types/auditLog';
+
+describe('auditListFormat', () => {
+    const audit: AuditEntity = {
+        id: 'a-1',
+        referenceId: 'env-1',
+        referenceType: 'ENVIRONMENT',
+        user: 'user-1',
+        createdAt: 1_700_000_000_000,
+        event: 'ENVIRONMENT_UPDATED',
+        properties: { USER: 'user-2', ROLE: 'role-1' },
+        patch: '[{"op":"replace","path":"/name","value":"Prod"}]',
+    };
+
+    const metadata = {
+        'USER:user-1:name': 'Ada Lovelace',
+        'ENVIRONMENT:env-1:name': 'Production',
+        'USER:user-2:name': 'Grace Hopper',
+        'ROLE:role-1:name': 'ADMIN',
+    };
+
+    it('resolves user, reference, and targets from metadata with raw fallbacks', () => {
+        const row = toAuditLogRow(audit, metadata);
+        expect(row.user).toBe('Ada Lovelace');
+        expect(row.reference).toBe('Production');
+        expect(row.targets).toEqual([
+            { key: 'USER', value: 'Grace Hopper' },
+            { key: 'ROLE', value: 'ADMIN' },
+        ]);
+        expect(formatAuditTargetText(row.targets)).toBe('USER: Grace Hopper; ROLE: ADMIN');
+    });
+
+    it('falls back to ids when metadata is missing', () => {
+        const row = toAuditLogRow(audit, {});
+        expect(row.user).toBe('user-1');
+        expect(row.reference).toBe('env-1');
+        expect(formatAuditTargets(audit.properties, {})).toEqual([
+            { key: 'USER', value: 'user-2' },
+            { key: 'ROLE', value: 'role-1' },
+        ]);
+        expect(metadataName({}, 'USER:user-1:name')).toBeUndefined();
+    });
+
+    it('maps date presets to from/to epoch milliseconds', () => {
+        const now = 1_800_000_000_000;
+        expect(resolveAuditDateRange('24h', undefined, now)).toEqual({ from: now - 24 * 60 * 60 * 1000, to: now });
+        expect(resolveAuditDateRange('7d', undefined, now).from).toBe(now - 7 * 24 * 60 * 60 * 1000);
+        expect(resolveAuditDateRange('', undefined, now)).toEqual({});
+    });
+
+    it('uses start-of-range and end-of-day for a custom picker range', () => {
+        const from = new Date('2026-08-01T08:00:00');
+        const to = new Date('2026-08-03T08:00:00');
+        const range = resolveAuditDateRange('custom', { from, to });
+        expect(range.from).toBe(from.getTime());
+        expect(range.to).toBe(endOfDayMs(to));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.spec.ts
@@ -65,6 +65,12 @@ describe('auditListFormat', () => {
         expect(metadataName({}, 'USER:user-1:name')).toBeUndefined();
     });
 
+    it('normalises a null referenceType, which the API emits for unresolved audits', () => {
+        const row = toAuditLogRow({ ...audit, referenceType: null }, metadata);
+        expect(row.referenceType).toBe('');
+        expect(row.reference).toBe('env-1');
+    });
+
     it('maps date presets to from/to epoch milliseconds', () => {
         const now = 1_800_000_000_000;
         expect(resolveAuditDateRange('24h', undefined, now)).toEqual({ from: now - 24 * 60 * 60 * 1000, to: now });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
@@ -42,12 +42,13 @@ export function formatAuditTargetText(targets: Array<{ key: string; value: strin
 }
 
 export function toAuditLogRow(audit: AuditEntity, metadata: Record<string, unknown>): AuditLogRow {
+    const referenceType = audit.referenceType ?? '';
     return {
         id: audit.id,
         createdAt: auditTimestamp(audit.createdAt),
         user: metadataName(metadata, `USER:${audit.user}:name`) ?? audit.user,
-        referenceType: audit.referenceType,
-        reference: metadataName(metadata, `${audit.referenceType}:${audit.referenceId}:name`) ?? audit.referenceId,
+        referenceType,
+        reference: metadataName(metadata, `${referenceType}:${audit.referenceId}:name`) ?? audit.referenceId,
         event: audit.event,
         targets: formatAuditTargets(audit.properties, metadata),
         patch: audit.patch ?? '',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
@@ -70,9 +70,10 @@ export function endOfDayMs(date: Date): number {
 }
 
 /**
- * Relative presets are computed from `now`. Snapshot `now` (or memoize the result)
- * when wiring this into a query key — calling it on every render with Date.now()
- * will change from/to each time and retrigger fetches forever.
+ * Relative presets are computed from `now`. When wiring this into a query key, pass an instant that
+ * is held in state (see `useAuditLogsPageState`) — letting it default to Date.now() on every render
+ * changes from/to each time and retriggers fetches forever. Memoizing is not enough: React may
+ * discard a useMemo cache, and the recomputed value would carry a different `now`.
  */
 export function resolveAuditDateRange(
     preset: AuditDatePreset,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditListFormat.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AuditDatePreset, AuditEntity, AuditLogRow } from '../types/auditLog';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function auditTimestamp(createdAt: number | string): number {
+    return typeof createdAt === 'number' ? createdAt : Date.parse(createdAt);
+}
+
+export function metadataName(metadata: Record<string, unknown>, key: string): string | undefined {
+    const value = metadata[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function formatAuditTargets(
+    properties: Record<string, string> | undefined,
+    metadata: Record<string, unknown>,
+): Array<{ key: string; value: string }> {
+    return Object.entries(properties ?? {}).map(([key, value]) => ({
+        key,
+        value: metadataName(metadata, `${key}:${value}:name`) ?? value,
+    }));
+}
+
+export function formatAuditTargetText(targets: Array<{ key: string; value: string }>): string {
+    return targets.map(target => `${target.key}: ${target.value}`).join('; ');
+}
+
+export function toAuditLogRow(audit: AuditEntity, metadata: Record<string, unknown>): AuditLogRow {
+    return {
+        id: audit.id,
+        createdAt: auditTimestamp(audit.createdAt),
+        user: metadataName(metadata, `USER:${audit.user}:name`) ?? audit.user,
+        referenceType: audit.referenceType,
+        reference: metadataName(metadata, `${audit.referenceType}:${audit.referenceId}:name`) ?? audit.referenceId,
+        event: audit.event,
+        targets: formatAuditTargets(audit.properties, metadata),
+        patch: audit.patch ?? '',
+    };
+}
+
+export function prettyPrintPatch(patch: string): string {
+    try {
+        return JSON.stringify(JSON.parse(patch), null, 2);
+    } catch {
+        return patch;
+    }
+}
+
+export function endOfDayMs(date: Date): number {
+    const end = new Date(date);
+    end.setHours(23, 59, 59, 999);
+    return end.getTime();
+}
+
+/**
+ * Relative presets are computed from `now`. Snapshot `now` (or memoize the result)
+ * when wiring this into a query key — calling it on every render with Date.now()
+ * will change from/to each time and retrigger fetches forever.
+ */
+export function resolveAuditDateRange(
+    preset: AuditDatePreset,
+    customRange: { from?: Date; to?: Date } | undefined,
+    now = Date.now(),
+): { from?: number; to?: number } {
+    if (preset === '24h') {
+        return { from: now - DAY_MS, to: now };
+    }
+    if (preset === '7d') {
+        return { from: now - 7 * DAY_MS, to: now };
+    }
+    if (preset === '30d') {
+        return { from: now - 30 * DAY_MS, to: now };
+    }
+    if (preset === '90d') {
+        return { from: now - 90 * DAY_MS, to: now };
+    }
+    if (preset === 'custom') {
+        return {
+            from: customRange?.from ? customRange.from.getTime() : undefined,
+            to: customRange?.to ? endOfDayMs(customRange.to) : undefined,
+        };
+    }
+    return {};
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditPermissions.ts
@@ -21,6 +21,3 @@ export const ENVIRONMENT_AUDIT_READ_PERMISSION = 'environment-audit-r' as const;
 // `environment-audit-r` gates the Environment one. Granting only one must not surface the other.
 export const ORGANIZATION_AUDIT_READ_PERMISSIONS = [ORGANIZATION_AUDIT_READ_PERMISSION] as const;
 export const ENVIRONMENT_AUDIT_READ_PERMISSIONS = [ENVIRONMENT_AUDIT_READ_PERMISSION] as const;
-
-// The 403 redirect strips both prefixes: either grant can be the one the backend just revoked.
-export const AUDIT_PERMISSION_PREFIXES = ['organization-audit-', 'environment-audit-'] as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/auditPermissions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ORGANIZATION_AUDIT_READ_PERMISSION = 'organization-audit-r' as const;
+export const ENVIRONMENT_AUDIT_READ_PERMISSION = 'environment-audit-r' as const;
+
+// Scoped separately, matching Classic: `organization-audit-r` gates the Organization Audit page and
+// `environment-audit-r` gates the Environment one. Granting only one must not surface the other.
+export const ORGANIZATION_AUDIT_READ_PERMISSIONS = [ORGANIZATION_AUDIT_READ_PERMISSION] as const;
+export const ENVIRONMENT_AUDIT_READ_PERMISSIONS = [ENVIRONMENT_AUDIT_READ_PERMISSION] as const;
+
+// The 403 redirect strips both prefixes: either grant can be the one the backend just revoked.
+export const AUDIT_PERMISSION_PREFIXES = ['organization-audit-', 'environment-audit-'] as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/queryKeys.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AuditScope, AuditSearchParams } from '../types/auditLog';
+
+export const auditKeys = {
+    all: ['audit-logs'] as const,
+    search: (scope: AuditScope, environmentId: string | undefined, params: AuditSearchParams) =>
+        [...auditKeys.all, 'search', scope, environmentId ?? '', params] as const,
+    events: (scope: AuditScope, environmentId: string | undefined) => [...auditKeys.all, 'events', scope, environmentId ?? ''] as const,
+    environments: () => [...auditKeys.all, 'environments'] as const,
+    applications: (environmentId: string | undefined) => [...auditKeys.all, 'applications', environmentId ?? ''] as const,
+    apis: (environmentId: string | undefined) => [...auditKeys.all, 'apis', environmentId ?? ''] as const,
+    orgApplications: () => [...auditKeys.all, 'org-applications'] as const,
+    orgApis: () => [...auditKeys.all, 'org-apis'] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/audit-logs/utils/queryKeys.ts
@@ -24,6 +24,9 @@ export const auditKeys = {
     environments: () => [...auditKeys.all, 'environments'] as const,
     applications: (environmentId: string | undefined) => [...auditKeys.all, 'applications', environmentId ?? ''] as const,
     apis: (environmentId: string | undefined) => [...auditKeys.all, 'apis', environmentId ?? ''] as const,
-    orgApplications: () => [...auditKeys.all, 'org-applications'] as const,
-    orgApis: () => [...auditKeys.all, 'org-apis'] as const,
+    // The org pickers are derived from the environment list, so it belongs in the key: without it a
+    // cached fan-out would survive an environment being added or removed. Sorted so the key does not
+    // change with the order `/environments` happens to return.
+    orgApplications: (environmentIds: readonly string[]) => [...auditKeys.all, 'org-applications', [...environmentIds].sort()] as const,
+    orgApis: (environmentIds: readonly string[]) => [...auditKeys.all, 'org-apis', [...environmentIds].sort()] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
@@ -16,12 +16,13 @@
 
 import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { EnvAuditLogsPage } from './EnvAuditLogsPage';
 import { useAuditApis, useAuditApplications, useAuditEvents, useAuditLogs } from '../features/audit-logs/hooks/useAuditLogs';
 import type { AuditEntity, AuditMetadataPage } from '../features/audit-logs/types/auditLog';
+import { ApimApiError } from '../shared/api/apimClient';
 
 const mockNavigate = jest.fn();
 
@@ -66,16 +67,17 @@ const PAGE: AuditMetadataPage = {
     metadata: { 'USER:user-1:name': 'Grace Hopper', 'APPLICATION:app-1:name': 'Portal' },
 };
 
-function renderPage() {
+function renderPage(permissions: string[] = ['environment-audit-r']) {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(['environment-permissions', 'prod'], ['environment-audit-r']);
-    return render(
+    queryClient.setQueryData(['environment-permissions', 'prod'], permissions);
+    const view = render(
         <QueryClientProvider client={queryClient}>
             <MemoryRouter initialEntries={['/environment-audit']}>
                 <EnvAuditLogsPage />
             </MemoryRouter>
         </QueryClientProvider>,
     );
+    return { ...view, queryClient };
 }
 
 describe('EnvAuditLogsPage', () => {
@@ -102,5 +104,19 @@ describe('EnvAuditLogsPage', () => {
         renderPage();
         expect(screen.getByText(/part of Gravitee Enterprise/i)).not.toBeNull();
         expect(mockUseAuditLogs).toHaveBeenCalledWith('environment', expect.anything(), 'prod', false);
+    });
+
+    it('on 403 strips only environment-audit permissions so Organization Audit stays available', async () => {
+        mockUseAuditLogs.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useAuditLogs>);
+
+        const { queryClient } = renderPage(['organization-audit-r', 'environment-audit-r']);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+        expect(queryClient.getQueryData(['environment-permissions', 'prod'])).toEqual(['organization-audit-r']);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { EnvAuditLogsPage } from './EnvAuditLogsPage';
+import { useAuditApis, useAuditApplications, useAuditEvents, useAuditLogs } from '../features/audit-logs/hooks/useAuditLogs';
+import type { AuditEntity, AuditMetadataPage } from '../features/audit-logs/types/auditLog';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasFeature: jest.fn(),
+    useEnvironment: jest.fn(),
+}));
+
+jest.mock('../features/audit-logs/hooks/useAuditLogs');
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockUseHasFeature = jest.mocked(useHasFeature);
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockUseAuditLogs = jest.mocked(useAuditLogs);
+const mockUseAuditEvents = jest.mocked(useAuditEvents);
+const mockUseAuditApplications = jest.mocked(useAuditApplications);
+const mockUseAuditApis = jest.mocked(useAuditApis);
+
+const PAGE: AuditMetadataPage = {
+    content: [
+        {
+            id: 'a-1',
+            referenceId: 'app-1',
+            referenceType: 'APPLICATION',
+            user: 'user-1',
+            createdAt: 1_700_000_000_000,
+            event: 'APPLICATION_UPDATED',
+            properties: {},
+            patch: '',
+        } satisfies AuditEntity,
+    ],
+    pageNumber: 1,
+    pageElements: 1,
+    totalElements: 1,
+    metadata: { 'USER:user-1:name': 'Grace Hopper', 'APPLICATION:app-1:name': 'Portal' },
+};
+
+function renderPage() {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'prod'], ['environment-audit-r']);
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/environment-audit']}>
+                <EnvAuditLogsPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('EnvAuditLogsPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseHasFeature.mockReturnValue(true);
+        mockUseEnvironment.mockReturnValue({ id: 'prod' } as ReturnType<typeof useEnvironment>);
+        mockUseAuditLogs.mockReturnValue({ data: PAGE, isLoading: false, isError: false, error: null } as ReturnType<typeof useAuditLogs>);
+        mockUseAuditEvents.mockReturnValue({ data: ['APPLICATION_UPDATED'], isLoading: false } as ReturnType<typeof useAuditEvents>);
+        mockUseAuditApplications.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useAuditApplications>);
+        mockUseAuditApis.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useAuditApis>);
+    });
+
+    it('loads environment-scoped audits for the current environment', () => {
+        renderPage();
+        expect(mockUseAuditLogs).toHaveBeenCalledWith('environment', expect.anything(), 'prod', true);
+        expect(screen.getByText('Grace Hopper')).not.toBeNull();
+        expect(screen.getByText('APPLICATION_UPDATED')).not.toBeNull();
+        expect(screen.getByText('this environment', { exact: false })).not.toBeNull();
+    });
+
+    it('shows the license dialog when apim-audit-trail is missing', () => {
+        mockUseHasFeature.mockReturnValue(false);
+        renderPage();
+        expect(screen.getByText(/part of Gravitee Enterprise/i)).not.toBeNull();
+        expect(mockUseAuditLogs).toHaveBeenCalledWith('environment', expect.anything(), 'prod', false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
@@ -74,7 +74,7 @@ export function EnvAuditLogsPage() {
             state={state}
             rows={rows}
             totalCount={logsQuery.data?.totalElements ?? 0}
-            loading={logsQuery.isLoading}
+            loading={logsQuery.isFetching}
             isError={Boolean(logsQuery.isError)}
             eventTypes={eventsQuery.data ?? []}
             applications={applicationsQuery.data ?? []}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
@@ -26,7 +26,6 @@ import { APIM_AUDIT_TRAIL_FEATURE } from '../features/audit-logs/license/auditTr
 import { exportEnvAudits } from '../features/audit-logs/services/auditLogs';
 import type { AuditSearchParams } from '../features/audit-logs/types/auditLog';
 import { toAuditLogRow } from '../features/audit-logs/utils/auditListFormat';
-import { AUDIT_PERMISSION_PREFIXES } from '../features/audit-logs/utils/auditPermissions';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
@@ -51,7 +50,7 @@ export function EnvAuditLogsPage() {
     const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
-        permissionPrefix: AUDIT_PERMISSION_PREFIXES,
+        permissionPrefix: 'environment-audit-',
         redirectTo: '../applications',
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment, useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AuditLogsPageView } from '../features/audit-logs/components/AuditLogsPageView';
+import { AuditTrailLicenseDialog } from '../features/audit-logs/components/AuditTrailLicenseDialog';
+import { useAuditApis, useAuditApplications, useAuditEvents, useAuditLogs } from '../features/audit-logs/hooks/useAuditLogs';
+import { useAuditLogsPageState } from '../features/audit-logs/hooks/useAuditLogsPageState';
+import { APIM_AUDIT_TRAIL_FEATURE } from '../features/audit-logs/license/auditTrailLicense';
+import { exportEnvAudits } from '../features/audit-logs/services/auditLogs';
+import type { AuditSearchParams } from '../features/audit-logs/types/auditLog';
+import { toAuditLogRow } from '../features/audit-logs/utils/auditListFormat';
+import { AUDIT_PERMISSION_PREFIXES } from '../features/audit-logs/utils/auditPermissions';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+export function EnvAuditLogsPage() {
+    const navigate = useNavigate();
+    const environment = useEnvironment();
+    const environmentId = environment?.id ?? '';
+    const hasLicense = useHasFeature(APIM_AUDIT_TRAIL_FEATURE);
+
+    const exportAudits = useCallback(
+        (params: Omit<AuditSearchParams, 'page' | 'size'>) => exportEnvAudits(environmentId, params),
+        [environmentId],
+    );
+    const state = useAuditLogsPageState(exportAudits);
+    const { referenceType } = state;
+
+    const logsQuery = useAuditLogs('environment', state.params, environmentId, hasLicense);
+    const eventsQuery = useAuditEvents('environment', environmentId, hasLicense);
+    const applicationsQuery = useAuditApplications(environmentId, hasLicense && referenceType === 'APPLICATION');
+    const apisQuery = useAuditApis(environmentId, hasLicense && referenceType === 'API');
+
+    const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: AUDIT_PERMISSION_PREFIXES,
+        redirectTo: '../applications',
+    });
+
+    const rows = useMemo(
+        () => (logsQuery.data?.content ?? []).map(audit => toAuditLogRow(audit, logsQuery.data?.metadata ?? {})),
+        [logsQuery.data],
+    );
+
+    if (!hasLicense) {
+        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('../applications')} />;
+    }
+
+    if (isForbidden) {
+        return null;
+    }
+
+    return (
+        <AuditLogsPageView
+            scope="environment"
+            description="Search configuration changes for this environment."
+            state={state}
+            rows={rows}
+            totalCount={logsQuery.data?.totalElements ?? 0}
+            loading={logsQuery.isLoading}
+            isError={Boolean(logsQuery.isError)}
+            eventTypes={eventsQuery.data ?? []}
+            applications={applicationsQuery.data ?? []}
+            apis={apisQuery.data ?? []}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
@@ -29,6 +29,7 @@ import {
 } from '../features/audit-logs/hooks/useAuditLogs';
 import { exportOrgAudits } from '../features/audit-logs/services/auditLogs';
 import type { AuditEntity, AuditMetadataPage } from '../features/audit-logs/types/auditLog';
+import { ApimApiError } from '../shared/api/apimClient';
 import { notify } from '../shared/notify';
 
 const mockNavigate = jest.fn();
@@ -83,16 +84,17 @@ const PAGE: AuditMetadataPage = {
     metadata: { 'USER:user-1:name': 'Ada Lovelace', 'API:api-1:name': 'Pets' },
 };
 
-function renderPage() {
+function renderPage(permissions: string[] = ['organization-audit-r']) {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(['environment-permissions', 'env-1'], ['organization-audit-r']);
-    return render(
+    queryClient.setQueryData(['environment-permissions', 'env-1'], permissions);
+    const view = render(
         <QueryClientProvider client={queryClient}>
             <MemoryRouter initialEntries={['/organization-audit']}>
                 <OrgAuditLogsPage />
             </MemoryRouter>
         </QueryClientProvider>,
     );
+    return { ...view, queryClient };
 }
 
 describe('OrgAuditLogsPage', () => {
@@ -136,6 +138,21 @@ describe('OrgAuditLogsPage', () => {
         expect(notify.success).toHaveBeenCalledWith('Audit logs exported.');
     });
 
+    it('keeps filters on screen when the audit search fails', () => {
+        mockUseAuditLogs.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new Error('network'),
+        } as ReturnType<typeof useAuditLogs>);
+
+        renderPage();
+
+        expect(screen.getByText('Failed to load audit logs. Please try again.')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by event type')).not.toBeNull();
+        expect(screen.getByLabelText('Filter by time period')).not.toBeNull();
+    });
+
     it('does not change relative time bounds on rerender after a date filter is selected', () => {
         let now = 1_800_000_000_000;
         jest.spyOn(Date, 'now').mockImplementation(() => {
@@ -167,5 +184,19 @@ describe('OrgAuditLogsPage', () => {
         const afterRerender = mockUseAuditLogs.mock.calls.at(-1)?.[1] as { from?: number; to?: number };
         expect(afterRerender.from).toBe(afterSelect.from);
         expect(afterRerender.to).toBe(afterSelect.to);
+    });
+
+    it('on 403 strips only organization-audit permissions so Environment Audit stays available', async () => {
+        mockUseAuditLogs.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof useAuditLogs>);
+
+        const { queryClient } = renderPage(['organization-audit-r', 'environment-audit-r']);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-audit-r']);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { OrgAuditLogsPage } from './OrgAuditLogsPage';
+import {
+    useAuditEnvironments,
+    useAuditEvents,
+    useAuditLogs,
+    useOrgAuditApis,
+    useOrgAuditApplications,
+} from '../features/audit-logs/hooks/useAuditLogs';
+import { exportOrgAudits } from '../features/audit-logs/services/auditLogs';
+import type { AuditEntity, AuditMetadataPage } from '../features/audit-logs/types/auditLog';
+import { notify } from '../shared/notify';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasFeature: jest.fn(),
+    useEnvironment: () => ({ id: 'env-1' }),
+}));
+
+jest.mock('../features/audit-logs/hooks/useAuditLogs');
+jest.mock('../features/audit-logs/services/auditLogs', () => ({
+    ...jest.requireActual('../features/audit-logs/services/auditLogs'),
+    exportOrgAudits: jest.fn(),
+}));
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../features/audit-logs/utils/auditExport', () => ({
+    ...jest.requireActual('../features/audit-logs/utils/auditExport'),
+    downloadAuditExport: jest.fn(),
+}));
+
+const mockUseHasFeature = jest.mocked(useHasFeature);
+const mockUseAuditLogs = jest.mocked(useAuditLogs);
+const mockUseAuditEvents = jest.mocked(useAuditEvents);
+const mockUseAuditEnvironments = jest.mocked(useAuditEnvironments);
+const mockUseOrgAuditApplications = jest.mocked(useOrgAuditApplications);
+const mockUseOrgAuditApis = jest.mocked(useOrgAuditApis);
+const mockExportOrgAudits = jest.mocked(exportOrgAudits);
+
+const AUDIT: AuditEntity = {
+    id: 'a-1',
+    referenceId: 'api-1',
+    referenceType: 'API',
+    user: 'user-1',
+    createdAt: 1_700_000_000_000,
+    event: 'API_UPDATED',
+    properties: { API: 'api-1' },
+    patch: '[]',
+};
+
+const PAGE: AuditMetadataPage = {
+    content: [AUDIT],
+    pageNumber: 1,
+    pageElements: 1,
+    totalElements: 1,
+    metadata: { 'USER:user-1:name': 'Ada Lovelace', 'API:api-1:name': 'Pets' },
+};
+
+function renderPage() {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['environment-permissions', 'env-1'], ['organization-audit-r']);
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/organization-audit']}>
+                <OrgAuditLogsPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('OrgAuditLogsPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseHasFeature.mockReturnValue(true);
+        mockUseAuditLogs.mockReturnValue({ data: PAGE, isLoading: false, isError: false, error: null } as ReturnType<typeof useAuditLogs>);
+        mockUseAuditEvents.mockReturnValue({ data: ['API_UPDATED'], isLoading: false } as ReturnType<typeof useAuditEvents>);
+        mockUseAuditEnvironments.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useAuditEnvironments>);
+        mockUseOrgAuditApplications.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useOrgAuditApplications>);
+        mockUseOrgAuditApis.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useOrgAuditApis>);
+        mockExportOrgAudits.mockResolvedValue(PAGE);
+        jest.mocked(notify.success).mockClear();
+        jest.mocked(notify.error).mockClear();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders organization audit rows', () => {
+        renderPage();
+        expect(screen.getByRole('heading', { name: 'Audit' })).not.toBeNull();
+        expect(screen.getByText('Ada Lovelace')).not.toBeNull();
+        expect(screen.getByText('API_UPDATED')).not.toBeNull();
+    });
+
+    it('shows the license dialog and skips the table when apim-audit-trail is missing', () => {
+        mockUseHasFeature.mockReturnValue(false);
+        renderPage();
+        expect(screen.getByText(/part of Gravitee Enterprise/i)).not.toBeNull();
+        expect(screen.queryByText('Ada Lovelace')).toBeNull();
+        expect(mockUseAuditLogs).toHaveBeenCalledWith('organization', expect.anything(), undefined, false);
+    });
+
+    it('exports filtered results and toasts success', async () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+        fireEvent.click(screen.getByRole('button', { name: 'CSV' }));
+        await waitFor(() => expect(mockExportOrgAudits).toHaveBeenCalled());
+        expect(notify.success).toHaveBeenCalledWith('Audit logs exported.');
+    });
+
+    it('does not change relative time bounds on rerender after a date filter is selected', () => {
+        let now = 1_800_000_000_000;
+        jest.spyOn(Date, 'now').mockImplementation(() => {
+            now += 1_000;
+            return now;
+        });
+
+        const queryClient = new QueryClient();
+        queryClient.setQueryData(['environment-permissions', 'env-1'], ['organization-audit-r']);
+        const ui = (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/organization-audit']}>
+                    <OrgAuditLogsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        const { rerender } = render(ui);
+
+        fireEvent.click(screen.getByLabelText('Filter by time period'));
+        fireEvent.click(screen.getByRole('option', { name: 'Last 24 hours' }));
+
+        const afterSelect = mockUseAuditLogs.mock.calls.at(-1)?.[1] as { from?: number; to?: number };
+        expect(afterSelect.from).toEqual(expect.any(Number));
+        expect(afterSelect.to).toEqual(expect.any(Number));
+
+        rerender(ui);
+        rerender(ui);
+
+        const afterRerender = mockUseAuditLogs.mock.calls.at(-1)?.[1] as { from?: number; to?: number };
+        expect(afterRerender.from).toBe(afterSelect.from);
+        expect(afterRerender.to).toBe(afterSelect.to);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.timeFilter.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.timeFilter.spec.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { OrgAuditLogsPage } from './OrgAuditLogsPage';
+import {
+    listAuditEnvironments,
+    listOrgAuditApisByEnvironment,
+    listOrgAuditApplicationsByEnvironment,
+    listOrgAuditEvents,
+    searchOrgAudits,
+} from '../features/audit-logs/services/auditLogs';
+import type { AuditMetadataPage } from '../features/audit-logs/types/auditLog';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasFeature: jest.fn(),
+    useEnvironment: () => ({ id: 'env-1' }),
+}));
+
+jest.mock('../features/audit-logs/services/auditLogs', () => ({
+    ...jest.requireActual('../features/audit-logs/services/auditLogs'),
+    searchOrgAudits: jest.fn(),
+    listOrgAuditEvents: jest.fn(),
+    listAuditEnvironments: jest.fn(),
+    listOrgAuditApplicationsByEnvironment: jest.fn(),
+    listOrgAuditApisByEnvironment: jest.fn(),
+}));
+
+const mockUseHasFeature = jest.mocked(useHasFeature);
+const mockSearchOrgAudits = jest.mocked(searchOrgAudits);
+const mockListOrgAuditEvents = jest.mocked(listOrgAuditEvents);
+const mockListAuditEnvironments = jest.mocked(listAuditEnvironments);
+const mockListOrgAuditApplications = jest.mocked(listOrgAuditApplicationsByEnvironment);
+const mockListOrgAuditApis = jest.mocked(listOrgAuditApisByEnvironment);
+
+const PAGE: AuditMetadataPage = {
+    content: [],
+    pageNumber: 1,
+    pageElements: 0,
+    totalElements: 0,
+    metadata: {},
+};
+
+function renderPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['environment-permissions', 'env-1'], ['organization-audit-r']);
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={['/organization-audit']}>
+                <OrgAuditLogsPage />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('OrgAuditLogsPage time filter', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        mockUseHasFeature.mockReturnValue(true);
+        mockSearchOrgAudits.mockResolvedValue(PAGE);
+        mockListOrgAuditEvents.mockResolvedValue([]);
+        mockListAuditEnvironments.mockResolvedValue([]);
+        mockListOrgAuditApplications.mockResolvedValue([]);
+        mockListOrgAuditApis.mockResolvedValue([]);
+    });
+
+    it('sends from/to on /audit when a relative time preset is selected', async () => {
+        renderPage();
+
+        await waitFor(() => expect(mockSearchOrgAudits).toHaveBeenCalled());
+        expect(mockSearchOrgAudits.mock.calls[0][0].from).toBeUndefined();
+        expect(mockSearchOrgAudits.mock.calls[0][0].to).toBeUndefined();
+
+        fireEvent.click(screen.getByLabelText('Filter by time period'));
+        fireEvent.click(screen.getByRole('option', { name: 'Last 24 hours' }));
+
+        await waitFor(() => {
+            const last = mockSearchOrgAudits.mock.calls.at(-1)?.[0];
+            expect(last?.from).toEqual(expect.any(Number));
+            expect(last?.to).toEqual(expect.any(Number));
+            expect(last!.to! - last!.from!).toBe(24 * 60 * 60 * 1000);
+        });
+    });
+
+    it('sends a 7-day from/to window when Last 7 days is selected', async () => {
+        renderPage();
+        await waitFor(() => expect(mockSearchOrgAudits).toHaveBeenCalled());
+
+        fireEvent.click(screen.getByLabelText('Filter by time period'));
+        fireEvent.click(screen.getByRole('option', { name: 'Last 7 days' }));
+
+        await waitFor(() => {
+            const last = mockSearchOrgAudits.mock.calls.at(-1)?.[0];
+            expect(last!.to! - last!.from!).toBe(7 * 24 * 60 * 60 * 1000);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasFeature } from '@gravitee/gamma-modules-sdk';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AuditLogsPageView } from '../features/audit-logs/components/AuditLogsPageView';
+import { AuditTrailLicenseDialog } from '../features/audit-logs/components/AuditTrailLicenseDialog';
+import {
+    useAuditEnvironments,
+    useAuditEvents,
+    useAuditLogs,
+    useOrgAuditApis,
+    useOrgAuditApplications,
+} from '../features/audit-logs/hooks/useAuditLogs';
+import { useAuditLogsPageState } from '../features/audit-logs/hooks/useAuditLogsPageState';
+import { APIM_AUDIT_TRAIL_FEATURE } from '../features/audit-logs/license/auditTrailLicense';
+import { exportOrgAudits } from '../features/audit-logs/services/auditLogs';
+import { toAuditLogRow } from '../features/audit-logs/utils/auditListFormat';
+import { AUDIT_PERMISSION_PREFIXES } from '../features/audit-logs/utils/auditPermissions';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+export function OrgAuditLogsPage() {
+    const navigate = useNavigate();
+    const hasLicense = useHasFeature(APIM_AUDIT_TRAIL_FEATURE);
+    const state = useAuditLogsPageState(exportOrgAudits);
+    const { referenceType } = state;
+
+    const logsQuery = useAuditLogs('organization', state.params, undefined, hasLicense);
+    const eventsQuery = useAuditEvents('organization', undefined, hasLicense);
+    const environmentsQuery = useAuditEnvironments(hasLicense && referenceType === 'ENVIRONMENT');
+    const applicationsQuery = useOrgAuditApplications(hasLicense && referenceType === 'APPLICATION');
+    const apisQuery = useOrgAuditApis(hasLicense && referenceType === 'API');
+
+    const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: AUDIT_PERMISSION_PREFIXES,
+        redirectTo: '../applications',
+    });
+
+    const rows = useMemo(
+        () => (logsQuery.data?.content ?? []).map(audit => toAuditLogRow(audit, logsQuery.data?.metadata ?? {})),
+        [logsQuery.data],
+    );
+
+    if (!hasLicense) {
+        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('../applications')} />;
+    }
+
+    if (isForbidden) {
+        return null;
+    }
+
+    return (
+        <AuditLogsPageView
+            scope="organization"
+            description="Search configuration changes across the organization."
+            state={state}
+            rows={rows}
+            totalCount={logsQuery.data?.totalElements ?? 0}
+            loading={logsQuery.isLoading}
+            isError={Boolean(logsQuery.isError)}
+            eventTypes={eventsQuery.data ?? []}
+            environments={environmentsQuery.data ?? []}
+            applications={applicationsQuery.data ?? []}
+            apis={apisQuery.data ?? []}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
@@ -31,7 +31,6 @@ import { useAuditLogsPageState } from '../features/audit-logs/hooks/useAuditLogs
 import { APIM_AUDIT_TRAIL_FEATURE } from '../features/audit-logs/license/auditTrailLicense';
 import { exportOrgAudits } from '../features/audit-logs/services/auditLogs';
 import { toAuditLogRow } from '../features/audit-logs/utils/auditListFormat';
-import { AUDIT_PERMISSION_PREFIXES } from '../features/audit-logs/utils/auditPermissions';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
@@ -50,7 +49,7 @@ export function OrgAuditLogsPage() {
     const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
-        permissionPrefix: AUDIT_PERMISSION_PREFIXES,
+        permissionPrefix: 'organization-audit-',
         redirectTo: '../applications',
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
@@ -42,9 +42,11 @@ export function OrgAuditLogsPage() {
 
     const logsQuery = useAuditLogs('organization', state.params, undefined, hasLicense);
     const eventsQuery = useAuditEvents('organization', undefined, hasLicense);
-    const environmentsQuery = useAuditEnvironments(hasLicense && referenceType === 'ENVIRONMENT');
-    const applicationsQuery = useOrgAuditApplications(hasLicense && referenceType === 'APPLICATION');
-    const apisQuery = useOrgAuditApis(hasLicense && referenceType === 'API');
+    const environmentsQuery = useAuditEnvironments(
+        hasLicense && (referenceType === 'ENVIRONMENT' || referenceType === 'APPLICATION' || referenceType === 'API'),
+    );
+    const applicationsQuery = useOrgAuditApplications(environmentsQuery.data, hasLicense && referenceType === 'APPLICATION');
+    const apisQuery = useOrgAuditApis(environmentsQuery.data, hasLicense && referenceType === 'API');
 
     const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
     useForbiddenResourceRedirect({

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
@@ -73,7 +73,7 @@ export function OrgAuditLogsPage() {
             state={state}
             rows={rows}
             totalCount={logsQuery.data?.totalElements ?? 0}
-            loading={logsQuery.isLoading}
+            loading={logsQuery.isFetching}
             isError={Boolean(logsQuery.isError)}
             eventTypes={eventsQuery.data ?? []}
             environments={environmentsQuery.data ?? []}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/browser/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/browser/index.ts
@@ -13,15 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FeatureLicenseDialog } from '../../../shared/components/FeatureLicenseDialog';
-import { SHARDING_TAGS_UPGRADE } from '../license/shardingTagsLicense';
 
-export function ShardingTagsLicenseDialog({
-    open,
-    onOpenChange,
-}: Readonly<{
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-}>) {
-    return <FeatureLicenseDialog upgrade={SHARDING_TAGS_UPGRADE} open={open} onOpenChange={onOpenChange} />;
-}
+export * from '../../../../../../gamma-ui-shared/src/browser/index';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/FeatureLicenseDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/FeatureLicenseDialog.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+import { CheckIcon, LockIcon } from '@gravitee/graphene-core/icons';
+
+const SELF_HOSTED_TRIAL_URL = 'https://gravitee.io/self-hosted-trial';
+
+/** Upgrade copy for one Enterprise feature, declared next to the feature it gates. */
+export interface FeatureUpgrade {
+    readonly title: string;
+    readonly description: string;
+    readonly features: readonly string[];
+}
+
+/** Shared "this is an Enterprise feature" dialog. Bind it to a feature's `FeatureUpgrade` copy. */
+export function FeatureLicenseDialog({
+    upgrade,
+    open,
+    onOpenChange,
+}: Readonly<{
+    upgrade: FeatureUpgrade;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-full max-w-md sm:max-w-md">
+                <DialogHeader>
+                    <div className="flex items-center gap-2">
+                        <LockIcon className="size-5 text-muted-foreground" aria-hidden />
+                        <DialogTitle>{upgrade.title}</DialogTitle>
+                    </div>
+                    <DialogDescription>{upgrade.description}</DialogDescription>
+                </DialogHeader>
+                <ul className="space-y-2 py-2 text-sm">
+                    {upgrade.features.map(feature => (
+                        <li key={feature} className="flex items-start gap-2">
+                            <CheckIcon className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+                            <span>{feature}</span>
+                        </li>
+                    ))}
+                </ul>
+                <DialogFooter className="sm:justify-end">
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                        Close
+                    </Button>
+                    <Button asChild>
+                        <a href={SELF_HOSTED_TRIAL_URL} target="_blank" rel="noopener noreferrer">
+                            Start a free trial
+                        </a>
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
Introduce audit log functionality with new endpoints, services, and UI components for organization and environment scopes. Update navigation and routing to include new audit log pages. Add permission handling and tests for access control.

## Issue

https://gravitee.atlassian.net/browse/FOUND-67
https://gravitee.atlassian.net/browse/FOUND-68
https://gravitee.atlassian.net/browse/FOUND-69
https://gravitee.atlassian.net/browse/FOUND-70

## Summary
- Adds Gamma organization and environment Audit pages in `gravitee-gamma-module-platform`, calling the existing v1 `/audit` APIs (no backend changes). Covers [FOUND-48](https://gravitee.atlassian.net/browse/FOUND-48): [FOUND-67](https://gravitee.atlassian.net/browse/FOUND-67) org search, [FOUND-70](https://gravitee.atlassian.net/browse/FOUND-70) env search, [FOUND-68](https://gravitee.atlassian.net/browse/FOUND-68) event types from `GET /audit/events`, [FOUND-69](https://gravitee.atlassian.net/browse/FOUND-69) client-side CSV/JSON export.
- Org search uses `GET /organizations/{org}/audit`; env search uses `GET /organizations/{org}/environments/{env}/audit`. License `apim-audit-trail` shows the existing Enterprise dialog instead of the table. Permissions: `organization-audit-r` / `environment-audit-r`.
- Time filters send `from`/`to` as epoch ms. Relative presets snapshot `Date.now()` when selected so the query key does not churn. The date range picker is always visible (Classic / API Audit parity); a custom range uses start of the first day through end of the last day.

**Out of scope (API cannot support):** summary cards, Result/failure column, actor query param, Labs badge.

## Test plan
- [x] Organization → System & Security → Audit lists org-wide logs; Environment → System & Security → Audit lists the current environment only.
- [x] Event, type, and (org) environment/API/application filters change the `/audit` query as expected.
- [x] Last 24 hours / 7 / 30 / 90 days: one request with `from` and `to`; changing the preset does not loop.
- [x] Calendar range: start and end dates appear as `from`/`to` (end date through 23:59:59.999).
- [x] Export CSV and JSON for the current filters; toast on success; too many rows is rejected.
- [x] Missing `apim-audit-trail` shows the license dialog and skips the table.
- [x] Missing audit read permission hides the nav item and redirects away from the page.

## Additional context


https://github.com/user-attachments/assets/17fa24b4-3aa8-47d1-bc1e-27db62869417


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



[FOUND-48]: https://gravitee.atlassian.net/browse/FOUND-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-67]: https://gravitee.atlassian.net/browse/FOUND-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-70]: https://gravitee.atlassian.net/browse/FOUND-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-68]: https://gravitee.atlassian.net/browse/FOUND-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-69]: https://gravitee.atlassian.net/browse/FOUND-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ