### PR TITLE
ci(sonar): make the analysis read the test sources, and give it time to finish

### DIFF
--- a/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
+++ b/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
@@ -61,6 +61,7 @@ export class SonarCloudAnalysisJob {
         name: 'Run Sonarcloud Analysis',
         command: `sonar-scanner -Dsonar.projectVersion=${apimVersion}`,
         working_directory: '<< parameters.working_directory >>',
+        no_output_timeout: '30m',
       }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new commands.cache.Save({

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -327,6 +327,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -211,6 +211,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -211,6 +211,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -260,6 +260,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -260,6 +260,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -213,6 +213,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -282,6 +282,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
@@ -216,6 +216,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -217,6 +217,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -285,6 +285,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -327,6 +327,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -285,6 +285,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -310,6 +310,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/gravitee-apim-console-webui/sonar-project.properties
+++ b/gravitee-apim-console-webui/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.sources=src
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.coverage.exclusions=**/*.stories.ts,**/*.fixture.ts

--- a/gravitee-apim-console-webui/sonar-project.properties
+++ b/gravitee-apim-console-webui/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_console-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_definition
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-definition-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-definition-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_gateway
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.sourceEncoding=UTF-8
 sonar.cpd.exclusions=gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/**/*Builder.java
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java, **/gravitee-apim-gateway-standalone-container/src/test/**, **/*IntegrationTest.java
 
 # Coverage

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-gateway-coverage/**, **/target/**, gravitee-apim-gateway-tests-sdk/src/test/java/testcases/**
 
 # Source encoding
-sonar.language=java
 sonar.sourceEncoding=UTF-8
 
 # Duplication

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-plugin-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_plugins
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-plugin-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-portal-webui-next/sonar-project.properties
+++ b/gravitee-apim-portal-webui-next/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-apim-portal-webui-next
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 

--- a/gravitee-apim-portal-webui-next/sonar-project.properties
+++ b/gravitee-apim-portal-webui-next/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.sources=src
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.coverage.exclusions=**/*.stories.ts,**/*.fixture.ts,**/stories/**

--- a/gravitee-apim-portal-webui/sonar-project.properties
+++ b/gravitee-apim-portal-webui/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_portal-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 sonar.exclusions=projects/portal-webclient-sdk/**

--- a/gravitee-apim-portal-webui/sonar-project.properties
+++ b/gravitee-apim-portal-webui/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.exclusions=projects/portal-webclient-sdk/**
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-reporter-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_reporter
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-reporter-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -19,7 +19,7 @@ sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**, gravitee-ap
 sonar.cpd.exclusions=gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/** 
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**, gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/**, gravitee-apim-repository-test/src/test/java/io/gravitee/repository/mock/**
 
 # Source encoding
-sonar.language=java
 
 # Duplication
 sonar.cpd.exclusions=gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/** 

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_repository
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_rest-api
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-rest-api-coverage/**, **/target/**, gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/**
 
 # Source encoding
-sonar.language=java
 sonar.sourceEncoding=UTF-8
 
 # Test
@@ -24,6 +23,3 @@ sonar.test.inclusions=**/*Test.java
 # Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/jacoco.xml
 sonar.coverage.exclusions=**/pom.xml, **/src/test/**, **/model/**, **/exception/**, **/fixtures/**, **/assertions/**, **/spring/**
-
-# Libraries
-sonar.libraries=${env.HOME}/.m2/repository/org/projectlombok/lombok/**/*.jar

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.exclusions=gravitee-apim-rest-api-coverage/**, **/target/**, gravitee-apim
 sonar.sourceEncoding=UTF-8
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-300

## Description

First step of putting the SonarCloud analysis back in working order. Three changes, one commit each, so that their effects can be told apart in CI:

1. **`no_output_timeout: 30m` on the analysis job.** The Sonar jobs inherited CircleCI's 10-minute default, which counts silence rather than total duration. That is why the same rest-api analysis passed at 985 s and was killed at 687 s. This has to land before anything that makes the analysis longer.
2. **Removal of `sonar.language` and `sonar.libraries`.** Both were dropped from SonarQube years ago and are silently ignored. Lombok belongs to the compile classpath, not to a scanner input.
3. **`sonar.test` → `sonar.tests`.** The property has been written in the singular since November 2021, in all nine files, and is therefore ignored: no test directory is declared. Since `sonar.test.inclusions` does exclude those same files from the sources, test code was analysed from neither side — on rest-api, 1,602 of 5,714 Java files.

Only the CI configuration and the nine `sonar-project.properties` change. No production code, no test code.

## Additional context

**This is a draft opened to watch what CI does with it**, specifically the third commit. Two things are expected and need to be read off this run before the change is propagated:

- **The analysis duration.** Declaring the test sources adds about 28% more files to parse. The rest-api job is the one to watch — it was already the longest at 687 s, and it is the reason the `no_output_timeout` is in this PR.
- **A possible `File can't be indexed twice` error.** Six of the nine projects declare `sonar.sources=.` and now `sonar.tests=.` over the same tree, with `sonar.test.inclusions` as the only separator. If the scanner rejects that overlap, the fix is to mirror the inclusion patterns into `sonar.exclusions`. Deliberately not done up front — better to know whether it is needed than to add nine exclusion lists on a hunch.

Backporting to the support branches is intentionally not done yet: the labels come once the effect above is known. The front-end coverage repair is **not** in this PR, and will not go below 4.11.x — measured on the public SonarCloud API, the Console and Portal Next branches of 4.9.x and 4.10.x report 74.5%/86.1% and 74.9%/86.1% respectively, against 0% from 4.11.x onwards. There is nothing to repair there.

Bytecode is out of scope here: no branch persists the compiled classes today, so it depends on the transport introduced by #19176.
