### PR TITLE
feat: add API Product subscription details view

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -546,7 +546,7 @@ describe('SubscriptionsDetailsComponent', () => {
 
   function expectSubscriptionWithKeys(subscriptionResponse: Subscription = fakeSubscription()) {
     httpTestingController
-      .expectOne(`${TESTING_BASE_URL}/subscriptions/testSubscriptionId?include=keys&include=consumerConfiguration`)
+      .expectOne(`${TESTING_BASE_URL}/subscriptions/testSubscriptionId?include=keys&include=consumerConfiguration&include=apiProduct`)
       .flush(subscriptionResponse);
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.html
@@ -1,0 +1,76 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card appearance="outlined" class="api-card" [attr.data-api-id]="api().id">
+  <mat-card-header>
+    <mat-card-title class="next-gen-h5">{{ api().name || api().id }}</mat-card-title>
+    @if (api().version) {
+      <mat-card-subtitle><span i18n="@@apiProductSubscriptionApiVersion">Version</span> {{ api().version }}</mat-card-subtitle>
+    }
+    @if (api().type) {
+      <mat-card-subtitle><span i18n="@@apiProductSubscriptionApiType">Type</span> {{ api().type }}</mat-card-subtitle>
+    }
+  </mat-card-header>
+
+  <mat-card-content class="api-card__content">
+    @if (available()) {
+      @if (accessEnabled()) {
+        @if (entrypoints().length === 1) {
+          <app-copy-code title="Base URL" i18n-title="@@apiProductSubscriptionBaseUrl" [text]="entrypoints()[0]" />
+        } @else if (entrypoints().length > 1) {
+          <mat-form-field appearance="outline" subscriptSizing="dynamic">
+            <mat-label i18n="@@apiProductSubscriptionBaseUrls">Base URLs</mat-label>
+            <mat-select
+              [value]="selectedEntrypointValue()"
+              (selectionChange)="selectedEntrypoint.set($event.value)"
+              data-testid="entrypoint-select"
+            >
+              @for (entrypoint of entrypoints(); track entrypoint) {
+                <mat-option [value]="entrypoint">{{ entrypoint }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        } @else {
+          <p class="next-gen-body" role="status" i18n="@@apiProductSubscriptionNoEntrypoints">No API entrypoint is available.</p>
+        }
+
+        @if (curlCommand()) {
+          <app-copy-code title="cURL" i18n-title="@@apiProductSubscriptionCurl" [text]="curlCommand()" />
+        }
+      } @else {
+        <p class="next-gen-body" role="status" i18n="@@apiProductSubscriptionApiAccessPending">
+          API access is not available for the current subscription status.
+        </p>
+      }
+
+      @if (api().documentation; as documentation) {
+        <a
+          [routerLink]="['/documentation', documentation.rootId]"
+          [queryParams]="{ selectedId: documentation.navigationItemId }"
+          i18n="@@apiProductSubscriptionViewDocumentation"
+          >View documentation</a
+        >
+      } @else {
+        <p class="next-gen-body" i18n="@@apiProductSubscriptionNoDocumentation">Documentation is not available.</p>
+      }
+    } @else if (api().availability === 'UNPUBLISHED') {
+      <p class="next-gen-body" i18n="@@apiProductSubscriptionApiUnpublished">This API is no longer published.</p>
+    } @else {
+      <p class="next-gen-body" i18n="@@apiProductSubscriptionApiUnavailable">This API is no longer available.</p>
+    }
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.scss
@@ -1,28 +1,32 @@
 /*
  * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use '../../../scss/layout' as layout;
-@use '../../../scss/theme' as app-theme;
+@use '../../../../../scss/layout' as layout;
+@use '../../../../../scss/theme' as app-theme;
 
-:host {
-  display: flex;
-  max-width: app-theme.$inner-content-width;
-  flex-direction: column;
-  width: 100%;
+.api-card {
+  height: 100%;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: layout.$container-padding-horizontal;
+    padding-top: layout.$container-padding-horizontal;
+  }
 }
 
-.subscription-details__error {
-  padding: layout.$container-padding-horizontal;
+mat-form-field {
+  width: 100%;
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { ApiProductSubscriptionApiAccessComponent } from './api-product-subscription-api-access.component';
+import { ApiProductSubscriptionApiAccessHarness } from './api-product-subscription-api-access.harness';
+import { ApiProductSubscriptionApi } from '../../../../../entities/subscription';
+import { ConfigService } from '../../../../../services/config.service';
+import { AppTestingModule, ConfigServiceStub } from '../../../../../testing/app-testing.module';
+
+describe('ApiProductSubscriptionApiAccessComponent', () => {
+  let fixture: ComponentFixture<ApiProductSubscriptionApiAccessComponent>;
+  let configService: ConfigServiceStub;
+
+  const api: ApiProductSubscriptionApi = {
+    id: 'api-id',
+    name: 'Orders API',
+    version: '1.0',
+    type: 'PROXY',
+    availability: 'AVAILABLE',
+    entrypoints: ['https://api.example.com/orders'],
+    documentation: { rootId: 'root-id', navigationItemId: 'navigation-item-id' },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionApiAccessComponent, AppTestingModule],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    configService = TestBed.inject(ConfigService) as unknown as ConfigServiceStub;
+    configService.configuration = { portal: { apikeyHeader: 'X-Gravitee-Api-Key' } };
+    fixture = TestBed.createComponent(ApiProductSubscriptionApiAccessComponent);
+    fixture.componentRef.setInput('api', api);
+    fixture.componentRef.setInput('accessEnabled', true);
+  });
+
+  it('should show the base URL, cURL command and documentation link for an available API', async () => {
+    fixture.componentRef.setInput('planSecurity', 'API_KEY');
+    fixture.componentRef.setInput('apiKey', 'secret-key');
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionApiAccessHarness);
+
+    expect(await harness.getText()).toContain('https://api.example.com/orders');
+    expect(await harness.getText()).toContain('curl --header "X-Gravitee-Api-Key: secret-key" https://api.example.com/orders');
+    expect(await harness.getDocumentationLink()).toContain('/documentation/root-id?selectedId=navigation-item-id');
+  });
+
+  it('should not expose endpoints or documentation for an unavailable API', async () => {
+    fixture.componentRef.setInput('api', { ...api, availability: 'UNAVAILABLE' });
+    fixture.detectChanges();
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionApiAccessHarness);
+
+    expect(await harness.getText()).toContain('This API is no longer available');
+    expect(await harness.getCopyCodeCount()).toBe(0);
+    expect(await harness.getDocumentationLink()).toBeNull();
+  });
+
+  it('should use an access token placeholder for OAuth2', () => {
+    fixture.componentRef.setInput('planSecurity', 'OAUTH2');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'curl --header "Authorization: Bearer {{ ACCESS_TOKEN }}" https://api.example.com/orders',
+    );
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.component.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { RouterLink } from '@angular/router';
+
+import { formatCurlCommandLine } from '../../../../../components/api-access/api-access.utils';
+import { CopyCodeComponent } from '../../../../../components/copy-code/copy-code.component';
+import { PlanSecurityEnum } from '../../../../../entities/plan/plan';
+import { ApiProductSubscriptionApi } from '../../../../../entities/subscription/api-product-subscription-details';
+import { ConfigService } from '../../../../../services/config.service';
+
+@Component({
+  selector: 'app-api-product-subscription-api-access',
+  imports: [CopyCodeComponent, MatCardModule, MatFormFieldModule, MatSelectModule, RouterLink],
+  templateUrl: './api-product-subscription-api-access.component.html',
+  styleUrl: './api-product-subscription-api-access.component.scss',
+})
+export class ApiProductSubscriptionApiAccessComponent {
+  private readonly configService = inject(ConfigService);
+
+  readonly api = input.required<ApiProductSubscriptionApi>();
+  readonly planSecurity = input<PlanSecurityEnum>();
+  readonly apiKey = input<string>();
+  readonly accessEnabled = input(false);
+
+  protected readonly selectedEntrypoint = signal<string>('');
+  protected readonly available = computed(() => this.api().availability === 'AVAILABLE');
+  protected readonly entrypoints = computed(() => this.api().entrypoints ?? []);
+  protected readonly selectedEntrypointValue = computed(() => {
+    const selectedEntrypoint = this.selectedEntrypoint();
+    const entrypoints = this.entrypoints();
+    return selectedEntrypoint && entrypoints.includes(selectedEntrypoint) ? selectedEntrypoint : (entrypoints[0] ?? '');
+  });
+  protected readonly curlCommand = computed(() =>
+    formatCurlCommandLine(
+      this.selectedEntrypointValue(),
+      this.planSecurity(),
+      this.configService.configuration.portal?.apikeyHeader,
+      this.apiKey(),
+    ),
+  );
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-api-access/api-product-subscription-api-access.harness.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiProductSubscriptionApiAccessHarness extends ComponentHarness {
+  static hostSelector = 'app-api-product-subscription-api-access';
+
+  private readonly documentationLink = this.locatorForOptional('a');
+  private readonly copyCodeBlocks = this.locatorForAll('app-copy-code');
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  async getDocumentationLink(): Promise<string | null> {
+    return (await this.documentationLink())?.getAttribute('href') ?? null;
+  }
+
+  async getCopyCodeCount(): Promise<number> {
+    return (await this.copyCodeBlocks()).length;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
@@ -1,0 +1,170 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h1 class="next-gen-h3" i18n="@@apiProductSubscriptionDetailsTitle">Subscription Details</h1>
+
+@if (product(); as productDetails) {
+  <mat-card appearance="outlined">
+    <mat-card-header>
+      <mat-card-title class="next-gen-h4" i18n="@@apiProductSubscriptionSummaryTitle">Subscription information</mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="details-grid" data-testid="product-subscription-summary">
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionStatus">Status</span>
+      <span>{{ subscription().status | capitalizeFirst }}</span>
+
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionProduct">API Product</span>
+      <span
+        >{{ productDetails.name || productDetails.id }}
+        @if (productDetails.version) {
+          ({{ productDetails.version }})
+        }
+      </span>
+
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionApplication">Application</span>
+      @if (applicationResource.value(); as application) {
+        <a [routerLink]="['/dashboard/applications', application.id]">{{ application.name }}</a>
+      } @else if (applicationResource.isLoading()) {
+        <span i18n="@@apiProductSubscriptionApplicationLoading">Loading application...</span>
+      } @else {
+        <span>{{ subscription().application }}</span>
+      }
+
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionId">Subscription ID</span>
+      <span>{{ subscription().id }}</span>
+
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionPlan">Plan</span>
+      <span>{{ productDetails.plan?.name || productDetails.plan?.id || subscription().plan }}</span>
+
+      @if (planSecurityLabel()) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionAuthentication">Authentication</span>
+        <span>{{ planSecurityLabel() }}</span>
+      }
+
+      @if (subscription().created_at; as createdAt) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionCreatedAt">Created at</span>
+        <span>{{ createdAt | date: 'medium' }}</span>
+      }
+      @if (subscription().start_at; as startAt) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionStartsAt">Starts at</span>
+        <span>{{ startAt | date: 'medium' }}</span>
+      }
+      @if (subscription().end_at; as endAt) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionEndsAt">Ends at</span>
+        <span>{{ endAt | date: 'medium' }}</span>
+      }
+
+      @if (productDetails.plan?.usageConfiguration?.quota?.limit; as quotaLimit) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionQuota">Quota</span>
+        <span>
+          <span i18n="@@apiProductSubscriptionUpTo">up to</span> {{ quotaLimit }} <span i18n="@@apiProductSubscriptionHits">hits</span> /
+          {{ productDetails.plan?.usageConfiguration?.quota ?? {} | toPeriodTimeUnitLabelPipe }}
+        </span>
+      }
+      @if (productDetails.plan?.usageConfiguration?.rate_limit?.limit; as rateLimit) {
+        <span class="details-grid__label" i18n="@@apiProductSubscriptionRateLimit">Rate limit</span>
+        <span>
+          <span i18n="@@apiProductSubscriptionUpTo">up to</span> {{ rateLimit }} <span i18n="@@apiProductSubscriptionHits">hits</span> /
+          {{ productDetails.plan?.usageConfiguration?.rate_limit ?? {} | toPeriodTimeUnitLabelPipe }}
+        </span>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  @if (productDetails.availability === 'UNAVAILABLE') {
+    <mat-card appearance="outlined">
+      <mat-card-content class="message" i18n="@@apiProductSubscriptionProductUnavailable">
+        This API Product is no longer available in the Developer Portal.
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <mat-card appearance="outlined" data-testid="product-subscription-credentials">
+    <mat-card-header>
+      <mat-card-title class="next-gen-h4" i18n="@@apiProductSubscriptionCredentialsTitle">API access</mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="credentials">
+      @if (subscription().status !== 'ACCEPTED') {
+        @switch (subscription().status) {
+          @case ('PENDING') {
+            <p i18n="@@apiProductSubscriptionPending">Your subscription request is being reviewed.</p>
+          }
+          @case ('REJECTED') {
+            <p i18n="@@apiProductSubscriptionRejected">This subscription request was rejected.</p>
+          }
+          @case ('PAUSED') {
+            <p i18n="@@apiProductSubscriptionPaused">This subscription is paused.</p>
+          }
+          @case ('CLOSED') {
+            <p i18n="@@apiProductSubscriptionClosed">This subscription is closed.</p>
+          }
+        }
+      } @else {
+        @if (productDetails.plan?.security === 'OAUTH2' || productDetails.plan?.security === 'JWT') {
+          @if (applicationResource.isLoading()) {
+            <app-loader />
+          } @else if (clientId()) {
+            <app-copy-code title="Client ID" i18n-title="@@apiProductSubscriptionClientId" [text]="clientId() ?? ''" />
+            @if (clientSecret()) {
+              <app-copy-code
+                title="Client Secret"
+                i18n-title="@@apiProductSubscriptionClientSecret"
+                [text]="clientSecret() ?? ''"
+                mode="PASSWORD"
+              />
+            }
+          } @else {
+            <p role="status" i18n="@@apiProductSubscriptionCredentialsUnavailable">Application credentials are not available.</p>
+          }
+        } @else {
+          @switch (productDetails.plan?.security) {
+            @case ('API_KEY') {
+              <app-api-keys-list [apiKeys]="subscription().keys ?? []" [canManageApiKey]="false" />
+            }
+            @case ('KEY_LESS') {
+              <p i18n="@@apiProductSubscriptionKeyless">No credentials are required for this plan.</p>
+            }
+            @default {
+              <p role="status" i18n="@@apiProductSubscriptionCredentialsUnavailable">Application credentials are not available.</p>
+            }
+          }
+        }
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <section class="included-apis" aria-labelledby="included-apis-title">
+    <h2 id="included-apis-title" class="next-gen-h4" i18n="@@apiProductSubscriptionIncludedApis">Included APIs</h2>
+    @if (productDetails.apis.length > 0) {
+      <div class="included-apis__grid">
+        @for (api of productDetails.apis; track api.id) {
+          <app-api-product-subscription-api-access
+            [api]="api"
+            [planSecurity]="productDetails.plan?.security"
+            [apiKey]="activeApiKey()"
+            [accessEnabled]="apiAccessEnabled()"
+          />
+        }
+      </div>
+    } @else {
+      <p i18n="@@apiProductSubscriptionNoIncludedApis">No APIs are available for this subscription.</p>
+    }
+  </section>
+} @else {
+  <div role="alert" class="message" i18n="@@apiProductSubscriptionDetailsUnavailable">
+    API Product subscription details are not available.
+  </div>
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/layout' as layout;
+@use '../../../../scss/theme' as app-theme;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$container-content-padding-horizontal;
+  width: 100%;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: minmax(140px, auto) 1fr;
+  gap: layout.$container-padding-horizontal;
+  padding-top: layout.$container-padding-horizontal;
+
+  &__label {
+    color: app-theme.$paragraph-color;
+  }
+}
+
+.credentials,
+.message {
+  padding-top: layout.$container-padding-horizontal;
+}
+
+.included-apis {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$container-padding-horizontal;
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: layout.$container-padding-horizontal;
+  }
+}
+
+@media (max-width: 600px) {
+  .details-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ApiProductSubscriptionDetailsComponent } from './api-product-subscription-details.component';
+import { ApiProductSubscriptionDetailsHarness } from './api-product-subscription-details.harness';
+import { fakeApplication } from '../../../../entities/application/application.fixture';
+import { fakeApiProductSubscriptionDetails, fakeSubscription } from '../../../../entities/subscription';
+import { ApplicationService } from '../../../../services/application.service';
+import { AppTestingModule } from '../../../../testing/app-testing.module';
+
+describe('ApiProductSubscriptionDetailsComponent', () => {
+  let fixture: ComponentFixture<ApiProductSubscriptionDetailsComponent>;
+  let applicationService: jest.Mocked<Pick<ApplicationService, 'get'>>;
+
+  beforeEach(async () => {
+    applicationService = {
+      get: jest.fn().mockReturnValue(of(fakeApplication({ name: 'My application' }))),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionDetailsComponent, AppTestingModule],
+      providers: [provideNoopAnimations(), provideRouter([]), { provide: ApplicationService, useValue: applicationService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductSubscriptionDetailsComponent);
+  });
+
+  it('should show API Product subscription summary and included APIs', async () => {
+    fixture.componentRef.setInput(
+      'subscription',
+      fakeSubscription({
+        status: 'ACCEPTED',
+        start_at: '2026-08-01T10:00:00Z',
+        end_at: '2027-08-01T10:00:00Z',
+        apiProduct: fakeApiProductSubscriptionDetails({
+          plan: { id: 'plan-id', name: 'Gold', security: 'KEY_LESS', mode: 'STANDARD' },
+        }),
+      }),
+    );
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+
+    expect(await harness.getSummaryText()).toContain('Commerce Product');
+    expect(await harness.getSummaryText()).toContain('Accepted');
+    expect(await harness.getSummaryText()).toContain('My application');
+    expect(await harness.getCredentialsText()).toContain('No credentials are required');
+    expect(await harness.getApiCount()).toBe(1);
+    expect(await harness.getApplicationLink()).toContain('/dashboard/applications/');
+  });
+
+  it('should show the subscription lifecycle state instead of credentials', async () => {
+    fixture.componentRef.setInput(
+      'subscription',
+      fakeSubscription({
+        status: 'PENDING',
+        apiProduct: fakeApiProductSubscriptionDetails(),
+      }),
+    );
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+
+    expect(await harness.getCredentialsText()).toContain('subscription request is being reviewed');
+    expect(fixture.nativeElement.querySelectorAll('app-api-product-subscription-api-access app-copy-code')).toHaveLength(0);
+  });
+
+  it.each(['CLOSED', 'REJECTED'] as const)('should not show KEY_LESS access for a %s subscription', async status => {
+    fixture.componentRef.setInput(
+      'subscription',
+      fakeSubscription({
+        status,
+        apiProduct: fakeApiProductSubscriptionDetails({
+          plan: { id: 'plan-id', name: 'Keyless', security: 'KEY_LESS', mode: 'STANDARD' },
+        }),
+      }),
+    );
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+
+    expect(await harness.getCredentialsText()).toContain(
+      status === 'CLOSED' ? 'subscription is closed' : 'subscription request was rejected',
+    );
+    expect(fixture.nativeElement.textContent).toContain('API access is not available for the current subscription status');
+    expect(fixture.nativeElement.querySelectorAll('app-api-product-subscription-api-access app-copy-code')).toHaveLength(0);
+  });
+
+  it('should show OAuth2 application credentials once', async () => {
+    fixture.componentRef.setInput(
+      'subscription',
+      fakeSubscription({
+        status: 'ACCEPTED',
+        apiProduct: fakeApiProductSubscriptionDetails({
+          plan: { id: 'plan-id', name: 'OAuth', security: 'OAUTH2', mode: 'STANDARD' },
+        }),
+      }),
+    );
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+
+    expect(await harness.getCredentialsText()).toContain('Client ID');
+    expect(await harness.getCredentialsText()).toContain('Client Secret');
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="product-subscription-credentials"] app-copy-code')).toHaveLength(2);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DatePipe } from '@angular/common';
+import { Component, computed, inject, input } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
+
+import { ApiProductSubscriptionApiAccessComponent } from './api-product-subscription-api-access/api-product-subscription-api-access.component';
+import { ApiKeysListComponent } from '../../../../components/api-access/api-keys-list/api-keys-list.component';
+import { CopyCodeComponent } from '../../../../components/copy-code/copy-code.component';
+import { LoaderComponent } from '../../../../components/loader/loader.component';
+import { getPlanSecurityTypeLabel } from '../../../../entities/plan/plan';
+import { isActiveApiKey, Subscription } from '../../../../entities/subscription/subscription';
+import { CapitalizeFirstPipe } from '../../../../pipe/capitalize-first.pipe';
+import { ToPeriodTimeUnitLabelPipe } from '../../../../pipe/time-unit.pipe';
+import { ApplicationService } from '../../../../services/application.service';
+
+@Component({
+  selector: 'app-api-product-subscription-details',
+  imports: [
+    ApiKeysListComponent,
+    ApiProductSubscriptionApiAccessComponent,
+    CapitalizeFirstPipe,
+    CopyCodeComponent,
+    DatePipe,
+    LoaderComponent,
+    MatCardModule,
+    RouterLink,
+    ToPeriodTimeUnitLabelPipe,
+  ],
+  templateUrl: './api-product-subscription-details.component.html',
+  styleUrl: './api-product-subscription-details.component.scss',
+})
+export class ApiProductSubscriptionDetailsComponent {
+  private readonly applicationService = inject(ApplicationService);
+
+  readonly subscription = input.required<Subscription>();
+
+  protected readonly product = computed(() => this.subscription().apiProduct);
+  protected readonly plan = computed(() => this.product()?.plan);
+  protected readonly planSecurityLabel = computed(() => getPlanSecurityTypeLabel(this.plan()?.security));
+  protected readonly apiAccessEnabled = computed(() => {
+    const status = this.subscription().status;
+    return status === 'ACCEPTED' || (this.plan()?.security === 'KEY_LESS' && status !== 'CLOSED' && status !== 'REJECTED');
+  });
+  protected readonly activeApiKey = computed(() => this.subscription().keys?.find(apiKey => isActiveApiKey(apiKey))?.key);
+  protected readonly applicationResource = rxResource({
+    params: () => this.subscription().application,
+    stream: ({ params }) => this.applicationService.get(params),
+  });
+  protected readonly clientId = computed(
+    () => this.applicationResource.value()?.settings.oauth?.client_id ?? this.applicationResource.value()?.settings.app?.client_id,
+  );
+  protected readonly clientSecret = computed(() => this.applicationResource.value()?.settings.oauth?.client_secret);
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
+  static hostSelector = 'app-api-product-subscription-details';
+
+  private readonly summary = this.locatorFor('[data-testid="product-subscription-summary"]');
+  private readonly credentials = this.locatorFor('[data-testid="product-subscription-credentials"]');
+  private readonly apiCards = this.locatorForAll('app-api-product-subscription-api-access');
+  private readonly applicationLink = this.locatorForOptional('a[href*="/dashboard/applications/"]');
+
+  async getSummaryText(): Promise<string> {
+    return (await this.summary()).text();
+  }
+
+  async getCredentialsText(): Promise<string> {
+    return (await this.credentials()).text();
+  }
+
+  async getApiCount(): Promise<number> {
+    return (await this.apiCards()).length;
+  }
+
+  async getApplicationLink(): Promise<string | null> {
+    return (await this.applicationLink())?.getAttribute('href') ?? null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
@@ -15,6 +15,20 @@
     limitations under the License.
 
 -->
-@if (apiId.value(); as _apiId) {
-  <app-subscriptions-details [apiId]="_apiId" [subscriptionId]="subscriptionId()" />
+@if (subscriptionResource.isLoading()) {
+  <app-loader />
+} @else if (subscriptionResource.error()) {
+  <div role="alert" class="subscription-details__error" i18n="@@subscriptionDetailsLoadError">
+    An error occurred while loading the subscription. Try again later.
+  </div>
+} @else if (subscriptionResource.value(); as subscription) {
+  @if (subscription.reference_type === 'API_PRODUCT') {
+    <app-api-product-subscription-details [subscription]="subscription" />
+  } @else if (apiId(); as resolvedApiId) {
+    <app-subscriptions-details [apiId]="resolvedApiId" [subscriptionId]="subscriptionId()" />
+  } @else {
+    <div role="alert" class="subscription-details__error" i18n="@@subscriptionDetailsTargetUnavailable">
+      Subscription details are not available.
+    </div>
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
@@ -17,10 +17,12 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
+import { ApiProductSubscriptionDetailsComponent } from './api-product-subscription-details/api-product-subscription-details.component';
 import SubscriptionDetailsComponent from './subscription-details.component';
 import { SubscriptionDetailsHarness } from './subscription-details.harness';
+import { fakeApiProductSubscriptionDetails, fakeSubscription } from '../../../entities/subscription';
 import { Subscription } from '../../../entities/subscription/subscription';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
@@ -38,6 +40,15 @@ class MockSubscriptionsDetailsComponent {
   @Input() subscriptionId!: string;
 }
 
+@Component({
+  selector: 'app-api-product-subscription-details',
+  template: '',
+  providers: [{ provide: ApiProductSubscriptionDetailsComponent, useExisting: MockApiProductSubscriptionDetailsComponent }],
+})
+class MockApiProductSubscriptionDetailsComponent {
+  @Input() subscription!: Subscription;
+}
+
 describe('SubscriptionDetailsComponent', () => {
   let fixture: ComponentFixture<SubscriptionDetailsComponent>;
   let subscriptionServiceMock: Partial<SubscriptionService>;
@@ -52,8 +63,8 @@ describe('SubscriptionDetailsComponent', () => {
       providers: [{ provide: SubscriptionService, useValue: subscriptionServiceMock }, provideHttpClient()],
     })
       .overrideComponent(SubscriptionDetailsComponent, {
-        remove: { imports: [SubscriptionsDetailsComponent] },
-        add: { imports: [MockSubscriptionsDetailsComponent] },
+        remove: { imports: [ApiProductSubscriptionDetailsComponent, SubscriptionsDetailsComponent] },
+        add: { imports: [MockApiProductSubscriptionDetailsComponent, MockSubscriptionsDetailsComponent] },
       })
       .compileComponents();
 
@@ -64,6 +75,42 @@ describe('SubscriptionDetailsComponent', () => {
   it('should show subscriptions details when apiId is retrieved', async () => {
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
     expect(await harness.hasSubscriptionsDetails()).toBeTruthy();
+  });
+
+  it('should show API Product subscription details for an API Product reference', async () => {
+    jest.mocked(subscriptionServiceMock.get!).mockReturnValue(
+      of(
+        fakeSubscription({
+          api: undefined,
+          reference_id: 'api-product-id',
+          reference_type: 'API_PRODUCT',
+          apiProduct: fakeApiProductSubscriptionDetails({ id: 'api-product-id' }),
+        }),
+      ),
+    );
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
+
+    expect(await harness.hasApiProductSubscriptionDetails()).toBeTruthy();
+    expect(await harness.hasSubscriptionsDetails()).toBeFalsy();
+  });
+
+  it('should use the API reference ID when the legacy api field is absent', async () => {
+    jest
+      .mocked(subscriptionServiceMock.get!)
+      .mockReturnValue(of(fakeSubscription({ api: undefined, reference_id: 'referenced-api-id', reference_type: 'API' })));
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
+
+    expect(await harness.hasSubscriptionsDetails()).toBeTruthy();
+  });
+
+  it('should show an error when the subscription cannot be loaded', async () => {
+    jest.mocked(subscriptionServiceMock.get!).mockReturnValue(throwError(() => new Error('load error')));
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
+
+    expect(await harness.getErrorText()).toContain('An error occurred while loading the subscription');
   });
 
   it('should set breadcrumbs for subscription details', () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, effect, inject, input } from '@angular/core';
+import { Component, computed, effect, inject, input } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
 
+import { ApiProductSubscriptionDetailsComponent } from './api-product-subscription-details/api-product-subscription-details.component';
+import { LoaderComponent } from '../../../components/loader/loader.component';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
 import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
@@ -24,17 +25,23 @@ import { subscriptionListBreadcrumb } from '../subscriptions/subscription-breadc
 
 @Component({
   selector: 'app-subscription-details',
-  imports: [SubscriptionsDetailsComponent],
+  imports: [ApiProductSubscriptionDetailsComponent, LoaderComponent, SubscriptionsDetailsComponent],
   templateUrl: './subscription-details.component.html',
   styleUrl: './subscription-details.component.scss',
 })
 export default class SubscriptionDetailsComponent {
   private readonly subscriptionService = inject(SubscriptionService);
   private readonly breadcrumbService = inject(BreadcrumbService);
-  subscriptionId = input.required<string>();
-  apiId = rxResource({
+
+  readonly subscriptionId = input.required<string>();
+
+  protected readonly subscriptionResource = rxResource({
     params: this.subscriptionId,
-    stream: ({ params }) => this.subscriptionService.get(params).pipe(map(subscription => subscription.api)),
+    stream: ({ params }) => this.subscriptionService.get(params),
+  });
+  protected readonly apiId = computed(() => {
+    const subscription = this.subscriptionResource.value();
+    return subscription?.api ?? (subscription?.reference_type === 'API' ? subscription.reference_id : undefined);
   });
 
   constructor() {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.harness.ts
@@ -19,8 +19,18 @@ export class SubscriptionDetailsHarness extends ComponentHarness {
   static hostSelector = 'app-subscription-details';
 
   private getSubscriptionsDetails = this.locatorForOptional('app-subscriptions-details');
+  private getApiProductSubscriptionDetails = this.locatorForOptional('app-api-product-subscription-details');
+  private getError = this.locatorForOptional('[role="alert"]');
 
   async hasSubscriptionsDetails(): Promise<boolean> {
     return !!(await this.getSubscriptionsDetails());
+  }
+
+  async hasApiProductSubscriptionDetails(): Promise<boolean> {
+    return !!(await this.getApiProductSubscriptionDetails());
+  }
+
+  async getErrorText(): Promise<string | undefined> {
+    return (await this.getError())?.text();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -24,6 +24,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { filter, tap } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
+import { formatCurlCommandLine } from './api-access.utils';
 import { ApiKeyFeedback, ApiKeysListComponent } from './api-keys-list/api-keys-list.component';
 import { NativeKafkaApiAccessComponent } from './native-kafka-api-access/native-kafka-api-access.component';
 import { ApiType } from '../../entities/api/api';
@@ -180,7 +181,14 @@ export class ApiAccessComponent {
     return selectedEntrypointUrl && entrypointUrls.includes(selectedEntrypointUrl) ? selectedEntrypointUrl : (entrypointUrls[0] ?? '');
   });
 
-  curlCmd = computed(() => this.formatCurlCommandLine(this.selectedEntrypointUrlValue(), this.planSecurityInput(), this.primaryApiKey()));
+  curlCmd = computed(() =>
+    formatCurlCommandLine(
+      this.selectedEntrypointUrlValue(),
+      this.planSecurityInput(),
+      this.configService.configuration.portal?.apikeyHeader,
+      this.primaryApiKey(),
+    ),
+  );
 
   protected revokeApiKeyRow(apiKey: SubscriptionDataKeys): void {
     const key = apiKey.key;
@@ -299,25 +307,5 @@ export class ApiAccessComponent {
           });
         },
       });
-  }
-
-  private formatCurlCommandLine(entrypointUrl: string, planSecurity: PlanSecurityEnum | undefined, apiKey?: string): string {
-    if (!entrypointUrl) {
-      return '';
-    }
-    let curlHeader = '';
-    switch (planSecurity) {
-      case 'JWT':
-      case 'OAUTH2':
-        curlHeader = '--header "Authorization: Bearer {{ ACCESS_TOKEN }}" ';
-        break;
-      case 'API_KEY':
-        if (this.configService.configuration.portal?.apikeyHeader) {
-          curlHeader = `--header "${this.configService.configuration.portal.apikeyHeader}: ${apiKey || '{{ API_KEY }}'}" `;
-        }
-        break;
-    }
-
-    return `curl ${curlHeader}${entrypointUrl}`;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.utils.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.utils.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatCurlCommandLine } from './api-access.utils';
+
+describe('formatCurlCommandLine', () => {
+  it('should return an empty command when no entrypoint is available', () => {
+    expect(formatCurlCommandLine('', 'API_KEY', 'X-Gravitee-Api-Key', 'api-key')).toBe('');
+  });
+
+  it('should format an API key command with the configured header and key', () => {
+    expect(formatCurlCommandLine('https://api.example.com', 'API_KEY', 'X-Gravitee-Api-Key', 'api-key')).toBe(
+      'curl --header "X-Gravitee-Api-Key: api-key" https://api.example.com',
+    );
+  });
+
+  it('should use an API key placeholder when no key is available', () => {
+    expect(formatCurlCommandLine('https://api.example.com', 'API_KEY', 'X-Gravitee-Api-Key')).toBe(
+      'curl --header "X-Gravitee-Api-Key: {{ API_KEY }}" https://api.example.com',
+    );
+  });
+
+  it.each(['JWT', 'OAUTH2'] as const)('should format a bearer token command for %s', planSecurity => {
+    expect(formatCurlCommandLine('https://api.example.com', planSecurity)).toBe(
+      'curl --header "Authorization: Bearer {{ ACCESS_TOKEN }}" https://api.example.com',
+    );
+  });
+
+  it('should format a headerless command for KEY_LESS', () => {
+    expect(formatCurlCommandLine('https://api.example.com', 'KEY_LESS')).toBe('curl https://api.example.com');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.utils.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.utils.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PlanSecurityEnum } from '../../entities/plan/plan';
+
+export function formatCurlCommandLine(
+  entrypointUrl: string,
+  planSecurity: PlanSecurityEnum | undefined,
+  apiKeyHeader?: string,
+  apiKey?: string,
+): string {
+  if (!entrypointUrl) {
+    return '';
+  }
+
+  let curlHeader = '';
+  switch (planSecurity) {
+    case 'JWT':
+    case 'OAUTH2':
+      curlHeader = '--header "Authorization: Bearer {{ ACCESS_TOKEN }}" ';
+      break;
+    case 'API_KEY':
+      if (apiKeyHeader) {
+        curlHeader = `--header "${apiKeyHeader}: ${apiKey || '{{ API_KEY }}'}" `;
+      }
+      break;
+  }
+
+  return `curl ${curlHeader}${entrypointUrl}`;
+}

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/configure-consumer/configure-consumer.component.spec.ts
@@ -352,7 +352,7 @@ describe('ConfigureConsumerComponent', () => {
 
   function expectSubscription(subscriptionResponse: Subscription = fakeSubscription()) {
     httpTestingController
-      .expectOne(`${TESTING_BASE_URL}/subscriptions/${SUBSCRIPTION_ID}?include=keys&include=consumerConfiguration`)
+      .expectOne(`${TESTING_BASE_URL}/subscriptions/${SUBSCRIPTION_ID}?include=keys&include=consumerConfiguration&include=apiProduct`)
       .flush(subscriptionResponse);
   }
 

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/api-product-subscription-details.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/api-product-subscription-details.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiType } from '../api/api';
+import { PlanMode, PlanSecurityEnum, PlanUsageConfiguration } from '../plan/plan';
+
+export interface ApiProductSubscriptionDetails {
+  id: string;
+  name?: string;
+  version?: string;
+  availability: ApiProductSubscriptionAvailability;
+  plan?: ApiProductSubscriptionPlan;
+  apis: ApiProductSubscriptionApi[];
+}
+
+export interface ApiProductSubscriptionPlan {
+  id: string;
+  name?: string;
+  security?: PlanSecurityEnum;
+  mode?: PlanMode;
+  usageConfiguration?: PlanUsageConfiguration;
+}
+
+export interface ApiProductSubscriptionApi {
+  id: string;
+  name?: string;
+  version?: string;
+  type?: ApiType;
+  availability: ApiProductSubscriptionApiAvailability;
+  entrypoints: string[];
+  documentation?: ApiProductSubscriptionApiDocumentation;
+}
+
+export interface ApiProductSubscriptionApiDocumentation {
+  rootId: string;
+  navigationItemId: string;
+}
+
+export type ApiProductSubscriptionAvailability = 'AVAILABLE' | 'UNAVAILABLE';
+export type ApiProductSubscriptionApiAvailability = 'AVAILABLE' | 'UNPUBLISHED' | 'UNAVAILABLE';

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './api-product-subscription-details';
 export * from './subscription-consumer-configuration';
 export * from './subscription.fixture';
 export * from './subscriptions-response';

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.fixture.ts
@@ -15,6 +15,7 @@
  */
 import { isFunction } from 'rxjs/internal/util/isFunction';
 
+import { ApiProductSubscriptionDetails } from './api-product-subscription-details';
 import { Subscription, SubscriptionConsumerStatusEnum } from './subscription';
 import { SubscriptionsResponse } from './subscriptions-response';
 
@@ -71,6 +72,46 @@ export function fakeSubscriptionResponse(
         name: 'testApplication',
       },
     },
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeApiProductSubscriptionDetails(
+  modifier?: Partial<ApiProductSubscriptionDetails> | ((baseDetails: ApiProductSubscriptionDetails) => ApiProductSubscriptionDetails),
+): ApiProductSubscriptionDetails {
+  const base: ApiProductSubscriptionDetails = {
+    id: 'f3302847-3e06-42d1-b028-473e0672d14a',
+    name: 'Commerce Product',
+    version: '1.0',
+    availability: 'AVAILABLE',
+    plan: {
+      id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
+      name: 'Gold',
+      security: 'API_KEY',
+      mode: 'STANDARD',
+    },
+    apis: [
+      {
+        id: 'c071c6e0-67d6-4a71-b1c6-e067d6fa7165',
+        name: 'Orders API',
+        version: '1.0',
+        type: 'PROXY',
+        availability: 'AVAILABLE',
+        entrypoints: ['https://api.example.com/orders'],
+        documentation: {
+          rootId: 'b23bff93-892a-425c-bbff-93892ae25c4f',
+          navigationItemId: 'd7627c9c-7afb-4cb7-a27c-9c7afbbcb761',
+        },
+      },
+    ],
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ApiProductSubscriptionDetails } from './api-product-subscription-details';
 import { SubscriptionConsumerConfiguration } from './subscription-consumer-configuration';
 
 export interface Subscription {
@@ -35,6 +36,7 @@ export interface Subscription {
   subscribed_by?: string;
   keys?: SubscriptionDataKeys[];
   consumerConfiguration?: SubscriptionConsumerConfiguration;
+  apiProduct?: ApiProductSubscriptionDetails;
 }
 
 export type SubscriptionReferenceType = 'API' | 'API_PRODUCT';

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -17,7 +17,13 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { SubscriptionService } from './subscription.service';
-import { fakeSubscriptionResponse, SubscriptionsResponse, SubscriptionStatusEnum } from '../entities/subscription';
+import {
+  fakeApiProductSubscriptionDetails,
+  fakeSubscription,
+  fakeSubscriptionResponse,
+  SubscriptionsResponse,
+  SubscriptionStatusEnum,
+} from '../entities/subscription';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('SubscriptionService', () => {
@@ -101,6 +107,25 @@ describe('SubscriptionService', () => {
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions?referenceTypes=API&referenceTypes=API_PRODUCT`);
     expect(req.request.method).toEqual('GET');
     req.flush(subscriptionResponse);
+  });
+
+  it('should return API Product subscription details', done => {
+    const subscription = fakeSubscription({
+      reference_type: 'API_PRODUCT',
+      reference_id: 'api-product-id',
+      apiProduct: fakeApiProductSubscriptionDetails({ id: 'api-product-id' }),
+    });
+
+    service.get(subscription.id).subscribe(response => {
+      expect(response.apiProduct).toEqual(subscription.apiProduct);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      `${TESTING_BASE_URL}/subscriptions/${subscription.id}?include=keys&include=consumerConfiguration&include=apiProduct`,
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(subscription);
   });
 
   it('should close subscription', done => {

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -63,7 +63,7 @@ export class SubscriptionService {
 
   get(subscriptionId: string): Observable<Subscription> {
     return this.http.get<Subscription>(
-      `${this.configService.baseURL}/subscriptions/${subscriptionId}?include=keys&include=consumerConfiguration`,
+      `${this.configService.baseURL}/subscriptions/${subscriptionId}?include=keys&include=consumerConfiguration&include=apiProduct`,
     );
   }
 


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-126

## Description

Adds the API Product subscription details view to Portal Next.

## Changes

- Reuses `/dashboard/subscriptions/:subscriptionId` for API and API Product subscriptions.
- Dispatches the details view based on the subscription reference type.
- Displays API Product, plan, application, status and subscription dates.
- Displays API keys or OAuth2/JWT application credentials once per subscription.
- Lists included APIs with their name, version, type and availability.
- Displays API-specific entrypoints, copyable cURL commands and documentation links.
- Handles unavailable products, unpublished APIs and inactive subscription statuses.
- Preserves the existing direct API subscription details flow.
- Adds frontend models, fixtures, component harnesses and focused tests.

## Dependency

This is a stacked PR based on:

`PORTAL-125-backend-expose-api-product-subscription-details`

