### PR TITLE
ci(sonar): make the analysis read the test sources, and give it time to finish

### DIFF
--- a/.circleci/ci/src/circleci-config/commands.ts
+++ b/.circleci/ci/src/circleci-config/commands.ts
@@ -30,6 +30,7 @@ export interface RunParameters {
   working_directory?: string;
   environment?: Record<string, string>;
   when?: When;
+  no_output_timeout?: string;
 }
 
 /** A `run` step. */

--- a/.circleci/ci/src/circleci-config/tests/commands.spec.ts
+++ b/.circleci/ci/src/circleci-config/tests/commands.spec.ts
@@ -22,7 +22,7 @@ describe('Run', () => {
     });
   });
 
-  it('emits environment, working_directory and when when provided', () => {
+  it('emits environment, working_directory, when and no_output_timeout when provided', () => {
     expect(
       new Run({
         name: 'Run',
@@ -30,6 +30,7 @@ describe('Run', () => {
         working_directory: 'gravitee-apim-rest-api',
         environment: { BUILD_ID: '1234' },
         when: 'always',
+        no_output_timeout: '30m',
       }).generate(),
     ).toStrictEqual({
       run: {
@@ -38,6 +39,7 @@ describe('Run', () => {
         working_directory: 'gravitee-apim-rest-api',
         environment: { BUILD_ID: '1234' },
         when: 'always',
+        no_output_timeout: '30m',
       },
     });
   });

--- a/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
+++ b/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
@@ -60,6 +60,7 @@ export class SonarCloudAnalysisJob {
         name: 'Run Sonarcloud Analysis',
         command: `sonar-scanner -Dsonar.projectVersion=${apimVersion}`,
         working_directory: '<< parameters.working_directory >>',
+        no_output_timeout: '30m',
       }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new commands.cache.Save({

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -240,6 +240,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -296,6 +296,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -298,6 +298,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -298,6 +298,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -299,6 +299,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -213,6 +213,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-next-only.yml
@@ -215,6 +215,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -216,6 +216,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -370,6 +370,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -370,6 +370,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -395,6 +395,7 @@ jobs:
           name: Run Sonarcloud Analysis
           command: sonar-scanner -Dsonar.projectVersion=4.2.0
           working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
       - cmd-notify-on-failure
       - save_cache:
           paths:

--- a/gravitee-apim-console-webui/sonar-project.properties
+++ b/gravitee-apim-console-webui/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.sources=src
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.coverage.exclusions=**/*.stories.ts,**/*.fixture.ts

--- a/gravitee-apim-console-webui/sonar-project.properties
+++ b/gravitee-apim-console-webui/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_console-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_definition
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-definition-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-definition/sonar-project.properties
+++ b/gravitee-apim-definition/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-definition-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_gateway
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.sourceEncoding=UTF-8
 sonar.cpd.exclusions=gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/**/*Builder.java
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java, **/gravitee-apim-gateway-standalone-container/src/test/**, **/*IntegrationTest.java
 
 # Coverage

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-gateway-coverage/**, **/target/**, gravitee-apim-gateway-tests-sdk/src/test/java/testcases/**
 
 # Source encoding
-sonar.language=java
 sonar.sourceEncoding=UTF-8
 
 # Duplication

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-plugin-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_plugins
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-plugin/sonar-project.properties
+++ b/gravitee-apim-plugin/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-plugin-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-portal-webui-next/sonar-project.properties
+++ b/gravitee-apim-portal-webui-next/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-apim-portal-webui-next
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 

--- a/gravitee-apim-portal-webui-next/sonar-project.properties
+++ b/gravitee-apim-portal-webui-next/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.sources=src
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.coverage.exclusions=**/*.stories.ts,**/*.fixture.ts,**/stories/**

--- a/gravitee-apim-portal-webui/sonar-project.properties
+++ b/gravitee-apim-portal-webui/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_portal-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=src
 sonar.exclusions=projects/portal-webclient-sdk/**

--- a/gravitee-apim-portal-webui/sonar-project.properties
+++ b/gravitee-apim-portal-webui/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.exclusions=projects/portal-webclient-sdk/**
 sonar.sourceEncoding=UTF-8
 
 # Coverage
-sonar.test=src
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.exclusions=gravitee-apim-reporter-coverage/**, **/target/**
 # Source encoding
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_reporter
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-reporter/sonar-project.properties
+++ b/gravitee-apim-reporter/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-reporter-coverage/**, **/target/**
 
 # Source encoding
-sonar.language=java
 
 # Test
 sonar.test=.

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -19,7 +19,7 @@ sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**, gravitee-ap
 sonar.cpd.exclusions=gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/** 
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**, gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/**, gravitee-apim-repository-test/src/test/java/io/gravitee/repository/mock/**
 
 # Source encoding
-sonar.language=java
 
 # Duplication
 sonar.cpd.exclusions=gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/** 

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_repository
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -14,7 +14,6 @@ sonar.java.binaries=**/target/**
 sonar.exclusions=gravitee-apim-rest-api-coverage/**, **/target/**, ../gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/templates/**
 
 # Source encoding
-sonar.language=java
 sonar.sourceEncoding=UTF-8
 
 # Test
@@ -24,6 +23,3 @@ sonar.test.inclusions=**/*Test.java
 # Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/jacoco.xml
 sonar.coverage.exclusions=**/pom.xml, **/src/test/**, **/model/**, **/exception/**, **/fixtures/**, **/assertions/**, **/spring/**
-
-# Libraries
-sonar.libraries=${env.HOME}/.m2/repository/org/projectlombok/lombok/**/*.jar

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -3,9 +3,6 @@ sonar.projectKey=gravitee-io_gravitee-api-management_rest-api
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
-# Disable enable summary comment
-sonar.pullrequest.github.summary_comment=false
-
 # Path to sources
 sonar.sources=.
 sonar.java.binaries=**/target/**

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.exclusions=gravitee-apim-rest-api-coverage/**, **/target/**, ../gravitee-a
 sonar.sourceEncoding=UTF-8
 
 # Test
-sonar.test=.
+sonar.tests=.
 sonar.test.inclusions=**/*Test.java
 
 # Coverage


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-300

## Description

Forward port of #19229 to `master`. Same four commits, one per observable effect:

1. **`no_output_timeout: 30m` on the analysis job.** The Sonar jobs inherit CircleCI's 10-minute default, which counts silence rather than total duration — the same rest-api analysis passed at 985 s and was killed at 687 s.
2. **Removal of `sonar.language` and `sonar.libraries`**, dropped from SonarQube years ago and silently ignored.
3. **`sonar.test` → `sonar.tests`.** Written in the singular since November 2021, therefore ignored: no test directory was declared, and since `sonar.test.inclusions` excludes those same files from the sources, test code was analysed from neither side.
4. **Removal of `sonar.pullrequest.github.summary_comment`.** That setting lives server-side — SonarCloud decorates pull requests from its own configuration and never reads the repository file. It read `false` in all nine files while the `reporter` project, whose server value had stayed at the inherited `true`, kept commenting on every pull request it touched.

The first commit had to be rewritten rather than cherry-picked: the SDK import differs on `master`, and the pull-request fixtures have diverged with the workflow refactoring. The three others applied cleanly, and the resulting diff on the nine `sonar-project.properties` is identical to #19229.

## Additional context

**Measured on #19229**, which ran green twice on `4.12.x`:

| | before | after |
| --- | --- | --- |
| rest-api, java files parsed | 4,109 | **5,514** (+34%) |
| gateway, files indexed | 1,157 | **1,790** (+55%) |
| rest-api job | 377 s (90-day median) | 319 s |
| gateway job | 155 s (90-day median) | 149 s |

No analysis slowed down, and none of the nine projects hit the `File can't be indexed twice` error that the overlap between `sonar.sources=.` and `sonar.tests=.` could have caused. The `no_output_timeout` did not have to fire; it stays because that job's 90-day maximum is 1,901 s.

**Why this matters for #19176.** That pull request carries the compiled classes into the test job, which makes the `sonar.java.binaries` glob match for the first time and turns a syntactic analysis into a semantic one — `JavaSensor` goes from 197 s to over 634 s. Without the `no_output_timeout`, merging it would make the rest-api Sonar job a coin flip on every run. This pull request should land first.

**One thing the fixtures show.** Regenerating them here touches 11 files, against 13 on `4.12.x`. The two that do not move are `pull-requests-master.yml` and `pull-requests-4-1-x.yml` — and the first no longer contains a single occurrence of "Sonar". A push on `master` has not run any analysis since 14 August, which is why pull requests targeting it have no new-code baseline and the server-side cache finds nothing to reuse. Restoring that is the next piece of BX-300, and the nightly workflow already carries `Setup` and `Build backend`, so it can host the analyses without a rebuild.

Bytecode is out of scope here, and the front-end lcov repair is a separate lot.
