### PR TITLE
test(rest-api): clear the security context between test classes too

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/testing/GraviteeContextCleanupExtension.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/testing/GraviteeContextCleanupExtension.java
@@ -18,16 +18,23 @@ package io.gravitee.rest.api.service.testing;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 // Auto-registered via META-INF/services/org.junit.jupiter.api.extension.Extension
 // together with junit-platform.properties enabling autodetection. Guards against
 // ThreadLocal pollution leaking from one test class to the next when forks share
 // a JVM (forkCount>1, reuseForks=true). Cleanup happens after the entire class
 // so @BeforeAll setups inside a class keep working.
+//
+// SecurityContextHolder is the second such ThreadLocal: AbstractService reads the
+// caller's roles from it, so a class that leaves an authentication behind decides
+// which branch the next class takes. Whether it is authenticated is not something
+// a test should inherit from whoever ran before it.
 public class GraviteeContextCleanupExtension implements AfterAllCallback {
 
     @Override
     public void afterAll(ExtensionContext context) {
         GraviteeContext.cleanContext();
+        SecurityContextHolder.clearContext();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-294

## Description

`UserServiceResetPasswordTargetTest.should_reset_password_with_gamma_target_and_build_registration_url` fails intermittently in the `Test rest-api` job on master with a `NullPointerException` on `permissionService`, which the test never injects.

The test covers the unauthenticated reset path. `UserServiceImpl.doResetPassword` only calls `canResetPassword` — and therefore `permissionService` — when `isAuthenticated()` is true, and `isAuthenticated()` reads `SecurityContextHolder`, a plain `ThreadLocal`. The test sets no security context of its own, so what it exercises is decided by whichever class ran before it in the same Surefire fork. With `forkCount=2` and `reuseForks=true`, that neighbour changes from run to run.

This is a cherry-pick of `01f56514ae` from #19176, where the same failure was hit while changing how classes are distributed across forks. The fix clears `SecurityContextHolder` in the JUnit extension that already clears `GraviteeContext` after each test class, so the whole family is covered rather than this one test.

The rest of #19176 is a larger performance change, still in conflict with master. Landing the isolation fix on its own stops the flake now.

## Additional context

Measured on the rest-api service module, JDK 25:

- With an authenticated, non-admin context in place when the test runs, it fails with exactly the NPE reported by CI. With an admin context, it fails differently — `UnnecessaryStubbingException`, because `canResetPassword` returning true makes the audit-throttle branch, and its `auditService.search` stub, unreachable. The test only passes on a clean context, which confirms the unauthenticated path is the one it means to cover.
- A probe class placed after a class that leaves an authentication behind sees that authentication without this change, and `null` with it.
- Full module suite: 9332 tests, no failure attributable to this change. Clearing the context between classes breaks nothing that was relying on inheriting one.

Master only, on purpose. 4.11.x and earlier do not have the extension at all — it arrived with the module's Surefire parallelisation, which never reached them.

4.12.x does have it, and the same disorder around it: 32 test classes set a security context, 8 never clear it. It was checked rather than assumed. Running the module suite there three ways — untouched, with this change, and with the extension inverted so that every class hands the next one an authenticated non-admin context — gives 8805 tests and no failure in all three. Nothing on that branch reads the ThreadLocal in a way that decides an outcome, so the change would be a no-op there and is not worth a commit on a maintenance branch.

