### PR TITLE
test(heartbeat): remove timing race in heartbeat event listener test

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListener.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.heartbeat.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.cluster.messaging.Message;
 import io.gravitee.node.api.cluster.messaging.MessageListener;
@@ -44,9 +45,10 @@ public class HeartbeatEventListener implements MessageListener<Event> {
     }
 
     /**
-     * Visible for testing: lets the test provide the executor the events are processed on, so it can wait for a
-     * submitted task to be fully completed instead of relying on timings.
+     * Lets the test provide the executor the events are processed on, so it can wait for a submitted task to be fully
+     * completed instead of relying on timings.
      */
+    @VisibleForTesting
     HeartbeatEventListener(
         final ClusterManager clusterManager,
         final EventRepository eventRepository,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListener.java
@@ -23,7 +23,6 @@ import io.gravitee.repository.management.model.Event;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,15 +30,32 @@ import lombok.extern.slf4j.Slf4j;
  * @author GraviteeSource Team
  */
 @Slf4j
-@RequiredArgsConstructor
 public class HeartbeatEventListener implements MessageListener<Event> {
 
     private final ClusterManager clusterManager;
     private final EventRepository eventRepository;
 
-    private final ExecutorService heartbeatExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "gio-heartbeat-listener"));
+    private final ExecutorService heartbeatExecutor;
 
     private final AtomicBoolean isProcessing = new AtomicBoolean(false);
+
+    public HeartbeatEventListener(final ClusterManager clusterManager, final EventRepository eventRepository) {
+        this(clusterManager, eventRepository, Executors.newSingleThreadExecutor(r -> new Thread(r, "gio-heartbeat-listener")));
+    }
+
+    /**
+     * Visible for testing: lets the test provide the executor the events are processed on, so it can wait for a
+     * submitted task to be fully completed instead of relying on timings.
+     */
+    HeartbeatEventListener(
+        final ClusterManager clusterManager,
+        final EventRepository eventRepository,
+        final ExecutorService heartbeatExecutor
+    ) {
+        this.clusterManager = clusterManager;
+        this.eventRepository = eventRepository;
+        this.heartbeatExecutor = heartbeatExecutor;
+    }
 
     @Override
     public void onMessage(Message<Event> message) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/impl/HeartbeatEventListenerTest.java
