### PR TITLE
fix: catch and handle MongoDB index options conflict errors in IndexU…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgrader.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.index;
 
+import com.mongodb.MongoCommandException;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.IndexMongoUpgrader;
 import java.time.Duration;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.bson.BsonInt32;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
@@ -30,6 +32,14 @@ import reactor.core.publisher.Mono;
 public abstract class IndexUpgrader extends IndexMongoUpgrader {
 
     private static final Logger LOG = LoggerFactory.getLogger(IndexUpgrader.class);
+
+    /**
+     * MongoDB error code returned when an index with the same key pattern already exists with different options
+     * (for instance a different name or collation). MongoDB only raises it when the key pattern, the name and the
+     * collation do not allow the two indexes to coexist; Amazon DocumentDB raises it for any second index on the same
+     * key pattern, whatever the name or collation.
+     */
+    static final int INDEX_OPTIONS_CONFLICT_ERROR_CODE = 85;
 
     protected abstract Index buildIndex();
 
@@ -58,6 +68,18 @@ public abstract class IndexUpgrader extends IndexMongoUpgrader {
             )
             .thenReturn(true)
             .onErrorResume(e -> {
+                if (isIndexOptionsConflict(e)) {
+                    // An index with the same key pattern already exists (typically on Amazon DocumentDB, which does not
+                    // allow several indexes on the same keys even with different collations). The existing index already
+                    // serves the same key pattern, so skipping the creation is safe and must not block the startup.
+                    LOG.warn(
+                        "Index {} on {} has not been created because an index with the same key pattern already exists (error {}). Skipping it.",
+                        name,
+                        collection,
+                        INDEX_OPTIONS_CONFLICT_ERROR_CODE
+                    );
+                    return Mono.just(true);
+                }
                 LOG.error(
                     "Unexpected error while creating index {} on {}",
                     name,
@@ -76,6 +98,21 @@ public abstract class IndexUpgrader extends IndexMongoUpgrader {
             .subscribe();
 
         return Boolean.TRUE.equals(create.block());
+    }
+
+    /**
+     * Spring Data wraps the driver exception (for instance in a DataIntegrityViolationException), so the Mongo error is
+     * looked up in the cause chain.
+     */
+    static boolean isIndexOptionsConflict(Throwable throwable) {
+        MongoCommandException mongoError = ExceptionUtils.throwableOfType(
+            throwable,
+            MongoCommandException.class
+        );
+        return (
+            mongoError != null &&
+            mongoError.getErrorCode() == INDEX_OPTIONS_CONFLICT_ERROR_CODE
+        );
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/groups/NameIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/groups/NameIndexUpgrader.java
@@ -33,4 +33,14 @@ public class NameIndexUpgrader extends IndexUpgrader {
             .key("name", ascending())
             .build();
     }
+
+    /**
+     * Run after the collation index name_collation_1 (GroupsEnvironmentIdCollationIndexUpgrader) on the same key pattern. On Amazon DocumentDB
+     * only one index per key pattern can exist: the collation one must be created first because it is the one used by
+     * the case-insensitive queries, this one is then skipped (see IndexUpgrader).
+     */
+    @Override
+    public int getOrder() {
+        return 1;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/IndexUpgraderTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.ServerAddress;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.index.ReactiveIndexOperations;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class IndexUpgraderTest {
+
+    private static final String COLLECTION = "groups";
+    private static final String INDEX_NAME = "name_1";
+
+    @Mock
+    private ReactiveMongoOperations template;
+
+    @Mock
+    private ReactiveIndexOperations indexOperations;
+
+    @Mock
+    private Environment environment;
+
+    private IndexUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        upgrader = new IndexUpgrader() {
+            @Override
+            protected Index buildIndex() {
+                return Index.builder()
+                    .collection(COLLECTION)
+                    .name(INDEX_NAME)
+                    .key("name", ascending())
+                    .build();
+            }
+        };
+        lenient()
+            .when(environment.getProperty("management.mongodb.prefix", ""))
+            .thenReturn("");
+        upgrader.setEnvironment(environment);
+        upgrader.setMongoTemplate(template);
+        lenient().when(template.indexOps(COLLECTION)).thenReturn(indexOperations);
+    }
+
+    @Test
+    void should_succeed_when_index_is_created() {
+        when(indexOperations.ensureIndex(any())).thenReturn(Mono.just(INDEX_NAME));
+
+        assertThat(upgrader.upgrade()).isTrue();
+    }
+
+    @Test
+    void should_skip_when_an_index_with_the_same_key_pattern_already_exists() {
+        // Amazon DocumentDB rejects a second index on the same key pattern, even with a different name or collation.
+        when(indexOperations.ensureIndex(any())).thenReturn(
+            Mono.error(indexOptionsConflict())
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+    }
+
+    @Test
+    void should_skip_when_the_conflict_is_wrapped_by_spring_data() {
+        // Spring Data translates MongoCommandException into a DataAccessException keeping the original as cause.
+        var wrapped = new DataIntegrityViolationException(
+            "Command failed with error 85",
+            indexOptionsConflict()
+        );
+        when(indexOperations.ensureIndex(any())).thenReturn(Mono.error(wrapped));
+
+        assertThat(upgrader.upgrade()).isTrue();
+    }
+
+    @Test
+    void should_fail_on_any_other_mongo_error() {
+        when(indexOperations.ensureIndex(any())).thenReturn(
+            Mono.error(mongoError(86, "IndexKeySpecsConflict"))
+        );
+
+        assertThat(upgrader.upgrade()).isFalse();
+    }
+
+    @Test
+    void should_fail_on_unexpected_error() {
+        when(indexOperations.ensureIndex(any())).thenReturn(
+            Mono.error(new IllegalStateException("boom"))
+        );
+
+        assertThat(upgrader.upgrade()).isFalse();
+    }
+
+    @Nested
+    class IsIndexOptionsConflict {
+
+        @Test
+        void should_detect_error_code_85() {
+            assertThat(
+                IndexUpgrader.isIndexOptionsConflict(indexOptionsConflict())
+            ).isTrue();
+        }
+
+        @Test
+        void should_detect_error_code_85_in_cause_chain() {
+            var wrapped = new RuntimeException(
+                "outer",
+                new DataIntegrityViolationException("inner", indexOptionsConflict())
+            );
+            assertThat(IndexUpgrader.isIndexOptionsConflict(wrapped)).isTrue();
+        }
+
+        @Test
+        void should_ignore_other_error_codes() {
+            assertThat(
+                IndexUpgrader.isIndexOptionsConflict(
+                    mongoError(86, "IndexKeySpecsConflict")
+                )
+            ).isFalse();
+        }
+
+        @Test
+        void should_ignore_non_mongo_errors() {
+            assertThat(
+                IndexUpgrader.isIndexOptionsConflict(new IllegalStateException("boom"))
+            ).isFalse();
+        }
+    }
+
+    private static MongoCommandException indexOptionsConflict() {
+        return mongoError(
+            IndexUpgrader.INDEX_OPTIONS_CONFLICT_ERROR_CODE,
+            "IndexOptionsConflict"
+        );
+    }
+
+    private static MongoCommandException mongoError(int code, String codeName) {
+        var response = new BsonDocument("ok", new BsonInt32(0))
+            .append("code", new BsonInt32(code))
+            .append("codeName", new BsonString(codeName))
+            .append(
+                "errmsg",
+                new BsonString("Index already exists with different options")
+            );
+        return new MongoCommandException(response, new ServerAddress("localhost", 27017));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-221

## Description

On Amazon DocumentDB, the Management API fails to start because the `IndexUpgrader`s abort the whole upgrade phase with a `MongoCommandException` code 85 (`IndexOptionsConflict`).

DocumentDB, unlike MongoDB, allows only **one index per key pattern**, whatever the index name or collation. APIM creates, for three key patterns, a pair of indexes: one with the `en` / strength 2 collation (used by the case-insensitive queries) and one with the default collation:

| Collection | Collation index (used by the code) | Simple index (never used by the code) |
|---|---|---|
| `groups` | `name_collation_1` | `name_1` |
| `tickets` | `a1fu1en` | `a1fu1` |
| `tickets` | `fu1en` | `fu1` |

On DocumentDB the second index of each pair is rejected with error 85, `IndexUpgrader.upgrade()` returns `false`, `UpgraderServiceImpl` marks the upgrade as FAILED and stops the node (`System.exit(1)`). MongoDB is not affected (both indexes are created).

Changes:

- `IndexUpgrader`: when `ensureIndex` fails with error code 85 (looked up through the cause chain, Spring Data wraps it in a `DataAccessException`), log a WARN and return `true` so the node keeps starting. Any other error keeps the current behavior (ERROR log, `false`, startup aborted).
- Ordering: the simple indexes (`NameIndexUpgrader`, `ApiFromUserCollationSimpleIndexUpgrader`, `FromUserCollationSimpleIndexUpgrader`) now declare `getOrder() = 1` so that the collation twin is always created first. Before, the order only came from Spring bean registration order (alphabetical by chance). Since the conflict is now tolerated instead of crashing, an inverted order would silently drop the collation index, which is the one the queries need.
- `IndexUpgraderTest`: success, code 85 direct and wrapped, other Mongo error code, non Mongo error, plus unit tests of `isIndexOptionsConflict`.

No behavior change on MongoDB: both indexes of each pair are still created and the new branch is never reached.

## Additional context

Reproduction: run the Management API of this branch against an Amazon DocumentDB 8.0 cluster with an empty database.

Before (4.9.x): the upgrade phase stops on the first `groups` / `tickets` pair with

```
Command failed with error 85 (IndexOptionsConflict): 'Index already exists with different options'
... Upgrader NameIndexUpgrader failed ... stopping node
```

After this PR: the node starts, the three simple indexes are skipped with

```
WARN  IndexUpgrader - Index name_1 on groups has not been created because an index with the same key pattern already exists (error 85). Skipping it.
WARN  IndexUpgrader - Index a1fu1 on tickets has not been created because an index with the same key pattern already exists (error 85). Skipping it.
WARN  IndexUpgrader - Index fu1 on tickets has not been created because an index with the same key pattern already exists (error 85). Skipping it.
```

and `db.groups.getIndexes()` / `db.tickets.getIndexes()` show `name_collation_1`, `a1fu1en`, `fu1en`.

Why skipping the simple indexes is safe: `TicketMongoRepositoryImpl.search()` and `MongoGroupRepository.search()` always query with the `en` / strength 2 collation, and MongoDB only uses an index whose collation matches the query collation for string comparisons, so `name_1`, `a1fu1` and `fu1` cannot be used by these queries.

Not in scope: the other DocumentDB incompatibility reported in the same issue (update with aggregation pipeline in upgraders introduced in 4.12.0) will be handled in a separate PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

