### PR TITLE
fix(ci): install the yarn workspace with the pinned package manager

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -15,7 +15,7 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -27,14 +27,20 @@ export class BuildBackendJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    // The reactor installs the yarn workspace (gravitee-gamma runs `yarn install` in
+    // generate-resources). Without corepack the image's yarn 1 cannot read the berry lockfile
+    // and resolves the whole workspace from the registry instead.
+    const installYarnCmd = InstallYarnCommand.get();
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(installYarnCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
+      new reusable.ReusedCommand(installYarnCmd),
       new commands.Run({
         name: 'Build engine',
         command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -P all-modules -DwithJavadoc`,

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -179,6 +179,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -63,6 +63,13 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -145,6 +152,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -320,6 +320,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -161,6 +161,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -162,6 +162,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -161,6 +161,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -161,6 +161,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -150,6 +150,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -206,6 +206,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -165,6 +165,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -280,6 +280,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -161,6 +161,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -280,6 +280,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -305,6 +305,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -63,6 +63,13 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -145,6 +152,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -162,6 +162,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-294

## Description

Every branch has been failing since about 14:00 today, in `Build backend`:

```
error Couldn't find any versions for "@rolldown/binding-darwin-x64" that matches "1.2.5"
[ERROR] Failed to execute goal exec-maven-plugin:3.6.3:exec (yarn-workspace-install) on project gravitee-gamma
```

A **macOS** binary, missing from the registry, taking down a **Linux** build — and the version it asks for is not the one the repository pins. `yarn.lock` holds `@rolldown/binding-darwin-x64@npm:1.0.3`; npm never published a 1.2.5 at all, it stops at 1.2.4.

The reason the lockfile has no say: `gravitee-gamma` runs `yarn install` in `generate-resources`, so the workspace is installed from `Build backend` — and that job is the only one of fourteen that never enabled corepack. The image ships yarn 1, which cannot read a berry lockfile, so it ignores it and resolves the whole workspace from the registry, optional platform binaries included.

This adds the existing `cmd-install-yarn` command to the job. Nothing else changes: the command was already written, already used by the frontend, e2e, danger and release jobs, and even by `Test rest-api`.

## Additional context

**Verified locally, on this branch:**

```
corepack enable && yarn --version          → 4.1.1
yarn install --immutable                   → Done with warnings in 48s (exit 0)
node_modules/@rolldown/binding-*/package.json → 1.0.3
```

The lockfile is consistent, an immutable install passes against it, and the version resolved is the pinned 1.0.3 rather than the 1.2.5 the CI was asking for. The failure disappears with the package manager the repository declares in `packageManager: yarn@4.1.1`.

**Why there is no `--immutable` in the pom.** Yarn Berry sets `enableImmutableInstalls` to true whenever `CI` is defined, so the install is already immutable on CircleCI once corepack is in play. Passing the flag explicitly would only change the behaviour for developers running a maven build locally, where it would fail instead of updating the lockfile — a regression for no gain in CI.

**Fixture churn.** Twenty-one workflow fixtures gain a `- cmd-install-yarn` line in the build job, and two gain the command definition. The diff is purely additive — no YAML line is removed — and the 153 test cases pass.

**This is the reproducibility defect BX-294 recorded and left open**, quoted there as: *"Build backend installs unpinned frontend dependencies. The image ships yarn 1, which cannot read a berry lockfile and resolves the whole workspace from the registry instead. A reproducibility problem, not a performance one."* It stayed harmless until a registry publication went wrong. Every build was one bad upstream release away from this.
