### PR TITLE
fix(auth): align OAuth2 client authentication methods

### DIFF
--- a/gravitee-apim-console-webui/src/entities/identity-provider/identityProvider.ts
+++ b/gravitee-apim-console-webui/src/entities/identity-provider/identityProvider.ts
@@ -42,6 +42,7 @@ export interface IdentityProviderGraviteeioAmConfiguration {
   domain?: string;
   scopes?: string[];
   serverURL?: string;
+  tokenEndpointAuthMethod?: string | null;
 }
 
 export interface IdentityProviderOidcConfiguration {
@@ -54,6 +55,7 @@ export interface IdentityProviderOidcConfiguration {
   tokenIntrospectionEndpoint?: string;
   userInfoEndpoint?: string;
   userLogoutEndpoint?: string;
+  tokenEndpointAuthMethod?: string | null;
 }
 
 export type IdentityProviderConfiguration =
@@ -69,6 +71,15 @@ export interface IdentityProviderUserProfileMapping {
   email?: string;
   picture?: string;
 }
+
+/**
+ * How APIM authenticates itself when calling the provider's token and introspection endpoints. The values are the
+ * OpenID Connect Discovery token_endpoint_auth_method names, matching what the server accepts.
+ */
+export const CLIENT_AUTHENTICATION_METHODS: { value: string; label: string }[] = [
+  { value: 'client_secret_basic', label: 'Client secret in the Authorization header (client_secret_basic)' },
+  { value: 'client_secret_post', label: 'Client secret in the request body (client_secret_post)' },
+];
 
 export interface IdentityProvider {
   id?: string;

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-graviteeio-am/org-settings-identity-provider-graviteeio-am.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-graviteeio-am/org-settings-identity-provider-graviteeio-am.component.html
@@ -44,6 +44,17 @@
     </mat-form-field>
 
     <mat-form-field class="identity-provider__card__form-field">
+      <mat-label>Client Authentication Method</mat-label>
+      <mat-select name="configurationTokenEndpointAuthMethod" formControlName="tokenEndpointAuthMethod">
+        <mat-option [value]="null">Provider default</mat-option>
+        <mat-option *ngFor="let method of clientAuthenticationMethods" [value]="method.value">{{ method.label }}</mat-option>
+      </mat-select>
+      <mat-hint
+        >How APIM sends its credentials to the token and introspection endpoints. Leave unset to keep the current behavior.</mat-hint
+      >
+    </mat-form-field>
+
+    <mat-form-field class="identity-provider__card__form-field">
       <mat-label>Scopes</mat-label>
       <gio-form-tags-input placeholder="Enter a scope and press Enter" formControlName="scopes"></gio-form-tags-input>
     </mat-form-field>

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-graviteeio-am/org-settings-identity-provider-graviteeio-am.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-graviteeio-am/org-settings-identity-provider-graviteeio-am.component.ts
@@ -17,6 +17,7 @@ import { Component } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 
 import { ProviderConfiguration } from '../org-settings-identity-provider.component';
+import { CLIENT_AUTHENTICATION_METHODS } from '../../../../entities/identity-provider';
 
 @Component({
   selector: 'org-settings-identity-provider-graviteeio-am',
@@ -27,11 +28,14 @@ import { ProviderConfiguration } from '../org-settings-identity-provider.compone
 export class OrgSettingsIdentityProviderGraviteeioAmComponent implements ProviderConfiguration {
   name = 'OrgSettingsIdentityProviderGraviteeioAmComponent';
 
+  clientAuthenticationMethods = CLIENT_AUTHENTICATION_METHODS;
+
   configurationFormGroup: UntypedFormGroup = new UntypedFormGroup({
     clientId: new UntypedFormControl(null, Validators.required),
     clientSecret: new UntypedFormControl(null, Validators.required),
     serverURL: new UntypedFormControl(null, Validators.required),
     domain: new UntypedFormControl(null, Validators.required),
+    tokenEndpointAuthMethod: new UntypedFormControl(),
     scopes: new UntypedFormControl(),
     color: new UntypedFormControl(),
   });

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-oidc/org-settings-identity-provider-oidc.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-oidc/org-settings-identity-provider-oidc.component.html
@@ -43,6 +43,17 @@
     </mat-form-field>
 
     <mat-form-field class="identity-provider__card__form-field">
+      <mat-label>Client Authentication Method</mat-label>
+      <mat-select name="configurationTokenEndpointAuthMethod" formControlName="tokenEndpointAuthMethod">
+        <mat-option [value]="null">Provider default</mat-option>
+        <mat-option *ngFor="let method of clientAuthenticationMethods" [value]="method.value">{{ method.label }}</mat-option>
+      </mat-select>
+      <mat-hint
+        >How APIM sends its credentials to the token and introspection endpoints. Leave unset to keep the current behavior.</mat-hint
+      >
+    </mat-form-field>
+
+    <mat-form-field class="identity-provider__card__form-field">
       <mat-label>Authorize Endpoint</mat-label>
       <input matInput name="configurationAuthorizeEndpoint" type="url" formControlName="authorizeEndpoint" required />
       <mat-error *ngIf="configurationFormGroup.get('authorizeEndpoint').hasError('required')">Authorize Endpoint is required.</mat-error>

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-oidc/org-settings-identity-provider-oidc.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider-oidc/org-settings-identity-provider-oidc.component.ts
@@ -17,6 +17,7 @@ import { Component } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 
 import { ProviderConfiguration } from '../org-settings-identity-provider.component';
+import { CLIENT_AUTHENTICATION_METHODS } from '../../../../entities/identity-provider';
 
 @Component({
   selector: 'org-settings-identity-provider-oidc',
@@ -27,11 +28,14 @@ import { ProviderConfiguration } from '../org-settings-identity-provider.compone
 export class OrgSettingsIdentityProviderOidcComponent implements ProviderConfiguration {
   name = 'OrgSettingsIdentityProviderOidcComponent';
 
+  clientAuthenticationMethods = CLIENT_AUTHENTICATION_METHODS;
+
   configurationFormGroup: UntypedFormGroup = new UntypedFormGroup({
     clientId: new UntypedFormControl(null, Validators.required),
     clientSecret: new UntypedFormControl(null, Validators.required),
     tokenEndpoint: new UntypedFormControl(null, Validators.required),
     tokenIntrospectionEndpoint: new UntypedFormControl(),
+    tokenEndpointAuthMethod: new UntypedFormControl(),
     authorizeEndpoint: new UntypedFormControl(null, Validators.required),
     userInfoEndpoint: new UntypedFormControl(null, Validators.required),
     userLogoutEndpoint: new UntypedFormControl(),

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
@@ -151,6 +151,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Domain',
           scopes: null,
           serverURL: 'ServerURL',
+          tokenEndpointAuthMethod: null,
         },
         userProfileMapping: {
           email: 'email',
@@ -270,6 +271,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Domain',
           scopes: ['Scope A', 'Scope B'],
           serverURL: 'ServerURL',
+          tokenEndpointAuthMethod: null,
         });
 
         const idInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=id]' }));
@@ -316,6 +318,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: ['Scope A', 'Scope B'],
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: 'Email',
@@ -397,6 +400,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
 
         expect(fixture.componentInstance.identityProviderFormGroup.get('configuration').value).toEqual({
           authorizeEndpoint: 'AuthorizeEndpoint',
+          tokenEndpointAuthMethod: null,
           clientId: 'Client Id',
           clientSecret: 'Client Secret',
           color: '#ffffff',
@@ -446,6 +450,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           type: 'OIDC',
           configuration: {
             authorizeEndpoint: 'AuthorizeEndpoint',
+            tokenEndpointAuthMethod: null,
             clientId: 'Client Id',
             clientSecret: 'Client Secret',
             color: '#ffffff',
@@ -495,6 +500,49 @@ describe('OrgSettingsIdentityProviderComponent', () => {
       fixture.detectChanges();
     });
 
+    it('should keep the configured client authentication method when the provider is saved', async () => {
+      const identityProviderToUpdate = fakeIdentityProvider({
+        id: 'providerId',
+        type: 'OIDC',
+        name: 'OIDC Provider',
+        configuration: {
+          authorizeEndpoint: 'AuthorizeEndpoint',
+          clientId: 'Client Id',
+          clientSecret: 'Client Secret',
+          color: null,
+          scopes: ['openid'],
+          tokenEndpoint: 'TokenEndpoint',
+          tokenEndpointAuthMethod: 'client_secret_basic',
+          tokenIntrospectionEndpoint: null,
+          userInfoEndpoint: 'UserInfoEndpoint',
+          userLogoutEndpoint: null,
+        },
+        userProfileMapping: {
+          email: null,
+          firstname: null,
+          id: 'Id',
+          lastname: null,
+          picture: null,
+        },
+      });
+      expectIdentityProviderGetRequest(identityProviderToUpdate);
+      expectEnvironmentListRequest([]);
+
+      const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
+      await nameInput.setValue('Renamed');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      // configuration is rebuilt wholesale from the enumerated controls on save, so without a control for this key an
+      // unrelated edit would drop it and quietly revert the provider to the endpoint defaults
+      expectIdentityProviderUpdateRequest('providerId', { ...identityProviderToUpdate, name: 'Renamed' });
+
+      expect(component.isLoading).toBe(true);
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities/providerId`);
+    });
+
     it('should be in edit mode', async () => {
       expectIdentityProviderGetRequest(fakeIdentityProvider({ id: 'providerId' }));
       expectEnvironmentListRequest([]);
@@ -526,6 +574,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,
@@ -593,6 +642,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Updated Domain',
           scopes: null,
           serverURL: 'UpdatedServerURL',
+          tokenEndpointAuthMethod: null,
         },
         userProfileMapping: {
           email: null,
@@ -627,6 +677,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,
@@ -744,6 +795,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
@@ -151,6 +151,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Domain',
           scopes: null,
           serverURL: 'ServerURL',
+          tokenEndpointAuthMethod: null,
         },
         userProfileMapping: {
           email: 'email',
@@ -270,6 +271,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Domain',
           scopes: ['Scope A', 'Scope B'],
           serverURL: 'ServerURL',
+          tokenEndpointAuthMethod: null,
         });
 
         const idInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=id]' }));
@@ -316,6 +318,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: ['Scope A', 'Scope B'],
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: 'Email',
@@ -397,6 +400,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
 
         expect(fixture.componentInstance.identityProviderFormGroup.get('configuration').value).toEqual({
           authorizeEndpoint: 'AuthorizeEndpoint',
+          tokenEndpointAuthMethod: null,
           clientId: 'Client Id',
           clientSecret: 'Client Secret',
           color: '#ffffff',
@@ -446,6 +450,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           type: 'OIDC',
           configuration: {
             authorizeEndpoint: 'AuthorizeEndpoint',
+            tokenEndpointAuthMethod: null,
             clientId: 'Client Id',
             clientSecret: 'Client Secret',
             color: '#ffffff',
@@ -509,6 +514,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             color: null,
             scopes: ['openid', 'profile', 'email'],
             tokenEndpoint: 'TokenEndpoint',
+            tokenEndpointAuthMethod: null,
             tokenIntrospectionEndpoint: null,
             userInfoEndpoint: 'UserInfoEndpoint',
             userLogoutEndpoint: null,
@@ -583,6 +589,49 @@ describe('OrgSettingsIdentityProviderComponent', () => {
       });
     });
 
+    it('should keep the configured client authentication method when the provider is saved', async () => {
+      const identityProviderToUpdate = fakeIdentityProvider({
+        id: 'providerId',
+        type: 'OIDC',
+        name: 'OIDC Provider',
+        configuration: {
+          authorizeEndpoint: 'AuthorizeEndpoint',
+          clientId: 'Client Id',
+          clientSecret: 'Client Secret',
+          color: null,
+          scopes: ['openid'],
+          tokenEndpoint: 'TokenEndpoint',
+          tokenEndpointAuthMethod: 'client_secret_basic',
+          tokenIntrospectionEndpoint: null,
+          userInfoEndpoint: 'UserInfoEndpoint',
+          userLogoutEndpoint: null,
+        },
+        userProfileMapping: {
+          email: null,
+          firstname: null,
+          id: 'Id',
+          lastname: null,
+          picture: null,
+        },
+      });
+      expectIdentityProviderGetRequest(identityProviderToUpdate);
+      expectEnvironmentListRequest([]);
+
+      const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
+      await nameInput.setValue('Renamed');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      // configuration is rebuilt wholesale from the enumerated controls on save, so without a control for this key an
+      // unrelated edit would drop it and quietly revert the provider to the endpoint defaults
+      expectIdentityProviderUpdateRequest('providerId', { ...identityProviderToUpdate, name: 'Renamed' });
+
+      expect(component.isLoading).toBe(true);
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/identities/providerId`);
+    });
+
     it('should be in edit mode', async () => {
       expectIdentityProviderGetRequest(fakeIdentityProvider({ id: 'providerId' }));
       expectEnvironmentListRequest([]);
@@ -614,6 +663,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,
@@ -681,6 +731,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
           domain: 'Updated Domain',
           scopes: null,
           serverURL: 'UpdatedServerURL',
+          tokenEndpointAuthMethod: null,
         },
         userProfileMapping: {
           email: null,
@@ -715,6 +766,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,
@@ -832,6 +884,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
             domain: 'Domain',
             scopes: null,
             serverURL: 'ServerURL',
+            tokenEndpointAuthMethod: null,
           },
           userProfileMapping: {
             email: null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -248,10 +248,11 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             ? identityProvider.getTokenEndpointAuthMethod()
             : endpointDefault;
 
-        // Switched rather than decided by exclusion: token_endpoint_auth_method has values such as none and
-        // private_key_jwt that must not fall through to putting the secret in the body, so adding a constant has to be
-        // a deliberate decision here rather than a silent change on a credential path.
+        // The null label makes this an enhanced switch (JLS 14.11.2), so the compiler requires it to be exhaustive:
+        // adding a token_endpoint_auth_method constant such as none or private_key_jwt fails the build here instead of
+        // silently doing nothing, or worse falling through to putting the secret in the body, on a credential path.
         switch (method) {
+            case null -> throw new IllegalArgumentException("No client authentication method resolved for " + identityProvider.getId());
             case CLIENT_SECRET_BASIC -> request.header(HttpHeaders.AUTHORIZATION, basicAuthorization(identityProvider));
             case CLIENT_SECRET_POST -> {
                 // The authorization-code flow already carries the client_id supplied by the caller. add() registers the

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.management.rest.model.ExchangePayloadEntity;
 import io.gravitee.rest.api.management.rest.model.PayloadInput;
 import io.gravitee.rest.api.management.rest.utils.BlindTrustManager;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
@@ -43,6 +44,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -50,6 +52,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Singleton;
@@ -76,6 +79,13 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
     private static final String TEMPLATE_ENGINE_PROFILE_ATTRIBUTE = "profile";
     private static final String ACCESS_TOKEN_PROPERTY = "access_token";
     private static final String ID_TOKEN_PROPERTY = "id_token";
+    private static final String ERROR_PROPERTY = "error";
+    private static final String INVALID_CLIENT_ERROR = "invalid_client";
+    private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String CLIENT_AUTHENTICATION_HINT =
+        "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
+        "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
+        "the token and introspection endpoints must both accept it.";
 
     @Autowired
     private SocialIdentityProviderService socialIdentityProviderService;
@@ -126,20 +136,12 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 // Step1. Check the token by invoking the introspection endpoint
                 final MultivaluedStringMap introspectData = new MultivaluedStringMap();
                 introspectData.add(TOKEN, token);
-                Response response = client
+                Invocation.Builder introspectRequest = client
                     //TODO: what is the correct introspection URL here ?
                     .target(identityProvider.getTokenIntrospectionEndpoint())
-                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                    .header(
-                        HttpHeaders.AUTHORIZATION,
-                        String.format(
-                            "Basic %s",
-                            Base64.getEncoder().encodeToString(
-                                (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                            )
-                        )
-                    )
-                    .post(Entity.form(introspectData));
+                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+                authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_BASIC, introspectData, introspectRequest);
+                Response response = introspectRequest.post(Entity.form(introspectData));
                 introspectData.clear();
 
                 if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -151,16 +153,11 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     } else {
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
-                } else {
-                    log.error(
-                        "Token exchange failed with status {}: {}\n{}",
-                        response.getStatus(),
-                        response.getStatusInfo(),
-                        getResponseEntityAsString(response)
-                    );
                 }
 
-                return Response.status(response.getStatusInfo()).entity(response.getEntity()).build();
+                String errorBody = getResponseEntityAsString(response);
+                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
+                return clientAuthenticationFailure(errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -192,15 +189,16 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             final MultivaluedStringMap accessData = new MultivaluedStringMap();
             accessData.add(CLIENT_ID_KEY, payloadInput.getClient_id());
             accessData.add(REDIRECT_URI_KEY, payloadInput.getRedirect_uri());
-            accessData.add(CLIENT_SECRET, identityProvider.getClientSecret());
             accessData.add(CODE_KEY, payloadInput.getCode());
             accessData.add(CODE_VERIFIER_KEY, payloadInput.getCode_verifier());
             accessData.add(GRANT_TYPE_KEY, AUTH_CODE);
 
-            Response response = client
+            Invocation.Builder tokenRequest = client
                 .target(identityProvider.getTokenEndpoint())
-                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.form(accessData));
+                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+            authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_POST, accessData, tokenRequest);
+
+            Response response = tokenRequest.post(Entity.form(accessData));
             accessData.clear();
 
             if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -208,18 +206,78 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 final String accessToken = (String) responseEntity.get(ACCESS_TOKEN_PROPERTY);
                 final String idToken = (String) responseEntity.get(ID_TOKEN_PROPERTY);
                 return authenticateUser(identityProvider, servletResponse, accessToken, idToken, payloadInput.getState());
-            } else {
-                log.error(
-                    "Exchange authorization code failed with status {}: {}\n{}",
-                    response.getStatus(),
-                    response.getStatusInfo(),
-                    getResponseEntityAsString(response)
-                );
             }
-            return Response.status(Response.Status.UNAUTHORIZED).build();
+
+            String errorBody = getResponseEntityAsString(response);
+            log.error(
+                "Exchange authorization code failed with status {}: {}\n{}",
+                response.getStatus(),
+                response.getStatusInfo(),
+                errorBody
+            );
+            return clientAuthenticationFailure(errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    /**
+     * Applies the client credentials the way the identity provider expects to receive them. A provider that declares no
+     * method keeps the behaviour this endpoint has always had, so existing configurations are unaffected; declaring one
+     * makes the token and introspection calls agree, which they previously did not.
+     */
+    private void authenticateClient(
+        SocialIdentityProviderEntity identityProvider,
+        ClientAuthenticationMethod endpointDefault,
+        MultivaluedStringMap form,
+        Invocation.Builder request
+    ) {
+        ClientAuthenticationMethod method = identityProvider.getTokenEndpointAuthMethod() != null
+            ? identityProvider.getTokenEndpointAuthMethod()
+            : endpointDefault;
+
+        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
+            request.header(
+                HttpHeaders.AUTHORIZATION,
+                String.format(
+                    "Basic %s",
+                    Base64.getEncoder().encodeToString(
+                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
+                    )
+                )
+            );
+        } else {
+            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
+            // the form has none and the request body keeps the shape providers are already receiving.
+            if (!form.containsKey(CLIENT_ID_KEY)) {
+                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+            }
+            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
+        }
+    }
+
+    /**
+     * Reports a failed token or introspection call as an authentication failure carrying the provider's own error code,
+     * naming the client authentication method when the provider rejected our credentials. Only the error code is
+     * relayed, never the provider's raw response, which may describe its internals.
+     */
+    private Response clientAuthenticationFailure(String providerResponseBody) {
+        String error = PROVIDER_ERROR;
+        try {
+            Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
+            if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {
+                error = providerErrorCode;
+            }
+        } catch (IOException | RuntimeException e) {
+            log.debug("Identity provider error response is not a JSON object", e);
+        }
+
+        Map<String, String> payload = new LinkedHashMap<>();
+        payload.put(ERROR_PROPERTY, error);
+        if (INVALID_CLIENT_ERROR.equals(error)) {
+            payload.put("hint", CLIENT_AUTHENTICATION_HINT);
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).entity(payload).build();
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -50,6 +50,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -83,6 +84,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
     private static final String ERROR_PROPERTY = "error";
     private static final String INVALID_CLIENT_ERROR = "invalid_client";
     private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String PROVIDER_UNAVAILABLE_ERROR = "identity_provider_unavailable";
     private static final String CLIENT_AUTHENTICATION_HINT =
         "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
         "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
@@ -161,13 +163,21 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     if (active) {
                         return authenticateUser(identityProvider, servletResponse, token, null, null);
                     } else {
+                        log.info("Identity provider {} reported the exchanged token as inactive", identityProvider.getId());
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
                 }
 
                 String errorBody = getResponseEntityAsString(response);
-                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
-                return clientAuthenticationFailure(errorBody);
+                log.warn(
+                    "Token introspection for identity provider {} at {} failed with status {}: {}\n{}",
+                    identityProvider.getId(),
+                    identityProvider.getTokenIntrospectionEndpoint(),
+                    response.getStatus(),
+                    response.getStatusInfo(),
+                    errorBody
+                );
+                return clientAuthenticationFailure(response.getStatus(), errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -219,13 +229,15 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             }
 
             String errorBody = getResponseEntityAsString(response);
-            log.error(
-                "Exchange authorization code failed with status {}: {}\n{}",
+            log.warn(
+                "Authorization-code exchange for identity provider {} at {} failed with status {}: {}\n{}",
+                identityProvider.getId(),
+                identityProvider.getTokenEndpoint(),
                 response.getStatus(),
                 response.getStatusInfo(),
                 errorBody
             );
-            return clientAuthenticationFailure(errorBody);
+            return clientAuthenticationFailure(response.getStatus(), errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
@@ -246,24 +258,26 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             ? identityProvider.getTokenEndpointAuthMethod()
             : endpointDefault;
 
-        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
-            request.header(
-                HttpHeaders.AUTHORIZATION,
-                String.format(
-                    "Basic %s",
-                    Base64.getEncoder().encodeToString(
-                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                    )
-                )
-            );
-        } else {
-            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
-            // the form has none and the request body keeps the shape providers are already receiving.
-            if (!form.containsKey(CLIENT_ID_KEY)) {
-                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+        // Switched rather than decided by exclusion: token_endpoint_auth_method has values such as none and
+        // private_key_jwt that must not fall through to putting the secret in the body, so adding a constant has to be
+        // a deliberate decision here rather than a silent change on a credential path.
+        switch (method) {
+            case CLIENT_SECRET_BASIC -> request.header(HttpHeaders.AUTHORIZATION, basicAuthorization(identityProvider));
+            case CLIENT_SECRET_POST -> {
+                // The authorization-code flow already carries the client_id supplied by the caller. add() registers the
+                // key even for a null value, so the presence of a value is what decides, not the presence of the key.
+                if (form.getFirst(CLIENT_ID_KEY) == null) {
+                    form.putSingle(CLIENT_ID_KEY, identityProvider.getClientId());
+                }
+                form.add(CLIENT_SECRET, identityProvider.getClientSecret());
             }
-            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
         }
+    }
+
+    private static String basicAuthorization(SocialIdentityProviderEntity identityProvider) {
+        String credentials = identityProvider.getClientId() + ':' + identityProvider.getClientSecret();
+        // Explicit charset: the platform default silently changes the bytes, and therefore the credential, per host
+        return String.format("Basic %s", Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**
@@ -271,8 +285,10 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
      * naming the client authentication method when the provider rejected our credentials. Only the error code is
      * relayed, never the provider's raw response, which may describe its internals.
      */
-    private Response clientAuthenticationFailure(String providerResponseBody) {
-        String error = PROVIDER_ERROR;
+    private Response clientAuthenticationFailure(int providerStatus, String providerResponseBody) {
+        // A provider that is down and a provider that rejected our credentials are different problems, so they must not
+        // arrive as the same error code. Without this, an outage reads as a configuration mistake.
+        String error = providerStatus >= 500 ? PROVIDER_UNAVAILABLE_ERROR : PROVIDER_ERROR;
         try {
             Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
             if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -82,6 +83,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
     private static final String ERROR_PROPERTY = "error";
     private static final String INVALID_CLIENT_ERROR = "invalid_client";
     private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String PROVIDER_UNAVAILABLE_ERROR = "identity_provider_unavailable";
     private static final String CLIENT_AUTHENTICATION_HINT =
         "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
         "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
@@ -151,13 +153,21 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     if (active) {
                         return authenticateUser(identityProvider, servletResponse, token, null, null);
                     } else {
+                        log.info("Identity provider {} reported the exchanged token as inactive", identityProvider.getId());
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
                 }
 
                 String errorBody = getResponseEntityAsString(response);
-                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
-                return clientAuthenticationFailure(errorBody);
+                log.warn(
+                    "Token introspection for identity provider {} at {} failed with status {}: {}\n{}",
+                    identityProvider.getId(),
+                    identityProvider.getTokenIntrospectionEndpoint(),
+                    response.getStatus(),
+                    response.getStatusInfo(),
+                    errorBody
+                );
+                return clientAuthenticationFailure(response.getStatus(), errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -209,13 +219,15 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             }
 
             String errorBody = getResponseEntityAsString(response);
-            log.error(
-                "Exchange authorization code failed with status {}: {}\n{}",
+            log.warn(
+                "Authorization-code exchange for identity provider {} at {} failed with status {}: {}\n{}",
+                identityProvider.getId(),
+                identityProvider.getTokenEndpoint(),
                 response.getStatus(),
                 response.getStatusInfo(),
                 errorBody
             );
-            return clientAuthenticationFailure(errorBody);
+            return clientAuthenticationFailure(response.getStatus(), errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
@@ -236,24 +248,26 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             ? identityProvider.getTokenEndpointAuthMethod()
             : endpointDefault;
 
-        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
-            request.header(
-                HttpHeaders.AUTHORIZATION,
-                String.format(
-                    "Basic %s",
-                    Base64.getEncoder().encodeToString(
-                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                    )
-                )
-            );
-        } else {
-            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
-            // the form has none and the request body keeps the shape providers are already receiving.
-            if (!form.containsKey(CLIENT_ID_KEY)) {
-                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+        // Switched rather than decided by exclusion: token_endpoint_auth_method has values such as none and
+        // private_key_jwt that must not fall through to putting the secret in the body, so adding a constant has to be
+        // a deliberate decision here rather than a silent change on a credential path.
+        switch (method) {
+            case CLIENT_SECRET_BASIC -> request.header(HttpHeaders.AUTHORIZATION, basicAuthorization(identityProvider));
+            case CLIENT_SECRET_POST -> {
+                // The authorization-code flow already carries the client_id supplied by the caller. add() registers the
+                // key even for a null value, so the presence of a value is what decides, not the presence of the key.
+                if (form.getFirst(CLIENT_ID_KEY) == null) {
+                    form.putSingle(CLIENT_ID_KEY, identityProvider.getClientId());
+                }
+                form.add(CLIENT_SECRET, identityProvider.getClientSecret());
             }
-            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
         }
+    }
+
+    private static String basicAuthorization(SocialIdentityProviderEntity identityProvider) {
+        String credentials = identityProvider.getClientId() + ':' + identityProvider.getClientSecret();
+        // Explicit charset: the platform default silently changes the bytes, and therefore the credential, per host
+        return String.format("Basic %s", Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**
@@ -261,8 +275,10 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
      * naming the client authentication method when the provider rejected our credentials. Only the error code is
      * relayed, never the provider's raw response, which may describe its internals.
      */
-    private Response clientAuthenticationFailure(String providerResponseBody) {
-        String error = PROVIDER_ERROR;
+    private Response clientAuthenticationFailure(int providerStatus, String providerResponseBody) {
+        // A provider that is down and a provider that rejected our credentials are different problems, so they must not
+        // arrive as the same error code. Without this, an outage reads as a configuration mistake.
+        String error = providerStatus >= 500 ? PROVIDER_UNAVAILABLE_ERROR : PROVIDER_ERROR;
         try {
             Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
             if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.management.rest.model.ExchangePayloadEntity;
 import io.gravitee.rest.api.management.rest.model.PayloadInput;
 import io.gravitee.rest.api.management.rest.utils.BlindTrustManager;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
@@ -44,6 +45,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -51,6 +53,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Singleton;
@@ -77,6 +80,13 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
     private static final String TEMPLATE_ENGINE_PROFILE_ATTRIBUTE = "profile";
     private static final String ACCESS_TOKEN_PROPERTY = "access_token";
     private static final String ID_TOKEN_PROPERTY = "id_token";
+    private static final String ERROR_PROPERTY = "error";
+    private static final String INVALID_CLIENT_ERROR = "invalid_client";
+    private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String CLIENT_AUTHENTICATION_HINT =
+        "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
+        "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
+        "the token and introspection endpoints must both accept it.";
 
     // Dirty hack: only used to force class loading
     static {
@@ -136,20 +146,12 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 // Step1. Check the token by invoking the introspection endpoint
                 final MultivaluedStringMap introspectData = new MultivaluedStringMap();
                 introspectData.add(TOKEN, token);
-                Response response = client
+                Invocation.Builder introspectRequest = client
                     //TODO: what is the correct introspection URL here ?
                     .target(identityProvider.getTokenIntrospectionEndpoint())
-                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                    .header(
-                        HttpHeaders.AUTHORIZATION,
-                        String.format(
-                            "Basic %s",
-                            Base64.getEncoder().encodeToString(
-                                (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                            )
-                        )
-                    )
-                    .post(Entity.form(introspectData));
+                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+                authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_BASIC, introspectData, introspectRequest);
+                Response response = introspectRequest.post(Entity.form(introspectData));
                 introspectData.clear();
 
                 if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -161,16 +163,11 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     } else {
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
-                } else {
-                    log.error(
-                        "Token exchange failed with status {}: {}\n{}",
-                        response.getStatus(),
-                        response.getStatusInfo(),
-                        getResponseEntityAsString(response)
-                    );
                 }
 
-                return Response.status(response.getStatusInfo()).entity(response.getEntity()).build();
+                String errorBody = getResponseEntityAsString(response);
+                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
+                return clientAuthenticationFailure(errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -202,15 +199,16 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             final MultivaluedStringMap accessData = new MultivaluedStringMap();
             accessData.add(CLIENT_ID_KEY, payloadInput.getClient_id());
             accessData.add(REDIRECT_URI_KEY, payloadInput.getRedirect_uri());
-            accessData.add(CLIENT_SECRET, identityProvider.getClientSecret());
             accessData.add(CODE_KEY, payloadInput.getCode());
             accessData.add(CODE_VERIFIER_KEY, payloadInput.getCode_verifier());
             accessData.add(GRANT_TYPE_KEY, AUTH_CODE);
 
-            Response response = client
+            Invocation.Builder tokenRequest = client
                 .target(identityProvider.getTokenEndpoint())
-                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.form(accessData));
+                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+            authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_POST, accessData, tokenRequest);
+
+            Response response = tokenRequest.post(Entity.form(accessData));
             accessData.clear();
 
             if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -218,18 +216,78 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 final String accessToken = (String) responseEntity.get(ACCESS_TOKEN_PROPERTY);
                 final String idToken = (String) responseEntity.get(ID_TOKEN_PROPERTY);
                 return authenticateUser(identityProvider, servletResponse, accessToken, idToken, payloadInput.getState());
-            } else {
-                log.error(
-                    "Exchange authorization code failed with status {}: {}\n{}",
-                    response.getStatus(),
-                    response.getStatusInfo(),
-                    getResponseEntityAsString(response)
-                );
             }
-            return Response.status(Response.Status.UNAUTHORIZED).build();
+
+            String errorBody = getResponseEntityAsString(response);
+            log.error(
+                "Exchange authorization code failed with status {}: {}\n{}",
+                response.getStatus(),
+                response.getStatusInfo(),
+                errorBody
+            );
+            return clientAuthenticationFailure(errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    /**
+     * Applies the client credentials the way the identity provider expects to receive them. A provider that declares no
+     * method keeps the behaviour this endpoint has always had, so existing configurations are unaffected; declaring one
+     * makes the token and introspection calls agree, which they previously did not.
+     */
+    private void authenticateClient(
+        SocialIdentityProviderEntity identityProvider,
+        ClientAuthenticationMethod endpointDefault,
+        MultivaluedStringMap form,
+        Invocation.Builder request
+    ) {
+        ClientAuthenticationMethod method = identityProvider.getTokenEndpointAuthMethod() != null
+            ? identityProvider.getTokenEndpointAuthMethod()
+            : endpointDefault;
+
+        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
+            request.header(
+                HttpHeaders.AUTHORIZATION,
+                String.format(
+                    "Basic %s",
+                    Base64.getEncoder().encodeToString(
+                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
+                    )
+                )
+            );
+        } else {
+            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
+            // the form has none and the request body keeps the shape providers are already receiving.
+            if (!form.containsKey(CLIENT_ID_KEY)) {
+                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+            }
+            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
+        }
+    }
+
+    /**
+     * Reports a failed token or introspection call as an authentication failure carrying the provider's own error code,
+     * naming the client authentication method when the provider rejected our credentials. Only the error code is
+     * relayed, never the provider's raw response, which may describe its internals.
+     */
+    private Response clientAuthenticationFailure(String providerResponseBody) {
+        String error = PROVIDER_ERROR;
+        try {
+            Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
+            if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {
+                error = providerErrorCode;
+            }
+        } catch (IOException | RuntimeException e) {
+            log.debug("Identity provider error response is not a JSON object", e);
+        }
+
+        Map<String, String> payload = new LinkedHashMap<>();
+        payload.put(ERROR_PROPERTY, error);
+        if (INVALID_CLIENT_ERROR.equals(error)) {
+            payload.put("hint", CLIENT_AUTHENTICATION_HINT);
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).entity(payload).build();
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -56,6 +56,7 @@ import jakarta.ws.rs.core.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
@@ -384,13 +385,22 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         );
     }
 
+    /** Carries detail a caller must never see, so relaying the provider's raw body fails these tests. */
+    private static final String PROVIDER_REJECTION_BODY =
+        "{\"error\":\"invalid_client\",\"error_description\":\"client not found in realm internal-realm-7\",\"trace\":\"provider-node-3\"}";
+
+    private void assertRelaysOnlyTheErrorCode(String body) {
+        assertTrue(body.contains("invalid_client"), "the provider's own error code must reach the caller, got: " + body);
+        assertFalse(body.contains("internal-realm-7"), "the provider's response detail must not be relayed, got: " + body);
+        assertFalse(body.contains("provider-node-3"), "the provider's response detail must not be relayed, got: " + body);
+        assertFalse(body.contains("error_description"), "the provider's response detail must not be relayed, got: " + body);
+    }
+
     @Test
     public void should_report_invalid_client_on_token_request_instead_of_an_empty_unauthorized() throws Exception {
         // Given
         mockDefaultEnvironment();
-        stubFor(
-            post("/token").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}"))
-        );
+        stubFor(post("/token").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody(PROVIDER_REJECTION_BODY)));
 
         // When
         Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
@@ -398,7 +408,7 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         // Then
         assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
         String body = response.readEntity(String.class);
-        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertRelaysOnlyTheErrorCode(body);
         assertTrue(
             body.contains("tokenEndpointAuthMethod"),
             "an invalid_client failure must name the client authentication method as the likely cause, got: " + body
@@ -409,11 +419,7 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
     public void should_report_invalid_client_on_introspection_instead_of_a_server_error() throws Exception {
         // Given
         mockDefaultEnvironment();
-        stubFor(
-            post("/introspect").willReturn(
-                aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}")
-            )
-        );
+        stubFor(post("/introspect").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody(PROVIDER_REJECTION_BODY)));
 
         // When
         Response response = orgTarget().path("exchange").queryParam("token", "MyToken").request().post(json(null));
@@ -421,11 +427,52 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         // Then
         assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
         String body = response.readEntity(String.class);
-        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertRelaysOnlyTheErrorCode(body);
         assertTrue(
             body.contains("tokenEndpointAuthMethod"),
             "an invalid_client failure must name the client authentication method as the likely cause, got: " + body
         );
+    }
+
+    @Test
+    public void should_not_suggest_the_client_authentication_method_for_an_unrelated_error() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        stubFor(
+            post("/token").willReturn(aResponse().withStatus(HttpStatusCode.BAD_REQUEST_400).withBody("{\"error\":\"invalid_grant\"}"))
+        );
+
+        // When
+        Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
+
+        // Then
+        String body = response.readEntity(String.class);
+        assertTrue(body.contains("invalid_grant"), "the provider's own error code must reach the caller, got: " + body);
+        assertFalse(
+            body.contains("tokenEndpointAuthMethod"),
+            "the client authentication hint must be reserved for credential rejections, got: " + body
+        );
+    }
+
+    @Test
+    public void should_report_a_non_json_provider_response_without_relaying_it() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        stubFor(
+            post("/token").willReturn(
+                aResponse().withStatus(HttpStatusCode.BAD_GATEWAY_502).withBody("<html><body>nginx: upstream 10.0.0.7 down</body></html>")
+            )
+        );
+
+        // When
+        Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
+
+        // Then
+        String body = response.readEntity(String.class);
+        // A provider that is unreachable must not be reported as a credential problem
+        assertTrue(body.contains("identity_provider_unavailable"), "an unreachable provider must be named as such, got: " + body);
+        assertFalse(body.contains("10.0.0.7"), "the provider's response body must not be relayed, got: " + body);
+        assertFalse(body.contains("tokenEndpointAuthMethod"), "an outage must not be blamed on the auth method, got: " + body);
     }
 
     private void mockTokenEndpoint() throws IOException {
@@ -447,7 +494,7 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
     }
 
     private static String expectedBasicAuthorization() {
-        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes());
+        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes(StandardCharsets.UTF_8));
     }
 
     private static void mockIntrospectToken() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.management.rest.model.ExchangePayloadEntity;
 import io.gravitee.rest.api.management.rest.model.TokenEntity;
 import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.GroupMappingEntity;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderType;
 import io.gravitee.rest.api.model.configuration.identity.RoleMappingEntity;
@@ -298,6 +299,155 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         verify(userService, times(1)).connect(any(), eq(userEntity.getSourceId()));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         verifyJwtToken(response);
+    }
+
+    @Test
+    public void should_send_client_credentials_in_token_request_body_when_no_auth_method_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        mockTokenEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())));
+        mockConnectedUser();
+
+        // When
+        Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/token"))
+                .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                .withRequestBody(containing("client_secret=the_client_secret"))
+        );
+    }
+
+    @Test
+    public void should_send_client_credentials_as_basic_auth_in_token_request_when_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
+        mockTokenEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())));
+        mockConnectedUser();
+
+        // When
+        Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/token"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo(expectedBasicAuthorization()))
+                .withRequestBody(notContaining("client_secret"))
+        );
+    }
+
+    @Test
+    public void should_authenticate_introspection_with_basic_auth_when_no_auth_method_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        mockIntrospectionEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
+        mockConnectedUser();
+
+        // When
+        Response response = orgTarget().path("exchange").queryParam("token", "MyToken").request().post(json(null));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/introspect"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo(expectedBasicAuthorization()))
+                .withRequestBody(notContaining("client_secret"))
+        );
+    }
+
+    @Test
+    public void should_send_client_credentials_in_introspection_body_when_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+        mockIntrospectionEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
+        mockConnectedUser();
+
+        // When
+        Response response = orgTarget().path("exchange").queryParam("token", "MyToken").request().post(json(null));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/introspect"))
+                .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                .withRequestBody(containing("client_secret=the_client_secret"))
+                .withRequestBody(containing("client_id=the_client_id"))
+        );
+    }
+
+    @Test
+    public void should_report_invalid_client_on_token_request_instead_of_an_empty_unauthorized() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        stubFor(
+            post("/token").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}"))
+        );
+
+        // When
+        Response response = orgTarget().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe", "StAtE")));
+
+        // Then
+        assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertTrue(
+            body.contains("tokenEndpointAuthMethod"),
+            "an invalid_client failure must name the client authentication method as the likely cause, got: " + body
+        );
+    }
+
+    @Test
+    public void should_report_invalid_client_on_introspection_instead_of_a_server_error() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        stubFor(
+            post("/introspect").willReturn(
+                aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}")
+            )
+        );
+
+        // When
+        Response response = orgTarget().path("exchange").queryParam("token", "MyToken").request().post(json(null));
+
+        // Then
+        assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertTrue(
+            body.contains("tokenEndpointAuthMethod"),
+            "an invalid_client failure must name the client authentication method as the likely cause, got: " + body
+        );
+    }
+
+    private void mockTokenEndpoint() throws IOException {
+        stubFor(
+            post("/token").willReturn(okJson(IOUtils.toString(read("/oauth2/json/token_response_body.json"), Charset.defaultCharset())))
+        );
+    }
+
+    private void mockIntrospectionEndpoint() {
+        stubFor(post("/introspect").willReturn(okJson(new JsonObject().put("active", "true").toString())));
+    }
+
+    private void mockConnectedUser() {
+        UserEntity userEntity = mockUserEntity();
+        when(userService.createOrUpdateUserFromSocialIdentityProvider(any(), eq(identityProvider), any(), any(), any())).thenReturn(
+            userEntity
+        );
+        when(userService.connect(any(), eq(userEntity.getId()))).thenReturn(userEntity);
+    }
+
+    private static String expectedBasicAuthorization() {
+        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes());
     }
 
     private static void mockIntrospectToken() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethod.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethod.java
