### PR TITLE
fix(console): default Period to last 5 minutes instead of none

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.harness.ts
@@ -115,6 +115,10 @@ export class ApiRuntimeLogsHarness extends ComponentHarness {
       .then(btn => btn.click());
   }
 
+  async getMoreFiltersForm() {
+    return this.moreFiltersHarness().then(moreFilters => moreFilters.getFormOptional());
+  }
+
   async selectPeriodFromMoreFilters() {
     return this.moreFiltersHarness().then(quickFilters => quickFilters.getPeriodSelectInput());
   }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -54,6 +54,8 @@ type ComponentInitData = {
   plans?: PlanV4[] | undefined;
   areLogsEnabled?: boolean;
   apiModifier?: Partial<ApiV4>;
+  from?: number;
+  to?: number;
 };
 
 const ENTRYPOINT_LIST: ConnectorPlugin[] = [
@@ -92,6 +94,12 @@ describe('ApiRuntimeLogsComponent', () => {
   const fromDateTime = new Date(fromDate).getTime();
   const toDate = '2023-10-24 15:21:00';
   const toDateTime = new Date(toDate).getTime();
+  const FAKE_NOW_MS = new Date('2023-10-05T00:00:00.000Z').getTime();
+  const DEFAULT_FROM_MS = FAKE_NOW_MS - 5 * 60 * 1000;
+  const DEFAULT_LOGS_TIME = { from: DEFAULT_FROM_MS, to: FAKE_NOW_MS };
+  const DEFAULT_QUERY_TIME = { period: '-5m', ...DEFAULT_LOGS_TIME };
+  let dateNowSpy: jest.SpyInstance;
+  let momentNowSpy: jest.SpyInstance;
 
   const initComponent = async () => {
     TestBed.configureTestingModule({
@@ -120,23 +128,64 @@ describe('ApiRuntimeLogsComponent', () => {
     fixture.detectChanges();
   };
 
-  const initComponentWithLogs = async ({ hasLogs, total, perPage, plans, apiModifier, areLogsEnabled = true }: ComponentInitData) => {
+  const initComponentWithLogs = async ({
+    hasLogs,
+    total,
+    perPage,
+    plans,
+    apiModifier,
+    areLogsEnabled = true,
+    from,
+    to,
+  }: ComponentInitData) => {
     await initComponent();
     expectPlanList(plans);
     expectEntrypointListGet();
-    hasLogs ? expectApiWithLogs(total) : expectApiWithNoLog();
+    hasLogs
+      ? expectApiWithLogs(total, {
+          page: 1,
+          perPage: perPage ?? 10,
+          from: from ?? DEFAULT_FROM_MS,
+          to: to ?? FAKE_NOW_MS,
+          expectErrorKeys: true,
+        })
+      : expectApiWithNoLog();
     areLogsEnabled ? expectApiWithLogEnabled(apiModifier) : expectApiWithLogDisabled();
-    expectRouterUrlChange(1, { page: 1, perPage: perPage ?? 10 });
+    expectRouterUrlChange(1, { page: 1, perPage: perPage ?? 10, ...DEFAULT_QUERY_TIME });
   };
+
+  beforeEach(() => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_MS);
+    momentNowSpy = jest.spyOn(moment, 'now').mockReturnValue(FAKE_NOW_MS);
+  });
 
   afterEach(() => {
     flushErrorKeys();
     httpTestingController.verify();
+    jest.restoreAllMocks();
   });
 
   function flushErrorKeys() {
     const errorKeysReqs = httpTestingController.match(req => req.url.includes('/logs/error-keys'));
     errorKeysReqs.filter(req => !req.cancelled).forEach(req => req.flush([]));
+  }
+
+  function errorKeysUrl(from?: number, to?: number): string {
+    const url = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/error-keys`;
+    const params: string[] = [];
+    if (from != null) params.push(`from=${from}`);
+    if (to != null) params.push(`to=${to}`);
+    return params.length > 0 ? `${url}?${params.join('&')}` : url;
+  }
+
+  function expectErrorKeysRequest(from?: number, to?: number, required = true) {
+    const expectedURL = errorKeysUrl(from, to);
+    const reqs = httpTestingController.match(req => req.url.includes('/logs/error-keys'));
+    if (required) {
+      expect(reqs.length).toBeGreaterThan(0);
+    }
+    reqs.forEach(req => expect(req.request.urlWithParams).toEqual(expectedURL));
+    reqs.filter(req => !req.cancelled).forEach(req => req.flush([]));
   }
 
   describe('GIVEN there are no logs', () => {
@@ -248,17 +297,21 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await paginator.getPageSize()).toBe(perPage);
         expect(await paginator.getRangeLabel()).toBe(`1 – 10 of 50`);
 
+        const laterNow = FAKE_NOW_MS + 60_000;
+        dateNowSpy.mockReturnValue(laterNow);
+        momentNowSpy.mockReturnValue(laterNow);
+
         await paginator.goToNextPage();
         tick(1000);
         expect(await paginator.getRangeLabel()).toBe(`11 – 20 of 50`);
-        expectApiWithLogs(total, { page: 2, perPage });
-        expectRouterUrlChange(2, { page: 2, perPage });
+        expectApiWithLogs(total, { page: 2, perPage, ...DEFAULT_LOGS_TIME, expectErrorKeys: false });
+        expectRouterUrlChange(2, { page: 2, perPage, ...DEFAULT_QUERY_TIME });
 
         await paginator.setPageSize(25);
         tick(1000);
         expect(await paginator.getRangeLabel()).toBe(`1 – 25 of 50`);
-        expectApiWithLogs(total, { page: 1, perPage: 25 });
-        expectRouterUrlChange(3, { page: 1, perPage: 25 });
+        expectApiWithLogs(total, { page: 1, perPage: 25, ...DEFAULT_LOGS_TIME, expectErrorKeys: false });
+        expectRouterUrlChange(3, { page: 1, perPage: 25, ...DEFAULT_QUERY_TIME });
         discardPeriodicTasks();
       }));
     });
@@ -279,19 +332,15 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await logsListHarness.countRows()).toStrictEqual(total);
         const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
         expect(await periodSelectInput.isDisabled()).toEqual(false);
-        expect(await periodSelectInput.getValueText()).toEqual('None');
+        expect(await periodSelectInput.getValueText()).toEqual('Last 5 Minutes');
       });
     });
 
     describe('when there is more than one page and we apply a period filter', () => {
-      const fakeNow = moment('2023-10-05T00:00:00.000Z');
-      const last5Min = 'Last 5 Minutes';
+      const last30Min = 'Last 30 Minutes';
 
       beforeEach(async () => {
-        await initComponentWithLogs({ hasLogs: true, total });
-
-        // moment() is relying on Date.now, so fix it to be able to assert on from and to filters
-        jest.spyOn(Date, 'now').mockReturnValue(new Date('2023-10-05T00:00:00.000Z').getTime());
+        await initComponentWithLogs({ hasLogs: true, total, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
       });
 
       it('should display the 1st page with default filter', async () => {
@@ -304,45 +353,57 @@ describe('ApiRuntimeLogsComponent', () => {
 
         const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
         expect(await periodSelectInput.isDisabled()).toEqual(false);
-        expect(await periodSelectInput.getValueText()).toEqual('None');
+        expect(await periodSelectInput.getValueText()).toEqual('Last 5 Minutes');
       });
 
-      it('should navigate filter on last 5 minutes and remove it', async () => {
+      it('should navigate filter on last 30 minutes and remove it', async () => {
         const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
         expect(await periodSelectInput.isDisabled()).toEqual(false);
-        expect(await periodSelectInput.getValueText()).toEqual('None');
-        await periodSelectInput.clickOptions({ text: last5Min });
-        expect(await periodSelectInput.getValueText()).toEqual(last5Min);
+        expect(await periodSelectInput.getValueText()).toEqual('Last 5 Minutes');
+        await periodSelectInput.clickOptions({ text: last30Min });
+        expect(await periodSelectInput.getValueText()).toEqual(last30Min);
 
-        const expectedTo = fakeNow.valueOf();
-        const expectedFrom = expectedTo - 5 * 60 * 1000;
-
-        expectApiWithLogs(total, { perPage, page: 1, from: expectedFrom, to: expectedTo });
+        expectApiWithLogs(total, { perPage, page: 1, from: FAKE_NOW_MS - 30 * 60 * 1000, to: FAKE_NOW_MS });
 
         // First time, add filters to URL
-        expectRouterUrlChange(2, { page: 1, perPage: 10, period: '-5m', from: expectedFrom, to: expectedTo });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, period: '-30m', from: FAKE_NOW_MS - 30 * 60 * 1000, to: FAKE_NOW_MS });
 
         await componentHarness.removePeriodChip();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
 
         // Second time, we removed the filter from URL
-        expectRouterUrlChange(3, { page: 1, perPage: 10 });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, period: '-5m', from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
 
         expect(await periodSelectInput.isDisabled()).toEqual(false);
-        expect(await periodSelectInput.getValueText()).toEqual('None');
+        expect(await periodSelectInput.getValueText()).toEqual('Last 5 Minutes');
         // We do not expect any chip since there is no filter
+        expect(await componentHarness.getQuickFiltersChips()).toBeNull();
+      });
+
+      it('should persist period None in the url and omit from and to', async () => {
+        const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
+        await periodSelectInput.clickOptions({ text: 'None' });
+        expect(await periodSelectInput.getValueText()).toEqual('None');
+
+        expectApiWithLogs(total, { perPage, page: 1, expectErrorKeys: true });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, period: '0' });
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: None');
+
+        await componentHarness.removePeriodChip();
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
+        expect(await periodSelectInput.getValueText()).toEqual('Last 5 Minutes');
         expect(await componentHarness.getQuickFiltersChips()).toBeNull();
       });
 
       it('should sync period filters from quick filters and more filters', async () => {
         const quickFiltersPeriod = await componentHarness.selectPeriodQuickFilter();
-        await quickFiltersPeriod.clickOptions({ text: last5Min });
-        expect(await quickFiltersPeriod.getValueText()).toEqual(last5Min);
-        expectApiWithLogs(total, { perPage, page: 1, from: fakeNow.valueOf() - 5 * 60 * 1000, to: fakeNow.valueOf() });
+        await quickFiltersPeriod.clickOptions({ text: last30Min });
+        expect(await quickFiltersPeriod.getValueText()).toEqual(last30Min);
+        expectApiWithLogs(total, { perPage, page: 1, from: FAKE_NOW_MS - 30 * 60 * 1000, to: FAKE_NOW_MS });
 
         await componentHarness.moreFiltersButtonClick();
         const moreFiltersPeriod = await componentHarness.selectPeriodFromMoreFilters();
-        expect(await moreFiltersPeriod.getValueText()).toEqual(last5Min);
+        expect(await moreFiltersPeriod.getValueText()).toEqual(last30Min);
       });
     });
 
@@ -367,8 +428,8 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.moreFiltersApply();
 
         expectApplicationList(); // call happening after selecting an option
-        expectApiWithLogs(total, { perPage, page: 1, applicationIds: application.id });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, applicationIds: application.id });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, applicationIds: application.id });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, applicationIds: application.id });
       }));
 
       it('should remove application filter', async () => {
@@ -382,13 +443,13 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.selectedApplication('a ( owner )');
         await componentHarness.moreFiltersApply();
         expectApplicationList(); // call happening after selecting an option
-        expectApiWithLogs(total, { perPage, page: 1, applicationIds: application.id });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, applicationIds: application.id });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, applicationIds: application.id });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, applicationIds: application.id });
 
         await componentHarness.removeApplicationsChip();
         expect(await componentHarness.getQuickFiltersChips()).toBeNull();
-        expectApiWithLogs(total, { perPage, page: 1 });
-        expectRouterUrlChange(3, { page: 1, perPage: 10 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getApplicationsTags()).toHaveLength(0);
@@ -405,25 +466,25 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.selectPlan(plan1.name);
         expect(await componentHarness.getSelectedPlans()).toEqual(plan1.name);
-        expectApiWithLogs(total, { perPage, page: 1, planIds: plan1.id });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, planIds: plan1.id });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, planIds: plan1.id });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, planIds: plan1.id });
 
         await componentHarness.selectPlan(plan2.name);
         expect(await componentHarness.getSelectedPlans()).toEqual(`${plan1.name}, ${plan2.name}`);
-        expectApiWithLogs(total, { perPage, page: 1, planIds: `${plan1.id},${plan2.id}` });
-        expectRouterUrlChange(3, { page: 1, perPage: 10, planIds: `${plan1.id},${plan2.id}` });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, planIds: `${plan1.id},${plan2.id}` });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, planIds: `${plan1.id},${plan2.id}` });
       }));
 
       it('should remove plan filter', async () => {
         await componentHarness.selectPlan(plan1.name);
         expect(await componentHarness.getSelectedPlans()).toEqual(plan1.name);
-        expectApiWithLogs(total, { perPage, page: 1, planIds: plan1.id });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, planIds: plan1.id });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, planIds: plan1.id });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, planIds: plan1.id });
 
         await componentHarness.removePlanChip();
         expect(await componentHarness.getQuickFiltersChips()).toBeNull();
-        expectApiWithLogs(total, { perPage, page: 1 });
-        expectRouterUrlChange(3, { page: 1, perPage: 10 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME });
       });
     });
 
@@ -437,46 +498,38 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.selectMethod('GET');
         expect(await componentHarness.getSelectedMethods()).toEqual('GET');
-        expectApiWithLogs(total, { perPage, page: 1, methods: 'GET' });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, methods: 'GET' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, methods: 'GET' });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, methods: 'GET' });
 
         await componentHarness.selectMethod('POST');
         expect(await componentHarness.getSelectedMethods()).toEqual('GET, POST');
-        expectApiWithLogs(total, { perPage, page: 1, methods: 'GET,POST' });
-        expectRouterUrlChange(3, { page: 1, perPage: 10, methods: 'GET,POST' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, methods: 'GET,POST' });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, methods: 'GET,POST' });
       });
 
       it('should remove methods filter', async () => {
         await componentHarness.selectMethod('GET');
         expect(await componentHarness.getSelectedMethods()).toEqual('GET');
-        expectApiWithLogs(total, { perPage, page: 1, methods: 'GET' });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, methods: 'GET' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, methods: 'GET' });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, methods: 'GET' });
         expect(await componentHarness.getMethodsChipText()).toStrictEqual('methods: GET');
 
         await componentHarness.removeMethodsChip();
         expect(await componentHarness.getQuickFiltersChips()).toBeNull();
-        expectApiWithLogs(total, { perPage, page: 1 });
-        expectRouterUrlChange(3, { page: 1, perPage: 10 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME });
       });
     });
 
     describe('when we click on more filters button', () => {
-      const fakeNow = moment('2023-10-25T00:00:00.000Z');
-
       beforeEach(async () => {
         await initComponentWithLogs({ hasLogs: true });
-        jest.spyOn(Date, 'now').mockReturnValue(new Date('2023-10-25T00:00:00.000Z').getTime());
       });
 
       it('should display more filters panel', async () => {
-        expect.assertions(2);
-        try {
-          await componentHarness.moreFiltersHarness();
-        } catch (e) {
-          expect(e.message).toMatch(/Failed to find element/);
-        }
+        expect(await componentHarness.getMoreFiltersForm()).toBeNull();
         await componentHarness.moreFiltersButtonClick();
-        expect(await componentHarness.moreFiltersHarness()).toBeTruthy();
+        expect(await componentHarness.getMoreFiltersForm()).toBeTruthy();
       });
 
       it('should clear all existing filters', async () => {
@@ -487,7 +540,7 @@ describe('ApiRuntimeLogsComponent', () => {
         expectApiWithLogs(total, { perPage, page: 1, from: fromDateTime });
 
         await componentHarness.moreFiltersClearAll();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getFromDate()).toStrictEqual('');
@@ -506,12 +559,13 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.moreFiltersApply();
 
         expectApiWithLogs(total, { perPage, page: 1, from: fromDateTime, to: toDateTime });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, from: fromDateTime, to: toDateTime });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, period: '0', from: fromDateTime, to: toDateTime });
         expect(await componentHarness.getFromChipText()).toEqual(`from:${fromDate}`);
         expect(await componentHarness.getToChipText()).toEqual(`to:${toDate}`);
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: None');
 
         await componentHarness.moreFiltersClearAll();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
 
         await componentHarness.moreFiltersButtonClick();
 
@@ -519,18 +573,18 @@ describe('ApiRuntimeLogsComponent', () => {
         await select.clickOptions({ text: 'Last 5 Minutes' });
         await componentHarness.moreFiltersApply();
         expect(await componentHarness.selectPeriodQuickFilter().then(select => select.getValueText())).toEqual('Last 5 Minutes');
-        expectApiWithLogs(total, { perPage, page: 1, from: fakeNow.valueOf() - 5 * 60 * 1000, to: fakeNow.valueOf() });
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
       });
 
       it('should close more filters panel without applying filter values', async () => {
         await componentHarness.moreFiltersButtonClick();
 
-        await componentHarness.selectPeriodInMoreFilters('Last 5 Minutes');
-        expect(await componentHarness.moreFiltersPeriodText()).toEqual('Last 5 Minutes');
+        await componentHarness.selectPeriodInMoreFilters('Last 30 Minutes');
+        expect(await componentHarness.moreFiltersPeriodText()).toEqual('Last 30 Minutes');
 
         await componentHarness.closeMoreFilters();
         await componentHarness.moreFiltersButtonClick();
-        expect(await componentHarness.moreFiltersPeriodText()).toEqual('None');
+        expect(await componentHarness.moreFiltersPeriodText()).toEqual('Last 5 Minutes');
       });
 
       it('should reset period when from or two is modified and vice versa', async () => {
@@ -558,16 +612,16 @@ describe('ApiRuntimeLogsComponent', () => {
       it('should reset filters when clicking on dedicated chip', async () => {
         await componentHarness.moreFiltersButtonClick();
 
-        await componentHarness.selectPeriodInMoreFilters('Last 5 Minutes');
+        await componentHarness.selectPeriodInMoreFilters('Last 30 Minutes');
         await componentHarness.moreFiltersApply();
-        expectApiWithLogs(total, { perPage, page: 1, from: fakeNow.valueOf() - 5 * 60 * 1000, to: fakeNow.valueOf() });
-        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: Last 5 Minutes');
+        expectApiWithLogs(total, { perPage, page: 1, from: FAKE_NOW_MS - 30 * 60 * 1000, to: FAKE_NOW_MS });
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: Last 30 Minutes');
 
         await componentHarness.removePeriodChip();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
 
         await componentHarness.moreFiltersButtonClick();
-        expect(await componentHarness.moreFiltersPeriodText()).toStrictEqual('None');
+        expect(await componentHarness.moreFiltersPeriodText()).toStrictEqual('Last 5 Minutes');
 
         await componentHarness.setFromDate(fromDate);
         await componentHarness.moreFiltersApply();
@@ -575,7 +629,7 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await componentHarness.getFromChipText()).toEqual(`from:${fromDate}`);
 
         await componentHarness.removeFromChip();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getFromDate()).toStrictEqual('');
@@ -586,10 +640,22 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await componentHarness.getToChipText()).toEqual(`to:${toDate}`);
 
         await componentHarness.removeToChip();
-        expectApiWithLogs(total, { perPage, page: 1 });
+        expectApiWithLogs(total, { perPage, page: 1, from: DEFAULT_FROM_MS, to: FAKE_NOW_MS });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getToDate()).toStrictEqual('');
+      });
+
+      it('should keep the remaining custom date when removing one bound', async () => {
+        await componentHarness.moreFiltersButtonClick();
+        await componentHarness.setFromDate(fromDate);
+        await componentHarness.setToDate(toDate);
+        await componentHarness.moreFiltersApply();
+        expectApiWithLogs(total, { perPage, page: 1, from: fromDateTime, to: toDateTime });
+
+        await componentHarness.removeFromChip();
+        expectApiWithLogs(total, { perPage, page: 1, to: toDateTime });
+        expect(await componentHarness.getToChipText()).toEqual(`to:${toDate}`);
       });
 
       it('should filter on http request status', async () => {
@@ -601,8 +667,8 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.moreFiltersApply();
         expect(await componentHarness.getStatusChip()).toStrictEqual('statuses: 200');
-        expectApiWithLogs(total, { perPage, page: 1, statuses: '200' });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, statuses: '200' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, statuses: '200' });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, statuses: '200' });
 
         await componentHarness.moreFiltersButtonClick();
         await componentHarness.addInputStatusesChip('202');
@@ -610,8 +676,8 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.moreFiltersApply();
         expect(await componentHarness.getStatusChip()).toStrictEqual('statuses: 200, 202');
-        expectApiWithLogs(total, { perPage, page: 1, statuses: '200,202' });
-        expectRouterUrlChange(3, { page: 1, perPage: 10, statuses: '200,202' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, statuses: '200,202' });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, statuses: '200,202' });
 
         await componentHarness.moreFiltersButtonClick();
         await componentHarness.removeInputStatusChip('200');
@@ -619,8 +685,8 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.moreFiltersApply();
         expect(await componentHarness.getStatusChip()).toStrictEqual('statuses: 202');
-        expectApiWithLogs(total, { perPage, page: 1, statuses: '202' });
-        expectRouterUrlChange(4, { page: 1, perPage: 10, statuses: '202' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, statuses: '202' });
+        expectRouterUrlChange(4, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, statuses: '202' });
       });
 
       it('should remove status filter', async () => {
@@ -628,12 +694,12 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.addInputStatusesChip('404');
         await componentHarness.moreFiltersApply();
 
-        expectApiWithLogs(total, { perPage, page: 1, statuses: '404' });
-        expectRouterUrlChange(2, { page: 1, perPage: 10, statuses: '404' });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME, statuses: '404' });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME, statuses: '404' });
 
         await componentHarness.removeStatusChip();
-        expectApiWithLogs(total, { perPage, page: 1 });
-        expectRouterUrlChange(3, { page: 1, perPage: 10 });
+        expectApiWithLogs(total, { perPage, page: 1, ...DEFAULT_LOGS_TIME });
+        expectRouterUrlChange(3, { page: 1, perPage: 10, ...DEFAULT_QUERY_TIME });
       });
     });
   });
@@ -658,7 +724,7 @@ describe('ApiRuntimeLogsComponent', () => {
         await initComponent();
         expectPlanList([plan1, plan2]);
         expectApplicationFindByIds([application, anotherApplication]);
-        expectApiWithLogs(10, { page: 1, perPage: 10, applicationIds: '1,2', planIds: '1,2' });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME, applicationIds: '1,2', planIds: '1,2' });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
       });
@@ -681,7 +747,7 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.removePlanChip();
         // removing a chip should not impact on the application chip computed from the cache
         expect(await componentHarness.getApplicationsChipText()).toStrictEqual(expectedApplicationChip);
-        expectApiWithLogs(10, { page: 1, perPage: 10, applicationIds: '1,2' });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME, applicationIds: '1,2' });
       });
 
       it("should reset all filters when clicking on 'reset filters'", async () => {
@@ -696,7 +762,7 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await componentHarness.quickFiltersHarness().then(harness => harness.clickResetFilters());
         expect(await componentHarness.getSelectedPlans()).toEqual('');
-        expectApiWithLogs(10, { page: 1, perPage: 10 });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getApplicationsTags()).toHaveLength(0);
@@ -704,10 +770,10 @@ describe('ApiRuntimeLogsComponent', () => {
         await componentHarness.setFromDate(fromDate);
         await componentHarness.setToDate(toDate);
         await componentHarness.moreFiltersApply();
-        expectApiWithLogs(10, { page: 1, perPage: 10, from: fromDateTime, to: toDateTime });
+        expectApiWithLogs(10, { page: 1, perPage: 10, from: fromDateTime, to: toDateTime, expectErrorKeys: true });
 
         await componentHarness.quickFiltersHarness().then(harness => harness.clickResetFilters());
-        expectApiWithLogs(10, { page: 1, perPage: 10 });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME });
 
         await componentHarness.moreFiltersButtonClick();
         expect(await componentHarness.getFromDate()).toStrictEqual('');
@@ -732,7 +798,7 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await initComponent();
         expectPlanList();
-        expectApiWithLogs(10, { page: 1, perPage: 10, from: fromDateTime, to: toDateTime });
+        expectApiWithLogs(10, { page: 1, perPage: 10, from: fromDateTime, to: toDateTime, expectErrorKeys: true });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
       });
@@ -743,6 +809,33 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await componentHarness.getFromChipText()).toEqual(`from:${fromDate}`);
         expect(await componentHarness.getToInputValue()).toEqual(toDate);
         expect(await componentHarness.getToChipText()).toEqual(`to:${toDate}`);
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: None');
+      });
+    });
+
+    describe('there is period None in the url', () => {
+      it('should init with None and omit from and to', async () => {
+        await TestBed.overrideProvider(ActivatedRoute, {
+          useValue: {
+            snapshot: {
+              params: { apiId: API_ID },
+              queryParams: {
+                ...queryParams,
+                period: '0',
+              },
+            },
+          },
+        }).compileComponents();
+
+        await initComponent();
+        expectPlanList();
+        expectApiWithLogs(10, { page: 1, perPage: 10, expectErrorKeys: true });
+        expectEntrypointListGet();
+        expectApiWithLogEnabled();
+
+        const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
+        expect(await periodSelectInput.getValueText()).toEqual('None');
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: None');
       });
     });
 
@@ -762,7 +855,7 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await initComponent();
         expectPlanList();
-        expectApiWithLogs(10, { page: 1, perPage: 10, methods: 'POST' });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME, methods: 'POST' });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
 
@@ -789,10 +882,10 @@ describe('ApiRuntimeLogsComponent', () => {
       });
 
       it('should init the form with filters preselected', async () => {
-        expectApiWithLogs(10, { page: 2, perPage: 10 });
+        expectApiWithLogs(10, { page: 2, perPage: 10, ...DEFAULT_LOGS_TIME });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
-        expectRouterUrlChange(1, { page: 2, perPage: 10 });
+        expectRouterUrlChange(1, { page: 2, perPage: 10, ...DEFAULT_QUERY_TIME });
       });
     });
 
@@ -812,7 +905,7 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await initComponent();
         expectPlanList();
-        expectApiWithLogs(10, { page: 1, perPage: 10, statuses: '200,202' });
+        expectApiWithLogs(10, { page: 1, perPage: 10, ...DEFAULT_LOGS_TIME, statuses: '200,202' });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
 
@@ -824,12 +917,8 @@ describe('ApiRuntimeLogsComponent', () => {
     });
 
     describe('there is a period filter in the url', () => {
-      const fakeNow = moment('2023-10-05T00:00:00.000Z');
-
-      it('should init the form with period preselected and restore it on back navigation', async () => {
-        jest.spyOn(Date, 'now').mockReturnValue(new Date('2023-10-05T00:00:00.000Z').getTime());
-
-        const expectedTo = fakeNow.valueOf();
+      it('should init the form with period preselected', async () => {
+        const expectedTo = FAKE_NOW_MS;
         const expectedFrom = expectedTo - 60 * 60 * 1000; // Last 1 Hour
 
         await TestBed.overrideProvider(ActivatedRoute, {
@@ -839,8 +928,6 @@ describe('ApiRuntimeLogsComponent', () => {
               queryParams: {
                 ...queryParams,
                 period: '-1h',
-                from: expectedFrom,
-                to: expectedTo,
               },
             },
           },
@@ -848,7 +935,7 @@ describe('ApiRuntimeLogsComponent', () => {
 
         await initComponent();
         expectPlanList();
-        expectApiWithLogs(10, { page: 1, perPage: 10, from: expectedFrom, to: expectedTo });
+        expectApiWithLogs(10, { page: 1, perPage: 10, from: expectedFrom, to: expectedTo, expectErrorKeys: true });
         expectEntrypointListGet();
         expectApiWithLogEnabled();
 
@@ -886,29 +973,34 @@ describe('ApiRuntimeLogsComponent', () => {
   function expectApiWithNoLog() {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs?page=1&perPage=10`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs?page=1&perPage=10&from=${DEFAULT_FROM_MS}&to=${FAKE_NOW_MS}`,
         method: 'GET',
       })
       .flush(fakeEmptyApiLogsResponse());
-    flushErrorKeys();
+    expectErrorKeysRequest(DEFAULT_FROM_MS, FAKE_NOW_MS);
     fixture.detectChanges();
   }
 
-  function expectApiWithLogs(total: number, param: ApiLogsParam = { perPage: 10, page: 1 }) {
-    const itemsInPage = total < param.perPage ? total : param.perPage;
-
+  function expectApiWithLogs(total: number, param: ApiLogsParam & { expectErrorKeys?: boolean } = { perPage: 10, page: 1 }) {
+    const { expectErrorKeys, ...rest } = param;
+    const page = rest.page ?? 1;
+    const perPage = rest.perPage ?? 10;
+    const itemsInPage = total < perPage ? total : perPage;
     const data: ConnectionLog[] = [];
     for (let i = 0; i < itemsInPage; i++) {
       data.push(fakeConnectionLog());
     }
 
-    let expectedURL = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs?page=${param.page ?? 1}&perPage=${param.perPage ?? 10}`;
-    if (param.from) expectedURL = expectedURL.concat(`&from=${param.from}`);
-    if (param.to) expectedURL = expectedURL.concat(`&to=${param.to}`);
-    if (param.applicationIds) expectedURL = expectedURL.concat(`&applicationIds=${param.applicationIds}`);
-    if (param.planIds) expectedURL = expectedURL.concat(`&planIds=${param.planIds}`);
-    if (param.methods) expectedURL = expectedURL.concat(`&methods=${param.methods}`);
-    if (param.statuses) expectedURL = expectedURL.concat(`&statuses=${param.statuses}`);
+    let expectedURL = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs?page=${page}&perPage=${perPage}`;
+    if (rest.from != null) expectedURL = expectedURL.concat(`&from=${rest.from}`);
+    if (rest.to != null) expectedURL = expectedURL.concat(`&to=${rest.to}`);
+    if (rest.entrypointIds) expectedURL = expectedURL.concat(`&entrypointIds=${rest.entrypointIds}`);
+    if (rest.applicationIds) expectedURL = expectedURL.concat(`&applicationIds=${rest.applicationIds}`);
+    if (rest.planIds) expectedURL = expectedURL.concat(`&planIds=${rest.planIds}`);
+    if (rest.methods) expectedURL = expectedURL.concat(`&methods=${rest.methods}`);
+    if (rest.mcpMethods) expectedURL = expectedURL.concat(`&mcpMethods=${rest.mcpMethods}`);
+    if (rest.statuses) expectedURL = expectedURL.concat(`&statuses=${rest.statuses}`);
+    if (rest.errorKeys) expectedURL = expectedURL.concat(`&errorKeys=${rest.errorKeys}`);
 
     httpTestingController
       .expectOne({
@@ -920,14 +1012,18 @@ describe('ApiRuntimeLogsComponent', () => {
           data,
           pagination: {
             totalCount: total,
-            page: param.page,
-            perPage: param.perPage,
-            pageCount: Math.ceil(total / param.perPage),
+            page,
+            perPage,
+            pageCount: Math.ceil(total / perPage),
             pageItemsCount: itemsInPage,
           },
         }),
       );
-    flushErrorKeys();
+    if (expectErrorKeys === false) {
+      expect(httpTestingController.match(req => req.url.includes('/logs/error-keys'))).toHaveLength(0);
+    } else {
+      expectErrorKeysRequest(rest.from, rest.to, expectErrorKeys === true);
+    }
     fixture.detectChanges();
   }
 
@@ -991,7 +1087,7 @@ describe('ApiRuntimeLogsComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectRouterUrlChange(nthCall: number, queryParams) {
+  function expectRouterUrlChange(nthCall: number, queryParams: Record<string, unknown> = {}) {
     expect(routerNavigateSpy).toHaveBeenNthCalledWith(nthCall, ['.'], {
       relativeTo: expect.anything(),
       queryParams: {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -22,7 +22,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import { QuickFiltersStoreService } from './services';
-import { LogFiltersInitialValues, PERIODS } from './models';
+import { LogFiltersInitialValues, PERIODS, resolveInitialLogPeriod } from './models';
 
 import { ApiLogsV2Service } from '../../../../services-ngx/api-logs-v2.service';
 import { ApiLogsParam, ApiLogsResponse, ApiType, ApiV4 } from '../../../../entities/management-api-v2';
@@ -71,6 +71,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
   apiType: Signal<ApiType> = toSignal(this.api$.pipe(map((api: ApiV4) => api.type)));
   initialValues: LogFiltersInitialValues;
   loading = true;
+  private lastSearchTimeRange: { from?: number | null; to?: number | null } | null = null;
 
   ngOnInit(): void {
     this.initData();
@@ -82,9 +83,6 @@ export class ApiRuntimeLogsComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(keys => this.errorKeysSubject$.next(keys));
-
-    const { from: initialFrom, to: initialTo } = this.quickFilterStore.toLogFilterQueryParam(this.quickFilterStore.getFilters(), 1, 10);
-    this.refetchErrorKeys$.next({ from: initialFrom ?? undefined, to: initialTo ?? undefined });
 
     this.quickFilterStore
       .filters$()
@@ -116,8 +114,12 @@ export class ApiRuntimeLogsComponent implements OnInit {
   }
 
   paginationUpdated(event: GioTableWrapperPagination) {
-    const logFilters = this.quickFilterStore.getFilters();
-    const params = this.quickFilterStore.toLogFilterQueryParam(logFilters, event.index, event.size);
+    const params = this.quickFilterStore.toLogFilterQueryParam(
+      this.quickFilterStore.getFilters(),
+      event.index,
+      event.size,
+      this.lastSearchTimeRange,
+    );
     this.searchConnectionLogs(params);
   }
 
@@ -126,6 +128,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
   }
 
   searchConnectionLogs(queryParam?: ApiLogsParam) {
+    this.lastSearchTimeRange = queryParam ? { from: queryParam.from, to: queryParam.to } : null;
     this.loading = true;
     this.apiLogsService
       .searchConnectionLogs(this.activatedRoute.snapshot.params.apiId, queryParam)
@@ -148,8 +151,8 @@ export class ApiRuntimeLogsComponent implements OnInit {
     const applicationIds: string[] = qp?.applicationIds ? qp.applicationIds.split(',') : null;
     const planIds: string[] = qp?.planIds ? qp.planIds.split(',') : null;
     const statuses: Set<number> = qp?.statuses ? new Set(qp.statuses.split(',').map(Number)) : null;
-    const period = PERIODS.find(p => p.value === qp?.period) ?? undefined;
-    const hasRelativePeriod = period && period.value !== '0';
+    const periodFromQuery = qp?.period != null ? PERIODS.find(p => p.value === String(qp.period)) : undefined;
+    const hasRelativePeriod = periodFromQuery && periodFromQuery.value !== '0';
 
     forkJoin([
       applicationIds?.length > 0 ? this.applicationService.findByIds(applicationIds, 1, applicationIds?.length ?? 10) : of(null),
@@ -157,8 +160,10 @@ export class ApiRuntimeLogsComponent implements OnInit {
     ])
       .pipe(
         map(([applications, plans]) => {
+          const from = !hasRelativePeriod && qp?.from ? moment(Number(qp.from)) : undefined;
+          const to = !hasRelativePeriod && qp?.to ? moment(Number(qp.to)) : undefined;
           return {
-            period,
+            period: resolveInitialLogPeriod(periodFromQuery, from, to),
             plans:
               planIds?.map(id => {
                 const plan = plans.find(p => p.id === id);
@@ -169,8 +174,8 @@ export class ApiRuntimeLogsComponent implements OnInit {
                 const application = applications.data.find(app => app.id === id);
                 return { value: id, label: `${application.name} ( ${application.owner?.displayName} )` };
               }) ?? undefined,
-            from: !hasRelativePeriod && qp?.from ? moment(Number(qp.from)) : undefined,
-            to: !hasRelativePeriod && qp?.to ? moment(Number(qp.to)) : undefined,
+            from,
+            to,
             methods: qp?.methods?.split(',') ?? undefined,
             mcpMethods: qp?.mcpMethods?.split(',') ?? undefined,
             statuses: statuses?.size > 0 ? statuses : undefined,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { KeyValue } from '@angular/common';
+import moment from 'moment';
+
+import { ApiRuntimeLogsQuickFiltersComponent } from './api-runtime-logs-quick-filters.component';
+
+import { DEFAULT_PERIOD, LogFilters, LogFiltersInitialValues, NONE_PERIOD, PERIODS } from '../../models';
+import { QuickFiltersStoreService } from '../../services';
+
+describe('ApiRuntimeLogsQuickFiltersComponent', () => {
+  const last30Minutes = PERIODS.find(period => period.value === '-30m');
+  const from = moment(1_000);
+  const to = moment(2_000);
+
+  function createComponent() {
+    const store = new QuickFiltersStoreService();
+    const component = new ApiRuntimeLogsQuickFiltersComponent(store);
+    component.plans = [];
+    component.initialValues = {
+      from: undefined,
+      to: undefined,
+      entrypoints: undefined,
+      methods: undefined,
+      mcpMethods: undefined,
+      statuses: undefined,
+    } as LogFiltersInitialValues;
+    component.ngOnInit();
+    return { component, store };
+  }
+
+  function chip(key: string): KeyValue<string, LogFilters> {
+    return { key, value: null };
+  }
+
+  it('should restore Last 5 Minutes and clear dates when the period chip is removed', () => {
+    const { component, store } = createComponent();
+    component.applyMoreFilters({ period: last30Minutes, from, to, statuses: null });
+
+    component.removeFilter(chip('period'));
+
+    expect(store.getFilters()).toEqual(
+      expect.objectContaining({
+        period: DEFAULT_PERIOD,
+        from: undefined,
+        to: undefined,
+      }),
+    );
+  });
+
+  it('should restore Last 5 Minutes when the last custom date chip is removed', () => {
+    const { component, store } = createComponent();
+    component.applyMoreFilters({ period: NONE_PERIOD, from, to: null, statuses: null });
+
+    component.removeFilter(chip('from'));
+
+    expect(store.getFilters()).toEqual(
+      expect.objectContaining({
+        period: DEFAULT_PERIOD,
+        from: undefined,
+        to: undefined,
+      }),
+    );
+  });
+
+  it('should keep the remaining custom date when one bound chip is removed', () => {
+    const { component, store } = createComponent();
+    component.applyMoreFilters({ period: NONE_PERIOD, from, to, statuses: null });
+
+    component.removeFilter(chip('from'));
+
+    expect(store.getFilters()).toEqual(
+      expect.objectContaining({
+        period: NONE_PERIOD,
+        from: undefined,
+        to: to.valueOf(),
+      }),
+    );
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
@@ -23,13 +23,13 @@ import { KeyValue } from '@angular/common';
 
 import {
   DEFAULT_FILTERS,
-  DEFAULT_PERIOD,
   LogFilters,
   LogFiltersForm,
   LogFiltersInitialValues,
   MoreFiltersForm,
   MultiFilter,
   PERIODS,
+  resolveInitialLogPeriod,
 } from '../../models';
 import { QuickFiltersStoreService } from '../../services';
 import { ApiType, Plan } from '../../../../../../entities/management-api-v2';
@@ -130,8 +130,9 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
   constructor(private readonly quickFilterStore: QuickFiltersStoreService) {}
 
   ngOnInit(): void {
+    const initialPeriod = resolveInitialLogPeriod(this.initialValues.period, this.initialValues.from, this.initialValues.to);
     this.moreFiltersValues = {
-      period: this.initialValues.period ?? DEFAULT_PERIOD,
+      period: initialPeriod,
       from: this.initialValues.from,
       to: this.initialValues.to,
       statuses: this.initialValues.statuses,
@@ -139,7 +140,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
       errorKeys: this.initialValues.errorKeys,
     };
     this.quickFiltersForm = new UntypedFormGroup({
-      period: new UntypedFormControl({ value: this.initialValues.period ?? DEFAULT_PERIOD, disabled: true }),
+      period: new UntypedFormControl({ value: initialPeriod, disabled: true }),
       entrypoints: new UntypedFormControl({ value: this.initialValues.entrypoints, disabled: true }),
       plans: new UntypedFormControl({
         value: this.initialValues.plans?.map(plan => plan.value) ?? DEFAULT_FILTERS.plans,
@@ -157,6 +158,20 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
   }
 
   removeFilter(removedFilter: KeyValue<string, LogFilters>) {
+    if (removedFilter.key === 'period') {
+      this.applyMoreFilters({ ...this.moreFiltersValues, period: DEFAULT_FILTERS.period, from: null, to: null });
+      return;
+    }
+
+    if (removedFilter.key === 'from' || removedFilter.key === 'to') {
+      const nextMoreFilters = { ...this.moreFiltersValues, [removedFilter.key]: null };
+      if (!nextMoreFilters.from && !nextMoreFilters.to) {
+        nextMoreFilters.period = DEFAULT_FILTERS.period;
+      }
+      this.applyMoreFilters(nextMoreFilters);
+      return;
+    }
+
     const defaultValue = DEFAULT_FILTERS[removedFilter.key];
     if (this.moreFiltersValues[removedFilter.key]) {
       this.applyMoreFilters({ ...this.moreFiltersValues, [removedFilter.key]: defaultValue });
@@ -201,7 +216,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
 
   private onQuickFiltersFormChanges() {
     this.quickFiltersForm.valueChanges.pipe(distinctUntilChanged(isEqual), takeUntil(this.unsubscribe$)).subscribe(values => {
-      if (values.period && values.period === DEFAULT_PERIOD) {
+      if (values.period && values.period.value === '0') {
         this.moreFiltersValues = { ...this.moreFiltersValues, period: values.period };
       } else {
         this.moreFiltersValues = { ...this.moreFiltersValues, period: values.period, from: null, to: null };

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/api-runtime-logs-more-filters/api-runtime-logs-more-filters.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/api-runtime-logs-more-filters/api-runtime-logs-more-filters.harness.ts
@@ -25,6 +25,7 @@ export class ApiRuntimeLogsMoreFiltersHarness extends ComponentHarness {
   public getApplyButton = this.locatorFor(MatButtonHarness.with({ text: 'Show results' }));
   public getCloseButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Close"]' }));
   public getForm = this.locatorFor(ApiRuntimeLogsMoreFiltersFormHarness);
+  public getFormOptional = this.locatorForOptional(ApiRuntimeLogsMoreFiltersFormHarness);
 
   async getPeriodSelectInput() {
     return this.getForm().then(form => form.getPeriodSelectInput());

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/api-runtime-logs-more-filters/components/api-runtime-logs-more-filters-form/api-runtime-logs-more-filters-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/api-runtime-logs-more-filters/components/api-runtime-logs-more-filters-form/api-runtime-logs-more-filters-form.component.ts
@@ -20,7 +20,7 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { Moment } from 'moment';
 import { MatChipInputEvent } from '@angular/material/chips';
 
-import { DEFAULT_FILTERS, DEFAULT_PERIOD, MoreFiltersForm, MultiFilter, PERIODS } from '../../../../../../models';
+import { DEFAULT_FILTERS, MoreFiltersForm, MultiFilter, NONE_PERIOD, PERIODS } from '../../../../../../models';
 
 @Component({
   selector: 'api-runtime-logs-more-filters-form',
@@ -85,7 +85,7 @@ export class ApiRuntimeLogsMoreFiltersFormComponent implements OnInit, OnDestroy
       .valueChanges.pipe(
         tap(from => {
           this.minDate = from;
-          this.datesForm.get('period').setValue(DEFAULT_PERIOD, { emitEvent: false, onlySelf: true });
+          this.datesForm.get('period').setValue(NONE_PERIOD, { emitEvent: false, onlySelf: true });
         }),
         takeUntil(this.unsubscribe$),
       )
@@ -94,7 +94,7 @@ export class ApiRuntimeLogsMoreFiltersFormComponent implements OnInit, OnDestroy
     this.datesForm
       .get('to')
       .valueChanges.pipe(
-        tap(() => this.datesForm.get('period').setValue(DEFAULT_PERIOD, { emitEvent: false, onlySelf: true })),
+        tap(() => this.datesForm.get('period').setValue(NONE_PERIOD, { emitEvent: false, onlySelf: true })),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => this.emitValues());

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DEFAULT_PERIOD, NONE_PERIOD, resolveInitialLogPeriod } from './api-runtime-logs-quick-filters.models';
+
+describe('resolveInitialLogPeriod', () => {
+  it('should keep an explicit period even when dates are present', () => {
+    expect(resolveInitialLogPeriod(DEFAULT_PERIOD, 1, 2)).toEqual(DEFAULT_PERIOD);
+  });
+
+  it('should use None when there is no period but dates are present', () => {
+    expect(resolveInitialLogPeriod(undefined, 1, undefined)).toEqual(NONE_PERIOD);
+    expect(resolveInitialLogPeriod(undefined, undefined, 2)).toEqual(NONE_PERIOD);
+  });
+
+  it('should use Last 5 Minutes when there is no period and no dates', () => {
+    expect(resolveInitialLogPeriod()).toEqual(DEFAULT_PERIOD);
+    expect(resolveInitialLogPeriod(undefined, undefined, undefined)).toEqual(DEFAULT_PERIOD);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
@@ -67,11 +67,22 @@ export type LogFiltersInitialValues = {
   errorKeys?: string[];
 };
 
-export const DEFAULT_PERIOD = { label: 'None', value: '0' };
+export const NONE_PERIOD = { label: 'None', value: '0' };
+export const DEFAULT_PERIOD = { label: 'Last 5 Minutes', value: '-5m' };
+
+export function resolveInitialLogPeriod(period?: SimpleFilter, from?: Moment | number | null, to?: Moment | number | null): SimpleFilter {
+  if (period) {
+    return period;
+  }
+  if (from || to) {
+    return NONE_PERIOD;
+  }
+  return DEFAULT_PERIOD;
+}
 
 export const PERIODS = [
+  NONE_PERIOD,
   DEFAULT_PERIOD,
-  { label: 'Last 5 Minutes', value: '-5m' },
   { label: 'Last 30 Minutes', value: '-30m' },
   { label: 'Last 1 Hour', value: '-1h' },
   { label: 'Last 3 Hours', value: '-3h' },

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QuickFiltersStoreService } from './quick-filters-store.service';
+
+import { DEFAULT_PERIOD, NONE_PERIOD } from '../models';
+
+describe('QuickFiltersStoreService', () => {
+  let service: QuickFiltersStoreService;
+
+  beforeEach(() => {
+    service = new QuickFiltersStoreService();
+  });
+
+  describe('toLogFilterQueryParam', () => {
+    it('should keep epoch 0 bounds instead of replacing them with the computed period', () => {
+      const queryParam = service.toLogFilterQueryParam({ period: DEFAULT_PERIOD, from: 0, to: 0 }, 1, 10);
+
+      expect(queryParam.from).toBe(0);
+      expect(queryParam.to).toBe(0);
+      expect(queryParam.period).toBe('-5m');
+    });
+
+    it('should use a frozen time range as-is', () => {
+      const queryParam = service.toLogFilterQueryParam({ period: DEFAULT_PERIOD }, 2, 25, { from: 100, to: 200 });
+
+      expect(queryParam).toEqual(
+        expect.objectContaining({
+          page: 2,
+          perPage: 25,
+          period: '-5m',
+          from: 100,
+          to: 200,
+        }),
+      );
+    });
+
+    it('should keep a frozen unbounded range unbounded', () => {
+      const queryParam = service.toLogFilterQueryParam({ period: DEFAULT_PERIOD }, 2, 10, { from: null, to: null });
+
+      expect(queryParam.from).toBeNull();
+      expect(queryParam.to).toBeNull();
+    });
+
+    it('should compute a relative period when no frozen range is provided', () => {
+      const queryParam = service.toLogFilterQueryParam({ period: DEFAULT_PERIOD }, 1, 10);
+
+      expect(queryParam.period).toBe('-5m');
+      expect(queryParam.to - queryParam.from).toBe(5 * 60 * 1000);
+    });
+
+    it('should omit dates when the period is None', () => {
+      const queryParam = service.toLogFilterQueryParam({ period: NONE_PERIOD }, 1, 10);
+
+      expect(queryParam.period).toBe('0');
+      expect(queryParam.from).toBeNull();
+      expect(queryParam.to).toBeNull();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.ts
@@ -19,7 +19,7 @@ import moment from 'moment';
 
 import DurationConstructor = moment.unitOfTime.DurationConstructor;
 
-import { DEFAULT_FILTERS, DEFAULT_PERIOD, LogFilters, SimpleFilter } from '../models';
+import { DEFAULT_FILTERS, LogFilters, SimpleFilter } from '../models';
 
 @Injectable()
 export class QuickFiltersStoreService {
@@ -37,14 +37,21 @@ export class QuickFiltersStoreService {
     this._filters$.next(values);
   }
 
-  public toLogFilterQueryParam(logFilters: LogFilters, page: number, perPage: number) {
-    const { from, to } = this.preparePeriodFilter(logFilters.period);
+  public toLogFilterQueryParam(
+    logFilters: LogFilters,
+    page: number,
+    perPage: number,
+    frozenTimeRange?: { from?: number | null; to?: number | null } | null,
+  ) {
+    const { from, to } = frozenTimeRange
+      ? { from: frozenTimeRange.from ?? null, to: frozenTimeRange.to ?? null }
+      : this.periodTimeRange(logFilters);
     return {
       page,
       perPage,
-      period: logFilters.period?.value !== DEFAULT_PERIOD.value ? logFilters.period?.value : null,
-      from: logFilters.from ? logFilters.from : from,
-      to: logFilters.to ? logFilters.to : to,
+      period: logFilters.period?.value ?? null,
+      from,
+      to,
       entrypointIds: logFilters.entrypoints?.length > 0 ? logFilters.entrypoints.join(',') : null,
       applicationIds: logFilters.applications?.length > 0 ? logFilters.applications?.map(app => app.value).join(',') : null,
       planIds: logFilters.plans?.length > 0 ? logFilters.plans?.map(plan => plan.value).join(',') : null,
@@ -55,8 +62,16 @@ export class QuickFiltersStoreService {
     };
   }
 
+  private periodTimeRange(logFilters: LogFilters): { from: number | null; to: number | null } {
+    const computed = this.preparePeriodFilter(logFilters.period);
+    return {
+      from: logFilters.from ?? computed.from,
+      to: logFilters.to ?? computed.to,
+    };
+  }
+
   private preparePeriodFilter(period: SimpleFilter): { from: number; to: number } {
-    if (period.value === '0') {
+    if (!period || period.value === '0') {
       return { from: null, to: null };
     }
     const now = moment();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-more-filters/webhook-logs-more-filters.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-more-filters/webhook-logs-more-filters.component.spec.ts
@@ -21,7 +21,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { WebhookLogsMoreFiltersComponent } from './webhook-logs-more-filters.component';
 import { WebhookLogsMoreFiltersHarness } from './webhook-logs-more-filters.harness';
 
-import { DEFAULT_PERIOD } from '../../../runtime-logs/models';
+import { NONE_PERIOD } from '../../../runtime-logs/models';
 
 describe('WebhookLogsMoreFiltersComponent', () => {
   let fixture: ComponentFixture<WebhookLogsMoreFiltersComponent>;
@@ -37,7 +37,7 @@ describe('WebhookLogsMoreFiltersComponent', () => {
     fixture = TestBed.createComponent(WebhookLogsMoreFiltersComponent);
     fixture.componentRef.setInput('showMoreFilters', true);
     fixture.componentRef.setInput('callbackUrls', callbackUrls);
-    fixture.componentRef.setInput('formValues', { period: DEFAULT_PERIOD, from: null, to: null, callbackUrls: [] });
+    fixture.componentRef.setInput('formValues', { period: NONE_PERIOD, from: null, to: null, callbackUrls: [] });
     fixture.detectChanges();
 
     harness = await TestbedHarnessEnvironment.harnessForFixture<WebhookLogsMoreFiltersHarness>(fixture, WebhookLogsMoreFiltersHarness);
@@ -53,7 +53,7 @@ describe('WebhookLogsMoreFiltersComponent', () => {
     await harness.clickApply();
 
     expect(applySpy).toHaveBeenCalledWith(
-      expect.objectContaining({ callbackUrls: [callbackUrls[0]], period: DEFAULT_PERIOD, from: null, to: null }),
+      expect.objectContaining({ callbackUrls: [callbackUrls[0]], period: NONE_PERIOD, from: null, to: null }),
     );
     expect(closeSpy).toHaveBeenCalled();
   });
@@ -66,7 +66,7 @@ describe('WebhookLogsMoreFiltersComponent', () => {
     await harness.clickClearAll();
 
     expect(applySpy).toHaveBeenCalledWith({
-      period: DEFAULT_PERIOD,
+      period: NONE_PERIOD,
       from: null,
       to: null,
       callbackUrls: [],

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-more-filters/webhook-logs-more-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-more-filters/webhook-logs-more-filters.component.ts
@@ -27,7 +27,7 @@ import { OWL_DATE_TIME_FORMATS, OwlDateTimeModule } from '@danielmoncada/angular
 import { OwlMomentDateTimeModule } from '@danielmoncada/angular-datetime-picker-moment-adapter';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
-import { DEFAULT_PERIOD, PERIODS, SimpleFilter } from '../../../runtime-logs/models';
+import { NONE_PERIOD, PERIODS, SimpleFilter } from '../../../runtime-logs/models';
 import { DATE_TIME_FORMATS } from '../../../../../../shared/utils/timeFrameRanges';
 import { WebhookMoreFiltersForm } from '../../models/webhook-logs.models';
 
@@ -55,7 +55,7 @@ export class WebhookLogsMoreFiltersComponent implements OnInit {
   @Output() closeMoreFiltersEvent = new EventEmitter<void>();
   @Output() applyMoreFiltersEvent = new EventEmitter<WebhookMoreFiltersForm>();
   showMoreFilters = input(false);
-  formValues = input<WebhookMoreFiltersForm>({ period: DEFAULT_PERIOD, from: null, to: null, callbackUrls: [] });
+  formValues = input<WebhookMoreFiltersForm>({ period: NONE_PERIOD, from: null, to: null, callbackUrls: [] });
   @Input() callbackUrls: string[] = [];
 
   form: FormGroup<{
@@ -74,7 +74,7 @@ export class WebhookLogsMoreFiltersComponent implements OnInit {
     private readonly destroyRef: DestroyRef,
   ) {
     this.form = this.fb.group({
-      period: this.fb.control<SimpleFilter | null>(DEFAULT_PERIOD),
+      period: this.fb.control<SimpleFilter | null>(NONE_PERIOD),
       from: this.fb.control<Moment | null>(null),
       to: this.fb.control<Moment | null>(null),
       callbackUrls: this.fb.control<string[]>([], { nonNullable: true }),
@@ -101,25 +101,25 @@ export class WebhookLogsMoreFiltersComponent implements OnInit {
     this.form.controls.from.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(from => {
       this.minDate = from ?? null;
       this.minDateDisplay = from ? from.toDate() : null;
-      this.form.controls.period.setValue(DEFAULT_PERIOD, { emitEvent: false, onlySelf: true });
+      this.form.controls.period.setValue(NONE_PERIOD, { emitEvent: false, onlySelf: true });
     });
 
     this.form.controls.to.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-      this.form.controls.period.setValue(DEFAULT_PERIOD, { emitEvent: false, onlySelf: true });
+      this.form.controls.period.setValue(NONE_PERIOD, { emitEvent: false, onlySelf: true });
     });
   }
 
   private updateFormFromInput(formValues: WebhookMoreFiltersForm): void {
     if (this.form) {
       const values: WebhookMoreFiltersForm = {
-        period: formValues?.period ?? DEFAULT_PERIOD,
+        period: formValues?.period ?? NONE_PERIOD,
         from: formValues?.from ?? null,
         to: formValues?.to ?? null,
         callbackUrls: formValues?.callbackUrls ?? [],
       };
       this.form.patchValue(
         {
-          period: values.period ?? DEFAULT_PERIOD,
+          period: values.period ?? NONE_PERIOD,
           from: values.from ?? null,
           to: values.to ?? null,
           callbackUrls: values.callbackUrls ?? [],
@@ -133,7 +133,7 @@ export class WebhookLogsMoreFiltersComponent implements OnInit {
   }
 
   resetMoreFilters(): void {
-    this.form.patchValue({ period: DEFAULT_PERIOD, from: null, to: null, callbackUrls: [] });
+    this.form.patchValue({ period: NONE_PERIOD, from: null, to: null, callbackUrls: [] });
     this.minDate = null;
     this.minDateDisplay = null;
     this.apply();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-quick-filters/webhook-logs-quick-filters.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-quick-filters/webhook-logs-quick-filters.component.spec.ts
@@ -22,7 +22,7 @@ import { WebhookLogsQuickFiltersComponent } from './webhook-logs-quick-filters.c
 
 import { Constants } from '../../../../../../entities/Constants';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../../shared/testing';
-import { DEFAULT_PERIOD } from '../../../runtime-logs/models';
+import { NONE_PERIOD } from '../../../runtime-logs/models';
 
 describe('WebhookLogsQuickFiltersComponent', () => {
   let fixture: ComponentFixture<WebhookLogsQuickFiltersComponent>;
@@ -73,7 +73,7 @@ describe('WebhookLogsQuickFiltersComponent', () => {
     component.quickFiltersForm.setValue({
       statuses: ['200', '500'],
       applications: ['app-1'],
-      period: DEFAULT_PERIOD,
+      period: NONE_PERIOD,
     });
 
     expect(filtersSpy).toHaveBeenCalledWith({
@@ -84,7 +84,7 @@ describe('WebhookLogsQuickFiltersComponent', () => {
 
   it('should emit active period when selection changes', () => {
     const filtersSpy = jest.spyOn(component.filtersChanged, 'emit');
-    const nonDefaultPeriod = component.periods.find(period => period.value !== DEFAULT_PERIOD.value)!;
+    const nonDefaultPeriod = component.periods.find(period => period.value !== NONE_PERIOD.value)!;
     component.quickFiltersForm.setValue({
       statuses: [],
       applications: [],
@@ -113,7 +113,7 @@ describe('WebhookLogsQuickFiltersComponent', () => {
 
     const from = moment('2025-01-01T00:00:00Z');
     const to = moment('2025-01-02T00:00:00Z');
-    component.applyMoreFilters({ period: DEFAULT_PERIOD, from, to, callbackUrls: [] });
+    component.applyMoreFilters({ period: NONE_PERIOD, from, to, callbackUrls: [] });
 
     expect(filtersSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -128,7 +128,7 @@ describe('WebhookLogsQuickFiltersComponent', () => {
     component.quickFiltersForm.setValue({
       statuses: ['200'],
       applications: ['app-1'],
-      period: DEFAULT_PERIOD,
+      period: NONE_PERIOD,
     });
     component.onApplicationCache([{ value: 'app-1', label: 'Acme App' }]);
     filtersSpy.mockClear();
@@ -141,7 +141,7 @@ describe('WebhookLogsQuickFiltersComponent', () => {
     expect(component.quickFiltersForm.value).toEqual({
       statuses: [],
       applications: [],
-      period: DEFAULT_PERIOD,
+      period: NONE_PERIOD,
     });
     expect(filtersSpy).toHaveBeenCalledWith({
       statuses: undefined,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-quick-filters/webhook-logs-quick-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-quick-filters/webhook-logs-quick-filters.component.ts
@@ -28,7 +28,7 @@ import { isEqual } from 'lodash';
 
 import { WebhookLogsApplicationsFilterComponent } from './components/webhook-logs-applications-filter/webhook-logs-applications-filter.component';
 
-import { DEFAULT_PERIOD, MultiFilter, PERIODS, SimpleFilter } from '../../../runtime-logs/models';
+import { MultiFilter, NONE_PERIOD, PERIODS, SimpleFilter } from '../../../runtime-logs/models';
 import {
   DEFAULT_WEBHOOK_LOGS_FILTERS,
   WebhookLogsQuickFilters,
@@ -47,7 +47,7 @@ type QuickFiltersFormValue = {
 const DEFAULT_FORM_VALUE: QuickFiltersFormValue = {
   statuses: [],
   applications: [],
-  period: DEFAULT_PERIOD,
+  period: NONE_PERIOD,
 };
 
 @Component({
@@ -118,7 +118,7 @@ export class WebhookLogsQuickFiltersComponent implements OnInit {
     const toValue = initialTo != null && !isNumber(initialTo) ? initialTo : null;
 
     return {
-      period: this.initialValues?.period ?? DEFAULT_PERIOD,
+      period: this.initialValues?.period ?? NONE_PERIOD,
       from: fromValue,
       to: toValue,
       callbackUrls: this.initialValues?.callbackUrls ?? [],
@@ -136,13 +136,13 @@ export class WebhookLogsQuickFiltersComponent implements OnInit {
     return new FormGroup({
       statuses: new FormControl<string[]>(initialStatuses, { nonNullable: true }),
       applications: new FormControl<string[]>(initialApplications, { nonNullable: true }),
-      period: new FormControl<SimpleFilter>(this.initialValues?.period ?? DEFAULT_PERIOD, { nonNullable: true }),
+      period: new FormControl<SimpleFilter>(this.initialValues?.period ?? NONE_PERIOD, { nonNullable: true }),
     });
   }
 
   resetAllFilters() {
     this.quickFiltersForm.reset(DEFAULT_FORM_VALUE, { emitEvent: false });
-    this.applyMoreFilters({ period: DEFAULT_PERIOD, from: null, to: null, callbackUrls: [] });
+    this.applyMoreFilters({ period: NONE_PERIOD, from: null, to: null, callbackUrls: [] });
   }
 
   openMoreFilters(): void {
@@ -171,7 +171,7 @@ export class WebhookLogsQuickFiltersComponent implements OnInit {
   }
 
   removePeriod(): void {
-    this.applyMoreFilters({ ...this.moreFiltersValues, period: DEFAULT_PERIOD });
+    this.applyMoreFilters({ ...this.moreFiltersValues, period: NONE_PERIOD });
   }
 
   removeDateRange(): void {
@@ -215,7 +215,7 @@ export class WebhookLogsQuickFiltersComponent implements OnInit {
   private onQuickFiltersFormChanges() {
     this.quickFiltersForm.valueChanges.pipe(distinctUntilChanged(isEqual), takeUntilDestroyed(this.destroyRef)).subscribe(values => {
       const formValues: QuickFiltersFormValue = values;
-      if (formValues.period && formValues.period === DEFAULT_PERIOD) {
+      if (formValues.period && formValues.period.value === '0') {
         this.moreFiltersValues = { ...this.moreFiltersValues, period: formValues.period };
       } else {
         this.moreFiltersValues = { ...this.moreFiltersValues, period: formValues.period, from: null, to: null };
@@ -247,7 +247,7 @@ export class WebhookLogsQuickFiltersComponent implements OnInit {
     return {
       statuses: statuses?.length > 0 ? statuses.map(status => Number(status)).filter(num => !Number.isNaN(num)) : undefined,
       applications: this.applicationsFromValues(applications),
-      period: period && period.value !== DEFAULT_PERIOD.value ? period : undefined,
+      period: period && period.value !== '0' ? period : undefined,
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.ts
@@ -46,7 +46,7 @@ import { ApiLogsV2Service } from '../../../../services-ngx/api-logs-v2.service';
 import { ApiSubscriptionV2Service } from '../../../../services-ngx/api-subscription-v2.service';
 import { ApplicationService } from '../../../../services-ngx/application.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
-import { DEFAULT_PERIOD, MultiFilter, PERIODS, SimpleFilter } from '../runtime-logs/models';
+import { NONE_PERIOD, MultiFilter, PERIODS, SimpleFilter } from '../runtime-logs/models';
 import { GioTableWrapperPagination } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 
 @Component({
@@ -130,7 +130,7 @@ export class WebhookLogsComponent implements OnInit {
     const initialFilters: WebhookLogsQuickFilters = {
       statuses: initialStatuses.length ? initialStatuses : undefined,
       applications: initialApplications?.length ? initialApplications : undefined,
-      period: initialPeriod.value !== DEFAULT_PERIOD.value ? initialPeriod : undefined,
+      period: initialPeriod.value !== NONE_PERIOD.value ? initialPeriod : undefined,
       from: initialFrom,
       to: initialTo,
       callbackUrls: initialCallbackUrls.length ? initialCallbackUrls : undefined,
@@ -435,11 +435,11 @@ export class WebhookLogsComponent implements OnInit {
       return undefined;
     }
     const match = this.periods.find(available => available.value === period.value);
-    return match && match.value !== DEFAULT_PERIOD.value ? match : undefined;
+    return match && match.value !== NONE_PERIOD.value ? match : undefined;
   }
 
   private preparePeriodRange(period: SimpleFilter): { from: number; to: number } | undefined {
-    if (!period || period.value === DEFAULT_PERIOD.value) {
+    if (!period || period.value === NONE_PERIOD.value) {
       return undefined;
     }
 
@@ -512,9 +512,9 @@ export class WebhookLogsComponent implements OnInit {
 
   private buildInitialPeriod(periodValue?: string): SimpleFilter {
     if (!periodValue) {
-      return DEFAULT_PERIOD;
+      return NONE_PERIOD;
     }
-    return this.periods.find(period => period.value === periodValue) ?? DEFAULT_PERIOD;
+    return this.periods.find(period => period.value === periodValue) ?? NONE_PERIOD;
   }
 
   /**


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14961

## Description
v4 API Runtime Logs defaulted Period to **None**, so Console called `GET .../apis/{apiId}/logs` with no `from`/`to`. Elasticsearch searched the full retention window and large tenants timed out (`NoStackTraceTimeoutException`).
**Runtime Logs (Console)**
- Default Period is **Last 5 Minutes** (`-5m`). First load sends a bounded `from`/`to`.
- **None** stays available. The URL stores `period=0` so refresh and shared links keep None and still omit dates (unbounded API search).
- Custom From/To still force the None sentinel so a reload does not drop the dates and recompute `-5m`.
- Clearing the period chip, or the last custom From/To chip, restores Last 5 Minutes instead of unbounded None.
- Pagination and page-size reuse the last searched `from`/`to` instead of calling `moment()` again. Refresh still recomputes “now” and resets to page 1.
- Error-keys load from the same store update as the table (no eager first call from the store seed). Bookmarked None / custom range / other periods no longer ask error-keys for 5 minutes first.
**Webhook Logs**
- Still default to **None**. `DEFAULT_PERIOD` is now Last 5 Minutes, so webhook code is retargeted to `NONE_PERIOD`. No product change on that page.

## Additional context
**Compatibility:** old Runtime Logs URLs with no `period` used to mean None (unbounded). They now mean Last 5 Minutes. Use `period=0` to keep None.
**Not affected:** Webhook Logs default, native Kafka logs, Management API contract.


https://github.com/user-attachments/assets/aad849db-a01a-4c1b-9236-f581f03ee061
