### PR TITLE
feat(gamma): added activity + updated history env alerts

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/time/formatRelativeDateTime.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/time/formatRelativeDateTime.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const EMPTY = '—';
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const ABSOLUTE_DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+};
+
+function parseDate(value: number | string | undefined | null): Date | undefined {
+    if (value === undefined || value === null || value === '') {
+        return undefined;
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+    return date;
+}
+
+/** Classic `date:'medium'` tooltip: always an absolute datetime. */
+export function formatAbsoluteDateTime(value: number | string | undefined | null): string {
+    const date = parseDate(value);
+    if (!date) {
+        return EMPTY;
+    }
+    return date.toLocaleString('en-GB', ABSOLUTE_DATE_TIME_OPTIONS);
+}
+
+/** Classic `humanDatetimeFilter`: relative time if younger than a week, else an absolute datetime. */
+export function formatRelativeDateTime(value: number | string | undefined | null, now = Date.now()): string {
+    const date = parseDate(value);
+    if (!date) {
+        return EMPTY;
+    }
+    const diffMs = now - date.getTime();
+    if (diffMs < WEEK_MS) {
+        return formatRelativeFromNow(diffMs);
+    }
+    return formatAbsoluteDateTime(value);
+}
+
+function formatRelativeFromNow(diffMs: number): string {
+    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always' });
+    const seconds = Math.max(0, Math.round(diffMs / 1000));
+    if (seconds < 60) {
+        return rtf.format(-seconds, 'second');
+    }
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) {
+        return rtf.format(-minutes, 'minute');
+    }
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) {
+        return rtf.format(-hours, 'hour');
+    }
+    return rtf.format(-Math.round(hours / 24), 'day');
+}

--- a/gravitee-gamma/gamma-ui-shared/src/time/index.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/time/index.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-export const platformAlertKeys = {
-    all: ['platform-alerts'] as const,
-    list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
-    history: (envId: string, alertId: string) => [...platformAlertKeys.all, 'history', envId, alertId] as const,
-    notifiers: (envId: string) => [...platformAlertKeys.all, 'notifiers', envId] as const,
-    notifierSchema: (envId: string, notifierId: string) => [...platformAlertKeys.all, 'notifier-schema', envId, notifierId] as const,
-    analytics: (envId: string, rangeId: string) => [...platformAlertKeys.all, 'analytics', envId, rangeId] as const,
-} as const;
+export { formatAbsoluteDateTime, formatRelativeDateTime } from './formatRelativeDateTime';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.spec.tsx
@@ -14,13 +14,26 @@
  * limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
 import { HistoryTab } from './HistoryTab';
+import { formatAbsoluteDateTime } from '../../../../../shared/time';
 
 jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
 
