### PR TITLE
Revert "fix: bump gravitee-policy-ratelimit to 5.0.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,9 +219,9 @@
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
-        <!--    <gravitee-policy-quota.version>5.0.2</gravitee-policy-quota.version>    -->
-        <!--    <gravitee-policy-spikearrest.version>5.0.2</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>5.0.2</gravitee-policy-ratelimit.version>
+        <!--    <gravitee-policy-quota.version>4.3.0</gravitee-policy-quota.version>    -->
+        <!--    <gravitee-policy-spikearrest.version>4.3.0</gravitee-policy-spikearrest.version>    -->
+        <gravitee-policy-ratelimit.version>4.3.0</gravitee-policy-ratelimit.version>
         <gravitee-policy-regex-threat-protection.version>1.6.0</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.1</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.15.1</gravitee-policy-request-validation.version>


### PR DESCRIPTION
Reverts gravitee-io/gravitee-api-management#19192