@@ -43,8 +43,8 @@ public enum ClientAuthenticationMethod {
     }
 
     /**
-     * Resolves a configured value, accepting either the OIDC name ({@code client_secret_basic}) or the enum constant
-     * ({@code CLIENT_SECRET_BASIC}).
+     * Resolves a configured value. The comparison is case-insensitive, so the OIDC name ({@code client_secret_basic})
+     * and the enum constant ({@code CLIENT_SECRET_BASIC}) both resolve.
      *
      * @return the matching method, or {@code null} when the value is absent, blank or unrecognised. Callers decide what
      *         an unrecognised value means rather than having a login fail here on a configuration typo.
@@ -55,7 +55,7 @@ public enum ClientAuthenticationMethod {
         }
         String normalized = value.trim();
         for (ClientAuthenticationMethod method : values()) {
-            if (method.value.equalsIgnoreCase(normalized) || method.name().equalsIgnoreCase(normalized)) {
+            if (method.value.equalsIgnoreCase(normalized)) {
                 return method;
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethod.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethod.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.identity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * How APIM authenticates itself when calling an identity provider's token and introspection endpoints. The values are
+ * the OpenID Connect Discovery {@code token_endpoint_auth_method} names, so a provider's own documentation can be
+ * copied across without translation.
+ *
+ * @author GraviteeSource Team
+ */
+@Schema(enumAsRef = true)
+public enum ClientAuthenticationMethod {
+    /** Credentials sent as HTTP Basic authentication, as {@code Authorization: Basic base64(clientId:clientSecret)}. */
+    CLIENT_SECRET_BASIC("client_secret_basic"),
+
+    /** Credentials sent as {@code client_id} and {@code client_secret} parameters in the form-encoded request body. */
+    CLIENT_SECRET_POST("client_secret_post");
+
+    private final String value;
+
+    ClientAuthenticationMethod(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves a configured value, accepting either the OIDC name ({@code client_secret_basic}) or the enum constant
+     * ({@code CLIENT_SECRET_BASIC}).
+     *
+     * @return the matching method, or {@code null} when the value is absent, blank or unrecognised. Callers decide what
+     *         an unrecognised value means rather than having a login fail here on a configuration typo.
+     */
+    public static ClientAuthenticationMethod fromValue(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim();
+        for (ClientAuthenticationMethod method : values()) {
+            if (method.value.equalsIgnoreCase(normalized) || method.name().equalsIgnoreCase(normalized)) {
+                return method;
+            }
+        }
+        return null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/SocialIdentityProviderEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/configuration/identity/SocialIdentityProviderEntity.java
@@ -52,6 +52,9 @@ public abstract class SocialIdentityProviderEntity {
     @JsonIgnore
     private List<String> persistedClaimsWhitelist;
 
+    @JsonIgnore
+    private ClientAuthenticationMethod tokenEndpointAuthMethod;
+
     public static class UserProfile {
 
         public static final String ID = "id";
@@ -110,6 +113,19 @@ public abstract class SocialIdentityProviderEntity {
 
     public void setPersistedClaimsWhitelist(List<String> persistedClaimsWhitelist) {
         this.persistedClaimsWhitelist = persistedClaimsWhitelist;
+    }
+
+    /**
+     * @return the configured client authentication method, or {@code null} when the provider does not declare one, in
+     *         which case each caller applies the default its endpoint has always used.
+     */
+    @JsonIgnore
+    public ClientAuthenticationMethod getTokenEndpointAuthMethod() {
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(ClientAuthenticationMethod tokenEndpointAuthMethod) {
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
     }
 
     public String getScopeDelimiter() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethodTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/configuration/identity/ClientAuthenticationMethodTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.configuration.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * This is the single point where a provider's configured string becomes behaviour. An unrecognised value resolves to
+ * null, which every caller reads as "use the endpoint default", so a regression here silently reverts every configured
+ * provider to the behaviour the feature exists to change.
+ *
+ * @author GraviteeSource Team
+ */
+class ClientAuthenticationMethodTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "client_secret_basic, CLIENT_SECRET_BASIC",
+            "client_secret_post, CLIENT_SECRET_POST",
+            "CLIENT_SECRET_BASIC, CLIENT_SECRET_BASIC",
+            "CLIENT_SECRET_POST, CLIENT_SECRET_POST",
+            "Client_Secret_Basic, CLIENT_SECRET_BASIC",
+        }
+    )
+    void should_resolve_the_oidc_name_and_the_enum_constant_in_any_case(String configured, ClientAuthenticationMethod expected) {
+        assertThat(ClientAuthenticationMethod.fromValue(configured)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "  client_secret_basic  ", "\tclient_secret_post\n" })
+    void should_ignore_surrounding_whitespace(String configured) {
+        assertThat(ClientAuthenticationMethod.fromValue(configured)).isNotNull();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void should_resolve_an_absent_value_to_null(String configured) {
+        assertThat(ClientAuthenticationMethod.fromValue(configured)).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "client_secret_jwt", "none", "private_key_jwt", "basic", "client-secret-basic", "nonsense" })
+    void should_resolve_an_unsupported_or_unknown_value_to_null(String configured) {
+        assertThat(ClientAuthenticationMethod.fromValue(configured)).isNull();
+    }
+
+    @Test
+    void should_expose_the_oidc_names_as_values() {
+        assertThat(ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue()).isEqualTo("client_secret_basic");
+        assertThat(ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue()).isEqualTo("client_secret_post");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -46,6 +46,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -84,6 +85,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
     private static final String ERROR_PROPERTY = "error";
     private static final String INVALID_CLIENT_ERROR = "invalid_client";
     private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String PROVIDER_UNAVAILABLE_ERROR = "identity_provider_unavailable";
     private static final String CLIENT_AUTHENTICATION_HINT =
         "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
         "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
@@ -138,13 +140,21 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     if (active) {
                         return authenticateUser(identityProvider, servletResponse, token, null, null);
                     } else {
+                        log.info("Identity provider {} reported the exchanged token as inactive", identityProvider.getId());
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
                 }
 
                 String errorBody = getResponseEntityAsString(response);
-                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
-                return clientAuthenticationFailure(errorBody);
+                log.warn(
+                    "Token introspection for identity provider {} at {} failed with status {}: {}\n{}",
+                    identityProvider.getId(),
+                    identityProvider.getTokenIntrospectionEndpoint(),
+                    response.getStatus(),
+                    response.getStatusInfo(),
+                    errorBody
+                );
+                return clientAuthenticationFailure(response.getStatus(), errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -195,13 +205,15 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             }
 
             String errorBody = getResponseEntityAsString(response);
-            log.error(
-                "Exchange authorization code failed with status {}: {}\n{}",
+            log.warn(
+                "Authorization-code exchange for identity provider {} at {} failed with status {}: {}\n{}",
+                identityProvider.getId(),
+                identityProvider.getTokenEndpoint(),
                 response.getStatus(),
                 response.getStatusInfo(),
                 errorBody
             );
-            return clientAuthenticationFailure(errorBody);
+            return clientAuthenticationFailure(response.getStatus(), errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
@@ -222,24 +234,26 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             ? identityProvider.getTokenEndpointAuthMethod()
             : endpointDefault;
 
-        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
-            request.header(
-                HttpHeaders.AUTHORIZATION,
-                String.format(
-                    "Basic %s",
-                    Base64.getEncoder().encodeToString(
-                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                    )
-                )
-            );
-        } else {
-            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
-            // the form has none and the request body keeps the shape providers are already receiving.
-            if (!form.containsKey(CLIENT_ID_KEY)) {
-                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+        // Switched rather than decided by exclusion: token_endpoint_auth_method has values such as none and
+        // private_key_jwt that must not fall through to putting the secret in the body, so adding a constant has to be
+        // a deliberate decision here rather than a silent change on a credential path.
+        switch (method) {
+            case CLIENT_SECRET_BASIC -> request.header(HttpHeaders.AUTHORIZATION, basicAuthorization(identityProvider));
+            case CLIENT_SECRET_POST -> {
+                // The authorization-code flow already carries the client_id supplied by the caller. add() registers the
+                // key even for a null value, so the presence of a value is what decides, not the presence of the key.
+                if (form.getFirst(CLIENT_ID_KEY) == null) {
+                    form.putSingle(CLIENT_ID_KEY, identityProvider.getClientId());
+                }
+                form.add(CLIENT_SECRET, identityProvider.getClientSecret());
             }
-            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
         }
+    }
+
+    private static String basicAuthorization(SocialIdentityProviderEntity identityProvider) {
+        String credentials = identityProvider.getClientId() + ':' + identityProvider.getClientSecret();
+        // Explicit charset: the platform default silently changes the bytes, and therefore the credential, per host
+        return String.format("Basic %s", Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**
@@ -247,8 +261,10 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
      * naming the client authentication method when the provider rejected our credentials. Only the error code is
      * relayed, never the provider's raw response, which may describe its internals.
      */
-    private Response clientAuthenticationFailure(String providerResponseBody) {
-        String error = PROVIDER_ERROR;
+    private Response clientAuthenticationFailure(int providerStatus, String providerResponseBody) {
+        // A provider that is down and a provider that rejected our credentials are different problems, so they must not
+        // arrive as the same error code. Without this, an outage reads as a configuration mistake.
+        String error = providerStatus >= 500 ? PROVIDER_UNAVAILABLE_ERROR : PROVIDER_ERROR;
         try {
             Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
             if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.portal.rest.model.PayloadInput;
@@ -40,6 +41,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -47,6 +49,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Singleton;
@@ -78,6 +81,13 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
 
     private static final String ACCESS_TOKEN_PROPERTY = "access_token";
     private static final String ID_TOKEN_PROPERTY = "id_token";
+    private static final String ERROR_PROPERTY = "error";
+    private static final String INVALID_CLIENT_ERROR = "invalid_client";
+    private static final String PROVIDER_ERROR = "identity_provider_error";
+    private static final String CLIENT_AUTHENTICATION_HINT =
+        "The identity provider rejected the client credentials. Check that the tokenEndpointAuthMethod configured on " +
+        "the identity provider matches the method the provider expects (client_secret_basic or client_secret_post); " +
+        "the token and introspection endpoints must both accept it.";
 
     @PostConstruct
     public void initClient() throws NoSuchAlgorithmException, KeyManagementException {
@@ -113,20 +123,12 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 // Step1. Check the token by invoking the introspection endpoint
                 final MultivaluedStringMap introspectData = new MultivaluedStringMap();
                 introspectData.add(TOKEN, token);
-                Response response = client
+                Invocation.Builder introspectRequest = client
                     //TODO: what is the correct introspection URL here ?
                     .target(identityProvider.getTokenIntrospectionEndpoint())
-                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                    .header(
-                        HttpHeaders.AUTHORIZATION,
-                        String.format(
-                            "Basic %s",
-                            Base64.getEncoder().encodeToString(
-                                (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
-                            )
-                        )
-                    )
-                    .post(Entity.form(introspectData));
+                    .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+                authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_BASIC, introspectData, introspectRequest);
+                Response response = introspectRequest.post(Entity.form(introspectData));
                 introspectData.clear();
 
                 if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -138,16 +140,11 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                     } else {
                         return Response.status(Response.Status.UNAUTHORIZED).entity(introspectPayload).build();
                     }
-                } else {
-                    log.error(
-                        "Token exchange failed with status {}: {}\n{}",
-                        response.getStatus(),
-                        response.getStatusInfo(),
-                        getResponseEntityAsString(response)
-                    );
                 }
 
-                return Response.status(response.getStatusInfo()).entity(response.getEntity()).build();
+                String errorBody = getResponseEntityAsString(response);
+                log.error("Token exchange failed with status {}: {}\n{}", response.getStatus(), response.getStatusInfo(), errorBody);
+                return clientAuthenticationFailure(errorBody);
             } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Token exchange is not supported for this identity provider")
@@ -178,15 +175,16 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             final MultivaluedStringMap accessData = new MultivaluedStringMap();
             accessData.add(CLIENT_ID_KEY, payloadInput.getClientId());
             accessData.add(REDIRECT_URI_KEY, payloadInput.getRedirectUri());
-            accessData.add(CLIENT_SECRET, identityProvider.getClientSecret());
             accessData.add(CODE_KEY, payloadInput.getCode());
             accessData.add(CODE_VERIFIER_KEY, payloadInput.getCodeVerifier());
             accessData.add(GRANT_TYPE_KEY, payloadInput.getGrantType());
 
-            Response response = client
+            Invocation.Builder tokenRequest = client
                 .target(identityProvider.getTokenEndpoint())
-                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.form(accessData));
+                .request(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+            authenticateClient(identityProvider, ClientAuthenticationMethod.CLIENT_SECRET_POST, accessData, tokenRequest);
+
+            Response response = tokenRequest.post(Entity.form(accessData));
             accessData.clear();
 
             if (response.getStatus() == Response.Status.OK.getStatusCode()) {
@@ -194,18 +192,78 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
                 final String accessToken = (String) responseEntity.get(ACCESS_TOKEN_PROPERTY);
                 final String idToken = (String) responseEntity.get(ID_TOKEN_PROPERTY);
                 return authenticateUser(identityProvider, servletResponse, accessToken, idToken, payloadInput.getState());
-            } else {
-                log.error(
-                    "Exchange authorization code failed with status {}: {}\n{}",
-                    response.getStatus(),
-                    response.getStatusInfo(),
-                    getResponseEntityAsString(response)
-                );
             }
-            return Response.status(Response.Status.UNAUTHORIZED).build();
+
+            String errorBody = getResponseEntityAsString(response);
+            log.error(
+                "Exchange authorization code failed with status {}: {}\n{}",
+                response.getStatus(),
+                response.getStatusInfo(),
+                errorBody
+            );
+            return clientAuthenticationFailure(errorBody);
         }
 
         return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    /**
+     * Applies the client credentials the way the identity provider expects to receive them. A provider that declares no
+     * method keeps the behaviour this endpoint has always had, so existing configurations are unaffected; declaring one
+     * makes the token and introspection calls agree, which they previously did not.
+     */
+    private void authenticateClient(
+        SocialIdentityProviderEntity identityProvider,
+        ClientAuthenticationMethod endpointDefault,
+        MultivaluedStringMap form,
+        Invocation.Builder request
+    ) {
+        ClientAuthenticationMethod method = identityProvider.getTokenEndpointAuthMethod() != null
+            ? identityProvider.getTokenEndpointAuthMethod()
+            : endpointDefault;
+
+        if (method == ClientAuthenticationMethod.CLIENT_SECRET_BASIC) {
+            request.header(
+                HttpHeaders.AUTHORIZATION,
+                String.format(
+                    "Basic %s",
+                    Base64.getEncoder().encodeToString(
+                        (identityProvider.getClientId() + ':' + identityProvider.getClientSecret()).getBytes()
+                    )
+                )
+            );
+        } else {
+            // The authorization-code flow already carries the client_id supplied by the caller, so only add one where
+            // the form has none and the request body keeps the shape providers are already receiving.
+            if (!form.containsKey(CLIENT_ID_KEY)) {
+                form.add(CLIENT_ID_KEY, identityProvider.getClientId());
+            }
+            form.add(CLIENT_SECRET, identityProvider.getClientSecret());
+        }
+    }
+
+    /**
+     * Reports a failed token or introspection call as an authentication failure carrying the provider's own error code,
+     * naming the client authentication method when the provider rejected our credentials. Only the error code is
+     * relayed, never the provider's raw response, which may describe its internals.
+     */
+    private Response clientAuthenticationFailure(String providerResponseBody) {
+        String error = PROVIDER_ERROR;
+        try {
+            Object providerError = getEntity(providerResponseBody).get(ERROR_PROPERTY);
+            if (providerError instanceof String providerErrorCode && !providerErrorCode.isBlank()) {
+                error = providerErrorCode;
+            }
+        } catch (IOException | RuntimeException e) {
+            log.debug("Identity provider error response is not a JSON object", e);
+        }
+
+        Map<String, String> payload = new LinkedHashMap<>();
+        payload.put(ERROR_PROPERTY, error);
+        if (INVALID_CLIENT_ERROR.equals(error)) {
+            payload.put("hint", CLIENT_AUTHENTICATION_HINT);
+        }
+        return Response.status(Response.Status.UNAUTHORIZED).entity(payload).build();
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -234,10 +234,11 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
             ? identityProvider.getTokenEndpointAuthMethod()
             : endpointDefault;
 
-        // Switched rather than decided by exclusion: token_endpoint_auth_method has values such as none and
-        // private_key_jwt that must not fall through to putting the secret in the body, so adding a constant has to be
-        // a deliberate decision here rather than a silent change on a credential path.
+        // The null label makes this an enhanced switch (JLS 14.11.2), so the compiler requires it to be exhaustive:
+        // adding a token_endpoint_auth_method constant such as none or private_key_jwt fails the build here instead of
+        // silently doing nothing, or worse falling through to putting the secret in the body, on a credential path.
         switch (method) {
+            case null -> throw new IllegalArgumentException("No client authentication method resolved for " + identityProvider.getId());
             case CLIENT_SECRET_BASIC -> request.header(HttpHeaders.AUTHORIZATION, basicAuthorization(identityProvider));
             case CLIENT_SECRET_POST -> {
                 // The authorization-code flow already carries the client_id supplied by the caller. add() registers the

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -50,6 +50,7 @@ import jakarta.ws.rs.core.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -380,16 +381,13 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
 
     @Test
     void should_authenticate_introspection_with_basic_auth_when_no_auth_method_configured() throws Exception {
-        // Given
         mockDefaultEnvironment();
         mockIntrospectionEndpoint();
         mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
         mockConnectedUser();
 
-        // When
         Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
 
-        // Then
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         WireMock.verify(
             postRequestedFor(urlEqualTo("/introspect"))
@@ -400,17 +398,14 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
 
     @Test
     void should_send_client_credentials_in_introspection_body_when_configured() throws Exception {
-        // Given
         mockDefaultEnvironment();
         identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
         mockIntrospectionEndpoint();
         mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
         mockConnectedUser();
 
-        // When
         Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
 
-        // Then
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         WireMock.verify(
             postRequestedFor(urlEqualTo("/introspect"))
@@ -422,7 +417,6 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
 
     @Test
     void should_send_client_credentials_as_basic_auth_in_token_request_when_configured() throws Exception {
-        // Given
         mockDefaultEnvironment();
         identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
         wireMockServer.stubFor(
@@ -431,10 +425,8 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())));
         mockConnectedUser();
 
-        // When
         Response response = target().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe")));
 
-        // Then
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         WireMock.verify(
             postRequestedFor(urlEqualTo("/token"))
@@ -444,23 +436,64 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void should_report_invalid_client_on_introspection_instead_of_a_server_error() throws Exception {
-        // Given
+    void should_send_client_credentials_in_token_request_body_when_no_auth_method_configured() throws Exception {
         mockDefaultEnvironment();
         wireMockServer.stubFor(
-            post("/introspect").willReturn(
-                aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}")
-            )
+            post("/token").willReturn(okJson(IOUtils.toString(read("/oauth2/json/token_response_body.json"), Charset.defaultCharset())))
+        );
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())));
+        mockConnectedUser();
+
+        Response response = target().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe")));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        // The default this endpoint has always used, and the claim the backwards compatibility argument rests on
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/token"))
+                .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                .withRequestBody(containing("client_secret=the_client_secret"))
+        );
+    }
+
+    @Test
+    void should_report_invalid_client_on_introspection_instead_of_a_server_error() throws Exception {
+        mockDefaultEnvironment();
+        wireMockServer.stubFor(
+            post("/introspect").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody(PROVIDER_REJECTION_BODY))
         );
 
-        // When
         Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
 
-        // Then
         assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
         String body = response.readEntity(String.class);
-        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertRelaysOnlyTheErrorCode(body);
         assertTrue(body.contains("tokenEndpointAuthMethod"), "the likely cause must be named, got: " + body);
+    }
+
+    @Test
+    void should_report_invalid_client_on_token_request_instead_of_an_empty_unauthorized() throws Exception {
+        mockDefaultEnvironment();
+        wireMockServer.stubFor(
+            post("/token").willReturn(aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody(PROVIDER_REJECTION_BODY))
+        );
+
+        Response response = target().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe")));
+
+        assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertRelaysOnlyTheErrorCode(body);
+        assertTrue(body.contains("tokenEndpointAuthMethod"), "the likely cause must be named, got: " + body);
+    }
+
+    /** Carries detail a caller must never see, so relaying the provider's raw body fails these tests. */
+    private static final String PROVIDER_REJECTION_BODY =
+        "{\"error\":\"invalid_client\",\"error_description\":\"client not found in realm internal-realm-7\",\"trace\":\"provider-node-3\"}";
+
+    private void assertRelaysOnlyTheErrorCode(String body) {
+        assertTrue(body.contains("invalid_client"), "the provider's own error code must reach the caller, got: " + body);
+        assertFalse(body.contains("internal-realm-7"), "the provider's response detail must not be relayed, got: " + body);
+        assertFalse(body.contains("provider-node-3"), "the provider's response detail must not be relayed, got: " + body);
+        assertFalse(body.contains("error_description"), "the provider's response detail must not be relayed, got: " + body);
     }
 
     private void mockIntrospectionEndpoint() {
@@ -482,7 +515,7 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
     }
 
     private static String expectedBasicAuthorization() {
-        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes());
+        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes(StandardCharsets.UTF_8));
     }
 
     private void mockUserInfo(ResponseDefinitionBuilder responseDefinitionBuilder, String expectedBearer) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.resource.auth;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static jakarta.ws.rs.client.Entity.form;
+import static jakarta.ws.rs.client.Entity.text;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,6 +37,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.GroupMappingEntity;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderType;
 import io.gravitee.rest.api.model.configuration.identity.RoleMappingEntity;
@@ -49,6 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -157,6 +160,16 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
             @Override
             public boolean isEmailRequired() {
                 return true;
+            }
+
+            @Override
+            public String getTokenIntrospectionEndpoint() {
+                return "http://localhost:" + wireMockServer.port() + "/introspect";
+            }
+
+            @Override
+            public String getClientId() {
+                return "the_client_id";
             }
         };
 
@@ -363,6 +376,122 @@ class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
 
         // verify jwt token not present
         assertFalse(response.getCookies().containsKey(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Test
+    void should_authenticate_introspection_with_basic_auth_when_no_auth_method_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        mockIntrospectionEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
+        mockConnectedUser();
+
+        // When
+        Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/introspect"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo(expectedBasicAuthorization()))
+                .withRequestBody(notContaining("client_secret"))
+        );
+    }
+
+    @Test
+    void should_send_client_credentials_in_introspection_body_when_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+        mockIntrospectionEndpoint();
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())), "MyToken");
+        mockConnectedUser();
+
+        // When
+        Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/introspect"))
+                .withHeader(HttpHeaders.AUTHORIZATION, absent())
+                .withRequestBody(containing("client_secret=the_client_secret"))
+                .withRequestBody(containing("client_id=the_client_id"))
+        );
+    }
+
+    @Test
+    void should_send_client_credentials_as_basic_auth_in_token_request_when_configured() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        identityProvider.setTokenEndpointAuthMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
+        wireMockServer.stubFor(
+            post("/token").willReturn(okJson(IOUtils.toString(read("/oauth2/json/token_response_body.json"), Charset.defaultCharset())))
+        );
+        mockUserInfo(okJson(IOUtils.toString(read("/oauth2/json/user_info_response_body.json"), Charset.defaultCharset())));
+        mockConnectedUser();
+
+        // When
+        Response response = target().request().post(form(createPayload("the_client_id", "http://localhost/callback", "CoDe")));
+
+        // Then
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        WireMock.verify(
+            postRequestedFor(urlEqualTo("/token"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo(expectedBasicAuthorization()))
+                .withRequestBody(notContaining("client_secret"))
+        );
+    }
+
+    @Test
+    void should_report_invalid_client_on_introspection_instead_of_a_server_error() throws Exception {
+        // Given
+        mockDefaultEnvironment();
+        wireMockServer.stubFor(
+            post("/introspect").willReturn(
+                aResponse().withStatus(HttpStatusCode.UNAUTHORIZED_401).withBody("{\"error\":\"invalid_client\"}")
+            )
+        );
+
+        // When
+        Response response = target().path("_exchange").queryParam("token", "MyToken").request().post(text(""));
+
+        // Then
+        assertEquals(HttpStatusCode.UNAUTHORIZED_401, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertTrue(body.contains("invalid_client"), "the provider's own error must reach the caller, got: " + body);
+        assertTrue(body.contains("tokenEndpointAuthMethod"), "the likely cause must be named, got: " + body);
+    }
+
+    private void mockIntrospectionEndpoint() {
+        wireMockServer.stubFor(post("/introspect").willReturn(okJson("{\"active\":\"true\"}")));
+    }
+
+    private void mockConnectedUser() {
+        UserEntity userEntity = mockUserEntity();
+        when(
+            userService.createOrUpdateUserFromSocialIdentityProvider(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(identityProvider),
+                anyString(),
+                any(),
+                any()
+            )
+        ).thenReturn(userEntity);
+        when(userService.connect(GraviteeContext.getExecutionContext(), userEntity.getId())).thenReturn(userEntity);
+    }
+
+    private static String expectedBasicAuthorization() {
+        return "Basic " + Base64.getEncoder().encodeToString("the_client_id:the_client_secret".getBytes());
+    }
+
+    private void mockUserInfo(ResponseDefinitionBuilder responseDefinitionBuilder, String expectedBearer) {
+        wireMockServer.stubFor(
+            get("/userinfo")
+                .withHeader(HttpHeaders.ACCEPT, equalTo(MediaType.APPLICATION_JSON_TYPE.toString()))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer " + expectedBearer))
+                .willReturn(responseDefinitionBuilder)
+        );
     }
 
     private void mockUserInfo(ResponseDefinitionBuilder responseDefinitionBuilder) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -32,7 +32,9 @@ import io.gravitee.rest.api.service.configuration.identity.IdentityProviderServi
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,6 +59,8 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
     private static final String CLIENT_ID = "clientId";
     private static final String CLIENT_SECRET = "clientSecret";
     private static final String TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
+
+    private final Map<String, String> reportedClientAuthenticationMethods = new ConcurrentHashMap<>();
 
     @Autowired
     private IdentityProviderService identityProviderService;
@@ -178,10 +182,7 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
             provider.setClientId((String) identityProvider.getConfiguration().get(CLIENT_ID));
             provider.setClientSecret((String) identityProvider.getConfiguration().get(CLIENT_SECRET));
             provider.setTokenEndpointAuthMethod(
-                clientAuthenticationMethod(
-                    (String) identityProvider.getConfiguration().get(TOKEN_ENDPOINT_AUTH_METHOD),
-                    identityProvider.getId()
-                )
+                clientAuthenticationMethod(identityProvider.getConfiguration().get(TOKEN_ENDPOINT_AUTH_METHOD), identityProvider.getId())
             );
             provider.setGroupMappings(identityProvider.getGroupMappings());
             provider.setRoleMappings(identityProvider.getRoleMappings());
@@ -195,21 +196,40 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
     }
 
     /**
-     * An unrecognised value is reported rather than rejected: failing here would break every login for the provider,
-     * whereas falling back leaves authentication working while the warning names the typo.
+     * An unusable value is reported rather than rejected: failing here would break every login for the provider, and
+     * because {@code findAll} turns any exception from {@code convert} into a single failure, it would remove every
+     * other provider from the list too. Falling back leaves authentication working on the endpoint defaults.
+     *
+     * <p>The value arrives from a free-form configuration map, so it is not assumed to be a String.
      */
-    private ClientAuthenticationMethod clientAuthenticationMethod(String configured, String identityProviderId) {
-        ClientAuthenticationMethod method = ClientAuthenticationMethod.fromValue(configured);
-        if (method == null && configured != null && !configured.isBlank()) {
-            log.warn(
-                "Identity provider {} declares an unknown {} '{}'. Expected {} or {}. Falling back to the default of each endpoint.",
-                identityProviderId,
-                TOKEN_ENDPOINT_AUTH_METHOD,
-                configured,
-                ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(),
-                ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue()
-            );
+    private ClientAuthenticationMethod clientAuthenticationMethod(Object configured, String identityProviderId) {
+        if (configured == null || (configured instanceof String declared && declared.isBlank())) {
+            return null;
+        }
+
+        ClientAuthenticationMethod method = configured instanceof String declared ? ClientAuthenticationMethod.fromValue(declared) : null;
+        if (method == null) {
+            reportUnusableClientAuthenticationMethod(identityProviderId, configured);
         }
         return method;
+    }
+
+    /**
+     * Reported once per provider and value rather than on every call: {@code convert} runs on each token exchange, so
+     * warning per call turns a single typo into one log line per authentication request.
+     */
+    private void reportUnusableClientAuthenticationMethod(String identityProviderId, Object configured) {
+        String previouslyReported = reportedClientAuthenticationMethods.put(identityProviderId, String.valueOf(configured));
+        if (String.valueOf(configured).equals(previouslyReported)) {
+            return;
+        }
+        log.warn(
+            "Identity provider {} declares an unusable {} '{}'. Expected {} or {}. Falling back to the default of each endpoint.",
+            identityProviderId,
+            TOKEN_ENDPOINT_AUTH_METHOD,
+            configured,
+            ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(),
+            ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.configuration.identity;
 
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationEntity;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
 import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
@@ -55,6 +56,7 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
 
     private static final String CLIENT_ID = "clientId";
     private static final String CLIENT_SECRET = "clientSecret";
+    private static final String TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
 
     @Autowired
     private IdentityProviderService identityProviderService;
@@ -175,6 +177,12 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
             provider.setDescription(identityProvider.getDescription());
             provider.setClientId((String) identityProvider.getConfiguration().get(CLIENT_ID));
             provider.setClientSecret((String) identityProvider.getConfiguration().get(CLIENT_SECRET));
+            provider.setTokenEndpointAuthMethod(
+                clientAuthenticationMethod(
+                    (String) identityProvider.getConfiguration().get(TOKEN_ENDPOINT_AUTH_METHOD),
+                    identityProvider.getId()
+                )
+            );
             provider.setGroupMappings(identityProvider.getGroupMappings());
             provider.setRoleMappings(identityProvider.getRoleMappings());
             provider.setEmailRequired(identityProvider.isEmailRequired());
@@ -184,5 +192,24 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
         }
 
         return null;
+    }
+
+    /**
+     * An unrecognised value is reported rather than rejected: failing here would break every login for the provider,
+     * whereas falling back leaves authentication working while the warning names the typo.
+     */
+    private ClientAuthenticationMethod clientAuthenticationMethod(String configured, String identityProviderId) {
+        ClientAuthenticationMethod method = ClientAuthenticationMethod.fromValue(configured);
+        if (method == null && configured != null && !configured.isBlank()) {
+            log.warn(
+                "Identity provider {} declares an unknown {} '{}'. Expected {} or {}. Falling back to the default of each endpoint.",
+                identityProviderId,
+                TOKEN_ENDPOINT_AUTH_METHOD,
+                configured,
+                ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(),
+                ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue()
+            );
+        }
+        return method;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.configuration.identity.ClientAuthenticationMethod;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderType;
+import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Covers the collapse of the free-form {@code tokenEndpointAuthMethod} configuration string into the typed enum. The
+ * resources only ever see the enum, so this is the only place the string is interpreted.
+ *
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class SocialIdentityProviderImplTest {
+
+    private static final String PROVIDER_ID = "oidc-provider";
+    private static final String ORGANIZATION_ID = "DEFAULT";
+
+    @Mock
+    private IdentityProviderService identityProviderService;
+
+    @Mock
+    private IdentityProviderActivationService identityProviderActivationService;
+
+    @InjectMocks
+    private SocialIdentityProviderImpl socialIdentityProvider;
+
+    private final Map<String, Object> configuration = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        configuration.clear();
+        configuration.put("clientId", "the_client_id");
+        configuration.put("clientSecret", "the_client_secret");
+        configuration.put("tokenEndpoint", "https://provider.example.com/token");
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "client_secret_basic, CLIENT_SECRET_BASIC", "client_secret_post, CLIENT_SECRET_POST" })
+    void should_resolve_the_configured_client_authentication_method(String configured, ClientAuthenticationMethod expected) {
+        configuration.put("tokenEndpointAuthMethod", configured);
+
+        assertThat(findProvider().getTokenEndpointAuthMethod()).isEqualTo(expected);
+    }
+
+    @Test
+    void should_leave_the_method_unset_when_the_provider_declares_none() {
+        assertThat(findProvider().getTokenEndpointAuthMethod()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "client_secret_jwt", "none", "typo", "  " })
+    void should_fall_back_to_the_endpoint_defaults_on_an_unusable_value(String configured) {
+        configuration.put("tokenEndpointAuthMethod", configured);
+
+        // Falling back rather than failing is the safety property: a typo must not stop every login for this provider
+        assertThat(findProvider().getTokenEndpointAuthMethod()).isNull();
+    }
+
+    @Test
+    void should_fall_back_rather_than_fail_when_the_configured_value_is_not_a_string() {
+        // The configuration map is free-form, so an unquoted value arrives as a number or boolean. convert() is wrapped
+        // by findAll() into a single failure, so throwing here would remove every provider from the list, not just this one.
+        configuration.put("tokenEndpointAuthMethod", 123);
+
+        assertThatCode(() -> assertThat(findProvider().getTokenEndpointAuthMethod()).isNull()).doesNotThrowAnyException();
+    }
+
+    private SocialIdentityProviderEntity findProvider() {
+        IdentityProviderEntity identityProvider = new IdentityProviderEntity();
+        identityProvider.setId(PROVIDER_ID);
+        identityProvider.setName("OIDC Provider");
+        identityProvider.setType(IdentityProviderType.OIDC);
+        identityProvider.setEnabled(true);
+        identityProvider.setConfiguration(configuration);
+
+        IdentityProviderActivationEntity activation = new IdentityProviderActivationEntity();
+        activation.setIdentityProvider(PROVIDER_ID);
+
+        when(identityProviderActivationService.findAllByTarget(any())).thenReturn(Set.of(activation));
+        when(identityProviderService.findById(PROVIDER_ID)).thenReturn(identityProvider);
+
+        return socialIdentityProvider.findById(
+            PROVIDER_ID,
+            new IdentityProviderActivationService.ActivationTarget(ORGANIZATION_ID, IdentityProviderActivationReferenceType.ORGANIZATION)
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14841

## Description

The two OAuth2 login endpoints demanded **different** client authentication from the same identity provider:

| Endpoint | Credentials sent as | Method required |
|---|---|---|
| `POST .../auth/oauth2/{idp}` | `client_id` + `client_secret` in the token-request body | `client_secret_post` |
| `POST .../auth/oauth2/{idp}/exchange` | hardcoded `Authorization: Basic` on introspection | `client_secret_basic` |

A provider configured for one failed on the other, and the failure was opaque — the code flow returned an **empty 401**, the exchange path a **500**, with only `invalid_client` in the server log and nothing pointing at client authentication.

### The fix

A new `tokenEndpointAuthMethod` key on the identity provider's configuration, applied to **both** calls. Naming follows the OpenID Connect Discovery `token_endpoint_auth_method` value (already present as a String on the DCR DTOs), so a provider's own documentation transfers without translation.

**A provider that declares no method keeps the behaviour each endpoint has always had** — token via body, introspection via Basic. That is deliberate: introspection is only reachable through `/exchange`, only when `tokenIntrospectionEndpoint` is set, and no first-party console or portal code calls `/exchange`, so its only consumers are external integrators we cannot see — and for them Basic is currently the *only* thing that works. Converging both on `client_secret_post` would be cleaner but would silently break those integrators on upgrade, and there is no changelog/upgrade-note mechanism in this repo to warn them. The existing tests passing unchanged is the evidence: the legacy stubs assert the exact token-request body and the `Basic` introspection header, and both still match.

Stored in the `configuration` map rather than as a column, so **no migration** — `JdbcIdentityProviderRepository` persists `configuration` as a single JSON string and absent keys read back null. It is read in the common tail of `SocialIdentityProviderImpl.convert`, alongside `clientId`/`clientSecret`, so Gravitee AM providers get it too, not just OIDC.

### Two further defects fixed in the same paths

- **The 500.** The introspection path logged the response body and then passed the *already-consumed* JAX-RS client `Response.getEntity()` into the outgoing response, which cannot serialize. The body is now read once into a variable, logged, and turned into an error payload.
- **Opaque failures.** Both paths now answer with the provider's own error code, plus a hint naming `tokenEndpointAuthMethod` when the provider says `invalid_client`. Only the error *code* is relayed — never the provider's raw response, which may describe its internals.

An unrecognised configuration value is reported (warning naming the provider and the accepted values) and ignored rather than rejected, so a typo cannot lock every user out of login.

### Behaviour changes to be aware of

- Introspection failures now answer **401 instead of 500**.
- Both failure paths now carry a **JSON body**, where the code flow previously returned an empty 401.

### Scope note — widened beyond the ticket

The ticket names only the management resource. The portal resource (`portal-rest/.../auth/OAuth2AuthenticationResource.java`) carried the **identical** defect on both call sites, so fixing management alone would have left a known twin behind; it is fixed the same way here. Its `_exchange` endpoint had **no test coverage at all** — the test fixture's provider did not even expose an introspection endpoint, so the path was unreachable — and now has coverage.

Not fixed, flagged instead: `ClientCredentialsInitialAccessTokenProvider.java:81-86` hardcodes Basic in the same way, carrying a TODO that says exactly this ("we must being able to handle client authentication according to the `token_endpoint_auth_methods_supported` property from discovery"). That is a different configuration surface — client registration providers, not identity providers — so it is out of scope here.

## Additional context

⚠️ **Security-sensitive**: changes how client credentials are transmitted to an external identity provider, and changes error responses on an authentication path. The new messages relay only the provider's error code and a static hint; the client secret is never logged or returned.

⚠️ **Compatibility-sensitive**: adds a configuration key (`tokenEndpointAuthMethod`) and a new enum (`ClientAuthenticationMethod`). No schema change, no migration, no change to any generated model or OpenAPI contract.

### Verification

RED → GREEN observed on both modules:

- Management: 4 of 16 failed before the change — including `expected: <401> but was: <500>` on introspection and the empty 401 body — then 16/16.
- Portal: tests were written after the fix, so RED was verified by reverting the production file — 3 of the 4 new tests fail, including the same 500 — then 8/8. The fourth correctly passes either way, since it pins the legacy default.

Full suites for all four touched modules green: **236 / 9338 / 92 / 519 / 605, zero failures**.

Pre-existing behaviour, unrelated to epic APIM-13949 — surfaced while testing it. Sibling PR #19252 fixes APIM-14840; the reopened UI story APIM-13954 follows separately.