### PR TITLE
feat(GKO-2543): Remove KUBERNETES origin checks from API danger zone

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ts
@@ -22,7 +22,6 @@ import { distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators'
 import { combineLatest, from, Subject } from 'rxjs';
 
 import { DocumentationService, Page } from '../../services/documentation.service';
-import { ApiService } from '../../services/api.service';
 
 @Component({
   template: '',
@@ -48,7 +47,6 @@ export class DocumentationManagementComponent extends UpgradeComponent {
     injector: Injector,
     private readonly activatedRoute: ActivatedRoute,
     @Inject('ajsDocumentationService') private readonly ajsDocumentationService: DocumentationService,
-    @Inject('ajsApiService') private readonly ajsApiService: ApiService,
   ) {
     super('documentationManagementAjs', elementRef, injector);
   }
@@ -57,13 +55,6 @@ export class DocumentationManagementComponent extends UpgradeComponent {
     this.activatedRoute.params
       .pipe(
         distinctUntilChanged(isEqual),
-        tap(params => {
-          if (params.apiId) {
-            this.ajsApiService.get(params.apiId).then(res => {
-              this.readOnly = res.data?.definition_context?.origin === 'kubernetes';
-            });
-          }
-        }),
         switchMap(params => {
           this.firstChange = true;
           this.apiId = params.apiId;

--- a/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ts
@@ -22,7 +22,6 @@ import { DocumentationService } from '../../services/documentation.service';
 import FetcherService from '../../services/fetcher.service';
 import CategoryService from '../../services/category.service';
 import { GroupService } from '../../services-ngx/group.service';
-import { ApiService } from '../../services/api.service';
 
 @Component({
   template: '',
@@ -41,7 +40,6 @@ export class DocumentationEditPageComponent extends UpgradeComponent {
     @Inject('ajsDocumentationService') private readonly ajsDocumentationService: DocumentationService,
     @Inject('ajsFetcherService') private readonly ajsFetcherService: FetcherService,
     @Inject('ajsCategoryService') private readonly ajsCategoryService: CategoryService,
-    @Inject('ajsApiService') private readonly ajsApiService: ApiService,
   ) {
     super('documentationEditPageAjs', elementRef, injector);
   }
@@ -97,9 +95,7 @@ export class DocumentationEditPageComponent extends UpgradeComponent {
       type === 'MARKDOWN' || type === 'ASCIIDOC' || type === 'ASYNCAPI'
         ? this.ajsDocumentationService.getMedia(pageId, apiId).then(response => response.data)
         : Promise.resolve(null),
-      apiId !== undefined
-        ? this.ajsApiService.get(apiId).then(res => res.data?.definition_context?.origin === 'kubernetes')
-        : Promise.resolve(null),
+      Promise.resolve(false),
     ]).then(
       ([
         resolvedFetchers,

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.spec.ts
@@ -242,11 +242,11 @@ describe('ApiLogsConfigurationComponent', () => {
 
       const groups = await loader.getAllHarnesses(GioFormSelectionInlineHarness);
       for (const group of groups) {
-        expect(await group.isDisabled()).toBe(true);
+        expect(await group.isDisabled()).toBe(false);
       }
 
-      expect(await loader.getHarness(MatSlideToggleHarness).then(toggle => toggle.isDisabled())).toStrictEqual(true);
-      expect(await loader.getHarness(MatInputHarness).then(input => input.isDisabled())).toStrictEqual(true);
+      expect(await loader.getHarness(MatSlideToggleHarness).then(toggle => toggle.isDisabled())).toStrictEqual(false);
+      expect(await loader.getHarness(MatInputHarness).then(input => input.isDisabled())).toStrictEqual(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.ts
@@ -152,7 +152,7 @@ export class ApiLogsConfigurationComponent implements OnInit, OnDestroy {
 
   private initForm(api: ApiV2) {
     const { mode, content, scope } = { ...this.defaultLogging, ...this.api.proxy.logging };
-    const isReadOnly = !this.permissionService.hasAnyMatching(['api-log-u']) || api.definitionContext?.origin === 'KUBERNETES';
+    const isReadOnly = !this.permissionService.hasAnyMatching(['api-log-u']);
     const enabled = !!api.proxy.logging && api.proxy.logging.mode !== 'NONE';
     this.mode = new UntypedFormControl({
       value: mode !== 'NONE' ? mode : 'CLIENT_PROXY',

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.ts
@@ -73,7 +73,7 @@ export class ApiPathMappingsComponent implements OnInit, OnDestroy {
           this.api = api;
           this.pathMappingsDS = this.toPathMappingDS(api);
           this.isLoadingData = false;
-          this.isReadOnly = api.definitionContext.origin === 'KUBERNETES';
+          this.isReadOnly = false;
         }),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.html
@@ -37,10 +37,6 @@
         <mat-icon matTooltip="Not published" class="api-navigation-title__states__icon" svgIcon="gio:cloud-unpublished"></mat-icon> Not
         Published
       </span>
-      <span class="gio-badge-primary" *ngIf="apiOrigin === 'KUBERNETES'">
-        <mat-icon matTooltip="Kubernetes Origin" class="api-navigation-title__states__icon" svgIcon="gio:kubernetes"></mat-icon> Kubernetes
-        Origin
-      </span>
     </div>
   }
 </div>

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.ts
@@ -35,8 +35,6 @@ export class ApiNavigationTitleComponent {
   @Input()
   public apiLifecycleState: Api['lifecycleState'];
   @Input()
-  public apiOrigin: string;
-  @Input()
   public separator: 'pipe' | 'border' = 'border';
   @Input()
   public definitionVersion: Api['definitionVersion'];

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
@@ -26,7 +26,6 @@
         [apiState]="currentApi.state"
         [apiLifecycleState]="currentApi.lifecycleState"
         [apiDeploymentState]="currentApi.deploymentState"
-        [apiOrigin]="currentApi.originContext.origin"
         [definitionVersion]="currentApi.definitionVersion"
       ></api-navigation-title>
       <div class="api-navigation__menu-items-scroll">
@@ -141,7 +140,6 @@
           [apiState]="currentApi.state"
           [apiLifecycleState]="currentApi.lifecycleState"
           [apiDeploymentState]="currentApi.deploymentState"
-          [apiOrigin]="currentApi.originContext.origin"
           *gioBreadcrumbItem
         ></api-navigation-title>
         <ng-template ngFor let-item [ngForOf]="computeBreadcrumbItems()">

--- a/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.html
@@ -15,4 +15,4 @@
     limitations under the License.
 
 -->
-<gio-metadata [readOnly]="readOnly" [metadataSaveServices]="metadataSaveServices" [description]="description"></gio-metadata>
+<gio-metadata [metadataSaveServices]="metadataSaveServices" [description]="description"></gio-metadata>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.spec.ts
@@ -68,7 +68,6 @@ describe('GioApiMetadataListComponent', () => {
     it('should load metadata list', async () => {
       const gioMetadata = await loader.getHarnessOrNull(GioMetadataHarness);
       expect(gioMetadata).toBeTruthy();
-      expectGetAPI();
     });
 
     it('should sort metadata', async () => {
@@ -83,8 +82,6 @@ describe('GioApiMetadataListComponent', () => {
       // Reverse direction on second click
       await gioMetadata.sortBy('name');
 
-      expectGetAPI();
-
       expectMetadataList({
         sortBy: '-name',
         page: 1,
@@ -96,8 +93,6 @@ describe('GioApiMetadataListComponent', () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
       await gioMetadata.selectSource('API');
 
-      expectGetAPI();
-
       expectMetadataList({
         source: 'API',
         page: 1,
@@ -108,8 +103,6 @@ describe('GioApiMetadataListComponent', () => {
     it('should reset filter metadata', async () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
       await gioMetadata.selectSource('API');
-
-      expectGetAPI();
 
       expectMetadataList({
         source: 'API',
@@ -139,8 +132,6 @@ describe('GioApiMetadataListComponent', () => {
     it('should reset sort when resetting filter metadata', async () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
       await gioMetadata.selectSource('API');
-
-      expectGetAPI();
 
       expectMetadataList({
         source: 'API',
@@ -172,8 +163,6 @@ describe('GioApiMetadataListComponent', () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
       await gioMetadata.sortBy('name');
 
-      expectGetAPI();
-
       expectMetadataList({
         sortBy: 'name',
         page: 1,
@@ -194,16 +183,12 @@ describe('GioApiMetadataListComponent', () => {
     it('should load value to filter select', async () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
 
-      expectGetAPI();
-
       expect(await gioMetadata.sourceSelectedText()).toEqual('Global');
     });
 
     it('should filter metadata with new value', async () => {
       const gioMetadata = await loader.getHarness(GioMetadataHarness);
       await gioMetadata.selectSource('API');
-
-      expectGetAPI();
 
       expectMetadataList({
         source: 'API',
@@ -212,13 +197,6 @@ describe('GioApiMetadataListComponent', () => {
       });
     });
   });
-
-  function expectGetAPI() {
-    httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`,
-      method: 'GET',
-    });
-  }
 
   function expectMetadataList(
     searchParams?: { page?: number; perPage?: number; source?: string; sortBy?: string },

--- a/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.ts
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { map, takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { MetadataSaveServices } from '../../../../components/gio-metadata/gio-metadata.component';
 import { ApiService } from '../../../../services-ngx/api.service';
 import { ApiMetadataV2Service } from '../../../../services-ngx/api-metadata-v2.service';
 import { Metadata } from '../../../../entities/metadata/metadata';
-import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 
 @Component({
   selector: 'gio-api-metadata-list',
@@ -30,17 +28,12 @@ import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
   styleUrls: ['./gio-api-metadata-list.component.scss'],
   standalone: false,
 })
-export class GioApiMetadataListComponent implements OnInit, OnDestroy {
+export class GioApiMetadataListComponent implements OnInit {
   metadataSaveServices: MetadataSaveServices;
   description: string;
 
-  readOnly = false;
-
-  private unsubscribe$ = new Subject<void>();
-
   constructor(
     private readonly apiService: ApiService,
-    private readonly apiV2Service: ApiV2Service,
     private readonly apiMetadataV2Service: ApiMetadataV2Service,
     private readonly activatedRoute: ActivatedRoute,
   ) {}
@@ -61,16 +54,5 @@ export class GioApiMetadataListComponent implements OnInit, OnDestroy {
       delete: metadataKey => this.apiService.deleteMetadata(this.activatedRoute.snapshot.params.apiId, metadataKey),
     };
     this.description = `Set metadata information on the API that can be easily accessed through Markdown templating`;
-    this.apiV2Service
-      .get(this.activatedRoute.snapshot.params.apiId)
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(api => {
-        this.readOnly = api.definitionContext?.origin === 'KUBERNETES';
-      });
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe$.next();
-    this.unsubscribe$.complete();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
@@ -268,10 +268,10 @@ describe('ApiCorsComponent', () => {
       expect(await saveBar.isVisible()).toBe(false);
 
       const allowMethodsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="allowMethods"]' }));
-      expect(await allowMethodsInput.isDisabled()).toEqual(true);
+      expect(await allowMethodsInput.isDisabled()).toEqual(false);
 
       const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
-      expect(await enabledSlideToggle.isDisabled()).toEqual(true);
+      expect(await enabledSlideToggle.isDisabled()).toEqual(false);
     });
   });
 
@@ -513,10 +513,10 @@ describe('ApiCorsComponent', () => {
       expect(await saveBar.isVisible()).toBe(false);
 
       const allowMethodsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="allowMethods"]' }));
-      expect(await allowMethodsInput.isDisabled()).toEqual(true);
+      expect(await allowMethodsInput.isDisabled()).toEqual(false);
 
       const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
-      expect(await enabledSlideToggle.isDisabled()).toEqual(true);
+      expect(await enabledSlideToggle.isDisabled()).toEqual(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
@@ -85,13 +85,13 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
             };
             requestValidation = api.proxy?.requestValidation ?? { rejectNullByte: false };
           }
-          const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+
           const hasUpdatePermission =
             api.definitionVersion === 'V4'
               ? this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u'])
               : this.permissionService.hasAnyMatching(['api-definition-u']);
 
-          const isReadOnly = !hasUpdatePermission || isKubernetesOrigin;
+          const isReadOnly = !hasUpdatePermission;
           const isCorsDisabled = isReadOnly || !cors.enabled;
 
           this.corsForm = new UntypedFormGroup({

--- a/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.spec.ts
@@ -114,7 +114,7 @@ describe('ApiDeploymentConfigurationComponent', () => {
         expect(await saveBar.isVisible()).toBe(false);
 
         const tagsSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="tags"]' }));
-        expect(await tagsSelect.isDisabled()).toEqual(true);
+        expect(await tagsSelect.isDisabled()).toEqual(false);
       });
     },
   );

--- a/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.ts
@@ -58,7 +58,7 @@ export class ApiDeploymentConfigurationComponent implements OnInit, OnDestroy {
       .pipe(
         tap(([api, shardingTags]) => {
           this.shardingTags = shardingTags;
-          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
 
           this.deploymentsForm = new FormGroup({
             tags: new FormControl({

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.ts
@@ -62,7 +62,7 @@ export class ApiDocumentationChooseExistingPageComponent implements OnInit {
       .pipe(
         tap(api => {
           this.api = api;
-          this.isReadOnly = this.api.originContext?.origin === 'KUBERNETES';
+          this.isReadOnly = false;
         }),
         switchMap(() => this.apiDocumentationV2Service.getApiPages(this.api.id)),
         takeUntil(this.unsubscribe$),

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -160,7 +160,7 @@ export class DocumentationEditPageComponent implements OnInit {
   ngOnInit(): void {
     this.isHomepage = this.page.homepage === true;
     this.name.set(this.page.name);
-    this.isReadOnly = this.api.originContext?.origin === 'KUBERNETES' || !this.permissionService.hasAnyMatching(['api-documentation-u']);
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-documentation-u']);
 
     const accessControlGroups = this.page.accessControls
       ? this.page.accessControls.filter(ac => ac.referenceType === 'GROUP').map(ac => ac.referenceId)

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -155,7 +155,7 @@ export class DocumentationNewPageComponent implements OnInit {
 
     this.sourceConfiguration = new FormControl<undefined | unknown>({});
 
-    this.isReadOnly = this.api.originContext?.origin === 'KUBERNETES';
+    this.isReadOnly = false;
 
     if (this.isReadOnly) {
       this.form.disable({ emitEvent: false });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.ts
@@ -98,7 +98,6 @@ export class ApiDocumentationV4DocumentationPagesTabComponent implements OnInit,
       }),
       map(([api, pagesResponse, apiSpecGenRequestState]) => {
         this.api = api;
-        this.isReadOnly = api.originContext?.origin === 'KUBERNETES';
         this.specGenState = this.getSpecGenState(api, apiSpecGenRequestState);
 
         return {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.ts
@@ -55,7 +55,7 @@ export class ApiDocumentationV4MainPagesTabComponent implements OnInit, OnDestro
       switchMap(({ apiId }) => (apiId ? combineLatest([this.apiV2Service.get(apiId), this.getApiPages(apiId)]) : EMPTY)),
       map(([api, pagesResponse]) => {
         this.api = api;
-        this.isReadOnly = api.originContext?.origin === 'KUBERNETES';
+        this.isReadOnly = false;
         return {
           hasCustomPages: !!pagesResponse.pages.filter(p => !p.homepage && p.type !== 'FOLDER').length,
           homepage: pagesResponse.pages.find(p => p.homepage === true),

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
@@ -122,7 +122,7 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']) || api.definitionContext?.origin === 'KUBERNETES';
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']);
 
     this.generalForm = new UntypedFormGroup({
       name: new UntypedFormControl(

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.ts
@@ -62,11 +62,7 @@ export class ApiEndpointGroupsLlmComponent {
   public shouldUpgrade$ = combineLatest([this.plugins$, toObservable(this.providersTableData)]).pipe(
     map(([plugins, providers]): boolean => providers.length > 0 && !plugins.get('llm-proxy')?.deployed),
   );
-  public isReadOnly = computed(() => {
-    const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
-    const api = this.api();
-    return api?.definitionContext?.origin === 'KUBERNETES' || !canUpdate;
-  });
+  public isReadOnly = computed(() => !this.permissionService.hasAnyMatching(['api-definition-u']));
   public llmProxyDisplayedColumns = ['model', 'costInput', 'costOutput', 'aliases'];
   private readonly messageLicenseOptions = {
     feature: ApimFeature.APIM_EN_MESSAGE_REACTOR,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.ts
@@ -93,7 +93,7 @@ export class ApiEndpointGroupsStandardComponent implements OnInit, OnDestroy {
           this.groupsTableData = toEndpoints(apiV4, tenants);
 
           const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
-          this.isReadOnly = this.api.definitionContext?.origin === 'KUBERNETES' || !canUpdate;
+          this.isReadOnly = !canUpdate;
           this.plugins = new Map(
             plugins.map(plugin => [
               plugin.id,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -93,9 +93,8 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
           this.isHttpProxyApi = api.type === 'PROXY' && !(api.listeners.find(listener => listener.type === 'TCP') != null);
           this.isNativeKafkaApi = api.type === 'NATIVE' && api.listeners.some(listener => listener.type === 'KAFKA');
 
-          const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
           const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
-          this.isReadOnly = isKubernetesOrigin || !canUpdate;
+          this.isReadOnly = !canUpdate;
           this.endpointGroup = api.endpointGroups[this.groupIndex];
 
           if (!this.endpointGroup) {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
@@ -166,9 +166,8 @@ export class ApiLlmProviderComponent implements OnInit {
   private initializeComponent(api: ApiV4): void {
     this.api = api;
 
-    const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
     const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
-    this.isReadOnly = isKubernetesOrigin || !canUpdate;
+    this.isReadOnly = !canUpdate;
 
     if (this.providerIndex !== null) {
       const endpointGroups = api.endpointGroups || [];

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
@@ -522,25 +522,25 @@ describe('ApiProxyGroupEditComponent', () => {
 
     it('should not allow user to update the form', async () => {
       const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[aria-label="Group name input"]' }));
-      expect(await nameInput.isDisabled()).toBeTruthy();
+      expect(await nameInput.isDisabled()).toBeFalsy();
 
       expect(
         await loader
           .getHarness(MatSelectHarness.with({ selector: '[aria-label="Load balancing algorithm"]' }))
           .then(select => select.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       await loader.getHarness(MatTabHarness.with({ label: 'Configuration' })).then(tab => tab.select());
 
       const endpointHttpConfigHarness = await loader.getHarness(EndpointHttpConfigHarness);
 
-      expect(await endpointHttpConfigHarness.getMatInput('connectTimeout').then(input => input.isDisabled())).toBeTruthy();
+      expect(await endpointHttpConfigHarness.getMatInput('connectTimeout').then(input => input.isDisabled())).toBeFalsy();
 
       await loader.getHarness(MatTabHarness.with({ label: 'Service discovery' })).then(tab => tab.select());
 
       expect(
         await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' })).then(slide => slide.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         (await loader.getAllHarnesses(MatSelectHarness.with({ selector: '[aria-label="Service discovery provider"]' }))).length,

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
@@ -71,7 +71,7 @@ export class ApiProxyGroupEditComponent implements OnInit, OnDestroy {
         onlyApiV2Filter(this.snackBarService),
         switchMap(api => {
           this.api = api;
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
           return this.serviceDiscoveryService.list();
         }),
         map((serviceDiscoveryItems: ResourceListItem[]) => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -690,31 +690,31 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
     it('should not allow user to update the form', async () => {
       expect(
         await loader.getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint name input"]' })).then(input => input.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Endpoint type"]' })).then(select => select.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         await loader
           .getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint weight input"]' }))
           .then(input => input.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         await loader
           .getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint target input"]' }))
           .then(input => input.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Endpoint tenants"]' })).then(input => input.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       expect(
         await loader.getHarness(MatCheckboxHarness.with({ selector: '[formControlName="backup"]' })).then(input => input.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
 
       await loader.getHarness(MatTabHarness.with({ label: 'Configuration' })).then(tab => tab.select());
       fixture.detectChanges();
@@ -723,7 +723,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
         await loader
           .getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }))
           .then(slider => slider.isDisabled()),
-      ).toBeTruthy();
+      ).toBeFalsy();
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -82,7 +82,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
           this.api = api;
           this.connectors = connectors;
           this.tenants = tenants;
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
           this.supportedTypes = this.connectors.map(connector => connector.supportedTypes).reduce((acc, val) => acc.concat(val), []);
           this.initForms();
         }),

--- a/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.ts
@@ -123,6 +123,6 @@ export class ApiProxyEndpointListComponent implements OnInit {
 
   private initData(api: ApiV2): void {
     this.endpointGroupsTableData = toEndpoints(api);
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']) || api.definitionContext?.origin === 'KUBERNETES';
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -333,7 +333,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       const hostHarness = await loader.getHarness(GioFormListenersKafkaHostHarness);
       const hostInput = await hostHarness.getHostInput();
       expect(await hostInput.getValue()).toEqual('host');
-      expect(await hostInput.isDisabled()).toBe(true);
+      expect(await hostInput.isDisabled()).toBe(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
@@ -121,9 +121,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit, OnDestroy {
       .subscribe(([restrictedDomains, api, availableEntrypoints]) => {
         this.domainRestrictions = restrictedDomains.map(value => value.domain) || [];
 
-        this.isReadOnly =
-          api.definitionContext?.origin === 'KUBERNETES' ||
-          !this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']);
+        this.isReadOnly = !this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']);
         if (api.definitionVersion === 'V4') {
           this.allEntrypoints = availableEntrypoints.filter(({ supportedApiType }) => supportedApiType === api.type);
           this.initForm(api);

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.spec.ts
@@ -126,11 +126,11 @@ describe('ApiProxyEntrypointsComponent', () => {
       expectApiGetPortalSettings();
 
       const saveButton = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Save changes' }));
-      expect(saveButton.length).toEqual(0);
+      expect(saveButton.length).toEqual(1);
 
       const formListenersContextPathHarness = await loader.getHarness(GioFormListenersContextPathHarness);
       const contextPathInput = await formListenersContextPathHarness.getLastListenerRow().then(row => row.pathInput);
-      expect(await contextPathInput.isDisabled()).toEqual(true);
+      expect(await contextPathInput.isDisabled()).toEqual(false);
       expectVerifyContextPath();
     });
 
@@ -220,23 +220,23 @@ describe('ApiProxyEntrypointsComponent', () => {
       expectVerifyContextPath();
 
       const saveButton = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Save changes' }));
-      expect(saveButton.length).toBe(0);
+      expect(saveButton.length).toBe(1);
 
       const formListenersContextPathHarness = await loader.getHarness(GioFormListenersVirtualHostHarness);
       const row = (await formListenersContextPathHarness.getListenerRows())[0];
       const vhTableFirstRowHostInput = row.hostSubDomainInput;
-      expect(await vhTableFirstRowHostInput.isDisabled()).toEqual(true);
+      expect(await vhTableFirstRowHostInput.isDisabled()).toEqual(false);
 
       const vhTableFirstRowPathInput = row.pathInput;
-      expect(await vhTableFirstRowPathInput.isDisabled()).toEqual(true);
+      expect(await vhTableFirstRowPathInput.isDisabled()).toEqual(false);
 
       const vhTableFirstRowOverrideCheckbox = row.overrideAccessInput;
-      expect(await vhTableFirstRowOverrideCheckbox.isDisabled()).toEqual(true);
+      expect(await vhTableFirstRowOverrideCheckbox.isDisabled()).toEqual(false);
 
       const vhTableFirstRowButtons = row.removeButton;
-      expect(vhTableFirstRowButtons).toBeNull();
+      expect(vhTableFirstRowButtons).not.toBeNull();
 
-      expect((await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Add virtual-host' }))).length).toEqual(0);
+      expect((await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Add context-path' }))).length).toEqual(1);
     });
 
     it('should add virtual-host', async () => {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
@@ -164,9 +164,7 @@ export class ApiEntrypointsComponent implements OnInit, OnDestroy {
     this.apiProxy = api.proxy;
     this.formGroup = new UntypedFormGroup({});
 
-    this.isReadOnly =
-      !this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']) ||
-      api.definitionContext?.origin === 'KUBERNETES';
+    this.isReadOnly = !this.permissionService.hasAllMatching(['api-definition-u', 'api-gateway_definition-u']);
 
     const paths: PathV4[] = this.getApiPaths(api);
     this.pathsFormControl = this.formBuilder.control({ value: paths, disabled: this.isReadOnly }, Validators.required);

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.spec.ts
@@ -240,32 +240,7 @@ describe('ApiV4FailoverComponent', () => {
     expect(await saveBar.isVisible()).toBe(false);
 
     const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
-    expect(await enabledSlideToggle.isChecked()).toEqual(false);
-
-    // Check each field is disabled
-    const forceNextToggle = await loader.getHarness(
-      MatSlideToggleHarness.with({ selector: '[formControlName="forceNextEndpointOnFailure"]' }),
-    );
-    expect(await forceNextToggle.isDisabled()).toBe(true);
-
-    const maxRetriesInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxRetries"]' }));
-    expect(await maxRetriesInput.isDisabled()).toBe(true);
-
-    const failureConditionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="failureCondition"]' }));
-    expect(await failureConditionInput.isDisabled()).toBe(true);
-
-    const slowCallDurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="slowCallDuration"]' }));
-    expect(await slowCallDurationInput.isDisabled()).toBe(true);
-
-    const openStateDurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="openStateDuration"]' }));
-    expect(await openStateDurationInput.isDisabled()).toBe(true);
-
-    const maxFailuresInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxFailures"]' }));
-    expect(await maxFailuresInput.isDisabled()).toBe(true);
-
-    const perSubscriptionToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="perSubscription"]' }));
-    expect(await perSubscriptionToggle.isDisabled()).toBe(true);
-    expect(await perSubscriptionToggle.isChecked()).toEqual(true);
+    expect(await enabledSlideToggle.isDisabled()).toBe(false);
   });
 
   it('should display and submit failureCondition and forceNextEndpointOnFailure', async () => {

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
@@ -71,7 +71,7 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
       .pipe(
         onlyApiV4Filter(this.snackBarService),
         tap((api: ApiV4) => {
-          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
           this.hasKafkaEndpointsGroup = api?.endpointGroups?.some(endpointGroup => endpointGroup.type === 'kafka');
           this.createForm(isReadOnly, api.type, api?.failover);
           this.setupDisablingFields();

--- a/gravitee-apim-console-webui/src/management/api/failover/api-failover.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover/api-failover.component.spec.ts
@@ -155,11 +155,8 @@ describe('ApiProxyFailoverComponent', () => {
     const saveBar = await loader.getHarness(GioSaveBarHarness);
     expect(await saveBar.isVisible()).toBe(false);
 
-    const maxAttemptsInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxAttempts"]' }));
-    expect(await maxAttemptsInput.isDisabled()).toBe(true);
-
-    const retryTimeoutInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="retryTimeout"]' }));
-    expect(await retryTimeoutInput.isDisabled()).toBe(true);
+    const enabledToggle = await loader.getHarness(MatSlideToggleHarness);
+    expect(await enabledToggle.isDisabled()).toBe(false);
   });
 
   function expectApiGetRequest(api: ApiV2) {

--- a/gravitee-apim-console-webui/src/management/api/failover/api-failover.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover/api-failover.component.ts
@@ -63,7 +63,7 @@ export class ApiFailoverComponent implements OnInit, OnDestroy {
       .pipe(
         onlyApiV2Filter(this.snackBarService),
         tap(api => {
-          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
           this.createForm(isReadOnly, api.proxy?.failover);
           this.setupDisablingFields();
         }),

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
@@ -22,18 +22,12 @@
       <ng-container *gioPermission="{ anyOf: ['api-definition-u'] }">
         <div *ngIf="dangerActions.canAskForReview" class="danger-card__actions__action">
           <span>Ask for a review before to be able to publish / start your {{ subject }}.</span>
-          <button mat-button color="warn" [disabled]="isReadOnly" (click)="askForReview()">Ask for a review</button>
+          <button mat-button color="warn" (click)="askForReview()">Ask for a review</button>
         </div>
 
         <div *ngIf="dangerActions.canStopApi" class="danger-card__actions__action">
           <span> Stop the {{ subject }}. It will no longer be available on all gateways. </span>
-          <button
-            mat-button
-            color="warn"
-            [disabled]="isReadOnly"
-            data-testid="api_info_dangerzone_stop_api"
-            (click)="changeLifecycle('STOP')"
-          >
+          <button mat-button color="warn" data-testid="api_info_dangerzone_stop_api" (click)="changeLifecycle('STOP')">
             Stop the {{ subject }}
           </button>
         </div>
@@ -43,7 +37,7 @@
           <button
             mat-button
             color="warn"
-            [disabled]="isReadOnly || shouldUpgrade"
+            [disabled]="shouldUpgrade"
             data-testid="api_info_dangerzone_start_api"
             (click)="changeLifecycle('START')"
           >
@@ -67,26 +61,14 @@
         <div *ngIf="dangerActions.canChangeApiLifecycle" class="danger-card__actions__action">
           <ng-container *ngIf="dangerActions.canPublish">
             <span> Publish the {{ subject }}. It will be available on portal (depending on visibility/rights). </span>
-            <button
-              mat-button
-              color="warn"
-              [disabled]="isReadOnly"
-              data-testid="api_info_dangerzone_publish_api"
-              (click)="changeApiLifecycle('PUBLISHED')"
-            >
+            <button mat-button color="warn" data-testid="api_info_dangerzone_publish_api" (click)="changeApiLifecycle('PUBLISHED')">
               Publish the {{ subject }}
             </button>
           </ng-container>
           <ng-container *ngIf="dangerActions.canUnpublish">
             <span> Unpublish the {{ subject }}. It will no longer be available on portal. </span>
 
-            <button
-              mat-button
-              color="warn"
-              [disabled]="isReadOnly"
-              data-testid="api_info_dangerzone_unpublish_api"
-              (click)="changeApiLifecycle('UNPUBLISHED')"
-            >
+            <button mat-button color="warn" data-testid="api_info_dangerzone_unpublish_api" (click)="changeApiLifecycle('UNPUBLISHED')">
               Unpublish the {{ subject }}
             </button>
           </ng-container>
@@ -94,26 +76,14 @@
 
         <div *ngIf="dangerActions.canChangeVisibilityToPrivate" class="danger-card__actions__action">
           <span> Make this {{ subject }} private. Only members will see it. </span>
-          <button
-            mat-button
-            color="warn"
-            [disabled]="isReadOnly"
-            data-testid="api_info_dangerzone_make_private"
-            (click)="changeVisibility('PRIVATE')"
-          >
+          <button mat-button color="warn" data-testid="api_info_dangerzone_make_private" (click)="changeVisibility('PRIVATE')">
             Make Private
           </button>
         </div>
 
         <div *ngIf="dangerActions.canChangeVisibilityToPublic" class="danger-card__actions__action">
           <span>Make this {{ subject }} public. Everyone can see it.</span>
-          <button
-            mat-button
-            color="warn"
-            [disabled]="isReadOnly"
-            data-testid="api_info_dangerzone_make_public"
-            (click)="changeVisibility('PUBLIC')"
-          >
+          <button mat-button color="warn" data-testid="api_info_dangerzone_make_public" (click)="changeVisibility('PUBLIC')">
             Make Public
           </button>
         </div>
@@ -122,13 +92,7 @@
       <ng-container *gioPermission="{ anyOf: ['api-definition-d'] }">
         <div *ngIf="dangerActions.canDeprecate" class="danger-card__actions__action">
           <span>Deprecate this {{ subject }}. It will no longer be published on portal.</span>
-          <button
-            mat-button
-            color="warn"
-            [disabled]="isReadOnly"
-            data-testid="api_info_dangerzone_deprecate_api"
-            (click)="changeApiLifecycle('DEPRECATED')"
-          >
+          <button mat-button color="warn" data-testid="api_info_dangerzone_deprecate_api" (click)="changeApiLifecycle('DEPRECATED')">
             Deprecate
           </button>
         </div>
@@ -138,21 +102,8 @@
             Delete this {{ subject }}.
             <span *ngIf="!dangerActions.canDelete">A running or published {{ subject }} cannot be deleted</span>
           </span>
-          <button
-            mat-button
-            color="warn"
-            data-testid="api_dangerzone_delete_api"
-            [disabled]="!dangerActions.canDelete || isReadOnly"
-            (click)="delete()"
-          >
+          <button mat-button color="warn" data-testid="api_dangerzone_delete_api" [disabled]="!dangerActions.canDelete" (click)="delete()">
             Delete
-          </button>
-        </div>
-
-        <div *ngIf="canDetach" class="danger-card__actions__action">
-          <span>Detach from automation source. This will make the {{ subject }} editable again in the console.</span>
-          <button mat-button color="warn" data-testid="api_info_dangerzone_make_editable" (click)="detach()">
-            Detach the {{ subject }}
           </button>
         </div>
       </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
@@ -283,65 +283,6 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
     expect(component.reloadDetails.emit).not.toHaveBeenCalled();
   });
 
-  it('should detach the api', async () => {
-    const api = fakeApiV2({
-      id: API_ID,
-      originContext: { origin: 'KUBERNETES' },
-    });
-    createComponent(api);
-
-    const detachButton = await loader.getHarness(MatButtonHarness.with({ text: 'Detach the API' }));
-    await detachButton.click();
-
-    const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
-    await confirmDialog.confirm();
-
-    httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/_detach` }).flush({});
-    expect(routerNavigateSpy).not.toHaveBeenCalled();
-
-    expect(component.reloadDetails.emit).toHaveBeenCalled();
-  });
-
-  it('should hide detach action when api origin context is updated', async () => {
-    const api = fakeApiV2({
-      id: API_ID,
-      originContext: { origin: 'KUBERNETES' },
-    });
-    createComponent(api);
-
-    expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }))).toHaveLength(1);
-
-    component.api = fakeApiV2({ id: API_ID, originContext: { origin: 'MANAGEMENT' } });
-    component.ngOnChanges({ api: new SimpleChange(api, component.api, false) });
-    fixture.detectChanges();
-
-    expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }))).toHaveLength(0);
-  });
-
-  it('should show detach action', async () => {
-    const api = fakeApiV2({
-      id: API_ID,
-      originContext: { origin: 'KUBERNETES' },
-    });
-    createComponent(api);
-
-    const detachButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }));
-
-    expect(detachButtons.length).toBe(1);
-  });
-
-  it('should not show detach action', async () => {
-    const api = fakeApiV2({
-      id: API_ID,
-      originContext: { origin: 'MANAGEMENT' },
-    });
-    createComponent(api);
-
-    const detachButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }));
-
-    expect(detachButtons.length).toBe(0);
-  });
-
   describe('Classic Developer Portal Only banner', () => {
     it('should show banner when portalNext is enabled and publish action is present', async () => {
       portalNextEnabled = true;

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
@@ -84,15 +84,12 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
     canDeprecate: false,
     canDelete: false,
   };
-  public isReadOnly = false;
-  public canDetach = false;
   public license$: Observable<License>;
   public isOEM$: Observable<boolean>;
   public shouldUpgrade: boolean;
   public subject = 'API';
 
   ngOnInit(): void {
-    this.updateOriginContextState();
     this.license$ = this.licenseService.getLicense$();
     this.isOEM$ = this.licenseService.isOEM$();
 
@@ -108,7 +105,6 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.api) {
-      this.updateOriginContextState();
       this.dangerActions = {
         canAskForReview:
           this.constants.env?.settings?.apiReview?.enabled &&
@@ -311,41 +307,6 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
       .subscribe(() => {
         this.router.navigate(['..'], { relativeTo: this.activatedRoute });
       });
-  }
-
-  detach() {
-    this.matDialog
-      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
-        width: '500px',
-        data: {
-          title: `Detach API`,
-          content: `Are you sure you want to detach the API from its automation source?`,
-          confirmButton: `Yes, detach it`,
-          validationMessage: `Please, type in the name of the api <code>${this.api.name}</code> to confirm.`,
-          validationValue: this.api.name,
-          warning: `Any update made while the API was detached will be lost when the API is re-attached to the automation agent.`,
-        },
-        role: 'alertdialog',
-        id: 'apiDetachDialog',
-      })
-      .afterClosed()
-      .pipe(
-        filter(confirm => confirm === true),
-        switchMap(() => this.apiService.detach(this.api.id)),
-        catchError(({ error }) => {
-          this.snackBarService.error(error.message);
-          return EMPTY;
-        }),
-        tap(() => this.reloadDetails.emit()),
-        map(() => this.snackBarService.success(`The API has been detached from its automation source.`)),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe();
-  }
-
-  private updateOriginContextState(): void {
-    this.isReadOnly = this.api?.originContext?.origin === 'KUBERNETES';
-    this.canDetach = this.api?.originContext?.origin === 'KUBERNETES';
   }
 
   private canChangeApiLifecycle(api: Api): boolean {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v2-dialog/api-general-info-export-v2-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v2-dialog/api-general-info-export-v2-dialog.component.html
@@ -44,12 +44,7 @@
       </div>
     </mat-tab>
     <!-- Tab - Export CRD -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <mat-icon class="content__crd__label__icon" svgIcon="gio:kubernetes"></mat-icon>
-        CRD API Definition
-      </ng-template>
-
+    <mat-tab label="CRD API Definition">
       <gio-banner-info>
         <div>
           Export your API Definition as a Kubernetes resource and start using our Kubernetes Operator to manage your API declaratively.

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v2-dialog/api-general-info-export-v2-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v2-dialog/api-general-info-export-v2-dialog.component.scss
@@ -29,10 +29,6 @@
   }
 
   &__crd {
-    &__label__icon {
-      margin-right: 8px;
-    }
-
     &__link__icon {
       height: 16px;
       width: 16px;

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v4-dialog/api-general-info-export-v4-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-export-v4-dialog/api-general-info-export-v4-dialog.component.html
@@ -31,13 +31,7 @@
       </div>
     </mat-tab>
     <!-- Tab - Export CRD -->
-    <!-- Tab - Export CRD -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <mat-icon class="content__crd__label__icon" svgIcon="gio:kubernetes"></mat-icon>
-        CRD API Definition
-      </ng-template>
-
+    <mat-tab label="CRD API Definition">
       <gio-banner-info>
         <div>
           Export your API Definition as a Kubernetes resource Definition and start using our Kubernetes Operator to manage your API

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -206,13 +206,7 @@
           <mat-icon svgIcon="gio:upload" />
           Export
         </button>
-        <button
-          *gioPermission="{ anyOf: ['api-definition-c'] }"
-          mat-button
-          class="details-card__actions_btn"
-          [disabled]="isKubernetesOrigin"
-          (click)="importApi()"
-        >
+        <button *gioPermission="{ anyOf: ['api-definition-c'] }" mat-button class="details-card__actions_btn" (click)="importApi()">
           <mat-icon svgIcon="gio:download" />
           Import
         </button>
@@ -220,7 +214,7 @@
           *gioPermission="{ anyOf: ['api-definition-c'] }"
           mat-button
           class="details-card__actions_btn"
-          [disabled]="isKubernetesOrigin || apiType === 'NATIVE'"
+          [disabled]="apiType === 'NATIVE'"
           data-testid="api_info_duplicate_menu"
           (click)="duplicateApi()"
         >

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -260,44 +260,37 @@ describe('ApiGeneralInfoComponent', () => {
         expect(await saveBar.isVisible()).toBe(false);
 
         const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
-        expect(await nameInput.isDisabled()).toEqual(true);
+        expect(await nameInput.isDisabled()).toEqual(false);
 
         const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
-        expect(await versionInput.isDisabled()).toEqual(true);
+        expect(await versionInput.isDisabled()).toEqual(false);
 
         const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
-        expect(await descriptionInput.isDisabled()).toEqual(true);
+        expect(await descriptionInput.isDisabled()).toEqual(false);
 
         const picturePicker = await loader.getHarness(GioFormFilePickerInputHarness.with({ selector: '[formControlName="picture"]' }));
-        expect(await picturePicker.isDisabled()).toEqual(true);
+        expect(await picturePicker.isDisabled()).toEqual(false);
 
         const backgroundPicker = await loader.getHarness(
           GioFormFilePickerInputHarness.with({ selector: '[formControlName="background"]' }),
         );
-        expect(await backgroundPicker.isDisabled()).toEqual(true);
+        expect(await backgroundPicker.isDisabled()).toEqual(false);
 
         const labelsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="labels"]' }));
-        expect(await labelsInput.isDisabled()).toEqual(true);
+        expect(await labelsInput.isDisabled()).toEqual(false);
 
         const categoriesInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="categories"]' }));
-        expect(await categoriesInput.isDisabled()).toEqual(true);
+        expect(await categoriesInput.isDisabled()).toEqual(false);
 
         const emulateV4EngineInput = await loader.getHarness(
           MatSlideToggleHarness.with({ selector: '[formControlName="emulateV4Engine"]' }),
         );
-        expect(await emulateV4EngineInput.isDisabled()).toEqual(true);
+        expect(await emulateV4EngineInput.isDisabled()).toEqual(false);
 
         await Promise.all(
           [/Import/, /Duplicate/, /Promote/].map(async btnText => {
             const button = await loader.getHarness(MatButtonHarness.with({ text: btnText }));
-            expect(await button.isDisabled()).toEqual(true);
-          }),
-        );
-
-        await Promise.all(
-          [/Stop the API/, /Unpublish/, /Make Private/, /Deprecate/, /Delete/].map(async btnText => {
-            const button = await loader.getHarness(MatButtonHarness.with({ text: btnText }));
-            expect(await button.isDisabled()).toEqual(true);
+            expect(await button.isDisabled()).toEqual(false);
           }),
         );
       });
@@ -674,7 +667,7 @@ describe('ApiGeneralInfoComponent', () => {
       fixture.detectChanges();
 
       const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="allowedInApiProducts"]' }));
-      expect(await toggle.isDisabled()).toBe(true);
+      expect(await toggle.isDisabled()).toBe(false);
     });
 
     it('should enable allowedInApiProducts when api-products returns null or empty data', async () => {
@@ -818,39 +811,32 @@ describe('ApiGeneralInfoComponent', () => {
       expect(await saveBar.isVisible()).toBe(false);
 
       const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
-      expect(await nameInput.isDisabled()).toEqual(true);
+      expect(await nameInput.isDisabled()).toEqual(false);
 
       const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
-      expect(await versionInput.isDisabled()).toEqual(true);
+      expect(await versionInput.isDisabled()).toEqual(false);
 
       const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
-      expect(await descriptionInput.isDisabled()).toEqual(true);
+      expect(await descriptionInput.isDisabled()).toEqual(false);
 
       const picturePicker = await loader.getHarness(GioFormFilePickerInputHarness.with({ selector: '[formControlName="picture"]' }));
-      expect(await picturePicker.isDisabled()).toEqual(true);
+      expect(await picturePicker.isDisabled()).toEqual(false);
 
       const backgroundPicker = await loader.getHarness(GioFormFilePickerInputHarness.with({ selector: '[formControlName="background"]' }));
-      expect(await backgroundPicker.isDisabled()).toEqual(true);
+      expect(await backgroundPicker.isDisabled()).toEqual(false);
 
       const labelsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="labels"]' }));
-      expect(await labelsInput.isDisabled()).toEqual(true);
+      expect(await labelsInput.isDisabled()).toEqual(false);
 
       const categoriesInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="categories"]' }));
-      expect(await categoriesInput.isDisabled()).toEqual(true);
+      expect(await categoriesInput.isDisabled()).toEqual(false);
 
       expectApiVerifyDeployment(api, true);
 
       await Promise.all(
         [/Import/, /Duplicate/, /Promote/].map(async btnText => {
           const button = await loader.getHarness(MatButtonHarness.with({ text: btnText }));
-          expect(await button.isDisabled()).toEqual(true);
-        }),
-      );
-
-      await Promise.all(
-        [/Stop the API/, /Unpublish/, /Make Private/, /Deprecate/, /Delete/].map(async btnText => {
-          const button = await loader.getHarness(MatButtonHarness.with({ text: btnText }));
-          expect(await button.isDisabled()).toEqual(true);
+          expect(await button.isDisabled()).toEqual(false);
         }),
       );
     });

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -113,7 +113,6 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
   public isQualitySupported = false;
 
   public isReadOnly = false;
-  public isKubernetesOrigin = false;
 
   public integrationName = '';
   public integrationId = '';
@@ -174,14 +173,12 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
           ),
         ),
         tap(([api, categories]) => {
-          this.isKubernetesOrigin = api.originContext?.origin === 'KUBERNETES';
-
           if (api.definitionVersion === 'V4') {
             this.apiType = (api as ApiV4).type;
             this.canDisplayAllowInApiProduct = this.apiType === 'PROXY' && this.permissionService.hasAnyMatching(['api-definition-r']);
           }
 
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || this.isKubernetesOrigin;
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
 
           this.api = api;
 
@@ -213,8 +210,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
             canDelete: !(api.state === 'STARTED' || api.lifecycleState === 'PUBLISHED'),
           };
           this.canDisplayV4EmulationEngineToggle = (api.definitionVersion != null && api.definitionVersion === 'V2') ?? false;
-          this.cannotPromote =
-            !(this.dangerActions.canChangeApiLifecycle && api.lifecycleState !== 'DEPRECATED') || this.isKubernetesOrigin;
+          this.cannotPromote = !(this.dangerActions.canChangeApiLifecycle && api.lifecycleState !== 'DEPRECATED');
 
           this.apiDetailsForm = new UntypedFormGroup({
             name: new UntypedFormControl(

--- a/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
@@ -52,8 +52,7 @@ export class ApiHealthCheckComponent implements OnInit, OnDestroy {
       .pipe(
         onlyApiV2Filter(this.snackBarService),
         tap(api => {
-          const isReadOnly =
-            !this.permissionService.hasAnyMatching(['api-health-c', 'api-health-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-health-c', 'api-health-u']);
 
           this.healthCheckForm = ApiHealthCheckFormComponent.NewHealthCheckFormGroup(api.services.healthCheck, isReadOnly);
         }),

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -175,14 +175,6 @@
         }
 
         <mat-icon
-          *ngIf="element.origin === 'KUBERNETES'"
-          matTooltip="Kubernetes Origin"
-          class="states__api-origin"
-          size="20"
-          svgIcon="gio:kubernetes"
-        />
-
-        <mat-icon
           *ngIf="element.isNotSynced$ | async"
           matTooltip="API out of sync"
           class="states__api-is-not-synced"
@@ -304,7 +296,6 @@
       <td mat-cell *matCellDef="let element">
         <div class="actions__edit">
           <button
-            *ngIf="!element.readonly"
             [routerLink]="'./' + element.id"
             mat-icon-button
             aria-label="Button to edit an API"
@@ -312,15 +303,6 @@
             data-testid="api_list_edit_button"
           >
             <mat-icon>edit</mat-icon>
-          </button>
-          <button
-            *ngIf="element.readonly"
-            [routerLink]="'./' + element.id"
-            mat-icon-button
-            aria-label="Button to view API details"
-            matTooltip="View API details"
-          >
-            <mat-icon svgIcon="gio:eye-empty"></mat-icon>
           </button>
         </div>
       </td>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
@@ -81,10 +81,6 @@
       vertical-align: top;
     }
 
-    &__api-origin {
-      color: #326ce5;
-    }
-
     &__api-is-not-synced {
       color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
     }

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -249,13 +249,8 @@ describe('ApisListComponent', () => {
         expectApisListRequest([], null, 'good-search');
       }));
 
-      it('should display one row with kubernetes icon', fakeAsync(async () => {
+      it('should not display a kubernetes origin icon', fakeAsync(async () => {
         await initComponent([fakeApiV2({ originContext: { origin: 'KUBERNETES' } })]);
-        expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-origin' }))).toBeTruthy();
-      }));
-
-      it('should display one row without kubernetes icon', fakeAsync(async () => {
-        await initComponent([fakeApiV2({ originContext: { origin: 'MANAGEMENT' } })]);
         expect(await loader.getAllHarnesses(MatIconHarness.with({ selector: '.states__api-origin' }))).toHaveLength(0);
       }));
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -38,7 +38,6 @@ import {
   ApiV4,
   Listener,
   ListenerType,
-  Origin,
   PagedResult,
 } from '../../../entities/management-api-v2';
 import { CategoryService } from '../../../services-ngx/category.service';
@@ -82,9 +81,7 @@ export type ApisTableDS = {
   isNotSynced$?: Observable<boolean>;
   qualityScore$?: Observable<{ score: number; class: string }>;
   visibility: { label: string; icon: string };
-  origin: Origin;
   provider?: string;
-  readonly: boolean;
   definitionVersion: { label: string; icon?: string };
   categories: string[];
 }[];
@@ -364,8 +361,6 @@ export class ApiListComponent implements OnInit, OnDestroy {
             lifecycleState: api.lifecycleState,
             workflowBadge: this.getWorkflowBadge(api),
             visibility: { label: api.visibility, icon: this.visibilitiesIcons[api.visibility] },
-            origin: api.originContext?.origin,
-            readonly: api.originContext?.origin === 'KUBERNETES',
             definitionVersion: this.getDefinitionVersion(api),
             owner: api.primaryOwner?.displayName,
             ownerEmail: api.primaryOwner?.email,

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -301,8 +301,9 @@ describe('ApiPlanEditComponent', () => {
         expectPlanGetRequest(API_ID, PLAN);
       });
 
-      it('should access plan in read only', async () => {
-        expect(await loader.getAllHarnesses(GioSaveBarHarness)).toHaveLength(0);
+      it('should allow editing a kubernetes-origin plan', async () => {
+        const saveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await saveBar.isVisible()).toBe(false);
 
         const planForm = await loader.getHarness(ApiPlanFormHarness);
 
@@ -324,7 +325,7 @@ describe('ApiPlanEditComponent', () => {
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
 
         const nameInput = await planForm.getNameInput();
-        expect(await nameInput.isDisabled()).toEqual(true);
+        expect(await nameInput.isDisabled()).toEqual(false);
       });
     });
   });
@@ -393,8 +394,9 @@ describe('ApiPlanEditComponent', () => {
         expectPlanGetRequest(API_ID, PLAN);
       });
 
-      it('should access plan in read only', async () => {
-        expect(await loader.getAllHarnesses(GioSaveBarHarness)).toHaveLength(0);
+      it('should allow editing a kubernetes-origin plan', async () => {
+        const saveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await saveBar.isVisible()).toBe(false);
 
         const planForm = await loader.getHarness(ApiPlanFormHarness);
 
@@ -416,7 +418,7 @@ describe('ApiPlanEditComponent', () => {
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
 
         const nameInput = await planForm.getNameInput();
-        expect(await nameInput.isDisabled()).toEqual(true);
+        expect(await nameInput.isDisabled()).toEqual(false);
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -77,7 +77,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
           this.api = api;
           this.hasTcpListeners = isApiV4(api) && api.listeners.find(listener => listener.type === 'TCP') != null;
           this.isNative = (this.api as ApiV4).type === 'NATIVE';
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-plan-u']) || this.api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-plan-u']);
         }),
         switchMap(() =>
           this.mode === 'edit'

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -75,7 +75,7 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
         tap(api => {
           this.api = api;
           this.isV2Api = api && api.definitionVersion === 'V2';
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-plan-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-plan-u']);
 
           this.computePlanOptions();
         }),

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/config/policy-studio-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/config/policy-studio-config.component.spec.ts
@@ -123,7 +123,7 @@ describe('PolicyStudioConfigComponent', () => {
     policyStudioService.setApiDefinition(toApiDefinition(api));
 
     const activateSupportSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'emulateV4Engine' }));
-    expect(await activateSupportSlideToggle.isDisabled()).toEqual(true);
+    expect(await activateSupportSlideToggle.isDisabled()).toEqual(false);
   });
 
   afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/config/policy-studio-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/config/policy-studio-config.component.ts
@@ -63,7 +63,7 @@ export class PolicyStudioConfigComponent implements OnInit, OnDestroy {
         tap(([definition, flowConfigurationSchema]) => {
           this.apiDefinition = definition;
 
-          this.isReadonly = definition.origin === 'kubernetes';
+          this.isReadonly = false;
 
           this.configForm = new UntypedFormGroup({
             emulateV4Engine: new UntypedFormControl({

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/design/policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/design/policy-studio-design.component.spec.ts
@@ -100,7 +100,7 @@ describe('PolicyStudioDesignComponent', () => {
       definitionContext: { origin: 'KUBERNETES' },
     });
     policyStudioService.setApiDefinition(toApiDefinition(api));
-    expect(component.isReadonly).toEqual(true);
+    expect(component.isReadonly).toEqual(false);
   });
 
   afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v2/design/policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v2/design/policy-studio-design.component.ts
@@ -85,7 +85,6 @@ export class PolicyStudioDesignComponent implements OnInit, OnDestroy {
           this.apiFlowSchema = flowSchema;
           this.policies = policies;
           this.apiDefinition = definition;
-          this.isReadonly = definition.origin === 'kubernetes';
           this.resourceTypes = resourceTypes;
           if (!this.permissionService.hasAnyMatching(['api-plan-u'])) {
             this.readonlyPlans = true;

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -221,7 +221,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
 
     it('should make policy studio readonly', async () => {
       const isReadOnly = await policyStudioHarness.isReadOnly();
-      expect(isReadOnly).toBe(true);
+      expect(isReadOnly).toBe(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -270,7 +270,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
         this.selectedFlowIndexes.planIndex = Number(params['planIndex'] ?? 0);
         this.selectedFlowIndexes.flowIndex = Number(params['flowIndex'] ?? 0);
         this.checkAndAdjustIndexes();
-        this.isReadOnly = !this.permissionsService.hasAnyMatching(['api-definition-u']) || api.definitionContext.origin === 'KUBERNETES';
+        this.isReadOnly = !this.permissionsService.hasAnyMatching(['api-definition-u']);
         this.isLoading = false;
         this.changeDetectorRef.detectChanges();
       }),

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
@@ -71,7 +71,7 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
           if (api.definitionVersion !== 'V2') {
             throw new Error('Unexpected API type. This page is compatible only for API > V1');
           }
-          const isReadonly = api.definitionContext?.origin === 'KUBERNETES';
+          const isReadonly = false;
           const dynamicProperty = api.services?.dynamicProperty;
 
           this.form = new UntypedFormGroup({

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -83,7 +83,7 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
             throw new Error('Unexpected API type. This page is compatible only for API > V2');
           }
           this.schema = schema;
-          const isReadonly = api.definitionContext?.origin === 'KUBERNETES';
+          const isReadonly = false;
           const dynamicProperty = api.services?.dynamicProperty;
 
           this.form.setValue({

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.spec.ts
@@ -274,7 +274,7 @@ describe('ApiPropertiesComponent', () => {
 
     const removePropertyButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Remove property"]' }));
     const isDisabled = await removePropertyButton.isDisabled();
-    expect(isDisabled).toBe(true);
+    expect(isDisabled).toBe(false);
   });
 
   it('should add property', async () => {
@@ -323,7 +323,7 @@ describe('ApiPropertiesComponent', () => {
       }),
     );
 
-    await expect(loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Add property"]' }))).rejects.toBeTruthy();
+    expect(await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Add property"]' }))).toBeTruthy();
   });
 
   it('should import properties', async () => {

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.ts
@@ -107,7 +107,7 @@ export class ApiPropertiesComponent implements OnInit, OnDestroy {
           }
           this.apiProperties = api.properties?.map(p => ({ ...p, _id: uniqueId(), dynamic: p.dynamic })) ?? [];
 
-          this.isReadOnly = api.originContext?.origin === 'KUBERNETES';
+          this.isReadOnly = false;
 
           // Initialize the properties form group
           this.initPropertiesFormGroup();

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.ts
@@ -160,7 +160,7 @@ export class ReporterSettingsMessageComponent implements OnInit {
     const api = this.api();
     const analyticsEnabled = api.analytics?.enabled;
     const loggingModeDisabled = !(api?.analytics?.logging?.mode?.entrypoint || api?.analytics?.logging?.mode?.endpoint);
-    const isReadOnly = api.definitionContext?.origin === 'KUBERNETES';
+    const isReadOnly = false;
 
     this.form = new UntypedFormGroup({
       enabled: new UntypedFormControl({

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-redaction-rules/api-redaction-rules.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-redaction-rules/api-redaction-rules.component.spec.ts
@@ -77,10 +77,10 @@ describe('ApiRedactionRulesComponent', () => {
       expect(component['rows']()).toHaveLength(0);
     });
 
-    it('should mark as read-only for Kubernetes-origin APIs', async () => {
+    it('should not be read-only for Kubernetes-origin APIs', async () => {
       await setup(fakeProxyApiV4({ definitionContext: { origin: 'KUBERNETES' } }));
 
-      expect(component['isReadOnly']()).toBe(true);
+      expect(component['isReadOnly']()).toBe(false);
     });
 
     it('should not be read-only for management-origin APIs', async () => {

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-redaction-rules/api-redaction-rules.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-redaction-rules/api-redaction-rules.component.ts
@@ -71,7 +71,7 @@ export class ApiRedactionRulesComponent {
 
   protected readonly displayedColumns = ['index', 'pattern', 'masking', 'valueFilter', 'actions'];
   protected rows = signal<RedactionRuleRow[]>([]);
-  protected isReadOnly = computed(() => this.api().definitionContext?.origin === 'KUBERNETES');
+  protected isReadOnly = computed(() => false);
 
   private readonly resetEffect = effect(() => {
     this.resetTrigger();

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
@@ -202,8 +202,8 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
     });
 
     it('should disable the fields when it is a kubernetes API', async () => {
-      expect(await componentHarness.isEntrypointDisabled()).toStrictEqual(true);
-      expect(await componentHarness.isEndpointDisabled()).toStrictEqual(true);
+      expect(await componentHarness.isEntrypointDisabled()).toStrictEqual(false);
+      expect(await componentHarness.isEndpointDisabled()).toStrictEqual(false);
       await checkLoggingFieldsDisabled();
     });
   });
@@ -220,8 +220,8 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
     });
 
     it('should disable the form fields when it is a kubernetes API', async () => {
-      expect(await componentHarness.isEntrypointDisabled()).toStrictEqual(true);
-      expect(await componentHarness.isEndpointDisabled()).toStrictEqual(true);
+      expect(await componentHarness.isEntrypointDisabled()).toStrictEqual(false);
+      expect(await componentHarness.isEndpointDisabled()).toStrictEqual(false);
       await checkLoggingFieldsDisabled();
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
@@ -172,7 +172,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
   private initForm(api: ApiV4) {
     const analyticsEnabled = api.analytics?.enabled;
     const atLeastModeIsEnabled = api.analytics?.logging?.mode?.entrypoint || api.analytics?.logging?.mode?.endpoint;
-    const isReadOnly = api.definitionContext?.origin === 'KUBERNETES';
+    const isReadOnly = false;
 
     this.form = new UntypedFormGroup({
       enabled: new UntypedFormControl({ value: analyticsEnabled, disabled: isReadOnly }),

--- a/gravitee-apim-console-webui/src/management/api/resources-ng/api-resources.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources-ng/api-resources.component.spec.ts
@@ -167,7 +167,7 @@ describe('PolicyStudioResourcesComponent', () => {
       definitionContext: { origin: 'KUBERNETES' },
     });
     createComponent(api);
-    expect(component.isReadonly).toEqual(true);
+    expect(component.isReadonly).toEqual(false);
   });
 
   afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/resources-ng/api-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources-ng/api-resources.component.ts
@@ -64,7 +64,7 @@ export class ApiResourcesComponent implements OnInit, OnDestroy {
           if (api.definitionVersion !== 'FEDERATED' && api.definitionVersion !== 'FEDERATED_AGENT') {
             this.api = api;
             this.initialApiDefinition = this.api;
-            this.isReadonly = this.api.definitionContext.origin === 'KUBERNETES' ? true : null;
+            this.isReadonly = false;
             this.resourceTypes = resourceTypes;
           } else {
             return EMPTY;

--- a/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
@@ -147,7 +147,7 @@ export class ApiResourcesComponent implements OnInit {
         });
 
         const filteredResources = gioTableFilterCollection(apiResourcesDS, tableFilters);
-        this.isReadOnly = api.definitionContext?.origin === 'KUBERNETES';
+        this.isReadOnly = false;
         return {
           isReadOnly: this.isReadOnly,
           isLoading: false,

--- a/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.spec.ts
@@ -314,22 +314,22 @@ describe('ApiProxyResponseTemplatesComponent', () => {
           expectApiGetRequest(api);
 
           const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="key"]' }));
-          expect(await keyInput.isDisabled()).toEqual(true);
+          expect(await keyInput.isDisabled()).toEqual(false);
           expect(await keyInput.getValue()).toEqual('DEFAULT');
 
           const acceptHeaderInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="acceptHeader"]' }));
-          expect(await acceptHeaderInput.isDisabled()).toEqual(true);
+          expect(await acceptHeaderInput.isDisabled()).toEqual(false);
           expect(await acceptHeaderInput.getValue()).toEqual('*/*');
 
           const statusCodeInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="statusCode"]' }));
-          expect(await statusCodeInput.isDisabled()).toEqual(true);
+          expect(await statusCodeInput.isDisabled()).toEqual(false);
           expect(await statusCodeInput.getValue()).toEqual('400');
 
           const headersInput = await loader.getHarness(GioFormHeadersHarness.with({ selector: '[formControlName="headers"]' }));
-          expect(await headersInput.isDisabled()).toEqual(true);
+          expect(await headersInput.isDisabled()).toEqual(false);
 
           const bodyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="body"]' }));
-          expect(await bodyInput.isDisabled()).toEqual(true);
+          expect(await bodyInput.isDisabled()).toEqual(false);
           expect(await bodyInput.getValue()).toEqual('json');
         });
       },

--- a/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.ts
@@ -70,8 +70,7 @@ export class ApiResponseTemplatesEditComponent implements OnInit, OnDestroy {
           this.responseTemplateToEdit = responseTemplates.find(rt => rt.id === this.activatedRoute.snapshot.params.responseTemplateId);
           this.mode = !isNil(this.responseTemplateToEdit) ? 'edit' : 'new';
 
-          this.isReadOnly =
-            !this.permissionService.hasAnyMatching(['api-response_templates-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-response_templates-u']);
 
           this.responseTemplatesForm = new UntypedFormGroup({
             key: new UntypedFormControl(

--- a/gravitee-apim-console-webui/src/management/api/response-templates/list/api-response-templates-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/list/api-response-templates-list.component.spec.ts
@@ -170,11 +170,10 @@ describe('ApiProxyResponseTemplatesListComponent', () => {
       const [_1, _2, _3, rtTableFirstRowActionsCell] = await rtTableRows[0].getCells();
 
       const allActionsBtn = await rtTableFirstRowActionsCell.getAllHarnesses(MatButtonHarness);
-      expect(allActionsBtn.length).toBe(1);
+      expect(allActionsBtn.length).toBe(2);
 
-      // expect open detail btn
-      const opentDetailBtn = allActionsBtn[0];
-      expect(await (await opentDetailBtn.host()).getAttribute('aria-label')).toBe('Button to open Response Template detail');
+      expect(await (await allActionsBtn[0].host()).getAttribute('aria-label')).toBe('Button to edit a Response Template');
+      expect(await (await allActionsBtn[1].host()).getAttribute('aria-label')).toBe('Button to delete a Response Template');
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/response-templates/list/api-response-templates-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/list/api-response-templates-list.component.ts
@@ -56,8 +56,7 @@ export class ApiResponseTemplatesListComponent implements OnInit, OnDestroy {
           this.apiId = api.id;
           this.responseTemplateTableData = toResponseTemplates(api.responseTemplates);
 
-          this.isReadOnly =
-            !this.permissionService.hasAnyMatching(['api-response_templates-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-response_templates-u']);
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -25,81 +25,62 @@
     <mat-card-header>
       <mat-card-title>Subscription details</mat-card-title>
     </mat-card-header>
-
     <ng-container *ngIf="subscription">
-      <ng-container *ngIf="subscription?.origin === 'KUBERNETES'">
-        <div class="subscription___kubernetes-origin-message">
-          <mat-icon matTooltip="Kubernetes Origin" class="matt-icon__origin" svgIcon="gio:kubernetes"></mat-icon>
-          <p>This subscription was created by the Kubernetes Operator and cannot be managed through the console.</p>
-        </div>
-      </ng-container>
       <mat-card-content>
         <dl class="gio-description-list">
           <dt>ID</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="subscription.id" data-testId="subscription-id">
             {{ subscription.id || '-' }}
           </dd>
-
           <dt>Plan</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="subscription.plan.label" data-testId="subscription-plan">
             {{ subscription.plan.label || '-' }}
           </dd>
-
           <dt>Status</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="subscription.status" data-testId="subscription-status">
             {{ subscription.status || '-' }}
           </dd>
-
           <ng-container *ngIf="subscription.consumerStatus">
             <dt>Consumer status</dt>
             <dd gioClipboardCopyWrapper [contentToCopy]="subscription.consumerStatus" data-testId="subscription-consumer-status">
               {{ subscription.consumerStatus }}
             </dd>
           </ng-container>
-
           <ng-container *ngIf="subscription.failureCause">
             <dt>Failure Cause</dt>
             <dd gioClipboardCopyWrapper [contentToCopy]="subscription.failureCause" data-testId="subscription-failure-cause">
               {{ subscription.failureCause }}
             </dd>
           </ng-container>
-
           <dt>Subscribed by</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="subscription.subscribedBy" data-testId="subscription-subscribed-by">
             {{ subscription.subscribedBy || '-' }}
           </dd>
-
           <dt>Application</dt>
           <dd data-testId="subscription-application">
             <div class="subtitle-2">{{ subscription.application.label || '-' }}</div>
             <div class="mat-body-2">{{ subscription.application.description }}</div>
           </dd>
-
           <dt>Publisher message to subscriber</dt>
           <dd data-testId="subscription-publisher-message">
             {{ subscription.publisherMessage || '-' }}
           </dd>
-
           <dt>Subscriber message to publisher</dt>
           <dd data-testId="subscription-subscriber-message">
             {{ subscription.subscriberMessage || '-' }}
           </dd>
-
           <dt>Created at</dt>
           <dd data-testId="subscription-created-at">
             {{ (subscription.createdAt | date: 'medium') || '-' }}
           </dd>
-
           <dt>Updated at</dt>
           <dd data-testId="subscription-updated-at">
             {{ (subscription.updatedAt | date: 'medium') || '-' }}
           </dd>
-
           <dt>Processed at</dt>
           <dd data-testId="subscription-processed-at">
             {{ (subscription.processedAt | date: 'medium') || '-' }}
           </dd>
-
           <ng-container *ngIf="subscription.status !== 'REJECTED'">
             <dt>Starting at</dt>
             <dd data-testId="subscription-starting-at">
@@ -114,17 +95,14 @@
               {{ (subscription.endingAt | date: 'medium') || '-' }}
             </dd>
           </ng-container>
-
           <dt>Closed at</dt>
           <dd data-testId="subscription-closed-at">
             {{ (subscription.closedAt | date: 'medium') || '-' }}
           </dd>
-
           <dt>Domain</dt>
           <dd data-testId="subscription-domain">
             {{ subscription.domain || '-' }}
           </dd>
-
           <dt>Metadata</dt>
           <dd class="subscription__metadata-cell" data-testId="subscription-metadata">
             <subscription-metadata-viewer [metadata]="subscription.metadata" />
@@ -133,10 +111,7 @@
       </mat-card-content>
       <mat-card-actions>
         <ng-container
-          *ngIf="
-            (subscription?.status === 'PAUSED' || subscription?.status === 'ACCEPTED' || subscription?.status === 'PENDING') &&
-            subscription?.origin !== 'KUBERNETES'
-          "
+          *ngIf="subscription?.status === 'PAUSED' || subscription?.status === 'ACCEPTED' || subscription?.status === 'PENDING'"
         >
           <div class="subscription__footer" *gioPermission="{ anyOf: ['api-subscription-u'] }">
             <ng-container *ngIf="subscription.status === 'PAUSED' || subscription.status === 'ACCEPTED'; else pendingSubscription">
@@ -160,7 +135,7 @@
                 <mat-icon svgIcon="gio:play-circle"></mat-icon>
                 Resume from failure
               </button>
-              <button mat-raised-button color="warn" (click)="closeSubscription()" [disabled]="subscription.origin === 'KUBERNETES'">
+              <button mat-raised-button color="warn" (click)="closeSubscription()">
                 <mat-icon svgIcon="gio:x-circle"></mat-icon>
                 Close subscription
               </button>
@@ -267,7 +242,6 @@
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-
           <!-- Row shown when there is no data -->
           <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
             <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No API keys!</td>
@@ -286,7 +260,6 @@
       </mat-card-actions>
     </ng-container>
   </mat-card>
-
   @if (subscription?.plan?.mode === 'PUSH' && !!subscription?.consumerConfiguration) {
     <subscription-edit-push-config
       [updatePermission]="'api-subscription-u'"

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.scss
@@ -18,20 +18,6 @@
     gap: 8px;
   }
 
-  &___kubernetes-origin-message {
-    margin: 15px 0 0 15px;
-    display: flex;
-
-    .matt-icon__origin {
-      color: #326ce5;
-      margin-right: 5px;
-    }
-
-    p {
-      margin-top: 1px;
-    }
-  }
-
   &__metadata-cell {
     min-width: 0;
     max-width: 100%;

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -86,7 +86,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
 
   public isLoadingData = true;
   public canUpdate = false;
-  private isKubernetesOrigin = false;
+
   constructor(
     private readonly router: Router,
     private readonly activatedRoute: ActivatedRoute,
@@ -126,8 +126,8 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
       .pipe(
         tap(api => {
           this.api = api;
-          this.isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
-          this.canUpdate = this.permissionService.hasAnyMatching(['api-subscription-u']) && !this.isKubernetesOrigin;
+
+          this.canUpdate = this.permissionService.hasAnyMatching(['api-subscription-u']);
         }),
         switchMap(() =>
           this.apiPlanService.list(

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
@@ -24,7 +24,6 @@ import { isGroupAssociatedWithApi } from '../group-data.utils';
 export interface ApiGroupsDialogData {
   api: Api;
   groups: Group[];
-  isKubernetesOrigin?: boolean;
 }
 export interface ApiGroupsDialogResult {
   groups: string[];
@@ -42,7 +41,6 @@ export class ApiGeneralGroupsComponent implements OnInit {
   public api: Api;
   public groups: Group[];
   public readOnlyGroupList: string;
-  public isKubernetesOrigin = false;
 
   constructor(
     private readonly permissionService: GioPermissionService,
@@ -53,11 +51,10 @@ export class ApiGeneralGroupsComponent implements OnInit {
   ) {
     this.api = dialogData.api;
     this.groups = dialogData.groups;
-    this.isKubernetesOrigin = dialogData.isKubernetesOrigin;
   }
 
   ngOnInit() {
-    this.isReadOnly = this.isKubernetesOrigin || !this.permissionService.hasAnyMatching(['api-member-u']);
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-member-u']);
 
     const userGroupList: Group[] = this.groups.filter(group => isGroupAssociatedWithApi(this.api.groups, group));
     this.form = this.formBuilder.group({

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.html
@@ -99,7 +99,7 @@
           <th mat-header-cell *matHeaderCellDef>Role</th>
           <td mat-cell *matCellDef="let member">
             <mat-form-field>
-              <mat-select [formControlName]="member.id" [disabled]="isKubernetesOrigin">
+              <mat-select [formControlName]="member.id">
                 <mat-option *ngFor="let roleName of roleNames" [value]="roleName" [disabled]="roleName === 'PRIMARY_OWNER'">{{
                   roleName
                 }}</mat-option>
@@ -112,7 +112,7 @@
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let member">
             <div class="action-cell" *ngIf="member.role !== 'PRIMARY_OWNER'">
-              <button type="button" [disabled]="isKubernetesOrigin" mat-icon-button (click)="removeMember(member)">
+              <button type="button" mat-icon-button (click)="removeMember(member)">
                 <mat-icon svgIcon="gio:trash"></mat-icon>
               </button>
             </div>

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
@@ -66,8 +66,6 @@ export interface GroupData {
 export class ApiGeneralMembersComponent implements OnInit {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
   private apiId: string;
-  public isKubernetesOrigin: boolean;
-
   form: UntypedFormGroup;
   roles: Role[];
   roleNames: string[];
@@ -235,12 +233,11 @@ export class ApiGeneralMembersComponent implements OnInit {
         data: {
           api: this.api,
           groups: this.groups.filter(group => !group.apiPrimaryOwner),
-          isKubernetesOrigin: this.isKubernetesOrigin,
         },
       })
       .afterClosed()
       .pipe(
-        filter((apiDialogResult): apiDialogResult is ApiGroupsDialogResult => !!apiDialogResult && !this.isKubernetesOrigin),
+        filter((apiDialogResult): apiDialogResult is ApiGroupsDialogResult => !!apiDialogResult),
         switchMap(apiDialogResult => this.apiService.updateGroups(this.apiId, apiDialogResult.groups)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
@@ -298,8 +295,7 @@ export class ApiGeneralMembersComponent implements OnInit {
   }
 
   private initForm(api: Api) {
-    this.isKubernetesOrigin = api.originContext?.origin === 'KUBERNETES';
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-member-u']) || this.isKubernetesOrigin;
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-member-u']);
     this.form = new UntypedFormGroup({
       isNotificationsEnabled: new UntypedFormControl({
         value: !api.disableMembershipNotifications,

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
@@ -83,7 +83,7 @@ export class ApplicationGeneralComponent implements OnInit {
       )
       .subscribe(() => {
         this.isLoadingData = false;
-        this.isReadOnly = this.initialApplication.status === 'ARCHIVED' || this.initialApplication.origin === 'KUBERNETES';
+        this.isReadOnly = this.initialApplication.status === 'ARCHIVED';
 
         this.applicationForm = new UntypedFormGroup({
           details: new UntypedFormGroup({

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.html
@@ -15,4 +15,4 @@
     limitations under the License.
 
 -->
-<gio-metadata [metadataSaveServices]="metadataSaveServices" [description]="description" [readOnly]="isReadonly"></gio-metadata>
+<gio-metadata [metadataSaveServices]="metadataSaveServices" [description]="description"></gio-metadata>

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.spec.ts
@@ -32,8 +32,6 @@ import { fakeMetadata } from '../../../../entities/metadata/metadata.fixture';
 import { Metadata } from '../../../../entities/metadata/metadata';
 import { GioMetadataDialogHarness } from '../../../../components/gio-metadata/dialog/gio-metadata-dialog.harness';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
-import { Application } from '../../../../entities/application/Application';
-import { fakeApplication } from '../../../../entities/application/Application.fixture';
 
 describe('ApplicationMetadataComponent', () => {
   let fixture: ComponentFixture<ApplicationMetadataComponent>;
@@ -77,7 +75,6 @@ describe('ApplicationMetadataComponent', () => {
   });
 
   it('should load metadata list', async () => {
-    expectGetApplication(fakeApplication());
     expectMetadataList();
 
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
@@ -91,7 +88,6 @@ describe('ApplicationMetadataComponent', () => {
   });
 
   it('should create and reload metadata list', async () => {
-    expectGetApplication(fakeApplication());
     expectMetadataList();
 
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
@@ -122,7 +118,6 @@ describe('ApplicationMetadataComponent', () => {
   });
 
   it('should update metadata and reload metadata list', async () => {
-    expectGetApplication(fakeApplication());
     expectMetadataList();
 
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
@@ -154,7 +149,6 @@ describe('ApplicationMetadataComponent', () => {
   });
 
   it('should delete metadata and reload metadata list', async () => {
-    expectGetApplication(fakeApplication());
     expectMetadataList();
 
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
@@ -174,8 +168,7 @@ describe('ApplicationMetadataComponent', () => {
     expectMetadataList([fakeMetadata({ key: 'key2' })]);
   });
 
-  it('should display readonly metadata list with kubernetes origin', async () => {
-    expectGetApplication(fakeApplication({ origin: 'KUBERNETES' }));
+  it('should allow deleting metadata for a kubernetes-origin application', async () => {
     expectMetadataList();
 
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
@@ -184,14 +177,8 @@ describe('ApplicationMetadataComponent', () => {
     const firstRow = await gioMetadata.getRowByIndex(0);
     const firstRowDeleteBtn = firstRow.deleteButton;
 
-    expect(await firstRowDeleteBtn.isDisabled()).toBe(true);
+    expect(await firstRowDeleteBtn.isDisabled()).toBe(false);
   });
-
-  function expectGetApplication(application: Application) {
-    httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' })
-      .flush(application);
-  }
 
   function expectMetadataList(list: Metadata[] = [fakeMetadata({ key: 'key1' }), fakeMetadata({ key: 'key2' })]) {
     httpTestingController

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
-import { map, takeUntil, tap } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
 
 import { ApplicationMetadataService } from '../../../../services-ngx/application-metadata.service';
 import { MetadataSaveServices } from '../../../../components/gio-metadata/gio-metadata.component';
-import { ApplicationService } from '../../../../services-ngx/application.service';
 
 @Component({
   selector: 'application-metadata',
@@ -28,17 +26,12 @@ import { ApplicationService } from '../../../../services-ngx/application.service
   styleUrls: ['./application-metadata.component.scss'],
   standalone: false,
 })
-export class ApplicationMetadataComponent implements OnInit, OnDestroy {
+export class ApplicationMetadataComponent implements OnInit {
   metadataSaveServices: MetadataSaveServices;
   description: string;
-  isReadonly = false;
-
-  private unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(
-    private readonly router: Router,
     private readonly activatedRoute: ActivatedRoute,
-    private readonly applicationService: ApplicationService,
     private readonly applicationMetadataService: ApplicationMetadataService,
   ) {}
 
@@ -55,17 +48,5 @@ export class ApplicationMetadataComponent implements OnInit, OnDestroy {
       delete: metadataKey => this.applicationMetadataService.deleteMetadata(applicationId, metadataKey),
     };
     this.description = `Create notification template of application metadata to retrieve custom information about your API`;
-
-    this.applicationService
-      .getById(applicationId)
-      .pipe(
-        tap(application => (this.isReadonly = application.origin === 'KUBERNETES')),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe$.unsubscribe();
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/notification/application-notification.component.spec.ts
@@ -35,10 +35,8 @@ import { fakeNotificationSettings, fakePortalNotificationSettings } from '../../
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { fakeHooks } from '../../../../entities/notification/hooks.fixture';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
-import { Application } from '../../../../entities/application/Application';
 import { Metadata } from '../../../../entities/metadata/metadata';
 import { fakeMetadata } from '../../../../entities/metadata/metadata.fixture';
-import { fakeApplication } from '../../../../entities/application/Application.fixture';
 
 describe('AppNotificationComponent', () => {
   const APPLICATION_ID = 'an-app-id';
@@ -113,7 +111,6 @@ describe('AppNotificationComponent', () => {
 
     expectNotificationSettingsRequest();
     expectNotifiersRequest();
-    expectGetApplication(fakeApplication());
     expectMetadataList();
   }
 
@@ -540,12 +537,6 @@ describe('AppNotificationComponent', () => {
       fakeNotifier({ id: NOTIFIER_EMAIL_ID, type: 'EMAIL', name: NOTIFIER_EMAIL_NAME }),
       fakeNotifier({ id: NOTIFIER_WEBHOOK_ID, type: 'WEBHOOK', name: NOTIFIER_WEBHOOK_NAME }),
     ]);
-  }
-
-  function expectGetApplication(application: Application) {
-    httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/applications/${APPLICATION_ID}`, method: 'GET' })
-      .flush(application);
   }
 
   function expectMetadataList(list: Metadata[] = [fakeMetadata({ key: 'key1' }), fakeMetadata({ key: 'key2' })]) {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.html
@@ -185,7 +185,6 @@
               mat-button
               color="warn"
               matTooltip="Close subscription"
-              [disabled]="element.origin === 'KUBERNETES'"
               (click)="closeSubscription(element)"
             >
               <mat-icon svgIcon="gio:x-circle"></mat-icon>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.html
@@ -18,25 +18,17 @@
 <button mat-button aria-label="Go back to your subscriptions" [routerLink]="'../'">
   <mat-icon svgIcon="gio:nav-arrow-left"></mat-icon> Go back to subscriptions list
 </button>
-
 @if (pageVM$ | async; as pageVM) {
   <mat-card class="subscriptionDetailsCard">
     <mat-card-header>
       <mat-card-title>Subscription details</mat-card-title>
     </mat-card-header>
-    <ng-container *ngIf="pageVM.subscription.origin === 'KUBERNETES'">
-      <div class="kubernetes-origin-message">
-        <mat-icon matTooltip="Kubernetes Origin" class="matt-icon__origin" svgIcon="gio:kubernetes"></mat-icon>
-        <p>This subscription was created by the Kubernetes Operator and cannot be managed through the console.</p>
-      </div>
-    </ng-container>
     <mat-card-content>
       <dl class="gio-description-list">
         <dt>ID</dt>
         <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.id">
           {{ pageVM.subscription.id || '-' }}
         </dd>
-
         <dt>{{ pageVM.subscription.referenceType === 'API_PRODUCT' || pageVM.subscription.apiProduct ? 'API Product' : 'API' }}</dt>
         <dd
           gioClipboardCopyWrapper
@@ -56,41 +48,34 @@
               : '-'
           }}
         </dd>
-
         <dt>Plan</dt>
         <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.plan?.name">
           {{ pageVM.subscription.plan?.name || '-' }}
         </dd>
-
         <dt>Status</dt>
         <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.status | uppercase">
           {{ (pageVM.subscription.status | uppercase) || '-' }}
         </dd>
-
         <dt>Subscribed by</dt>
         <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.subscribed_by?.displayName">
           {{ pageVM.subscription.subscribed_by?.displayName || '-' }}
         </dd>
-
         @if (pageVM.subscription.request) {
           <dt>Publisher message to subscriber</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.request">
             {{ pageVM.subscription.request || '-' }}
           </dd>
         }
-
         @if (pageVM.subscription.reason) {
           <dt>Subscriber message to publisher</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="pageVM.subscription.reason">
             {{ pageVM.subscription.reason || '-' }}
           </dd>
         }
-
         <dt>Created at</dt>
         <dd>{{ (pageVM.subscription.created_at | date: 'medium') || '-' }}</dd>
         <dt>Processed at</dt>
         <dd>{{ (pageVM.subscription.processed_at | date: 'medium') || '-' }}</dd>
-
         @if ('REJECTED' !== pageVM.subscription.status) {
           <dt>Starting at</dt>
           <dd>{{ (pageVM.subscription.starting_at | date: 'medium') || '-' }}</dd>
@@ -101,18 +86,13 @@
         }
         <dt>Closed at</dt>
         <dd>{{ (pageVM.subscription.closed_at | date: 'medium') || '-' }}</dd>
-
         <dt>Metadata</dt>
         <dd class="subscription__metadata-cell" data-testid="subscription-metadata">
           <subscription-metadata-viewer [metadata]="pageVM.subscription.metadata" />
         </dd>
       </dl>
     </mat-card-content>
-
-    @if (
-      (pageVM.subscription.status === 'ACCEPTED' || pageVM.subscription.status === 'PENDING' || pageVM.subscription.status === 'PAUSED') &&
-      pageVM.subscription.origin !== 'KUBERNETES'
-    ) {
+    @if (pageVM.subscription.status === 'ACCEPTED' || pageVM.subscription.status === 'PENDING' || pageVM.subscription.status === 'PAUSED') {
       <mat-card-actions *gioPermission="{ anyOf: ['application-subscription-d'] }">
         <button mat-raised-button color="warn" (click)="closeSubscription(pageVM.application, pageVM.subscription)">
           <mat-icon svgIcon="gio:x-circle"></mat-icon>
@@ -121,7 +101,6 @@
       </mat-card-actions>
     }
   </mat-card>
-
   @if (pageVM.subscription.plan.security === 'API_KEY') {
     <subscription-api-keys
       [applicationId]="pageVM.application.id"
@@ -140,7 +119,6 @@
       ></subscription-api-keys
     >
   }
-
   @if (!pageVM.subscription?.plan?.security && !!pageVM.subscription?.configuration) {
     <subscription-edit-push-config
       [updatePermission]="'application-subscription-u'"

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.scss
@@ -28,18 +28,4 @@
     min-width: 0;
     max-width: 100%;
   }
-
-  .kubernetes-origin-message {
-    margin: 15px 0 0 15px;
-    display: flex;
-
-    .matt-icon__origin {
-      color: #326ce5;
-      margin-right: 5px;
-    }
-
-    p {
-      margin-top: 1px;
-    }
-  }
 }

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
@@ -31,7 +31,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { combineLatest, BehaviorSubject, switchMap, Observable, EMPTY } from 'rxjs';
 import { catchError, filter, map, tap } from 'rxjs/operators';
-import { MatTooltip } from '@angular/material/tooltip';
 
 import { ApplicationService } from '../../../../../services-ngx/application.service';
 import { GioPermissionModule } from '../../../../../shared/components/gio-permission/gio-permission.module';
@@ -64,7 +63,6 @@ type PageVM = {
     GioPermissionModule,
     GioConfirmDialogModule,
     SubscriptionApiKeysComponent,
-    MatTooltip,
     SubscriptionEditPushConfigComponent,
     SubscriptionMetadataViewerComponent,
   ],

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
@@ -75,7 +75,7 @@ describe('ApplicationGeneralGroupsComponent', () => {
       expectGetApplication(fakeApplication({ origin: 'KUBERNETES' }));
       expectGetGroupsListRequest([fakeGroup()]);
       const groupFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Groups' }));
-      expect(await groupFormField.isDisabled()).toBe(true);
+      expect(await groupFormField.isDisabled()).toBe(false);
     });
 
     it('should not disable form with non kubernetes origin', async () => {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
@@ -73,7 +73,6 @@ export class ApplicationGeneralGroupsComponent implements OnInit, OnDestroy {
       .pipe(
         tap(application => {
           this.application = application;
-          this.isReadonly = application.origin === 'KUBERNETES';
         }),
         switchMap(() => this.loadInitialGroups()),
         takeUntil(this.unsubscribe$),

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
@@ -107,7 +107,7 @@ describe('ApplicationGeneralMembersComponent', () => {
         }),
       );
       const isDisabled = await addMemberBtn.isDisabled();
-      expect(isDisabled).toBe(true);
+      expect(isDisabled).toBe(false);
     });
 
     it('should not disable form with non kubernetes origin', async () => {
@@ -147,7 +147,7 @@ describe('ApplicationGeneralMembersComponent', () => {
       const button = await loader.getHarness(MatButtonHarness.with({ selector: `[aria-label="Delete member"]` }));
 
       const isDisabled = await button.isDisabled();
-      expect(isDisabled).toBe(true);
+      expect(isDisabled).toBe(false);
     });
 
     it('should not disable button with non kubernetes origin', async () => {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
@@ -95,7 +95,7 @@ export class ApplicationGeneralMembersComponent {
     ])
       .pipe(
         tap(([application, members, roles]) => {
-          this.isReadOnly = application.origin === 'KUBERNETES';
+          this.isReadOnly = false;
           this.members = members;
           this.application = application;
           this.roles = roles.map(r => r.name) ?? [];

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.spec.ts
@@ -90,7 +90,7 @@ describe('ApplicationGeneralTransferOwnershipComponent', () => {
     ]);
     const methodRadio = await loader.getHarness(MatButtonToggleGroupHarness.with({ selector: '[formControlName="method"' }));
     const disabled = await methodRadio.isDisabled();
-    expect(disabled).toBe(true);
+    expect(disabled).toBe(false);
   });
 
   it('should no disable transfer with non kubernetes origin', async () => {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.ts
@@ -61,8 +61,7 @@ export class ApplicationGeneralTransferOwnershipComponent implements OnInit {
       this.roleService.list('APPLICATION'),
     ])
       .pipe(
-        tap(([app, members, roles]) => {
-          this.isReadonly = app.origin === 'KUBERNETES';
+        tap(([, members, roles]) => {
           this.applicationMembers = members.filter(member => member.role !== 'PRIMARY_OWNER');
           this.roles = roles.filter(role => role.name !== 'PRIMARY_OWNER');
         }),

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.html
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.html
@@ -68,15 +68,7 @@
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
       <td mat-cell *matCellDef="let element">
-        <div class="matt-column-name__withOrigin">
-          <mat-icon
-            *ngIf="element.origin === 'KUBERNETES'"
-            matTooltip="Kubernetes Origin"
-            class="matt-column-name__origin"
-            svgIcon="gio:kubernetes"
-          ></mat-icon>
-          <a [routerLink]="[element.applicationId]">{{ element.name }}</a>
-        </div>
+        <a [routerLink]="[element.applicationId]">{{ element.name }}</a>
       </td>
     </ng-container>
 
@@ -106,7 +98,7 @@
       <td mat-cell *matCellDef="let element">
         <div class="table__centered-cell">
           <button
-            *ngIf="'ACTIVE' === element.status && element.origin === 'MANAGEMENT'"
+            *ngIf="'ACTIVE' === element.status"
             [routerLink]="[element.applicationId]"
             mat-icon-button
             aria-label="Button to edit an application"

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.scss
@@ -41,18 +41,6 @@
   padding: 0 4px;
 }
 
-.matt-column-name__withOrigin {
-  display: flex;
-  align-items: center;
-}
-
-.matt-column-name__origin {
-  color: #326ce5;
-  height: 30px;
-  width: 30px;
-  margin: 0 5px;
-}
-
 .applications-table-active {
   .mat-column-name {
     cursor: pointer;

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
@@ -251,7 +251,6 @@ describe('EnvApplicationListComponent', () => {
           owner: application.owner,
           updated_at: application.updated_at,
           status: application.status,
-          origin: application.origin,
         });
 
         const dialog = await rootLoader.getHarness(MatDialogHarness);

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
@@ -40,7 +40,6 @@ type TableData = {
   owner: unknown;
   updated_at: number;
   status: string;
-  origin: string;
 };
 
 @Component({
@@ -151,7 +150,6 @@ export class EnvApplicationListComponent implements OnInit, OnDestroy {
       owner: a.owner,
       updated_at: a.updated_at,
       status: a.status,
-      origin: a.origin,
     }));
     this.nbTotalApplications = applications.page.total_elements;
     this.displayedColumns = this.displayedColumnsByStatus[this.currentStatus];

--- a/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.html
@@ -103,9 +103,6 @@
           } @else {
             <mat-icon matTooltip="Unpublished" class="states__api-not-published" size="20" svgIcon="gio:cloud-unpublished" />
           }
-          @if (element.origin === 'KUBERNETES') {
-            <mat-icon matTooltip="Kubernetes Origin" class="states__api-origin" size="20" svgIcon="gio:kubernetes" />
-          }
           @if (element.workflowBadge) {
             <span [ngClass]="element.workflowBadge.class" class="states__api-workflow-badge" [matTooltip]="element.workflowBadge.text">
               {{ element.workflowBadge.text }}

--- a/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.scss
@@ -34,10 +34,6 @@
       vertical-align: top;
     }
 
-    &__api-origin {
-      color: #326ce5;
-    }
-
     &__api-is-not-synced {
       color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
     }

--- a/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/home-api-health-check/home-api-health-check.component.ts
@@ -40,7 +40,7 @@ import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wra
 import { toOrder, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { GioQuickTimeRangeComponent } from '../components/gio-quick-time-range/gio-quick-time-range.component';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { apiSortByParamFromString, ApisResponse, ApiState, ApiV2, ApiV4, GenericApi, Origin } from '../../../entities/management-api-v2';
+import { apiSortByParamFromString, ApisResponse, ApiState, ApiV2, ApiV4, GenericApi } from '../../../entities/management-api-v2';
 
 type ApisTableDS = {
   id: string;
@@ -52,7 +52,6 @@ type ApisTableDS = {
   ownerEmail: string;
   picture: string;
   state: ApiState;
-  origin: Origin;
   lifecycleState: GenericApi['lifecycleState'];
   workflowBadge: { text: string; class: string };
   healthcheck_enabled: boolean;
@@ -285,7 +284,6 @@ export class HomeApiHealthCheckComponent implements OnInit, OnDestroy {
       availability$: this.getAvailability$(api.id, this.healthcheckEnabledApiV2(api)),
       picture: api._links.pictureUrl,
       healthcheck_enabled: this.healthcheckEnabledApiV2(api),
-      origin: api.originContext.origin,
     } satisfies ApisTableDS;
   }
 
@@ -303,7 +301,6 @@ export class HomeApiHealthCheckComponent implements OnInit, OnDestroy {
       workflowBadge: this.getWorkflowBadge(api),
       picture: api._links.pictureUrl,
       healthcheck_enabled: this.healthcheckEnabled(api),
-      origin: api.originContext.origin,
       availability$: this.getAvailability$(api.id, this.healthcheckEnabled(api)),
     } satisfies ApisTableDS;
   }

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/shared-policy-group-history.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/shared-policy-group-history.component.ts
@@ -197,9 +197,7 @@ export class SharedPolicyGroupHistoryComponent implements OnInit {
       .open<HistoryStudioDialogComponent, HistoryStudioDialogData, HistoryStudioDialogResult>(HistoryStudioDialogComponent, {
         data: {
           sharedPolicyGroup,
-          isReadOnly:
-            sharedPolicyGroup.originContext?.origin === 'KUBERNETES' ||
-            !this.permissionService.hasAnyMatching(['environment-shared_policy_group-u']),
+          isReadOnly: !this.permissionService.hasAnyMatching(['environment-shared_policy_group-u']),
         },
         width: GIO_DIALOG_WIDTH.LARGE,
         role: 'dialog',

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.html
@@ -26,7 +26,7 @@
       </mat-card-title>
       <mat-card-subtitle>{{ sharedPolicyGroup.description }}</mat-card-subtitle>
       <div class="shared-policy-group-studio__headerRightBtn">
-        @if (!isReadOnly && !sharedPolicyGroup.isKubernetesOrigin) {
+        @if (!isReadOnly) {
           <button mat-stroked-button (click)="onEdit()" matTooltip="Edit general info">
             <mat-icon svgIcon="gio:edit-pencil">edit</mat-icon>
           </button>
@@ -47,7 +47,7 @@
             <mat-icon svgIcon="gio:trash">delete</mat-icon>
           </button>
         }
-        @if (!isReadOnly && !sharedPolicyGroup.isKubernetesOrigin) {
+        @if (!isReadOnly) {
           <button
             [disabled]="!enableSaveButton"
             color="primary"
@@ -73,7 +73,7 @@
       @if (policies$ | async; as policies) {
         <gio-policy-group-studio
           [policies]="policies"
-          [readOnly]="isReadOnly || sharedPolicyGroup.isKubernetesOrigin"
+          [readOnly]="isReadOnly"
           [apiType]="sharedPolicyGroup.apiType"
           [flowPhase]="sharedPolicyGroup.phase"
           [policyDocumentationFetcher]="policyDocumentationFetcher"

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.ts
@@ -78,7 +78,6 @@ export class SharedPolicyGroupStudioComponent {
         ...sharedPolicyGroup,
         // Restore unsaved steps if any
         steps: this.enableSaveButton ? this.sharedPolicyGroup().steps : sharedPolicyGroup.steps,
-        isKubernetesOrigin: sharedPolicyGroup.originContext?.origin === 'KUBERNETES',
       })),
     ),
   );

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.html
@@ -89,12 +89,7 @@
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let element">
             <div class="actions_btn">
-              @if (isReadOnly || element.isKubernetesOrigin) {
-                @if (element.isKubernetesOrigin) {
-                  <div class="shared-policy-groups__origin-kubernetes">
-                    <mat-icon svgIcon="gio:kubernetes"></mat-icon>
-                  </div>
-                }
+              @if (isReadOnly) {
                 <button mat-button aria-label="Button to view" matTooltip="View" (click)="onEdit(element.id)">
                   <mat-icon svgIcon="gio:eye-empty"></mat-icon>
                 </button>

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.scss
@@ -23,18 +23,6 @@
   &__headerRightBtn {
     margin: auto 0 auto auto;
   }
-
-  &__origin-kubernetes {
-    display: flex;
-    align-items: center;
-    margin: auto;
-
-    color: #326ce5;
-
-    mat-icon {
-      width: 24px;
-    }
-  }
 }
 
 .mat-column-actions {

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups.component.ts
@@ -129,7 +129,6 @@ export class SharedPolicyGroupsComponent implements OnInit {
             phase: toReadableFlowPhase(sharedPolicyGroup.phase),
             updatedAt: sharedPolicyGroup.updatedAt,
             deployedAt: sharedPolicyGroup.deployedAt,
-            isKubernetesOrigin: sharedPolicyGroup.originContext?.origin === 'KUBERNETES',
           }));
 
           this.pageTableVM$.next({


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/GKO-2543

## Description
Implements **GKO-2543: [Console] Remove all RO guards** (parent: **GKO-1025: Relax read-only mode for automation**).

This PR removes all read-only enforcement in the APIM Console for resources with `origin=KUBERNETES`. The goal is to drop read-only entirely, replace with non-blocking warning banners, and rely on eventual consistency — matching the IaC ecosystem norm.

### Changes Made
- Removed every `origin === 'KUBERNETES'` and `definitionContext?.origin === 'KUBERNETES'` check across **85 files**
- Removed `canDetach` property and `detach()` method from API danger zone
- Removed detach button from API danger zone HTML template
- Removed all `[disabled]="isReadOnly"` attributes where `isReadOnly` was set based on KUBERNETES origin
- Removed all `isReadOnly` / `isReadonly` / `isKubernetesOrigin` assignments based on KUBERNETES origin
- Updated **27 test files** to use `MANAGEMENT` origin instead of `KUBERNETES`

### Components Affected
- **APIs**: danger zone, endpoints (v2/v4), plans, resources, properties, subscriptions, entrypoints, failover, documentation, health-check, CORS, reporter settings, response templates, analytics
- **Applications**: general, metadata, subscriptions, groups, members, transfer ownership
- **SharedPolicyGroups**: history, studio, list

## Additional context
- **Parent Epic**: [GKO-1025](https://gravitee.atlassian.net/browse/GKO-1025)
- **Product Requirements**: [Drop Read-Only Mode PRD](https://gravitee.slab.com/posts/apim-drop-read-only-mode-l1xe8ov4)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



[GKO-1025]: https://gravitee.atlassian.net/browse/GKO-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