+jest.mock('@gravitee/graphene-core', () => {
+    const actual = jest.requireActual('@gravitee/graphene-core');
+    return {
+        ...actual,
+        Tooltip: ({ children }: { children: ReactNode }) => children,
+        TooltipProvider: ({ children }: { children: ReactNode }) => children,
+        TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+        TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    };
+});
+
 describe('HistoryTab', () => {
-    it('renders a date from created_at epoch millis, not Invalid Date', () => {
+    it('renders relative time from created_at epoch millis, not Invalid Date', () => {
         const createdAt = Date.now() - 3 * 60_000;
         render(
             <HistoryTab
@@ -32,7 +45,23 @@ describe('HistoryTab', () => {
         );
 
         expect(screen.queryByText('Invalid Date')).toBeNull();
+        expect(screen.getByText(/minutes ago/)).not.toBeNull();
         expect(screen.getByText(/response.response_time: 304/)).not.toBeNull();
+    });
+
+    it('shows an absolute timestamp in a tooltip', () => {
+        const createdAt = Date.now() - 3 * 60_000;
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [{ message: 'Health check failed', created_at: createdAt }],
+                    totalElements: 1,
+                }}
+            />,
+        );
+
+        expect(screen.getByText(/minutes ago/)).not.toBeNull();
+        expect(screen.getByText(formatAbsoluteDateTime(createdAt))).not.toBeNull();
     });
 
     it('renders two events that share a message', () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
@@ -25,8 +25,13 @@ import {
     TableHead,
     TableHeader,
     TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
 } from '@gravitee/graphene-core';
 
+import { formatAbsoluteDateTime, formatRelativeDateTime } from '../../../../../shared/time';
 import type { AlertHistoryPage } from '../../../types';
 
 export interface HistoryTabProps {
@@ -43,24 +48,33 @@ export function HistoryTab({ historyPage }: HistoryTabProps) {
                 </CardHeader>
                 <CardContent>
                     {historyPage && historyPage.content.length > 0 ? (
-                        <div className="rounded-lg border">
-                            <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead>Date</TableHead>
-                                        <TableHead>Message</TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {historyPage.content.map((evt, i) => (
-                                        <TableRow key={`${evt.created_at}-${i}`}>
-                                            <TableCell className="text-sm">{new Date(evt.created_at).toLocaleString()}</TableCell>
-                                            <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
+                        <TooltipProvider delayDuration={200}>
+                            <div className="rounded-lg border">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Date</TableHead>
+                                            <TableHead>Message</TableHead>
                                         </TableRow>
-                                    ))}
-                                </TableBody>
-                            </Table>
-                        </div>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {historyPage.content.map((evt, i) => (
+                                            <TableRow key={`${evt.created_at}-${i}`}>
+                                                <TableCell className="text-sm">
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <span>{formatRelativeDateTime(evt.created_at)}</span>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>{formatAbsoluteDateTime(evt.created_at)}</TooltipContent>
+                                                    </Tooltip>
+                                                </TableCell>
+                                                <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        </TooltipProvider>
                     ) : (
                         <div className="py-8 text-center text-sm text-muted-foreground">No data to display.</div>
                     )}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/alerts.ts
@@ -238,7 +238,7 @@ export async function getAlertHistory(
     environmentId: string,
     apiId: string,
     alertId: string,
-    page = 1,
+    page = 0,
     size = 10,
 ): Promise<AlertHistoryPage> {
     return apimFetchJsonV1Env<AlertHistoryPage>(

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/time/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/time/index.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-export const platformAlertKeys = {
-    all: ['platform-alerts'] as const,
-    list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
-    history: (envId: string, alertId: string) => [...platformAlertKeys.all, 'history', envId, alertId] as const,
-    notifiers: (envId: string) => [...platformAlertKeys.all, 'notifiers', envId] as const,
-    notifierSchema: (envId: string, notifierId: string) => [...platformAlertKeys.all, 'notifier-schema', envId, notifierId] as const,
-    analytics: (envId: string, rangeId: string) => [...platformAlertKeys.all, 'analytics', envId, rangeId] as const,
-} as const;
+export * from '../../../../../../gamma-ui-shared/src/time/index';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -126,6 +126,14 @@ jest.mock('../pages/EnvAuditLogsPage', () => ({
     EnvAuditLogsPage: () => <div data-testid="env-audit-logs-page" />,
 }));
 
+jest.mock('../features/alerts/pages/AlertsActivityPage', () => ({
+    AlertsActivityPage: () => <div data-testid="alerts-activity-page" />,
+}));
+
+jest.mock('../features/alerts/pages/AlertFormPage', () => ({
+    AlertFormPage: () => <div data-testid="alert-form-page" />,
+}));
+
 function renderPlatform(path = '/applications') {
     render(
         <MemoryRouter initialEntries={[path]}>
@@ -442,6 +450,31 @@ describe('AppRoutes', () => {
         );
 
         expect(screen.getByTestId('alerts-page')).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'My alerts' })).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Activity' })).not.toBeNull();
+    });
+
+    it('routes to the Alerts activity page', () => {
+        render(
+            <MemoryRouter initialEntries={['/alerts/activity']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('alerts-activity-page')).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Activity' })).not.toBeNull();
+    });
+
+    it('does not show My alerts / Activity tabs on the alert form', () => {
+        render(
+            <MemoryRouter initialEntries={['/alerts/new']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('alert-form-page')).not.toBeNull();
+        expect(screen.queryByRole('link', { name: 'My alerts' })).toBeNull();
+        expect(screen.queryByRole('link', { name: 'Activity' })).toBeNull();
     });
 
     it('shows the Alerts nav item when the user has read permission', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -42,7 +42,9 @@ import {
     type PlatformNavSection,
 } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
+import { AlertsLayout } from '../features/alerts/components/AlertsLayout';
 import { AlertFormPage } from '../features/alerts/pages/AlertFormPage';
+import { AlertsActivityPage } from '../features/alerts/pages/AlertsActivityPage';
 import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { ENVIRONMENT_AUDIT_READ_PERMISSIONS, ORGANIZATION_AUDIT_READ_PERMISSIONS } from '../features/audit-logs/utils/auditPermissions';
@@ -513,7 +515,10 @@ export function AppRoutes() {
                                     </PermissionPageGuard>
                                 }
                             >
-                                <Route index element={<AlertsPage />} />
+                                <Route element={<AlertsLayout />}>
+                                    <Route index element={<AlertsPage />} />
+                                    <Route path="activity" element={<AlertsActivityPage />} />
+                                </Route>
                                 <Route path="new" element={<AlertFormPage />} />
                                 <Route path=":alertId" element={<AlertFormPage />} />
                             </Route>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/AlertsLayout.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { NavLink, Outlet } from 'react-router-dom';
+
+const TABS = [
+    { to: '.', end: true, label: 'My alerts' },
+    { to: 'activity', end: false, label: 'Activity' },
+] as const;
+
+/**
+ * Sibling tabs for the env alerts list and activity board.
+ * Create/edit routes sit outside this layout so the form stays a full page.
+ */
+export function AlertsLayout() {
+    return (
+        <div className="space-y-6">
+            <div className="border-b">
+                <nav className="flex items-center gap-6" aria-label="Alerts sections">
+                    {TABS.map(tab => (
+                        <NavLink
+                            key={tab.label}
+                            to={tab.to}
+                            end={tab.end}
+                            className={({ isActive }) =>
+                                cn(
+                                    '-mb-px border-b-2 px-0.5 pb-3 text-sm transition-colors',
+                                    isActive
+                                        ? 'border-foreground font-semibold text-foreground'
+                                        : 'border-transparent text-muted-foreground hover:text-foreground',
+                                )
+                            }
+                        >
+                            {tab.label}
+                        </NavLink>
+                    ))}
+                </nav>
+            </div>
+            <Outlet />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.spec.tsx
@@ -14,13 +14,26 @@
  * limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
 import { HistoryTab } from './HistoryTab';
+import { formatAbsoluteDateTime } from '../../../shared/time';
 
 jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
 
+jest.mock('@gravitee/graphene-core', () => {
+    const actual = jest.requireActual('@gravitee/graphene-core');
+    return {
+        ...actual,
+        Tooltip: ({ children }: { children: ReactNode }) => children,
+        TooltipProvider: ({ children }: { children: ReactNode }) => children,
+        TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+        TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    };
+});
+
 describe('HistoryTab', () => {
-    it('renders a date from created_at epoch millis, not Invalid Date', () => {
+    it('renders relative time from created_at epoch millis, not Invalid Date', () => {
         const createdAt = Date.now() - 3 * 60_000;
         render(
             <HistoryTab
@@ -32,7 +45,23 @@ describe('HistoryTab', () => {
         );
 
         expect(screen.queryByText('Invalid Date')).toBeNull();
+        expect(screen.getByText(/minutes ago/)).not.toBeNull();
         expect(screen.getByText(/response.response_time: 304/)).not.toBeNull();
+    });
+
+    it('shows an absolute timestamp in a tooltip', () => {
+        const createdAt = Date.now() - 3 * 60_000;
+        render(
+            <HistoryTab
+                historyPage={{
+                    content: [{ message: 'Health check failed', created_at: createdAt }],
+                    totalElements: 1,
+                }}
+            />,
+        );
+
+        expect(screen.getByText(/minutes ago/)).not.toBeNull();
+        expect(screen.getByText(formatAbsoluteDateTime(createdAt))).not.toBeNull();
     });
 
     it('renders two events that share a message', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/components/HistoryTab.tsx
@@ -26,8 +26,13 @@ import {
     TableHead,
     TableHeader,
     TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
 } from '@gravitee/graphene-core';
 
+import { formatAbsoluteDateTime, formatRelativeDateTime } from '../../../shared/time';
 import type { AlertHistoryPage } from '../types';
 
 export interface HistoryTabProps {
@@ -55,24 +60,33 @@ export function HistoryTab({ historyPage, onRefresh, isRefreshing = false }: His
                 </CardHeader>
                 <CardContent>
                     {historyPage && historyPage.content.length > 0 ? (
-                        <div className="rounded-lg border">
-                            <Table>
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead>Date</TableHead>
-                                        <TableHead>Message</TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {historyPage.content.map((evt, i) => (
-                                        <TableRow key={`${evt.created_at}-${i}`}>
-                                            <TableCell className="text-sm">{new Date(evt.created_at).toLocaleString()}</TableCell>
-                                            <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
+                        <TooltipProvider delayDuration={200}>
+                            <div className="rounded-lg border">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Date</TableHead>
+                                            <TableHead>Message</TableHead>
                                         </TableRow>
-                                    ))}
-                                </TableBody>
-                            </Table>
-                        </div>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {historyPage.content.map((evt, i) => (
+                                            <TableRow key={`${evt.created_at}-${i}`}>
+                                                <TableCell className="text-sm">
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <span>{formatRelativeDateTime(evt.created_at)}</span>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>{formatAbsoluteDateTime(evt.created_at)}</TooltipContent>
+                                                    </Tooltip>
+                                                </TableCell>
+                                                <TableCell className="text-sm text-muted-foreground">{evt.message}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        </TooltipProvider>
                     ) : (
                         <div className="py-8 text-center text-sm text-muted-foreground">No data to display.</div>
                     )}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/activityTimeRanges.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/constants/activityTimeRanges.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Classic `TimeframeRanges` for env alert activity (interval unused — analytics is from/to only). */
+export const ALERT_ACTIVITY_TIME_RANGES = [
+    { id: '1m', title: 'Last minute', rangeMs: 1000 * 60 },
+    { id: '1h', title: 'Last hour', rangeMs: 1000 * 60 * 60 },
+    { id: '1d', title: 'Last day', rangeMs: 1000 * 60 * 60 * 24 },
+    { id: '1w', title: 'Last week', rangeMs: 1000 * 60 * 60 * 24 * 7 },
+    { id: '1M', title: 'Last month', rangeMs: 1000 * 60 * 60 * 24 * 30 },
+] as const;
+
+export type AlertActivityTimeRangeId = (typeof ALERT_ACTIVITY_TIME_RANGES)[number]['id'];
+
+export const DEFAULT_ALERT_ACTIVITY_TIME_RANGE_ID: AlertActivityTimeRangeId = '1m';
+
+export function getAlertActivityTimeRange(id: AlertActivityTimeRangeId) {
+    return ALERT_ACTIVITY_TIME_RANGES.find(range => range.id === id) ?? ALERT_ACTIVITY_TIME_RANGES[0];
+}
+
+export function activityTimeWindow(rangeMs: number, now = Date.now()): { from: number; to: number } {
+    return { from: now - rangeMs, to: now };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertsActivityPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertsActivityPage.spec.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { AlertsActivityPage } from './AlertsActivityPage';
+import { getPlatformAlertAnalytics } from '../services/alerts';
+import type { AlertAnalytics } from '../types';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+jest.mock('../services/alerts', () => ({
+    getPlatformAlertAnalytics: jest.fn(),
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockGetPlatformAlertAnalytics = jest.mocked(getPlatformAlertAnalytics);
+
+const ANALYTICS: AlertAnalytics = {
+    bySeverity: { INFO: 114, WARNING: 0, CRITICAL: 0 },
+    alerts: [
+        { id: 'alert-1', name: 'Blackrock-okta-alert', severity: 'INFO', type: 'METRICS_SIMPLE_CONDITION', events_count: 51 },
+        { id: 'alert-2', name: 'BlackRock-IDP-1-Down', severity: 'CRITICAL', type: 'NODE_HEALTHCHECK', events_count: 51 },
+    ],
+};
+
+const NOW = 1_700_000_000_000;
+
+function renderPage() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={['/alerts/activity']}>
+                <Routes>
+                    <Route path="alerts">
+                        <Route path="activity" element={<AlertsActivityPage />} />
+                        <Route path=":alertId" element={<div />} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('AlertsActivityPage', () => {
+    beforeAll(() => {
+        Element.prototype.hasPointerCapture = jest.fn();
+        Element.prototype.setPointerCapture = jest.fn();
+        Element.prototype.releasePointerCapture = jest.fn();
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(Date, 'now').mockReturnValue(NOW);
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
+        mockGetPlatformAlertAnalytics.mockResolvedValue(ANALYTICS);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('loads analytics for the last minute by default and shows summary cards and table', async () => {
+        renderPage();
+
+        await waitFor(() => expect(mockGetPlatformAlertAnalytics).toHaveBeenCalledWith('env-1', NOW - 60_000, NOW));
+        expect(await screen.findByText('Total Alerts')).not.toBeNull();
+
+        expect(screen.getByRole('heading', { name: 'Alerts board' })).not.toBeNull();
+        expect(screen.getByText('All alert events in last minute')).not.toBeNull();
+        expect(screen.getByText('Total Alerts').parentElement?.textContent).toContain('114');
+        expect(screen.getByText('Info').parentElement?.textContent).toContain('114');
+        expect(screen.getByText('Warning').parentElement?.textContent).toContain('0');
+        expect(screen.getByText('Critical').parentElement?.textContent).toContain('0');
+        expect(screen.getByText('Blackrock-okta-alert')).not.toBeNull();
+        expect(screen.getByText('info')).not.toBeNull();
+        expect(screen.getByText('critical')).not.toBeNull();
+        expect(screen.getAllByText('51')).toHaveLength(2);
+    });
+
+    it('refetches analytics without replacing the board with a skeleton', async () => {
+        const user = userEvent.setup();
+        let resolveRefresh: (value: AlertAnalytics) => void = () => undefined;
+        mockGetPlatformAlertAnalytics.mockResolvedValueOnce(ANALYTICS).mockImplementationOnce(
+            () =>
+                new Promise(resolve => {
+                    resolveRefresh = resolve;
+                }),
+        );
+
+        renderPage();
+        expect(await screen.findByText('Blackrock-okta-alert')).not.toBeNull();
+
+        jest.mocked(Date.now).mockReturnValue(NOW + 5_000);
+        await user.click(screen.getByRole('button', { name: /^refresh$/i }));
+
+        expect(screen.getByText('Blackrock-okta-alert')).not.toBeNull();
+        expect(screen.getByText('Total Alerts')).not.toBeNull();
+
+        resolveRefresh(ANALYTICS);
+        await waitFor(() => expect(mockGetPlatformAlertAnalytics).toHaveBeenCalledWith('env-1', NOW + 5_000 - 60_000, NOW + 5_000));
+    });
+
+    it('refetches analytics for the last hour when the time range changes', async () => {
+        const user = userEvent.setup();
+        renderPage();
+        await waitFor(() => expect(mockGetPlatformAlertAnalytics).toHaveBeenCalledTimes(1));
+        expect(await screen.findByText('Blackrock-okta-alert')).not.toBeNull();
+
+        await user.click(screen.getByRole('combobox', { name: 'Quick time range' }));
+        await user.click(await screen.findByRole('option', { name: 'Last hour' }));
+
+        await waitFor(() => expect(mockGetPlatformAlertAnalytics).toHaveBeenCalledWith('env-1', NOW - 3_600_000, NOW));
+        expect(screen.getByText('All alert events in last hour')).not.toBeNull();
+    });
+
+    it('keeps the board visible when the time range changes', async () => {
+        const user = userEvent.setup();
+        let resolveHour: (value: AlertAnalytics) => void = () => undefined;
+        mockGetPlatformAlertAnalytics.mockResolvedValueOnce(ANALYTICS).mockImplementationOnce(
+            () =>
+                new Promise(resolve => {
+                    resolveHour = resolve;
+                }),
+        );
+
+        renderPage();
+        expect(await screen.findByText('Blackrock-okta-alert')).not.toBeNull();
+
+        await user.click(screen.getByRole('combobox', { name: 'Quick time range' }));
+        await user.click(await screen.findByRole('option', { name: 'Last hour' }));
+
+        expect(screen.getByText('Blackrock-okta-alert')).not.toBeNull();
+        expect(screen.getByText('Total Alerts')).not.toBeNull();
+
+        resolveHour({ ...ANALYTICS, bySeverity: { INFO: 3, WARNING: 0, CRITICAL: 0 } });
+        await waitFor(() => expect(screen.getByText('Total Alerts').parentElement?.textContent).toContain('3'));
+    });
+
+    it('links View history to the alert history tab with a unique accessible name', async () => {
+        renderPage();
+        await waitFor(() => expect(screen.getByText('Blackrock-okta-alert')).not.toBeNull());
+
+        const historyLink = screen.getByRole('link', { name: 'View history for Blackrock-okta-alert' });
+        expect(historyLink.getAttribute('href')).toBe('/alerts/alert-1?tab=history');
+        expect(screen.getByRole('link', { name: 'View history for BlackRock-IDP-1-Down' })).not.toBeNull();
+    });
+
+    it('shows an empty message when there are no events in the window', async () => {
+        mockGetPlatformAlertAnalytics.mockResolvedValue({ bySeverity: {}, alerts: [] });
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('No alert events')).not.toBeNull());
+    });
+
+    it('shows an error when analytics fail to load', async () => {
+        mockGetPlatformAlertAnalytics.mockRejectedValue(new Error('boom'));
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText(/failed to load alert activity/i)).not.toBeNull());
+        expect(screen.queryByText('Total Alerts')).toBeNull();
+        expect(screen.queryByText('Blackrock-okta-alert')).toBeNull();
+    });
+
+    it('keeps the board and shows an error banner when refresh of the current range fails', async () => {
+        const user = userEvent.setup();
+        mockGetPlatformAlertAnalytics.mockResolvedValueOnce(ANALYTICS).mockRejectedValueOnce(new Error('boom'));
+
+        renderPage();
+        expect(await screen.findByText('Blackrock-okta-alert')).not.toBeNull();
+
+        await user.click(screen.getByRole('button', { name: /^refresh$/i }));
+
+        expect(await screen.findByText(/failed to load alert activity/i)).not.toBeNull();
+        expect(screen.getByText('Blackrock-okta-alert')).not.toBeNull();
+        expect(screen.getByText('Total Alerts')).not.toBeNull();
+    });
+
+    it('shows a full error card when a new time range fails to load', async () => {
+        const user = userEvent.setup();
+        mockGetPlatformAlertAnalytics.mockResolvedValueOnce(ANALYTICS).mockRejectedValueOnce(new Error('boom'));
+
+        renderPage();
+        expect(await screen.findByText('Blackrock-okta-alert')).not.toBeNull();
+
+        await user.click(screen.getByRole('combobox', { name: 'Quick time range' }));
+        await user.click(await screen.findByRole('option', { name: 'Last hour' }));
+
+        expect(await screen.findByText(/failed to load alert activity/i)).not.toBeNull();
+        expect(screen.queryByText('Blackrock-okta-alert')).toBeNull();
+        expect(screen.queryByText('Total Alerts')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertsActivityPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/pages/AlertsActivityPage.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useId, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { SeverityBadge } from '../components/SeverityBadge';
+import {
+    ALERT_ACTIVITY_TIME_RANGES,
+    type AlertActivityTimeRangeId,
+    DEFAULT_ALERT_ACTIVITY_TIME_RANGE_ID,
+    activityTimeWindow,
+    getAlertActivityTimeRange,
+} from '../constants/activityTimeRanges';
+import { getPlatformAlertAnalytics } from '../services/alerts';
+import { platformAlertKeys } from '../utils/queryKeys';
+
+function severityCount(bySeverity: Record<string, number> | undefined, key: string): number {
+    return bySeverity?.[key] ?? 0;
+}
+
+export function AlertsActivityPage() {
+    const env = useEnvironment();
+    const environmentId = env?.id ?? '';
+    const timeRangeSelectId = useId();
+
+    const [rangeId, setRangeId] = useState<AlertActivityTimeRangeId>(DEFAULT_ALERT_ACTIVITY_TIME_RANGE_ID);
+    const selectedRange = getAlertActivityTimeRange(rangeId);
+
+    const { data, isLoading, isError, isFetching, refetch } = useQuery({
+        queryKey: platformAlertKeys.analytics(environmentId, rangeId),
+        queryFn: () => {
+            const { from, to } = activityTimeWindow(getAlertActivityTimeRange(rangeId).rangeMs);
+            return getPlatformAlertAnalytics(environmentId, from, to);
+        },
+        enabled: !!environmentId,
+        placeholderData: keepPreviousData,
+    });
+
+    const info = severityCount(data?.bySeverity, 'INFO');
+    const warning = severityCount(data?.bySeverity, 'WARNING');
+    const critical = severityCount(data?.bySeverity, 'CRITICAL');
+    const total = info + warning + critical;
+
+    const summaryCards = [
+        { key: 'total', label: 'Total Alerts', value: total },
+        { key: 'INFO', label: 'Info', value: info },
+        { key: 'WARNING', label: 'Warning', value: warning },
+        { key: 'CRITICAL', label: 'Critical', value: critical },
+    ];
+
+    const alerts = data?.alerts ?? [];
+
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Alerts board</h1>
+                    <p className="text-sm text-muted-foreground">All alert events in {selectedRange.title.toLowerCase()}</p>
+                </div>
+                <div className="flex shrink-0 items-end gap-2">
+                    <div className="space-y-1.5">
+                        <Label htmlFor={timeRangeSelectId} className="text-xs">
+                            Quick time range
+                        </Label>
+                        <Select value={rangeId} onValueChange={val => setRangeId(val as AlertActivityTimeRangeId)}>
+                            <SelectTrigger id={timeRangeSelectId} aria-label="Quick time range" className="w-44">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ALERT_ACTIVITY_TIME_RANGES.map(range => (
+                                    <SelectItem key={range.id} value={range.id}>
+                                        {range.title}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <Button type="button" variant="outline" size="sm" disabled={isFetching} onClick={() => void refetch()}>
+                        {isFetching ? 'Refreshing…' : 'Refresh'}
+                    </Button>
+                </div>
+            </div>
+
+            {isLoading && !data && (
+                <div className="space-y-3">
+                    <div className="flex gap-4">
+                        {[1, 2, 3, 4].map(i => (
+                            <Skeleton key={i} className="h-24 flex-1 rounded-lg" />
+                        ))}
+                    </div>
+                    <Skeleton className="h-40 w-full rounded-lg" />
+                </div>
+            )}
+
+            {isError && !data && (
+                <Card>
+                    <CardContent className="pt-4 pb-4">
+                        <p className="text-sm text-destructive">Failed to load alert activity. Please try again.</p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {data && (
+                <>
+                    {isError && (
+                        <Alert variant="destructive">
+                            <AlertDescription>Failed to load alert activity. Please try again.</AlertDescription>
+                        </Alert>
+                    )}
+                    <div className="flex flex-wrap gap-4">
+                        {summaryCards.map(card => (
+                            <Card key={card.key} className="min-w-[10rem] flex-1">
+                                <CardContent className="pt-5 pb-4">
+                                    <p className="text-sm font-medium text-muted-foreground">{card.label}</p>
+                                    <p className="mt-0.5 text-2xl font-semibold">{card.value.toLocaleString()}</p>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    {alerts.length === 0 ? (
+                        <Card>
+                            <CardContent className="pt-4 pb-4">
+                                <p className="text-sm text-muted-foreground">No alert events</p>
+                            </CardContent>
+                        </Card>
+                    ) : (
+                        <div className="rounded-lg border">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Alert Name</TableHead>
+                                        <TableHead>Severity</TableHead>
+                                        <TableHead>Total Alerts Triggered</TableHead>
+                                        <TableHead>History</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {alerts.map(alert => (
+                                        <TableRow key={alert.id}>
+                                            <TableCell>
+                                                <p className="text-sm font-medium">{alert.name}</p>
+                                            </TableCell>
+                                            <TableCell>
+                                                <SeverityBadge severity={alert.severity} />
+                                            </TableCell>
+                                            <TableCell>
+                                                <span className="text-sm">{alert.events_count}</span>
+                                            </TableCell>
+                                            <TableCell>
+                                                <Button asChild variant="link" className="h-auto px-0">
+                                                    <Link to={`../${alert.id}?tab=history`} aria-label={`View history for ${alert.name}`}>
+                                                        View history
+                                                    </Link>
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.spec.ts
@@ -21,6 +21,7 @@ import {
     formNotifToApi,
     listPlatformAlertEvents,
     listPlatformAlerts,
+    getPlatformAlertAnalytics,
     parseNotificationConfiguration,
     updatePlatformAlert,
     updatePlatformAlertFromForm,
@@ -190,11 +191,27 @@ describe('platform alerts service', () => {
     });
 
     describe('listPlatformAlertEvents', () => {
+        it('GETs /platform/alerts/{id}/events with 0-based page like classic console', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ content: [], totalElements: 0 });
+            await listPlatformAlertEvents('env-1', 'alert-1');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/alert-1/events?page=0&size=10');
+        });
+
         it('GETs /platform/alerts/{id}/events with pagination', async () => {
             mockApimFetchJsonV1Env.mockResolvedValue({ content: [], totalElements: 0 });
             await listPlatformAlertEvents('env-1', 'alert-1', 2, 20);
 
             expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/alert-1/events?page=2&size=20');
+        });
+    });
+
+    describe('getPlatformAlertAnalytics', () => {
+        it('GETs /platform/alerts/analytics with from and to timestamps', async () => {
+            mockApimFetchJsonV1Env.mockResolvedValue({ bySeverity: {}, alerts: [] });
+            await getPlatformAlertAnalytics('env-1', 1000, 2000);
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/platform/alerts/analytics?from=1000&to=2000');
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/services/alerts.ts
@@ -19,6 +19,7 @@ import type {
     AlertApiCondition,
     AlertApiNotification,
     AlertApiPeriod,
+    AlertAnalytics,
     AlertFormCondition,
     AlertFormNotification,
     AlertFormTimeframe,
@@ -314,9 +315,13 @@ export async function deletePlatformAlert(environmentId: string, alertId: string
     });
 }
 
-export async function listPlatformAlertEvents(environmentId: string, alertId: string, page = 1, size = 10): Promise<AlertHistoryPage> {
+export async function listPlatformAlertEvents(environmentId: string, alertId: string, page = 0, size = 10): Promise<AlertHistoryPage> {
     return apimFetchJsonV1Env<AlertHistoryPage>(
         environmentId,
         `/platform/alerts/${encodeURIComponent(alertId)}/events?page=${page}&size=${size}`,
     );
+}
+
+export async function getPlatformAlertAnalytics(environmentId: string, from: number, to: number): Promise<AlertAnalytics> {
+    return apimFetchJsonV1Env<AlertAnalytics>(environmentId, `/platform/alerts/analytics?from=${from}&to=${to}`);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/types/alert.ts
@@ -141,3 +141,16 @@ export interface AlertHistoryPage {
     content: AlertHistoryEvent[];
     totalElements: number;
 }
+
+export interface AlertTriggerAnalytics {
+    id: string;
+    name: string;
+    severity: AlertSeverity;
+    type: string;
+    events_count: number;
+}
+
+export interface AlertAnalytics {
+    bySeverity: Partial<Record<AlertSeverity, number>>;
+    alerts: AlertTriggerAnalytics[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/formatRelativeDateTime.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/alerts/utils/formatRelativeDateTime.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatAbsoluteDateTime, formatRelativeDateTime } from '../../../shared/time';
+
+describe('formatRelativeDateTime', () => {
+    it('formats recent timestamps as relative time from epoch millis', () => {
+        const now = Date.parse('2026-08-19T06:30:00.000Z');
+        expect(formatRelativeDateTime(now - 3 * 60_000, now)).toBe('3 minutes ago');
+        expect(formatRelativeDateTime(now - 5_000, now)).toMatch(/second/);
+        expect(formatRelativeDateTime(now - 2 * 60 * 60_000, now)).toBe('2 hours ago');
+        expect(formatRelativeDateTime(undefined, now)).toBe('—');
+        expect(formatRelativeDateTime('not-a-date', now)).toBe('—');
+        expect(formatRelativeDateTime(now - 8 * 24 * 60 * 60_000, now)).not.toMatch(/Invalid Date|ago/);
+    });
+});
+
+describe('formatAbsoluteDateTime', () => {
+    it('formats epoch millis as an absolute datetime, not Invalid Date', () => {
+        const createdAt = Date.parse('2026-08-19T06:27:00.000Z');
+        expect(formatAbsoluteDateTime(createdAt)).not.toMatch(/Invalid Date|ago/);
+        expect(formatAbsoluteDateTime(createdAt)).toMatch(/2026/);
+        expect(formatAbsoluteDateTime(undefined)).toBe('—');
+        expect(formatAbsoluteDateTime('not-a-date')).toBe('—');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/time/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/time/index.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-export const platformAlertKeys = {
-    all: ['platform-alerts'] as const,
-    list: (envId: string) => [...platformAlertKeys.all, 'list', envId] as const,
-    history: (envId: string, alertId: string) => [...platformAlertKeys.all, 'history', envId, alertId] as const,
-    notifiers: (envId: string) => [...platformAlertKeys.all, 'notifiers', envId] as const,
-    notifierSchema: (envId: string, notifierId: string) => [...platformAlertKeys.all, 'notifier-schema', envId, notifierId] as const,
-    analytics: (envId: string, rangeId: string) => [...platformAlertKeys.all, 'analytics', envId, rangeId] as const,
-} as const;
+export * from '../../../../../../gamma-ui-shared/src/time/index';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14913

## Description

Adds the Gamma environment Activity tab: summary cards (Total / Info / Warning / Critical) and a table of alert name, events triggered, and a link to history. My alerts and Activity are sibling tabs; create/edit stay full-page.

Also fixes alert history: events API defaults to page=0, and timestamps use created_at (epoch millis) with classic-style relative time instead of Invalid Date.

## Additional context


https://github.com/user-attachments/assets/61944a85-d403-4b02-a899-55620be96eca



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>