### PR TITLE
ci(sonar): analyse the reference branch in the nightly build

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -154,6 +154,7 @@ const slack = {
     apiManagementTeamNotifications: 'C02JENTV2AX',
     apimCiNotificationsBridgeCompatibilityTests: 'C08H9K43WSV',
     apimCiNotificationsHelmTests: 'C08GWL40VB7',
+    apimCiNotificationsNightly: 'C0BR8DK75N2',
     apimCiNotificationsRepositoriesTests: 'C08HMNYPHA4',
     graviteeReleaseAlerts: 'C02NGT20S4W',
   },

--- a/.circleci/ci/src/pipelines/tests/pipeline-nightly.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-nightly.spec.ts
@@ -15,6 +15,7 @@
  */
 import * as fs from 'fs';
 import { generateNightlyConfig } from '../pipeline-nightly';
+import { generatePullRequestsConfig } from '../pipeline-pull-requests';
 
 describe('Nightly', () => {
   it('should generate the nightly pipeline', () => {
@@ -33,5 +34,35 @@ describe('Nightly', () => {
 
     const expected = fs.readFileSync(`./src/pipelines/tests/resources/nightly/nightly.yml`, 'utf-8');
     expect(result.stringify()).toStrictEqual(expected);
+  });
+
+  // The nightly spells out its own analyses, so nothing stops the two lists from drifting: a
+  // seventh module added to the pull-request groups would never be analysed on the reference
+  // branch, and the snapshot above would accept it.
+  it('should analyse exactly the projects a pull request analyses', () => {
+    const environment = {
+      baseBranch: 'master',
+      branch: 'master',
+      sha1: '784ff35ca',
+      changedFiles: [],
+      buildNum: '1234',
+      buildId: '1234',
+      graviteeioVersion: '4.2.0',
+      isDryRun: false,
+      apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+    };
+
+    const sonarJobs = (yaml: string): string[] => [...yaml.matchAll(/name: (Sonar - [\w-]+)/g)].map((match) => match[1]).sort();
+
+    const nightly = generateNightlyConfig({ ...environment, action: 'nightly' }).stringify();
+    const pullRequest = generatePullRequestsConfig({
+      ...environment,
+      action: 'pull_requests',
+      branch: 'APIM-1234-my-custom-branch',
+      changedFiles: ['pom.xml'],
+    }).stringify();
+
+    expect(sonarJobs(nightly)).toEqual(sonarJobs(pullRequest));
+    expect(sonarJobs(nightly)).toHaveLength(9);
   });
 });

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -295,6 +295,330 @@ jobs:
             kubectl rollout restart deployment -n apim-apim-master-ce
             kubectl rollout restart deployment -n apim-apim-master-oem
       - cmd-notify-on-failure
+  job-sonarcloud-analysis:
+    parameters:
+      working_directory:
+        type: string
+        default: gravitee-apim-rest-api
+        description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
+    docker:
+      - image: sonarsource/sonar-scanner-cli:11.2
+    resource_class: large
+    steps:
+      - checkout:
+          method: full
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-sonarcloud-analysis-<< parameters.cache_type >>
+      - keeper/env-export:
+          secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
+          var-name: SONAR_TOKEN
+      - run:
+          name: Run Sonarcloud Analysis
+          command: sonar-scanner -Dsonar.projectVersion=4.2.0-SNAPSHOT
+          working_directory: << parameters.working_directory >>
+          no_output_timeout: 30m
+      - cmd-notify-on-failure
+      - save_cache:
+          paths:
+            - /opt/sonar-scanner/.sonar/cache
+          key: gravitee-api-management-v14-sonarcloud-analysis-<< parameters.cache_type >>
+          when: always
+  job-test-definition:
+    docker:
+      - image: cimg/openjdk:25.0.3
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-definition
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - run:
+          name: Run definition tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-definition
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
+  job-test-gateway:
+    docker:
+      - image: cimg/openjdk:25.0.3
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-gateway
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - run:
+          name: Run gateway tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-gateway
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-gateway/gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/
+  job-test-rest-api:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-jdk
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-rest-api
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-install-yarn
+      - run:
+          name: Run Rest API tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-rest-api
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/
+  job-test-plugin:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
+    steps:
+      - checkout
+      - cmd-install-jdk
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-plugin
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - run:
+          name: Run plugin tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-plugin
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-plugin/gravitee-apim-plugin-coverage/target/site/jacoco-aggregate/
+  job-test-reporter:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
+    steps:
+      - checkout
+      - cmd-install-jdk
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-reporter
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - run:
+          name: Run reporter tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-reporter
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-reporter/gravitee-apim-reporter-coverage/target/site/jacoco-aggregate/
+  job-test-repository:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: large
+    steps:
+      - checkout
+      - cmd-install-jdk
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-test-repository
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - run:
+          name: Run repository tests
+          command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
+      - run:
+          name: Save test results
+          command: |-
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - cmd-notify-on-failure
+      - cmd-save-maven-job-cache:
+          jobName: job-test-repository
+      - store_test_results:
+          path: ~/test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-repository/gravitee-apim-repository-coverage/target/site/jacoco-aggregate/
+  job-nx-webui-lint-test:
+    parameters:
+      apim-ui-project-workdir:
+        type: string
+        default: ""
+        description: the directory name of the UI project
+      nx-project:
+        type: string
+        default: ""
+        description: the Nx project name
+      resource_class:
+        type: string
+        default: medium
+        description: Resource class to use for executor
+      max-workers:
+        type: string
+        default: 35%
+        description: Maximum number of workers for Jest tests
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: << parameters.resource_class >>
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check License
+          command: yarn nx run << parameters.nx-project >>:lint-license
+      - run:
+          name: Run Prettier and ESLint
+          command: yarn nx lint << parameters.nx-project >>
+      - run:
+          name: Run unit tests
+          command: yarn << parameters.nx-project >>:test:ci
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - << parameters.apim-ui-project-workdir >>/coverage/lcov.info
+      - store_artifacts:
+          path: << parameters.apim-ui-project-workdir >>/coverage/lcov.info
+      - store_test_results:
+          path: << parameters.apim-ui-project-workdir >>/coverage/junit.xml
+  job-webui-lint-test:
+    parameters:
+      apim-ui-project:
+        type: string
+        default: ""
+        description: the name of the UI project
+      apim-ui-project-workdir:
+        type: string
+        default: ""
+        description: the directory name of the UI project
+      resource_class:
+        type: string
+        default: medium
+        description: Resource class to use for executor
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: << parameters.resource_class >>
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: << parameters.apim-ui-project >>
+          apim-ui-project-workdir: << parameters.apim-ui-project-workdir >>
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check License
+          command: yarn lint:license
+          working_directory: << parameters.apim-ui-project-workdir >>
+      - run:
+          name: Run Prettier and ESLint
+          command: yarn lint
+          working_directory: << parameters.apim-ui-project-workdir >>
+      - run:
+          name: Run unit tests
+          command: yarn test:coverage
+          working_directory: << parameters.apim-ui-project-workdir >>
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - << parameters.apim-ui-project-workdir >>/coverage/lcov.info
+      - store_artifacts:
+          path: << parameters.apim-ui-project-workdir >>/coverage/lcov.info
+      - store_test_results:
+          path: << parameters.apim-ui-project-workdir >>/coverage/junit.xml
   job-setup:
     docker:
       - image: cimg/base:stable
@@ -868,6 +1192,136 @@ workflows:
             - cicd-orchestrator
           requires:
             - Build backend
+      - job-test-definition:
+          name: Test definition
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-definition
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test definition
+          working_directory: gravitee-apim-definition
+          cache_type: backend
+      - job-test-gateway:
+          name: Test gateway
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-gateway
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test gateway
+          working_directory: gravitee-apim-gateway
+          cache_type: backend
+      - job-test-rest-api:
+          name: Test rest-api
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-rest-api
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test rest-api
+          working_directory: gravitee-apim-rest-api
+          cache_type: backend
+      - job-test-plugin:
+          name: Test plugins
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-plugin
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test plugins
+          working_directory: gravitee-apim-plugin
+          cache_type: backend
+      - job-test-reporter:
+          name: Test reporters
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-reporter
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test reporters
+          working_directory: gravitee-apim-reporter
+          cache_type: backend
+      - job-test-repository:
+          name: Test repository
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-repository
+          context:
+            - cicd-orchestrator
+          requires:
+            - Test repository
+          working_directory: gravitee-apim-repository
+          cache_type: backend
+      - job-nx-webui-lint-test:
+          name: Lint & test APIM Console
+          context:
+            - cicd-orchestrator
+          apim-ui-project-workdir: gravitee-apim-console-webui
+          nx-project: console
+          resource_class: xlarge
+          max-workers: "7"
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-console-webui
+          context:
+            - cicd-orchestrator
+          requires:
+            - Lint & test APIM Console
+          working_directory: gravitee-apim-console-webui
+          cache_type: frontend
+      - job-nx-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project-workdir: gravitee-apim-portal-webui-next
+          nx-project: portal-next
+          max-workers: "2"
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-portal-webui-next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Lint & test APIM Portal Next
+          working_directory: gravitee-apim-portal-webui-next
+          cache_type: frontend
+      - job-webui-lint-test:
+          name: Lint & test APIM Portal
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui
+          apim-ui-project-workdir: gravitee-apim-portal-webui
+          resource_class: large
+      - job-sonarcloud-analysis:
+          name: Sonar - gravitee-apim-portal-webui
+          context:
+            - cicd-orchestrator
+          requires:
+            - Lint & test APIM Portal
+          working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-e2e-generate-sdk:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -59,7 +59,7 @@ commands:
           secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
-          channel: C02JENTV2AX
+          channel: C0BR8DK75N2
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1

--- a/.circleci/ci/src/utils/slack.ts
+++ b/.circleci/ci/src/utils/slack.ts
@@ -23,6 +23,8 @@ export function computeSlackChannelToUse(action: string | undefined) {
       return config.slack.channels.apimCiNotificationsBridgeCompatibilityTests;
     case 'helm_tests':
       return config.slack.channels.apimCiNotificationsHelmTests;
+    case 'nightly':
+      return config.slack.channels.apimCiNotificationsNightly;
   }
   return config.slack.channels.apiManagementTeamNotifications;
 }

--- a/.circleci/ci/src/workflows/workflow-nightly.ts
+++ b/.circleci/ci/src/workflows/workflow-nightly.ts
@@ -13,8 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Config, workflow, Workflow } from '../circleci-config';
-import { AikidoScanDockerImagesJob, DeployOnAzureJob, TestIntegrationJob } from '../jobs';
+import { Config, Job, workflow, Workflow } from '../circleci-config';
+import {
+  AikidoScanDockerImagesJob,
+  DeployOnAzureJob,
+  SonarCloudAnalysisJob,
+  TestDefinitionJob,
+  TestGatewayJob,
+  TestIntegrationJob,
+  TestPluginJob,
+  TestReporterJob,
+  TestRepositoryJob,
+  TestRestApiJob,
+  WebuiLintTestJob,
+} from '../jobs';
 import { CircleCIEnvironment } from '../pipelines';
 import { config } from '../config';
 import { devEnvironmentJobs } from './groups/dev-environment-jobs';