@@ -34,6 +34,8 @@ import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,18 +63,30 @@ class HeartbeatEventListenerTest {
     @Mock
     private Member member;
 
+    private ExecutorService heartbeatExecutor;
+
     private HeartbeatEventListener cut;
 
     @BeforeEach
     public void beforeEach() {
         when(member.primary()).thenReturn(true);
         when(clusterManager.self()).thenReturn(member);
-        cut = new HeartbeatEventListener(clusterManager, eventRepository);
+        heartbeatExecutor = Executors.newSingleThreadExecutor(r -> new Thread(r, "gio-heartbeat-listener"));
+        cut = new HeartbeatEventListener(clusterManager, eventRepository, heartbeatExecutor);
     }
 
     @AfterEach
     public void afterEach() {
         cut.shutdownNow();
+    }
+
+    /**
+     * The listener releases the flag guarding the processing in a finally block, once the repository call has returned.
+     * As events are processed on a single thread, waiting for an extra task submitted to that same executor guarantees
+     * the previous event has been fully processed, flag release included.
+     */
+    private void awaitEventProcessed() throws Exception {
+        heartbeatExecutor.submit(() -> {}).get(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -121,7 +135,7 @@ class HeartbeatEventListenerTest {
     }
 
     @Test
-    void should_discard_heartbeat_event_when_another_is_already_being_processed() throws InterruptedException, TechnicalException {
+    void should_discard_heartbeat_event_when_another_is_already_being_processed() throws Exception {
         when(member.primary()).thenReturn(true);
 
         // Create a latch that will block the first event processing
@@ -151,16 +165,17 @@ class HeartbeatEventListenerTest {
         secondEvent.setType(EventType.GATEWAY_STARTED);
         cut.onMessage(new Message<>("topic", secondEvent));
 
+        // Release the first event to complete
+        processingLatch.countDown();
+        awaitEventProcessed();
+
         // Verify that only the first event was processed
         verify(eventRepository, times(1)).createOrPatch(firstEvent);
         verify(eventRepository, times(1)).createOrPatch(any());
-
-        // Release the first event to complete
-        processingLatch.countDown();
     }
 
     @Test
-    void should_process_new_event_after_previous_one_completes() throws TechnicalException, InterruptedException {
+    void should_process_new_event_after_previous_one_completes() throws Exception {
         when(member.primary()).thenReturn(true);
 
         // First event
@@ -168,28 +183,16 @@ class HeartbeatEventListenerTest {
         firstEvent.setId("1");
         firstEvent.setType(EventType.GATEWAY_STARTED);
 
-        CountDownLatch firstLatch = new CountDownLatch(1);
-        when(eventRepository.createOrPatch(firstEvent)).thenAnswer(invocation -> {
-            firstLatch.countDown();
-            return null;
-        });
-
         cut.onMessage(new Message<>("topic", firstEvent));
-        assertThat(firstLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitEventProcessed();
 
-        // Second event - should be processed after first completes
+        // Second event - should be processed as the first one is completed
         Event secondEvent = new Event();
         secondEvent.setId("2");
         secondEvent.setType(EventType.GATEWAY_STARTED);
 
-        CountDownLatch secondLatch = new CountDownLatch(1);
-        when(eventRepository.createOrPatch(secondEvent)).thenAnswer(invocation -> {
-            secondLatch.countDown();
-            return null;
-        });
-
         cut.onMessage(new Message<>("topic", secondEvent));
-        assertThat(secondLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        awaitEventProcessed();
 
         // Verify both events were processed
         verify(eventRepository).createOrPatch(firstEvent);
@@ -198,7 +201,7 @@ class HeartbeatEventListenerTest {
     }
 
     @Test
-    void should_discard_multiple_events_when_one_is_being_processed() throws InterruptedException, TechnicalException {
+    void should_discard_multiple_events_when_one_is_being_processed() throws Exception {
         when(member.primary()).thenReturn(true);
 
         // Create a latch that will block the first event processing
@@ -238,11 +241,12 @@ class HeartbeatEventListenerTest {
         fourthEvent.setType(EventType.GATEWAY_STARTED);
         cut.onMessage(new Message<>("topic", fourthEvent));
 
+        // Release the first event to complete
+        processingLatch.countDown();
+        awaitEventProcessed();
+
         // Verify that only the first event was processed
         verify(eventRepository, times(1)).createOrPatch(firstEvent);
         verify(eventRepository, times(1)).createOrPatch(any());
-
-        // Release the first event to complete
-        processingLatch.countDown();
     }
 }


### PR DESCRIPTION
## Issue

N/A - no JIRA ticket opened for this one. Spotted on a CI run of `Test gateway`:
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/92469/workflows/cc04e7b6-ead9-473d-9eca-d8944598f953/jobs/2004953/tests

## Description

`HeartbeatEventListenerTest.should_process_new_event_after_previous_one_completes` is flaky. The listener
releases its `isProcessing` flag in a `finally` block, once `createOrPatch` has returned, while the test used
to wake up on a `CountDownLatch` counted down from inside the `createOrPatch` mock. The main thread could
therefore post the second event before the worker had reached the `finally`: the event was discarded, the
second latch was never counted down, and the test failed after its 5s timeout.

Instead of retrying or sleeping, the test is now given a real synchronization point: the executor becomes
injectable, and since it is single-threaded, an extra task submitted behind an event is only run once that
event has been fully processed, flag release included. The public constructor keeps the exact same behaviour.

While in there, the two `discard` tests were doing their `verify` while the worker was still blocked, so they
would have passed even if the extra events had been accepted and queued. They now assert after the blocked
event has been released and the queue drained.

## Additional context

Failure as seen in CI - the discard of the second event and the 5s timeout are one and the same test:

```
07:56:44.899 [main] WARN HeartbeatEventListener -- Discarding heartbeat event id[2] type[GATEWAY_STARTED] - another heartbeat event is already being processed
[ERROR] should_process_new_event_after_previous_one_completes -- Time elapsed: 5.045 s <<< FAILURE!
Expecting value to be true but was false        (HeartbeatEventListenerTest.java:192)
```

Race made reproducible by delaying the flag release by 100ms (unfavourable scheduling, as on a loaded CI
machine): the previous test then fails exactly as in CI, while the new one stays green. Module suite green
locally (13 tests).

The test file is identical on `4.9.x`, `4.10.x`, `4.11.x`, `4.12.x` and `master`, hence the apply-on labels.
The cherry-pick to `4.11.x` will conflict on a single line, the log annotation (`@Slf4j` here, `@CustomLog`
from 4.11.x on) sitting right above the constructor.
