### PR TITLE
fix(users): purge IdP claims when whitelist is cleared

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
@@ -75,6 +75,11 @@ public class User {
 
     /**
      * IdP claims captured at login (whitelisted on the identity provider), for later use such as DCR injection.
+     *
+     * <p>{@code null} and an empty map are not interchangeable, and callers rely on the difference: {@code null} means
+     * no claims are stored and clears the value, while an empty map is itself a stored value. Every implementation of
+     * {@link io.gravitee.repository.management.api.UserRepository} must preserve that distinction, so a caller wanting
+     * to remove what was captured sets {@code null} rather than an empty map.
      */
     private Map<String, String> idpClaims;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1891,7 +1891,8 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     /**
      * Persists the IdP claims whitelisted on the social identity provider onto the user record, refreshing them on
-     * every login. When no whitelist is configured the feature is inactive and the user record is left untouched.
+     * every login. An absent or empty whitelist means nothing may be retained, so previously captured claims are
+     * removed instead of being left behind (APIM-14840).
      */
     private void persistWhitelistedClaims(
         List<String> whitelist,
@@ -1900,16 +1901,21 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         String accessTokenPayload,
         String idTokenPayload
     ) {
-        if (whitelist == null || whitelist.isEmpty()) {
-            return;
-        }
-        Map<String, String> idpClaims = extractWhitelistedClaims(whitelist, userInfo, accessTokenPayload, idTokenPayload);
+        // Null rather than an empty map: both backends serialize an empty map verbatim, which would leave the stored
+        // claims populated with "{}" instead of cleared.
+        Map<String, String> idpClaims = whitelist == null || whitelist.isEmpty()
+            ? null
+            : extractWhitelistedClaims(whitelist, userInfo, accessTokenPayload, idTokenPayload);
         try {
             Optional<User> optionalUser = userRepository.findById(userId);
             if (optionalUser.isPresent()) {
                 User user = optionalUser.get();
-                user.setIdpClaims(idpClaims);
-                userRepository.update(user);
+                // Every login reaches this point and most deployments configure no whitelist at all, so without this
+                // guard the common case would add a redundant write to each login.
+                if (!Objects.equals(user.getIdpClaims(), idpClaims)) {
+                    user.setIdpClaims(idpClaims);
+                    userRepository.update(user);
+                }
             }
         } catch (TechnicalException e) {
             log.warn("Unable to persist IdP claims for user {}", userId, e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1892,7 +1892,10 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     /**
      * Persists the IdP claims whitelisted on the social identity provider onto the user record, refreshing them on
      * every login. An absent or empty whitelist means nothing may be retained, so previously captured claims are
-     * removed instead of being left behind (APIM-14840).
+     * removed at the user's next login (APIM-14840).
+     *
+     * <p>Removal is therefore only as timely as that login: a user who never authenticates again keeps whatever was
+     * captured, and no bulk purge or administrative delete exists to reach them.
      */
     private void persistWhitelistedClaims(
         List<String> whitelist,
@@ -1901,24 +1904,31 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         String accessTokenPayload,
         String idTokenPayload
     ) {
-        // Null rather than an empty map: both backends serialize an empty map verbatim, which would leave the stored
-        // claims populated with "{}" instead of cleared.
+        // Null, not an empty map: User.setIdpClaims treats null as "no claims stored" and an empty map as a stored
+        // empty value, and only the former clears the column.
         Map<String, String> idpClaims = whitelist == null || whitelist.isEmpty()
             ? null
             : extractWhitelistedClaims(whitelist, userInfo, accessTokenPayload, idTokenPayload);
         try {
             Optional<User> optionalUser = userRepository.findById(userId);
-            if (optionalUser.isPresent()) {
-                User user = optionalUser.get();
-                // Every login reaches this point and most deployments configure no whitelist at all, so without this
-                // guard the common case would add a redundant write to each login.
-                if (!Objects.equals(user.getIdpClaims(), idpClaims)) {
-                    user.setIdpClaims(idpClaims);
-                    userRepository.update(user);
-                }
+            if (optionalUser.isEmpty()) {
+                // The user was created or refreshed a few statements ago, so this means concurrent deletion or replica
+                // lag. On a retention path a silent skip would leave no trace that the purge was even attempted.
+                log.warn("Cannot apply the IdP claims whitelist: user {} was not found", userId);
+                return;
+            }
+
+            User user = optionalUser.get();
+            // Every login reaches this point and most deployments configure no whitelist at all, so without this
+            // guard the common case would add a redundant write to each login.
+            if (!Objects.equals(user.getIdpClaims(), idpClaims)) {
+                user.setIdpClaims(idpClaims);
+                userRepository.update(user);
             }
         } catch (TechnicalException e) {
-            log.warn("Unable to persist IdP claims for user {}", userId, e);
+            // Deliberately not rethrown: a claims failure must not fail the login. Logged as a retention failure rather
+            // than a persistence one, because when the whitelist was cleared the claims are still stored.
+            log.error("Unable to apply the IdP claims whitelist for user {}; previously stored claims may remain", userId, e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1813,14 +1813,35 @@ public class UserServiceTest {
     }
 
     @Test
-    public void shouldNotPersistClaimsWhenNoWhitelistConfigured() throws IOException, TechnicalException {
+    public void shouldPurgePersistedClaimsWhenWhitelistCleared() throws IOException, TechnicalException {
         reset(identityProvider, userRepository);
         mockDefaultEnvironment();
 
         User user = mockUser();
-        // Pre-set a sentinel so the assertion actually pins the no-op: if the whitelist guard were removed, the code
-        // would overwrite this with an empty map. mockUser() leaves idpClaims null, which would make assertNull vacuous.
-        user.setIdpClaims(Map.of("pre_existing", "value"));
+        user.setIdpClaims(Map.of("org_id", "org-42"));
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.emptyList());
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        // Nothing whitelisted means nothing retained, so an administrator who clears the whitelist to stop capturing a
+        // sensitive claim also gets the already-captured value removed (APIM-14840)
+        assertNull(user.getIdpClaims());
+    }
+
+    @Test
+    public void shouldPurgePersistedClaimsWhenWhitelistNotConfigured() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        user.setIdpClaims(Map.of("org_id", "org-42"));
         when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
@@ -1831,8 +1852,28 @@ public class UserServiceTest {
 
         userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
 
-        // No whitelist configured → the persistence path is a no-op and leaves the existing claims untouched
-        assertEquals(Map.of("pre_existing", "value"), user.getIdpClaims());
+        assertNull(user.getIdpClaims());
+    }
+
+    @Test
+    public void shouldNotUpdateUserWhenThereAreNoClaimsToPurge() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        // The common case is no whitelist and no stored claims: purging must not cost an extra write on every login,
+        // so the only update is the one the profile refresh already performs
+        verify(userRepository, times(1)).update(any(User.class));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -1833,6 +1833,9 @@ public class UserServiceTest {
         // Nothing whitelisted means nothing retained, so an administrator who clears the whitelist to stop capturing a
         // sensitive claim also gets the already-captured value removed (APIM-14840)
         assertNull(user.getIdpClaims());
+        // Production mutates the instance the findById stub returns, so asserting on it only proves the setter ran.
+        // The second write is what proves the cleared value reached the repository: one from the profile refresh, one here.
+        verify(userRepository, times(2)).update(any(User.class));
     }
 
     @Test
@@ -1845,6 +1848,8 @@ public class UserServiceTest {
         when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        // Stubbed explicitly: an unstubbed List-returning mock yields an empty list, which is the other branch
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(null);
 
         String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
         String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
@@ -1853,6 +1858,81 @@ public class UserServiceTest {
         userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
 
         assertNull(user.getIdpClaims());
+        verify(userRepository, times(2)).update(any(User.class));
+    }
+
+    @Test
+    public void shouldNotUpdateUserWhenTheWhitelistedClaimsAreUnchanged() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("service_id"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        // The steady state the write guard exists for: a stable whitelist and an unchanged token on re-login. The first
+        // login writes the claims, the second must not write them again.
+        assertEquals(Map.of("service_id", "585252525"), user.getIdpClaims());
+        verify(userRepository, times(3)).update(any(User.class));
+    }
+
+    @Test
+    public void shouldJsonSerializeANonScalarWhitelistedClaim() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("groups"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        userService.createOrUpdateUserFromSocialIdentityProvider(EXECUTION_CONTEXT, identityProvider, userInfo, accessToken, idToken);
+
+        // Array and object claims are stored as their JSON form rather than a Java toString (APIM-13951)
+        assertEquals("[\"platform-admin\",\"api-reviewer\"]", user.getIdpClaims().get("groups"));
+    }
+
+    @Test
+    public void shouldNotFailTheLoginWhenTheClaimsCannotBePersisted() throws IOException, TechnicalException {
+        reset(identityProvider, userRepository);
+        mockDefaultEnvironment();
+
+        User user = mockUser();
+        when(userRepository.findBySource(null, user.getSourceId(), ORGANIZATION)).thenReturn(Optional.of(user));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(identityProvider.getPersistedClaimsWhitelist()).thenReturn(Collections.singletonList("service_id"));
+        // The profile refresh writes first and must succeed; the claims write is the one that fails
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg()).thenThrow(new TechnicalException("boom"));
+
+        String userInfo = IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset());
+        String accessToken = IOUtils.toString(read("/oauth2/jwt/access_token.jwt"), Charset.defaultCharset());
+        String idToken = IOUtils.toString(read("/oauth2/jwt/id_token.jwt"), Charset.defaultCharset());
+
+        // A claims failure is reported but swallowed: it must never stop a user logging in
+        UserEntity connectedUser = userService.createOrUpdateUserFromSocialIdentityProvider(
+            EXECUTION_CONTEXT,
+            identityProvider,
+            userInfo,
+            accessToken,
+            idToken
+        );
+
+        assertNotNull(connectedUser);
+        verify(userRepository, times(2)).update(any(User.class));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/oauth2/json/user_info_response_body.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/oauth2/json/user_info_response_body.json
@@ -7,5 +7,6 @@
   "picture":"http://example.com/janedoe/me.jpg",
   "identity_provider_id": "idp_5",
   "job_id": "API_FRIENDLY_USER",
-  "service_id": "585252525"
+  "service_id": "585252525",
+  "groups": ["platform-admin", "api-reviewer"]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14840

## Description

The persisted-claims whitelist governed what got **written** to `users.idp_claims`, but nothing governed what **stayed** written. Removing a claim from the whitelist left the already-captured value on every user indefinitely — across logins, restarts and further configuration changes — which defeats the premise of APIM-13950 that sensitive or unnecessary claims are not retained. No REST surface exposes or deletes `idpClaims` either (`UserService.findIdpClaims` is internal, consumed only by `ApplicationServiceImpl`), so direct database access was the only cleanup path.

`UserServiceImpl.persistWhitelistedClaims` returned early on a null/empty whitelist, so the stored map was never rewritten.

**Fix:** treat an absent or empty whitelist as *"retain nothing"* rather than *"do nothing"*.

Two details worth reviewing:

- Claims are cleared to **`null`, not an empty map**. `JdbcUserRepository.serializeIdpClaims` returns null only for null; an empty map serializes verbatim, which would leave the column populated with `{}` rather than cleared. Mongo behaves the same.
- The write is **skipped when nothing changes** (`!Objects.equals(...)`). This path now runs on every login, and most deployments configure no whitelist at all, so without the guard the common case would gain a redundant `update` per login. `UserEntity` carries no `idpClaims` field (only the repository `User` does), so the `findById` cannot be avoided without widening an `Indexable`, REST-serialized model — not worth it here, especially as every social login already performs several read/writes on that row.

A populated whitelist whose claims are simply absent from the token still stores an empty map, unchanged — that is APIM-13951's contract and is covered by an existing test.

### Scope

Purging takes effect on the user's **next login**. Users who never log in again keep their stored claims. Fully remediating those needs an admin-facing read/delete of `idpClaims` or a purge triggered on configuration change — deliberately out of scope here, and worth its own ticket if wanted. APIM-13951's final acceptance criterion ("not exposed unless explicitly requested with a permission check") anticipated such an endpoint and none was implemented.

### Test note

`shouldNotPersistClaimsWhenNoWhitelistConfigured` asserted the previous behaviour deliberately, with a sentinel claim and a comment noting that removing the guard would overwrite it. Rather than quietly rewriting a committed test, calling it out: that test pinned the defect, so it is replaced by `shouldPurgePersistedClaimsWhenWhitelistCleared` / `...WhenWhitelistNotConfigured`, plus `shouldNotUpdateUserWhenThereAreNoClaimsToPurge` covering the write guard.

RED → GREEN verified: both purge tests failed with `expected: <null> but was: <{org_id=org-42}>` before the change. Full `gravitee-apim-rest-api-service` suite green afterwards — 9338 tests, 0 failures.

## Additional context

⚠️ **Security-sensitive**: changes what PII-bearing IdP claim data is retained on the user record (`UserMongo.idpClaims` is `@ToString.Exclude`d as PII for exactly this reason). No change to authentication or authorization logic.

Found during QA of epic APIM-13949. Sibling bug APIM-14841 (OAuth2 client authentication method mismatch) and the reopened UI story APIM-13954 follow in separate PRs.

Reproduction (from the ticket): configure an OIDC provider with `persistedClaimsWhitelist: ["org_id"]`, log in as a federated user, clear the whitelist via `PUT .../configuration/identities/{id}`, log in again — stored claims were previously byte-identical, and are now removed.