@@ -24,11 +36,19 @@ import { chainguardFipsImageJobs } from './groups/chainguard-fips-image-jobs';
 /**
  * The scheduled build, one per branch: the default branch and every live support branch.
  *
- * It is the dev-environment refresh plus the two suites that run nowhere else. Pull requests
- * cover their own scope — the changed-files predicates are dependency-aware, so anything a
- * change could affect is retested before merge — and a push to a branch only refreshes the
- * environment. What no one runs, then, is the real-plugin integration tests and the end-to-end
- * suites. It deliberately does not replay the per-module or frontend test suites.
+ * Two chains hang off a single `Build backend`, for two unrelated purposes.
+ *
+ * The first refreshes the development environment: the web UIs and the docker images the
+ * cluster runs, then the end-to-end suites and the deployment.
+ *
+ * The second gives SonarCloud an analysis of the reference branch. A push to a branch only
+ * refreshes the environment, so nothing has analysed the default branch since that became
+ * true — and without it a pull request has no new-code baseline and the server-side cache
+ * finds nothing to reuse. The suites are replayed here for the coverage reports they leave
+ * behind, not to retest what pull requests already covered.
+ *
+ * The jobs are spelled out rather than borrowed from the pull-request groups: those carry a
+ * changed-files filter and a build-and-publish scope this workflow has no use for.
  */
 export class NightlyWorkflow {
   static create(dynamicConfig: Config, environment: CircleCIEnvironment): Workflow {
@@ -37,6 +57,30 @@ export class NightlyWorkflow {
 
     const deployOnAzureJob = DeployOnAzureJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(deployOnAzureJob);
+
+    // The analysis chain. One parameterized analysis job, reused with a different working
+    // directory; one test job per module, each waiting on the shared `Build backend`.
+    const sonarAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(sonarAnalysisJob);
+
+    const backendSuites: { job: Job; name: string; project: string }[] = [
+      { job: TestDefinitionJob.create(dynamicConfig, environment), name: 'Test definition', project: 'gravitee-apim-definition' },
+      { job: TestGatewayJob.create(dynamicConfig, environment), name: 'Test gateway', project: 'gravitee-apim-gateway' },
+      { job: TestRestApiJob.create(dynamicConfig, environment), name: 'Test rest-api', project: 'gravitee-apim-rest-api' },
+      { job: TestPluginJob.create(dynamicConfig, environment), name: 'Test plugins', project: 'gravitee-apim-plugin' },
+      { job: TestReporterJob.create(dynamicConfig, environment), name: 'Test reporters', project: 'gravitee-apim-reporter' },
+      { job: TestRepositoryJob.create(dynamicConfig, environment), name: 'Test repository', project: 'gravitee-apim-repository' },
+    ];
+    backendSuites.forEach(({ job }) => dynamicConfig.addJob(job));
+
+    const consoleLintTestJob = WebuiLintTestJob.createNx(dynamicConfig, environment);
+    dynamicConfig.addJob(consoleLintTestJob);
+
+    const portalNextLintTestJob = WebuiLintTestJob.createNx(dynamicConfig, environment);
+    dynamicConfig.addJob(portalNextLintTestJob);
+
+    const portalLintTestJob = WebuiLintTestJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(portalLintTestJob);
 
     return new Workflow('nightly', [
       ...devEnvironmentJobs(dynamicConfig, environment),
@@ -49,6 +93,69 @@ export class NightlyWorkflow {
         name: 'Integration tests',
         context: config.jobContext,
         requires: ['Build backend'],
+      }),
+
+      // The analysis chain: the suites that produce the coverage reports, each followed by the
+      // analysis that reads them. Nothing downstream waits on these.
+      ...backendSuites.flatMap(({ job, name, project }) => [
+        new workflow.WorkflowJob(job, {
+          name,
+          context: config.jobContext,
+          requires: ['Build backend'],
+        }),
+        new workflow.WorkflowJob(sonarAnalysisJob, {
+          name: `Sonar - ${project}`,
+          context: config.jobContext,
+          requires: [name],
+          working_directory: project,
+          cache_type: 'backend',
+        }),
+      ]),
+
+      new workflow.WorkflowJob(consoleLintTestJob, {
+        name: 'Lint & test APIM Console',
+        context: config.jobContext,
+        'apim-ui-project-workdir': config.components.console.workdir,
+        'nx-project': 'console',
+        resource_class: 'xlarge',
+        'max-workers': '7',
+      }),
+      new workflow.WorkflowJob(sonarAnalysisJob, {
+        name: 'Sonar - gravitee-apim-console-webui',
+        context: config.jobContext,
+        requires: ['Lint & test APIM Console'],
+        working_directory: config.components.console.project,
+        cache_type: 'frontend',
+      }),
+
+      new workflow.WorkflowJob(portalNextLintTestJob, {
+        name: 'Lint & test APIM Portal Next',
+        context: config.jobContext,
+        'apim-ui-project-workdir': config.components.portal.next.project,
+        'nx-project': 'portal-next',
+        'max-workers': '2',
+      }),
+      new workflow.WorkflowJob(sonarAnalysisJob, {
+        name: 'Sonar - gravitee-apim-portal-webui-next',
+        context: config.jobContext,
+        requires: ['Lint & test APIM Portal Next'],
+        working_directory: config.components.portal.next.project,
+        cache_type: 'frontend',
+      }),
+
+      new workflow.WorkflowJob(portalLintTestJob, {
+        name: 'Lint & test APIM Portal',
+        context: config.jobContext,
+        'apim-ui-project': config.components.portal.project,
+        'apim-ui-project-workdir': config.components.portal.workdir,
+        resource_class: 'large',
+      }),
+      new workflow.WorkflowJob(sonarAnalysisJob, {
+        name: 'Sonar - gravitee-apim-portal-webui',
+        context: config.jobContext,
+        requires: ['Lint & test APIM Portal'],
+        working_directory: config.components.portal.workdir,
+        cache_type: 'frontend',
       }),
       ...e2eJobs(dynamicConfig, environment),
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-300

## Description

Nothing has analysed `master` since **14 August**. The workflow refactoring reduced a push on a branch to refreshing the development environment, so the per-module suites — and the analyses that depend on them — no longer run there. Two consequences, both invisible until you look for them:

- a pull request targeting `master` has **no new-code baseline**, so its quality gate compares against nothing;
- the server-side cache finds nothing to reuse — `0 out of 5,514 files` in the scanner log — so every pull request analysis re-parses the whole project.

This adds a second chain to the nightly build: the suites that produce the coverage reports, each followed by the analysis that reads them. They are replayed for their reports, not to retest what pull requests already cover.

```mermaid
flowchart LR
  subgraph env["Environment chain — unchanged"]
    direction LR
    setup["Setup"] --> build["Build backend"]
    build --> imgback["Backend docker images"]
    front["Frontend builds"] --> imgfront["Frontend docker images"]
    build --> integ["Integration tests"]
    build --> sdk["Generate e2e tests SDK"] --> e2ebuild["Lint & Build APIM e2e"]
    e2ebuild --> e2e["E2E (matrix)"]
    e2ebuild --> cypress["Run Cypress UI tests"]
    imgback --> e2e
    imgback --> cypress
    imgfront --> cypress
    integ --> deploy["Deploy on Azure cluster"]
    cypress --> deploy
    imgback --> aikido["Scan docker images with Aikido"]
    imgfront --> aikido
  end

  subgraph ana["Analysis chain — added"]
    direction LR
    testback["6 backend suites"] --> sonarback["6 SonarCloud analyses"]
    testfront["3 frontend suites"] --> sonarfront["3 SonarCloud analyses"]
  end

  build --> testback
```

## Additional context

**One junction, and nothing waits on an analysis.** The six backend suites hang off the `Build backend` the workflow already runs — the same way `Integration tests` does — so nothing is recompiled. The three frontend suites are roots: `Lint & test APIM Console` does not depend on `Build APIM Console`. And the nine analyses are leaves: no job lists them in `requires`, so a slow or failing analysis can neither delay the deployment nor block the image scans in the dependency graph. Runner contention is a separate matter: nine extra jobs queued alongside the e2e matrix can still push the deployment back under org concurrency limits.

**The jobs are spelled out rather than borrowed from the pull-request groups.** `backendJobs` and `frontendJobs` carry a changed-files filter and a build-and-publish scope this workflow has no use for, and reusing them would have meant either declaring `Setup` and `Build backend` twice, or reordering the jobs the pull-request fixtures pin. Only `workflow-nightly.ts` and its own fixture change here — **the other 152 test cases pass untouched, so the pull-request YAML is identical byte for byte.**

**Cost**, from the durations observed today:

| | today | with the analyses |
| --- | --- | --- |
| declared jobs | 22 | 40 |
| wall clock | 31 min | + 0 to 16 min |
| cumulative machine time | 161 min | ≈ 240 min |

Those are **per-branch** figures: the nightly is one scheduled pipeline per branch, so a support branch that gets its own schedule pays them again.

The longest added branch is `Build backend → Test rest-api (629 s) → Sonar rest-api (319 s)`, about sixteen minutes after the build, against a workflow that already takes thirty-one. It has a fair chance of running in the shadow of the end-to-end chain — the first run will tell.

**Support branches are unaffected by this PR.** `workflow-nightly.ts` exists only on `master` — the four live support branches do not carry it, and they still analyse on every push because they do not carry the workflow refactoring either. Nothing here runs on a branch by itself: `nightly` is a `ci_action` value, so a branch is analysed only once a schedule is created for it. `4.13.x`, born from `master`, will need that schedule like any other.
