### PR TITLE
chore(4.12.x): bump gravitee-reactor-native-kafka from 7.0.6 to 7.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.6</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.0.7</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14943

## Description

Bumps the native Kafka reactor from `7.0.6` to `7.0.7` on `4.12.x`.

`7.0.7` carries the fix for APIM-14943: a client negotiating `SASL_HANDSHAKE v0` could no longer authenticate against the Kafka gateway. The connection was torn down mid-handshake with:

```
An unexpected internal error occurred. Unable to return proper response to the downstream client
org.apache.kafka.common.errors.InvalidRequestException: Error parsing request header. Our best guess of the apiKey is: 50
```

Connection lifecycle metrics were reading the client-id off every frame entering `handleAuthenticate`, but with handshake v0 the SASL tokens that follow are raw bytes with no Kafka request header — so the gateway tried to parse a header out of the `PLAIN` payload and failed fatally. The reactor now captures the client-id on a best-effort basis.

Reactor PR: gravitee-io/gravitee-reactor-native-kafka#399

## Additional context

**Scope.** `4.12.x` pins `7.0.6` and is the only maintenance branch affected:

| APIM branch | Reactor pin | Status |
|---|---|---|
| `4.12.x` | `7.0.6` → `7.0.7` | affected, fixed by this PR |
| `4.11.x` | `6.3.4` | not affected — the regression is 7.x only |
| `4.10.x` | `5.0.7` | not affected |
| `master` | `7.1.0-alpha.7` | **affected**, see below |

The regression was introduced in the reactor by `4cb4ba2d` (2026-04-28) and ships in `7.0.0` → `7.0.6` plus the `7.1.0-alpha` line. Reactor branches `1.x` through `6.x` never contained it.

**`master` still needs a follow-up.** It pins `7.1.0-alpha.7`, which is affected. The fix landed on the reactor's `main`, and its `alpha` branch does not have it yet — `alpha` needs the usual forward merge and a new alpha release before APIM `master` can be bumped. Not covered by this PR.

**Verification.** The published `7.0.7` artifact resolves and its `KafkaServerAuthenticator.class` contains the fix. On the reactor side, the new integration test drives a v0 handshake over a raw socket: it fails 3/3 runs without the fix on the exact `InvalidRequestException` above, passes with it, and the full module suite is green (1161 tests, 0 failures).
