### PR TITLE
feat(gamma): invite group members by email and manage invitations

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/sheetLayout.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/sheetLayout.ts
@@ -13,9 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/** Default right sheet width (30rem / 480px). */
-export const STANDARD_SHEET_WIDTH = '480px';
-
-/** Wider sheet for multi-column forms or category sections (48rem / 768px). */
-export const WIDE_SHEET_WIDTH = '48rem';
+export { STANDARD_SHEET_WIDTH, WIDE_SHEET_WIDTH } from '../../../shared/layout/sheetLayout';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/dataTableTypes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/dataTableTypes.ts
@@ -13,10 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { DataTableColumnHeaderProps } from '@gravitee/graphene-core';
-
-/** Column header render props for Graphene `DataTable` column definitions. */
-export type ColHeader<T> = { column: DataTableColumnHeaderProps<T, unknown>['column'] };
-
-/** Column cell render props for Graphene `DataTable` column definitions. */
-export type ColCell<T> = { row: { original: T } };
+export type { ColCell, ColHeader } from '../../../shared/utils/dataTableTypes';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/paginationConstants.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-/** Shared page-size options for application tables (UI-COMP-12). */
-export const TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+export { TABLE_PAGE_SIZE_OPTIONS } from '../../../shared/utils/paginationConstants';
 
 export const DEFAULT_APPLICATION_LIST_PAGE_SIZE = 25;
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.spec.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import { useQuery } from '@tanstack/react-query';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { GroupAddMembersSheet } from './GroupAddMembersSheet';
+import { installFormActionTestEnvironment } from '../../../shared/testing/formAction';
 import type { SearchableUser } from '../../../shared/types/userSearch';
 import type { GroupMember } from '../types/group';
 import { GROUP_SEARCH_DEBOUNCE_MS } from '../utils/paginationConstants';
@@ -26,8 +27,15 @@ jest.mock('@tanstack/react-query', () => ({
     useQuery: jest.fn(),
 }));
 
+let restoreTestEnvironment: () => void;
+
 beforeAll(() => {
     Element.prototype.scrollIntoView = jest.fn();
+    restoreTestEnvironment = installFormActionTestEnvironment();
+});
+
+afterAll(() => {
+    restoreTestEnvironment();
 });
 
 const mockUseQuery = jest.mocked(useQuery);
@@ -42,6 +50,13 @@ function typeSearch(value: string) {
     fireEvent.change(screen.getByPlaceholderText('Search by name or email…'), { target: { value } });
     act(() => {
         jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS);
+    });
+}
+
+async function submitMembers() {
+    await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+        await Promise.resolve();
     });
 }
 
@@ -70,7 +85,6 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupAddMemb
             maxInvitation={null}
             onClose={onClose}
             onSubmit={onSubmit}
-            isSaving={false}
             {...overrides}
         />,
     );
@@ -109,6 +123,11 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.getByText('Explorer')).not.toBeNull();
     });
 
+    it('seeds the search field from initialSearch', () => {
+        renderSheet({ initialSearch: 'anna@lufthansa.com' });
+        expect(screen.getByPlaceholderText('Search by name or email…')).toHaveProperty('value', 'anna@lufthansa.com');
+    });
+
     it('has no "make selected users group admins" option — that only applies when editing an existing member', () => {
         renderSheet();
         expect(screen.queryByText(/group admin/i)).toBeNull();
@@ -134,13 +153,13 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.getByRole('button', { name: 'Add member' })).toHaveProperty('disabled', true);
     });
 
-    it('submits selected users with all classic group-member role scopes', () => {
+    it('submits selected users with all classic group-member role scopes', async () => {
         const { onSubmit } = renderSheet();
 
         typeSearch('an');
         fireEvent.click(screen.getByText('Anna Schmidt'));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+        await submitMembers();
 
         expect(onSubmit).toHaveBeenCalledWith([
             {
@@ -158,12 +177,12 @@ describe('GroupAddMembersSheet', () => {
         ]);
     });
 
-    it('omits id for LDAP users so the backend resolves via reference', () => {
+    it('omits id for LDAP users so the backend resolves via reference', async () => {
         const { onSubmit } = renderSheet();
 
         typeSearch('ld');
         fireEvent.click(screen.getByText('LDAP Anna'));
-        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+        await submitMembers();
 
         expect(onSubmit).toHaveBeenCalledWith([
             {
@@ -181,12 +200,12 @@ describe('GroupAddMembersSheet', () => {
     });
 
     describe('default role pre-fill', () => {
-        it('pre-fills API/API product/Application from the group’s configured default roles', () => {
+        it('pre-fills API/API product/Application from the group’s configured default roles', async () => {
             const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'USER' } });
 
             typeSearch('an');
             fireEvent.click(screen.getByText('Anna Schmidt'));
-            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+            await submitMembers();
 
             expect(onSubmit).toHaveBeenCalledWith([
                 {
@@ -204,12 +223,12 @@ describe('GroupAddMembersSheet', () => {
             ]);
         });
 
-        it('falls back to USER for any scope missing from the group’s configured roles', () => {
+        it('falls back to USER for any scope missing from the group’s configured roles', async () => {
             const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER' } });
 
             typeSearch('an');
             fireEvent.click(screen.getByText('Anna Schmidt'));
-            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+            await submitMembers();
 
             expect(onSubmit).toHaveBeenCalledWith([
                 {
@@ -227,12 +246,12 @@ describe('GroupAddMembersSheet', () => {
             ]);
         });
 
-        it('always defaults Integration/Cluster/Explorer to USER — classic hardcodes these regardless of group config', () => {
+        it('always defaults Integration/Cluster/Explorer to USER — classic hardcodes these regardless of group config', async () => {
             const { onSubmit } = renderSheet();
 
             typeSearch('an');
             fireEvent.click(screen.getByText('Anna Schmidt'));
-            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+            await submitMembers();
 
             expect(onSubmit).toHaveBeenCalledWith([
                 expect.objectContaining({
@@ -288,12 +307,29 @@ describe('GroupAddMembersSheet', () => {
         expect(screen.getByRole('option', { name: 'USER' }).getAttribute('aria-disabled')).not.toBe('true');
     });
 
-    it('locks role selects and search while the add-members mutation is in flight', () => {
-        renderSheet({ isSaving: true });
+    it('locks role selects and search while the React action is pending', async () => {
+        let resolveMembers: (() => void) | undefined;
+        const onSubmit = jest.fn(
+            () =>
+                new Promise<void>(resolve => {
+                    resolveMembers = resolve;
+                }),
+        );
+        renderSheet({ onSubmit });
+        typeSearch('an');
+        fireEvent.click(screen.getByText('Anna Schmidt'));
+        fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
 
         expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
         expect(screen.getByLabelText('Search users')).toHaveProperty('disabled', true);
         expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Adding…' })).toHaveProperty('disabled', true);
+
+        await act(async () => {
+            resolveMembers?.();
+            await Promise.resolve();
+        });
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Add member' })).not.toBeNull());
     });
 
     it('associates the search label with the search input', () => {
@@ -389,7 +425,7 @@ describe('GroupAddMembersSheet', () => {
             expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
         });
 
-        it('keeps only a single selected user once PRIMARY_OWNER is chosen', () => {
+        it('keeps only a single selected user once PRIMARY_OWNER is chosen', async () => {
             const { onSubmit } = renderSheet({
                 apiPrimaryOwnerMode: 'GROUP',
                 apiProductPrimaryOwnerMode: 'GROUP',
@@ -405,7 +441,7 @@ describe('GroupAddMembersSheet', () => {
 
             expect(screen.getByText('1 user selected')).not.toBeNull();
 
-            fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+            await submitMembers();
 
             expect(onSubmit).toHaveBeenCalledWith([
                 {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupAddMembersSheet.tsx
@@ -25,34 +25,17 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@gravitee/graphene-core';
+import { useActionState } from 'react';
 
 import { GroupScopedRoleSelects } from './GroupScopedRoleSelects';
 import { GroupUserSearchPicker } from './GroupUserSearchPicker';
+import { FormActionSubmitButton } from '../../../shared/components/FormActionSubmitButton';
+import { useOpenRemountKey } from '../../../shared/hooks/useOpenRemountKey';
+import { STANDARD_SHEET_WIDTH } from '../../../shared/layout/sheetLayout';
 import { useGroupAddMembersForm } from '../hooks/useGroupAddMembersForm';
 import type { GroupMember, GroupMembershipPayload, GroupRole } from '../types/group';
 
-export function GroupAddMembersSheet({
-    open,
-    groupName,
-    groupRoles,
-    members,
-    apiRoles,
-    applicationRoles,
-    apiProductRoles,
-    integrationRoles,
-    clusterRoles,
-    explorerRoles,
-    lockApiRole,
-    lockApiProductRole,
-    lockApplicationRole,
-    canOverrideLocks,
-    maxInvitation,
-    apiPrimaryOwnerMode,
-    apiProductPrimaryOwnerMode,
-    onClose,
-    onSubmit,
-    isSaving,
-}: Readonly<{
+type GroupAddMembersSheetProps = Readonly<{
     open: boolean;
     groupName: string;
     groupRoles: Record<string, string> | undefined;
@@ -70,10 +53,38 @@ export function GroupAddMembersSheet({
     maxInvitation: number | null;
     apiPrimaryOwnerMode?: string;
     apiProductPrimaryOwnerMode?: string;
+    initialSearch?: string;
     onClose: () => void;
-    onSubmit: (memberships: GroupMembershipPayload[]) => void;
-    isSaving: boolean;
-}>) {
+    onSubmit: (memberships: GroupMembershipPayload[]) => Promise<void>;
+}>;
+
+export function GroupAddMembersSheet(props: GroupAddMembersSheetProps) {
+    const resetKey = useOpenRemountKey(props.open, `${props.groupName}-${props.initialSearch ?? ''}`);
+    return <GroupAddMembersSheetContent key={resetKey} {...props} />;
+}
+
+function GroupAddMembersSheetContent({
+    open,
+    groupName,
+    groupRoles,
+    members,
+    apiRoles,
+    applicationRoles,
+    apiProductRoles,
+    integrationRoles,
+    clusterRoles,
+    explorerRoles,
+    lockApiRole,
+    lockApiProductRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    maxInvitation,
+    apiPrimaryOwnerMode,
+    apiProductPrimaryOwnerMode,
+    initialSearch,
+    onClose,
+    onSubmit,
+}: GroupAddMembersSheetProps) {
     const form = useGroupAddMembersForm({
         open,
         groupRoles,
@@ -85,72 +96,80 @@ export function GroupAddMembersSheet({
         maxInvitation,
         apiPrimaryOwnerMode,
         apiProductPrimaryOwnerMode,
+        initialSearch,
         onSubmit,
     });
+    const [, submitMembers, isPending] = useActionState<null, FormData>(async () => {
+        if (!form.canSubmit) return null;
+        await form.handleSubmit();
+        return null;
+    }, null);
 
     return (
-        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isSaving && onClose()}>
-            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isPending && onClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
                 <SheetHeader>
                     <SheetTitle>Add members</SheetTitle>
                     <SheetDescription>Search platform users and assign roles for membership in {groupName}.</SheetDescription>
                 </SheetHeader>
 
-                <ScrollArea className="min-h-0 flex-1">
-                    <div className="space-y-6 px-4 pb-4">
-                        <div className="space-y-3">
-                            <Label className="text-sm font-medium">Default roles for selected users</Label>
-                            <GroupScopedRoleSelects
-                                idPrefix="add-members-role"
-                                roles={{
-                                    api: apiRoles,
-                                    apiProduct: apiProductRoles,
-                                    application: applicationRoles,
-                                    integration: integrationRoles,
-                                    cluster: clusterRoles,
-                                    explorer: explorerRoles,
-                                }}
-                                values={form.roleValues}
-                                onChange={form.handleRoleChange}
-                                locks={form.roleLocks}
-                                disabled={isSaving}
-                                disabledOptionNames={form.disabledOptionNames}
+                <form action={submitMembers} className="flex min-h-0 flex-1 flex-col">
+                    <ScrollArea className="min-h-0 flex-1">
+                        <div className="space-y-6 px-4 pb-4">
+                            <div className="space-y-3">
+                                <Label className="text-sm font-medium">Default roles for selected users</Label>
+                                <GroupScopedRoleSelects
+                                    idPrefix="add-members-role"
+                                    roles={{
+                                        api: apiRoles,
+                                        apiProduct: apiProductRoles,
+                                        application: applicationRoles,
+                                        integration: integrationRoles,
+                                        cluster: clusterRoles,
+                                        explorer: explorerRoles,
+                                    }}
+                                    values={form.roleValues}
+                                    onChange={form.handleRoleChange}
+                                    locks={form.roleLocks}
+                                    disabled={isPending}
+                                    disabledOptionNames={form.disabledOptionNames}
+                                />
+                            </div>
+
+                            {form.primaryOwnerSelected && (
+                                <p className="text-xs text-muted-foreground">
+                                    The primary owner role can be granted to a single member only.
+                                </p>
+                            )}
+
+                            <GroupUserSearchPicker
+                                search={form.search}
+                                onSearchChange={form.setSearch}
+                                debouncedQuery={form.debouncedQuery}
+                                isFetching={form.isFetching}
+                                candidates={form.candidates}
+                                selected={form.selected}
+                                onToggle={form.handleToggle}
+                                invitationLimitReached={form.invitationLimitReached}
+                                groupMemberCapReached={form.groupMemberCapReached}
+                                disabled={isPending}
                             />
+
+                            {form.selected.length > 0 && (
+                                <p className="text-xs text-muted-foreground">
+                                    {form.selected.length} user{form.selected.length !== 1 ? 's' : ''} selected
+                                </p>
+                            )}
                         </div>
+                    </ScrollArea>
 
-                        {form.primaryOwnerSelected && (
-                            <p className="text-xs text-muted-foreground">The primary owner role can be granted to a single member only.</p>
-                        )}
-
-                        <GroupUserSearchPicker
-                            search={form.search}
-                            onSearchChange={form.setSearch}
-                            debouncedQuery={form.debouncedQuery}
-                            isFetching={form.isFetching}
-                            candidates={form.candidates}
-                            selected={form.selected}
-                            onToggle={form.handleToggle}
-                            invitationLimitReached={form.invitationLimitReached}
-                            groupMemberCapReached={form.groupMemberCapReached}
-                            disabled={isSaving}
-                        />
-
-                        {form.selected.length > 0 && (
-                            <p className="text-xs text-muted-foreground">
-                                {form.selected.length} user{form.selected.length !== 1 ? 's' : ''} selected
-                            </p>
-                        )}
-                    </div>
-                </ScrollArea>
-
-                <SheetFooter className="shrink-0 flex-row justify-end border-t">
-                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
-                        Cancel
-                    </Button>
-                    <Button type="button" onClick={form.handleSubmit} disabled={!form.canSubmit || isSaving}>
-                        {isSaving ? 'Adding…' : form.submitLabel}
-                    </Button>
-                </SheetFooter>
+                    <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+                            Cancel
+                        </Button>
+                        <FormActionSubmitButton disabled={!form.canSubmit} label={form.submitLabel} pendingLabel="Adding…" />
+                    </SheetFooter>
+                </form>
             </SheetContent>
         </Sheet>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.spec.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupInvitationsTable } from './GroupInvitationsTable';
+import type { GroupInvitation } from '../types/group';
+
+const ANNA: GroupInvitation = {
+    id: 'invitation-1',
+    reference_id: 'group-1',
+    email: 'anna@lufthansa.com',
+    api_role: 'USER',
+    application_role: 'OWNER',
+    created_at: 1_700_000_000_000,
+};
+
+const BEN: GroupInvitation = {
+    id: 'invitation-2',
+    reference_id: 'group-1',
+    email: 'ben@lufthansa.com',
+};
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof GroupInvitationsTable>> = {}) {
+    return render(<GroupInvitationsTable invitations={[ANNA, BEN]} loading={false} canManageMembers onDelete={jest.fn()} {...overrides} />);
+}
+
+describe('GroupInvitationsTable', () => {
+    it('renders each invitation’s email and roles', () => {
+        renderTable();
+        const annaRow = screen.getByText('anna@lufthansa.com').closest('tr')!;
+        expect(annaRow.textContent).toContain('USER');
+        expect(annaRow.textContent).toContain('OWNER');
+    });
+
+    it('sorts invitations by email like the classic Console', () => {
+        renderTable({ invitations: [BEN, ANNA] });
+
+        expect(screen.getAllByText(/@lufthansa\.com$/).map(element => element.textContent)).toEqual([
+            'anna@lufthansa.com',
+            'ben@lufthansa.com',
+        ]);
+    });
+
+    it('shows a placeholder for missing roles or invitation date', () => {
+        renderTable();
+        const benRow = screen.getByText('ben@lufthansa.com').closest('tr')!;
+        expect(benRow.textContent).toContain('—');
+    });
+
+    it('hides the actions column entirely without permission', () => {
+        renderTable({ canManageMembers: false });
+        expect(screen.queryByRole('button', { name: /Delete invitation/ })).toBeNull();
+    });
+
+    it('calls onDelete with the row’s invitation', async () => {
+        const user = userEvent.setup();
+        const onDelete = jest.fn();
+        renderTable({ onDelete });
+
+        await user.click(screen.getByRole('button', { name: 'Delete invitation sent to anna@lufthansa.com' }));
+
+        expect(onDelete).toHaveBeenCalledWith(ANNA);
+    });
+
+    it('filters invitations by email client-side', async () => {
+        renderTable();
+        fireEvent.change(screen.getByLabelText('Search invitations'), { target: { value: 'anna' } });
+        await waitFor(() => expect(screen.queryByText('ben@lufthansa.com')).toBeNull());
+        expect(screen.getByText('anna@lufthansa.com')).not.toBeNull();
+    });
+
+    it('shows a first-use empty state with no invitations', () => {
+        renderTable({ invitations: [] });
+        expect(screen.queryByText('No invitations sent to display')).not.toBeNull();
+        expect(screen.queryByRole('table')).toBeNull();
+    });
+
+    it('shows a no-results empty state when the search matches nothing', async () => {
+        renderTable();
+        fireEvent.change(screen.getByLabelText('Search invitations'), { target: { value: 'nobody' } });
+        expect(await screen.findByText('No invitations match your search')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInvitationsTable.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, cn, DataTable, DataTableEmptyState, DateCell, type DataTableProps } from '@gravitee/graphene-core';
+import { MailIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useDeferredValue, useMemo, useState } from 'react';
+
+import { ClientSideTableSearchField } from '../../../shared/components/ClientSideTableSearchField';
+import { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+import type { ColCell } from '../../../shared/utils/dataTableTypes';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../../../shared/utils/paginationConstants';
+import type { GroupInvitation } from '../types/group';
+
+const PAGE_SIZE = 10;
+
+function buildColumns({
+    canManageMembers,
+    onDelete,
+}: {
+    canManageMembers: boolean;
+    onDelete: (invitation: GroupInvitation) => void;
+}): DataTableProps<GroupInvitation>['columns'] {
+    const columns: DataTableProps<GroupInvitation>['columns'] = [
+        {
+            id: 'email',
+            accessorKey: 'email',
+            header: 'Email',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => <span className="text-sm font-medium">{row.original.email}</span>,
+        },
+        {
+            id: 'apiRole',
+            header: 'API role',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => (
+                <span className="text-sm text-muted-foreground">{row.original.api_role ?? '—'}</span>
+            ),
+        },
+        {
+            id: 'applicationRole',
+            header: 'Application role',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) => (
+                <span className="text-sm text-muted-foreground">{row.original.application_role ?? '—'}</span>
+            ),
+        },
+        {
+            id: 'invitationDate',
+            header: 'Invitation date',
+            enableSorting: false,
+            cell: ({ row }: ColCell<GroupInvitation>) =>
+                row.original.created_at ? (
+                    <DateCell value={new Date(row.original.created_at)} format="absolute" />
+                ) : (
+                    <span className="text-sm text-muted-foreground">—</span>
+                ),
+        },
+    ];
+
+    if (!canManageMembers) {
+        return columns;
+    }
+
+    columns.push({
+        id: 'actions',
+        header: () => <span className="sr-only">Actions</span>,
+        size: 56,
+        enableSorting: false,
+        enableHiding: false,
+        cell: ({ row }: ColCell<GroupInvitation>) => (
+            <div className="flex justify-end">
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label={`Delete invitation sent to ${row.original.email}`}
+                    onClick={() => onDelete(row.original)}
+                >
+                    <Trash2Icon className="size-4" aria-hidden />
+                </Button>
+            </div>
+        ),
+    });
+
+    return columns;
+}
+
+interface GroupInvitationsTableProps {
+    readonly invitations: GroupInvitation[];
+    readonly loading: boolean;
+    readonly canManageMembers: boolean;
+    readonly onDelete: (invitation: GroupInvitation) => void;
+}
+
+export function GroupInvitationsTable({ invitations, loading, canManageMembers, onDelete }: GroupInvitationsTableProps) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
+    const deferredSearch = useDeferredValue(search);
+    const isFiltering = search !== deferredSearch;
+    const hasActiveSearch = deferredSearch.trim().length > 0;
+
+    const filtered = useMemo(() => {
+        const query = deferredSearch.trim().toLowerCase();
+        const matchingInvitations = query ? invitations.filter(invitation => invitation.email.toLowerCase().includes(query)) : invitations;
+        return [...matchingInvitations].sort((left, right) => left.email.localeCompare(right.email));
+    }, [deferredSearch, invitations]);
+
+    const totalCount = filtered.length;
+    const totalPages = totalPagesFor(totalCount, pageSize);
+    const safePage = Math.min(page, totalPages);
+    const pageData = useMemo(() => paginate(filtered, safePage, pageSize), [filtered, safePage, pageSize]);
+    const columns = useMemo(() => buildColumns({ canManageMembers, onDelete }), [canManageMembers, onDelete]);
+
+    function handleSearchChange(value: string) {
+        setSearch(value);
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    if (!loading && invitations.length === 0 && !hasActiveSearch) {
+        return (
+            <div className="rounded-lg border">
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<MailIcon className="size-8" aria-hidden />}
+                    title="No invitations sent to display"
+                    description="Invitations sent to this group will appear here."
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div aria-busy={isFiltering} className={cn('transition-opacity', isFiltering && 'opacity-60')}>
+            <DataTable
+                aria-label="Invitations"
+                columns={columns}
+                data={pageData}
+                loading={loading}
+                skeletonCount={pageSize}
+                serverSide
+                pagination={{
+                    page: safePage,
+                    pageSize,
+                    totalCount,
+                    pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                    onPageChange: setPage,
+                    onPageSizeChange: handlePageSizeChange,
+                }}
+                emptyMessage={
+                    <DataTableEmptyState
+                        variant="no-results"
+                        icon={<SearchIcon className="size-8" aria-hidden />}
+                        title="No invitations match your search"
+                        description="Try adjusting your search terms."
+                        action={
+                            <Button size="sm" variant="outline" onClick={() => handleSearchChange('')}>
+                                Clear search
+                            </Button>
+                        }
+                    />
+                }
+                toolbar={
+                    <ClientSideTableSearchField
+                        id="group-invitations-search"
+                        label="Search invitations"
+                        placeholder="Search invitations…"
+                        value={search}
+                        onChange={handleSearchChange}
+                    />
+                }
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.spec.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { GroupInviteMemberSheet } from './GroupInviteMemberSheet';
+import { installFormActionTestEnvironment } from '../../../shared/testing/formAction';
+import type { GroupMember } from '../types/group';
+
+let restoreTestEnvironment: () => void;
+
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+    restoreTestEnvironment = installFormActionTestEnvironment();
+});
+
+afterAll(() => {
+    restoreTestEnvironment();
+});
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof GroupInviteMemberSheet>> = {}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <GroupInviteMemberSheet
+            open
+            groupName="API Team"
+            groupRoles={undefined}
+            members={[]}
+            apiRoles={[
+                { name: 'USER', scope: 'API' },
+                { name: 'OWNER', scope: 'API' },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ]}
+            applicationRoles={[{ name: 'USER', scope: 'APPLICATION' }]}
+            lockApiRole={false}
+            lockApplicationRole={false}
+            canOverrideLocks
+            apiPrimaryOwnerMode="HYBRID"
+            onClose={onClose}
+            onSubmit={onSubmit}
+            {...overrides}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('GroupInviteMemberSheet', () => {
+    it('does not render sheet content when closed', () => {
+        renderSheet({ open: false });
+        expect(screen.queryByRole('heading', { name: 'Email invitation' })).toBeNull();
+    });
+
+    it('shows the group name in the description', () => {
+        renderSheet();
+        expect(screen.getByText('Invite a new user to API Team and assign their default roles.')).not.toBeNull();
+    });
+
+    it('disables Send invitation until an email is entered', () => {
+        renderSheet();
+        expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', true);
+    });
+
+    it('keeps Send invitation disabled for a malformed email and describes the error', () => {
+        renderSheet();
+
+        fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'not-an-email' } });
+
+        expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('textbox', { name: /Email/i }).getAttribute('aria-invalid')).toBe('true');
+        expect(screen.getByRole('textbox', { name: /Email/i }).getAttribute('aria-describedby')).toBe('invite-email-error');
+        expect(screen.getByText('Enter a valid email')).not.toBeNull();
+    });
+
+    it('does not show an email error while the field is empty', () => {
+        renderSheet();
+        expect(screen.getByRole('textbox', { name: /Email/i }).getAttribute('aria-invalid')).not.toBe('true');
+        expect(screen.queryByText('Enter a valid email')).toBeNull();
+    });
+
+    it('submits the email with the USER fallback default roles when the group has no configured defaults', async () => {
+        const user = userEvent.setup();
+        const { onSubmit } = renderSheet();
+
+        fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+        await user.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+        await waitFor(() =>
+            expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'USER', applicationRole: 'USER' }),
+        );
+    });
+
+    it('has no "None" role option — classic\'s invite-member-dialog has no such mat-option', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.queryByRole('option', { name: 'None' })).toBeNull();
+    });
+
+    describe('default role pre-fill', () => {
+        it('pre-fills API/Application from the group’s configured default roles', async () => {
+            const user = userEvent.setup();
+            const { onSubmit } = renderSheet({ groupRoles: { API: 'OWNER', APPLICATION: 'USER' } });
+
+            fireEvent.change(screen.getByRole('textbox', { name: /Email/i }), { target: { value: 'anna.schmidt@lufthansa.com' } });
+            await user.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+            await waitFor(() =>
+                expect(onSubmit).toHaveBeenCalledWith({ email: 'anna.schmidt@lufthansa.com', apiRole: 'OWNER', applicationRole: 'USER' }),
+            );
+        });
+    });
+
+    it('calls onClose when Cancel is clicked', () => {
+        const { onClose } = renderSheet();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the PRIMARY_OWNER option once one already exists', () => {
+        const existingOwner: GroupMember = { id: 'user-3', displayName: 'Ravi Patel', roles: { API: 'PRIMARY_OWNER' } };
+        renderSheet({ members: [existingOwner] });
+
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('leaves PRIMARY_OWNER selectable when no one holds it yet', () => {
+        renderSheet();
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('disables PRIMARY_OWNER when API primary-owner mode is USER', () => {
+        renderSheet({ apiPrimaryOwnerMode: 'USER' });
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('disables non-PRIMARY_OWNER system roles on the API select', () => {
+        renderSheet({
+            apiRoles: [
+                { name: 'USER', scope: 'API' },
+                { name: 'ADMIN', scope: 'API', system: true },
+                { name: 'PRIMARY_OWNER', scope: 'API', system: true },
+            ],
+        });
+        fireEvent.click(screen.getAllByRole('combobox')[0]);
+        expect(screen.getByRole('option', { name: 'ADMIN' }).getAttribute('aria-disabled')).toBe('true');
+        expect(screen.getByRole('option', { name: 'PRIMARY_OWNER' }).getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('locks fields while the React action is pending', async () => {
+        const user = userEvent.setup();
+        let resolveInvitation: (() => void) | undefined;
+        const onSubmit = jest.fn(
+            () =>
+                new Promise<void>(resolve => {
+                    resolveInvitation = resolve;
+                }),
+        );
+        renderSheet({ onSubmit });
+
+        await user.type(screen.getByRole('textbox', { name: /Email/i }), 'anna.schmidt@lufthansa.com');
+        await user.click(screen.getByRole('button', { name: 'Send invitation' }));
+
+        expect(screen.getByRole('button', { name: 'Sending…' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('textbox', { name: /Email/i })).toHaveProperty('disabled', true);
+        expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveProperty('disabled', true);
+
+        await act(async () => {
+            resolveInvitation?.();
+            await Promise.resolve();
+        });
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Send invitation' })).toHaveProperty('disabled', false));
+    });
+
+    describe('lock flags', () => {
+        it('disables a locked role select without canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: false });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', true);
+        });
+
+        it('leaves a locked role select enabled with canOverrideLocks', () => {
+            renderSheet({ lockApiRole: true, canOverrideLocks: true });
+            expect(screen.getAllByRole('combobox')[0]).toHaveProperty('disabled', false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupInviteMemberSheet.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Input, Label, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@gravitee/graphene-core';
+import { useActionState, useState } from 'react';
+
+import { GroupRoleSelect } from './GroupRoleSelect';
+import { FormActionSubmitButton } from '../../../shared/components/FormActionSubmitButton';
+import { useOpenRemountKey } from '../../../shared/hooks/useOpenRemountKey';
+import { STANDARD_SHEET_WIDTH } from '../../../shared/layout/sheetLayout';
+import { isValidEmail } from '../../../shared/utils/email';
+import type { GroupMember, GroupRole } from '../types/group';
+import { PRIMARY_OWNER_ROLE } from '../types/group';
+import { getMemberRoleLockFlags, isPrimaryOwnerUnavailable } from '../utils/memberRoles';
+
+type InvitationValues = { email: string; apiRole: string; applicationRole: string };
+
+type GroupInviteMemberSheetProps = Readonly<{
+    open: boolean;
+    groupName: string;
+    groupRoles: Record<string, string> | undefined;
+    members: GroupMember[];
+    apiRoles: GroupRole[];
+    applicationRoles: GroupRole[];
+    lockApiRole: boolean;
+    lockApplicationRole: boolean;
+    canOverrideLocks: boolean;
+    apiPrimaryOwnerMode?: string;
+    onClose: () => void;
+    onSubmit: (values: InvitationValues) => Promise<void>;
+}>;
+
+export function GroupInviteMemberSheet(props: GroupInviteMemberSheetProps) {
+    const resetKey = useOpenRemountKey(props.open, props.groupName);
+    return <GroupInviteMemberSheetContent key={resetKey} {...props} />;
+}
+
+function GroupInviteMemberSheetContent({
+    open,
+    groupName,
+    groupRoles,
+    members,
+    apiRoles,
+    applicationRoles,
+    lockApiRole,
+    lockApplicationRole,
+    canOverrideLocks,
+    apiPrimaryOwnerMode,
+    onClose,
+    onSubmit,
+}: GroupInviteMemberSheetProps) {
+    const [email, setEmail] = useState('');
+    const [apiRole, setApiRole] = useState(() => groupRoles?.API ?? 'USER');
+    const [applicationRole, setApplicationRole] = useState(() => groupRoles?.APPLICATION ?? 'USER');
+    const [, submitInvitation, isPending] = useActionState<null, FormData>(async () => {
+        if (!isValidEmail(email)) return null;
+        await onSubmit({ email: email.trim(), apiRole, applicationRole });
+        return null;
+    }, null);
+
+    const apiPrimaryOwnerDisabled =
+        isPrimaryOwnerUnavailable(apiPrimaryOwnerMode) || members.some(m => m.roles?.API === PRIMARY_OWNER_ROLE);
+    const roleLocks = getMemberRoleLockFlags({ lockApiRole, lockApiProductRole: false, lockApplicationRole }, canOverrideLocks);
+
+    const canSubmit = isValidEmail(email);
+    const emailInvalid = email.trim().length > 0 && !canSubmit;
+
+    return (
+        <Sheet open={open} onOpenChange={isOpen => !isOpen && !isPending && onClose()}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: STANDARD_SHEET_WIDTH }}>
+                <SheetHeader>
+                    <SheetTitle>Email invitation</SheetTitle>
+                    <SheetDescription>Invite a new user to {groupName} and assign their default roles.</SheetDescription>
+                </SheetHeader>
+
+                <form action={submitInvitation} className="flex min-h-0 flex-1 flex-col">
+                    <div className="flex-1 space-y-6 px-4">
+                        <div className="space-y-1.5">
+                            <Label htmlFor="invite-email" className="text-sm font-medium">
+                                Email <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="invite-email"
+                                type="email"
+                                placeholder="user@example.com"
+                                value={email}
+                                onChange={e => setEmail(e.target.value)}
+                                disabled={isPending}
+                                aria-invalid={emailInvalid}
+                                aria-describedby={emailInvalid ? 'invite-email-error' : undefined}
+                            />
+                            {emailInvalid && (
+                                <p id="invite-email-error" className="text-sm text-destructive">
+                                    Enter a valid email
+                                </p>
+                            )}
+                        </div>
+
+                        <GroupRoleSelect
+                            id="invite-api-role"
+                            label="Default API role"
+                            roles={apiRoles}
+                            value={apiRole}
+                            onChange={setApiRole}
+                            disabled={roleLocks.api || isPending}
+                            disabledOptionNames={apiPrimaryOwnerDisabled ? new Set([PRIMARY_OWNER_ROLE]) : undefined}
+                            disableSystemRoles="except-primary-owner"
+                        />
+
+                        <GroupRoleSelect
+                            id="invite-application-role"
+                            label="Default application role"
+                            roles={applicationRoles}
+                            value={applicationRole}
+                            onChange={setApplicationRole}
+                            disabled={roleLocks.application || isPending}
+                            disableSystemRoles="all"
+                        />
+                    </div>
+
+                    <SheetFooter className="shrink-0 flex-row justify-end border-t">
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+                            Cancel
+                        </Button>
+                        <FormActionSubmitButton disabled={!canSubmit} label="Send invitation" pendingLabel="Sending…" />
+                    </SheetFooter>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.spec.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GroupTooManyUsersDialog } from './GroupTooManyUsersDialog';
+
+describe('GroupTooManyUsersDialog', () => {
+    it('explains the ambiguous email match', () => {
+        render(<GroupTooManyUsersDialog open email="user@example.com" onClose={jest.fn()} onContinue={jest.fn()} />);
+
+        expect(screen.getByText(/user@example\.com/)).not.toBeNull();
+        expect(screen.getByText(/select and add a specific user/)).not.toBeNull();
+    });
+
+    it('continues to user search', () => {
+        const onContinue = jest.fn();
+        render(<GroupTooManyUsersDialog open email="user@example.com" onClose={jest.fn()} onContinue={onContinue} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+        expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes without continuing', () => {
+        const onClose = jest.fn();
+        const onContinue = jest.fn();
+        render(<GroupTooManyUsersDialog open email="user@example.com" onClose={onClose} onContinue={onContinue} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onContinue).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupTooManyUsersDialog.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+
+export function GroupTooManyUsersDialog({
+    open,
+    email,
+    onClose,
+    onContinue,
+}: Readonly<{
+    open: boolean;
+    email: string | null;
+    onClose: () => void;
+    onContinue: () => void;
+}>) {
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Many Users Found</DialogTitle>
+                    <DialogDescription>Do you want to continue?</DialogDescription>
+                </DialogHeader>
+                <div className="space-y-3 px-6">
+                    <Alert variant="default">
+                        <InfoIcon className="size-4" aria-hidden />
+                        <AlertDescription>
+                            More than one user already exists with the email {email} in the organization. You can select and add a specific
+                            user using the add member function.
+                        </AlertDescription>
+                    </Alert>
+                </div>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={onContinue}>
+                        Continue
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupUserSearchPicker.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/components/GroupUserSearchPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Badge, Button, Checkbox, Input, Label, Skeleton } from '@gravitee/graphene-core';
+import { Badge, Button, Checkbox, cn, InputGroup, InputGroupAddon, InputGroupInput, Label, Skeleton } from '@gravitee/graphene-core';
 import { SearchIcon, XIcon } from '@gravitee/graphene-core/icons';
 
 import type { SearchableUser } from '../../../shared/types/userSearch';
@@ -49,22 +49,74 @@ export function GroupUserSearchPicker({
 }>) {
     const searchDisabled = disabled || invitationLimitReached;
 
+    function renderSearchResults() {
+        if (invitationLimitReached) {
+            return (
+                <p className="px-1 py-2 text-sm text-muted-foreground">
+                    {groupMemberCapReached
+                        ? 'This group has reached its maximum number of members.'
+                        : 'Selection limit reached for this group.'}
+                </p>
+            );
+        }
+        if (debouncedQuery.trim().length < 2) {
+            return <p className="px-1 py-2 text-sm text-muted-foreground">Type at least 2 characters to search for users.</p>;
+        }
+        if (isFetching || search !== debouncedQuery) {
+            return (
+                <div className="space-y-2 p-1">
+                    <Skeleton className="h-10 rounded" />
+                    <Skeleton className="h-10 rounded" />
+                </div>
+            );
+        }
+        if (candidates.length === 0) {
+            return <p className="px-1 py-2 text-sm text-muted-foreground">No users found.</p>;
+        }
+        return (
+            <div className="rounded-lg border">
+                {candidates.map(user => {
+                    const isChecked = selected.some(u => isSameUser(u, user));
+                    const inputId = `add-member-${user.id ?? user.reference}`;
+                    return (
+                        <label
+                            key={user.id ?? user.reference}
+                            htmlFor={inputId}
+                            className={cn(
+                                'flex items-center gap-3 border-b px-3 py-2.5 last:border-b-0',
+                                disabled ? 'opacity-50' : 'cursor-pointer hover:bg-muted/50',
+                            )}
+                        >
+                            <Checkbox id={inputId} checked={isChecked} onCheckedChange={() => onToggle(user)} disabled={disabled} />
+                            <UserAvatar name={user.displayName} />
+                            <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-medium">{user.displayName}</p>
+                                {user.email ? <p className="truncate text-xs text-muted-foreground">{user.email}</p> : null}
+                            </div>
+                        </label>
+                    );
+                })}
+            </div>
+        );
+    }
+
     return (
         <div className="space-y-2">
             <Label htmlFor={SEARCH_INPUT_ID} className="text-sm font-medium">
                 Search users
             </Label>
-            <div className="relative">
-                <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
-                <Input
+            <InputGroup>
+                <InputGroupAddon align="inline-start">
+                    <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                </InputGroupAddon>
+                <InputGroupInput
                     id={SEARCH_INPUT_ID}
-                    className="pl-10"
                     placeholder="Search by name or email…"
                     value={search}
                     onChange={e => onSearchChange(e.target.value)}
                     disabled={searchDisabled}
                 />
-            </div>
+            </InputGroup>
 
             {selected.length > 0 && (
                 <div className="flex flex-wrap gap-1.5" aria-label="Selected users">
@@ -87,43 +139,7 @@ export function GroupUserSearchPicker({
                 </div>
             )}
 
-            {invitationLimitReached ? (
-                <p className="px-1 py-2 text-sm text-muted-foreground">
-                    {groupMemberCapReached
-                        ? 'This group has reached its maximum number of members.'
-                        : 'Selection limit reached for this group.'}
-                </p>
-            ) : debouncedQuery.trim().length < 2 ? (
-                <p className="px-1 py-2 text-sm text-muted-foreground">Type at least 2 characters to search for users.</p>
-            ) : isFetching || search !== debouncedQuery ? (
-                <div className="space-y-2 p-1">
-                    <Skeleton className="h-10 rounded" />
-                    <Skeleton className="h-10 rounded" />
-                </div>
-            ) : candidates.length === 0 ? (
-                <p className="px-1 py-2 text-sm text-muted-foreground">No users found.</p>
-            ) : (
-                <div className="rounded-lg border">
-                    {candidates.map(user => {
-                        const isChecked = selected.some(u => isSameUser(u, user));
-                        const inputId = `add-member-${user.id ?? user.reference}`;
-                        return (
-                            <label
-                                key={user.id ?? user.reference}
-                                htmlFor={inputId}
-                                className={`flex items-center gap-3 border-b px-3 py-2.5 last:border-b-0 ${disabled ? 'opacity-50' : 'hover:bg-muted/50 cursor-pointer'}`}
-                            >
-                                <Checkbox id={inputId} checked={isChecked} onCheckedChange={() => onToggle(user)} disabled={disabled} />
-                                <UserAvatar name={user.displayName} />
-                                <div className="min-w-0 flex-1">
-                                    <p className="text-sm font-medium truncate">{user.displayName}</p>
-                                    {user.email ? <p className="text-xs text-muted-foreground truncate">{user.email}</p> : null}
-                                </div>
-                            </label>
-                        );
-                    })}
-                </div>
-            )}
+            {renderSearchResults()}
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.spec.tsx
@@ -50,9 +50,9 @@ describe('useGroupAddMembersForm', () => {
         return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
     }
 
-    function renderForm(open: boolean) {
+    function renderForm(open: boolean, initialSearch?: string) {
         return renderHook(
-            ({ isOpen }) =>
+            ({ isOpen, seed }) =>
                 useGroupAddMembersForm({
                     open: isOpen,
                     groupRoles: undefined,
@@ -64,9 +64,10 @@ describe('useGroupAddMembersForm', () => {
                     maxInvitation: null,
                     apiPrimaryOwnerMode: 'GROUP',
                     apiProductPrimaryOwnerMode: 'GROUP',
+                    initialSearch: seed,
                     onSubmit: jest.fn(),
                 }),
-            { initialProps: { isOpen: open }, wrapper },
+            { initialProps: { isOpen: open, seed: initialSearch }, wrapper },
         );
     }
 
@@ -105,5 +106,18 @@ describe('useGroupAddMembersForm', () => {
 
         expect(result.current.debouncedQuery).toBe('');
         expect(mockSearchUsers).not.toHaveBeenCalled();
+    });
+
+    it('seeds search from initialSearch when the sheet opens', async () => {
+        const { result } = renderForm(true, 'anna@lufthansa.com');
+
+        expect(result.current.search).toBe('anna@lufthansa.com');
+
+        await act(async () => {
+            jest.advanceTimersByTime(GROUP_SEARCH_DEBOUNCE_MS);
+            await Promise.resolve();
+        });
+
+        expect(mockSearchUsers).toHaveBeenCalledWith('anna@lufthansa.com');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupAddMembersForm.ts
@@ -21,17 +21,10 @@ import { searchUsers } from '../../../shared/services/userSearch';
 import type { SearchableUser } from '../../../shared/types/userSearch';
 import type { GroupMember, GroupMembershipPayload } from '../types/group';
 import { PRIMARY_OWNER_ROLE } from '../types/group';
-import { buildMembershipRoles, getMemberRoleLockFlags, type RoleField } from '../utils/memberRoles';
+import { buildMembershipRoles, getMemberRoleLockFlags, isPrimaryOwnerUnavailable, type RoleField } from '../utils/memberRoles';
 import { GROUP_SEARCH_DEBOUNCE_MS } from '../utils/paginationConstants';
 import { groupKeys } from '../utils/queryKeys';
 import { nextSearchableUserSelection } from '../utils/searchableUsers';
-
-const PRIMARY_OWNER_MODE_USER = 'USER';
-
-/** Fail closed: until the mode is known and is not USER, PRIMARY_OWNER must stay unavailable. */
-function isPrimaryOwnerUnavailable(mode: string | undefined): boolean {
-    return mode === undefined || mode.toUpperCase() === PRIMARY_OWNER_MODE_USER;
-}
 
 const DEFAULT_USER_ROLES: Record<RoleField, string> = {
     apiRole: 'USER',
@@ -53,6 +46,7 @@ export function useGroupAddMembersForm({
     maxInvitation,
     apiPrimaryOwnerMode,
     apiProductPrimaryOwnerMode,
+    initialSearch,
     onSubmit,
 }: {
     open: boolean;
@@ -65,28 +59,18 @@ export function useGroupAddMembersForm({
     maxInvitation: number | null;
     apiPrimaryOwnerMode: string | undefined;
     apiProductPrimaryOwnerMode: string | undefined;
-    onSubmit: (memberships: GroupMembershipPayload[]) => void;
+    initialSearch?: string;
+    onSubmit: (memberships: GroupMembershipPayload[]) => Promise<void>;
 }) {
-    const [search, setSearch] = useState('');
+    const [search, setSearch] = useState(() => initialSearch?.trim() ?? '');
     const [debouncedQuery, setDebouncedQuery] = useState('');
     const [selected, setSelected] = useState<SearchableUser[]>([]);
-    const [roleValues, setRoleValues] = useState(DEFAULT_USER_ROLES);
-
-    useEffect(() => {
-        if (!open) return;
-        setSearch('');
-        setDebouncedQuery('');
-        setSelected([]);
-        setRoleValues({
-            apiRole: groupRoles?.API ?? 'USER',
-            apiProductRole: groupRoles?.API_PRODUCT ?? 'USER',
-            applicationRole: groupRoles?.APPLICATION ?? 'USER',
-            integrationRole: 'USER',
-            clusterRole: 'USER',
-            explorerRole: 'USER',
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on the open transition only
-    }, [open]);
+    const [roleValues, setRoleValues] = useState<Record<RoleField, string>>(() => ({
+        ...DEFAULT_USER_ROLES,
+        apiRole: groupRoles?.API ?? 'USER',
+        apiProductRole: groupRoles?.API_PRODUCT ?? 'USER',
+        applicationRole: groupRoles?.APPLICATION ?? 'USER',
+    }));
 
     useEffect(() => {
         if (!open) return;
@@ -143,7 +127,7 @@ export function useGroupAddMembersForm({
         handleToggle: (user: SearchableUser) => setSelected(prev => nextSearchableUserSelection(prev, user, primaryOwnerSelected)),
         handleSubmit: () => {
             const roles = buildMembershipRoles(roleValues);
-            onSubmit(
+            return onSubmit(
                 selected.map(user => ({
                     ...(user.id ? { id: user.id } : {}),
                     reference: user.reference,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupDetail.ts
@@ -17,7 +17,7 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
-import { getEnvironmentSettings, getGroup, listGroupMembers, listGroupMemberships } from '../services/groups';
+import { getEnvironmentSettings, getGroup, listGroupInvitations, listGroupMembers, listGroupMemberships } from '../services/groups';
 import type { GroupMembershipType } from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
@@ -37,6 +37,16 @@ export function useGroupMembers(groupId: string | undefined) {
     return useQuery({
         queryKey: groupKeys.members(env?.id ?? '', groupId ?? ''),
         queryFn: () => listGroupMembers(env!.id, groupId!),
+        enabled: Boolean(env && groupId),
+    });
+}
+
+export function useGroupInvitations(groupId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: groupKeys.invitations(env?.id ?? '', groupId ?? ''),
+        queryFn: () => listGroupInvitations(env!.id, groupId!),
         enabled: Boolean(env && groupId),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMemberActions.ts
@@ -16,19 +16,33 @@
 
 import { useState } from 'react';
 
-import { useAddGroupMembers } from './useGroupMutations';
+import { useGroupInvitations } from './useGroupDetail';
+import { useAddGroupMembers, useDeleteGroupInvitation, useInviteGroupMember } from './useGroupMutations';
 import { notify } from '../../../shared/notify';
-import type { GroupMembershipPayload } from '../types/group';
+import type { GroupInvitation, GroupMembershipPayload } from '../types/group';
 
-type MemberSheetState = 'closed' | 'search';
+type MemberSheetState = 'closed' | 'search' | 'invite';
+type MemberTab = 'members' | 'invitations';
 
 export function useGroupMemberActions(groupId: string | undefined) {
+    const [memberTab, setMemberTab] = useState<MemberTab>('members');
     const [memberSheet, setMemberSheet] = useState<MemberSheetState>('closed');
+    const [tooManyUsersEmail, setTooManyUsersEmail] = useState<string | null>(null);
+    const [searchSeed, setSearchSeed] = useState<string | null>(null);
+    const [deletingInvitation, setDeletingInvitation] = useState<GroupInvitation | null>(null);
 
     const addMembersMutation = useAddGroupMembers();
+    const inviteMemberMutation = useInviteGroupMember();
+    const deleteInvitationMutation = useDeleteGroupInvitation();
+    const {
+        data: invitations = [],
+        isLoading: invitationsLoading,
+        isError: invitationsError,
+    } = useGroupInvitations(memberTab === 'invitations' ? groupId : undefined);
 
     function closeMemberSheet() {
         setMemberSheet('closed');
+        setSearchSeed(null);
     }
 
     async function handleAddMembers(memberships: GroupMembershipPayload[]) {
@@ -42,11 +56,73 @@ export function useGroupMemberActions(groupId: string | undefined) {
         }
     }
 
+    async function handleInviteMember(values: { email: string; apiRole: string; applicationRole: string }) {
+        if (!groupId) return;
+        try {
+            const result = await inviteMemberMutation.mutateAsync({
+                groupId,
+                data: {
+                    reference_type: 'GROUP',
+                    reference_id: groupId,
+                    email: values.email,
+                    api_role: values.apiRole,
+                    application_role: values.applicationRole,
+                },
+            });
+            closeMemberSheet();
+            switch (result.outcome) {
+                case 'ambiguous':
+                    setTooManyUsersEmail(values.email);
+                    return;
+                case 'member-added':
+                    notify.success('Member added successfully');
+                    setMemberTab('members');
+                    return;
+                case 'invitation-created':
+                    notify.success('Successfully invited user to the group.');
+                    setMemberTab('invitations');
+                    return;
+            }
+        } catch (error) {
+            notify.error(error, 'Failed to invite member');
+        }
+    }
+
+    function handleTooManyUsersContinue() {
+        setSearchSeed(tooManyUsersEmail);
+        setTooManyUsersEmail(null);
+        setMemberSheet('search');
+    }
+
+    async function handleDeleteInvitation() {
+        if (!groupId || !deletingInvitation) return;
+        try {
+            await deleteInvitationMutation.mutateAsync({ groupId, invitationId: deletingInvitation.id });
+            notify.success('Invitation deleted successfully');
+            setDeletingInvitation(null);
+        } catch (error) {
+            notify.error(error, 'Failed to delete invitation');
+        }
+    }
+
     return {
+        memberTab,
+        setMemberTab,
         memberSheet,
         setMemberSheet,
         closeMemberSheet,
-        addMembersMutation,
+        tooManyUsersEmail,
+        setTooManyUsersEmail,
+        searchSeed,
+        deletingInvitation,
+        setDeletingInvitation,
+        invitations,
+        invitationsLoading,
+        invitationsError,
+        deleteInvitationMutation,
         handleAddMembers,
+        handleInviteMember,
+        handleTooManyUsersContinue,
+        handleDeleteInvitation,
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.spec.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useAddGroupMembers, useDeleteGroupInvitation, useInviteGroupMember } from './useGroupMutations';
+import { addGroupMembers, deleteGroupInvitation, inviteGroupMember } from '../services/groups';
+import { groupKeys } from '../utils/queryKeys';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+}));
+jest.mock('../services/groups', () => ({
+    addGroupMembers: jest.fn(),
+    createGroup: jest.fn(),
+    deleteGroup: jest.fn(),
+    deleteGroupInvitation: jest.fn(),
+    inviteGroupMember: jest.fn(),
+    updateGroup: jest.fn(),
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockAddGroupMembers = jest.mocked(addGroupMembers);
+const mockInviteGroupMember = jest.mocked(inviteGroupMember);
+const mockDeleteGroupInvitation = jest.mocked(deleteGroupInvitation);
+const INVITATION_DATA = {
+    reference_type: 'GROUP',
+    reference_id: 'group-1',
+    email: 'user@example.com',
+    api_role: 'USER',
+    application_role: 'USER',
+} as const;
+
+describe('group mutation invalidation', () => {
+    let queryClient: QueryClient;
+    let invalidateQueries: jest.SpiedFunction<QueryClient['invalidateQueries']>;
+
+    beforeEach(() => {
+        queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+        invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' } as ReturnType<typeof useEnvironment>);
+        mockAddGroupMembers.mockResolvedValue(undefined);
+        mockInviteGroupMember.mockResolvedValue({ outcome: 'invitation-created' });
+        mockDeleteGroupInvitation.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        queryClient.clear();
+        jest.clearAllMocks();
+    });
+
+    function wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+
+    it('invalidates only members after adding members', async () => {
+        const { result } = renderHook(() => useAddGroupMembers(), { wrapper });
+
+        await act(() =>
+            result.current.mutateAsync({
+                groupId: 'group-1',
+                memberships: [{ id: 'user-1', roles: [{ scope: 'API', name: 'USER' }] }],
+            }),
+        );
+
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: groupKeys.members('DEFAULT', 'group-1') });
+    });
+
+    it('invalidates only invitations after creating a pending invitation', async () => {
+        const { result } = renderHook(() => useInviteGroupMember(), { wrapper });
+
+        await act(() =>
+            result.current.mutateAsync({
+                groupId: 'group-1',
+                data: INVITATION_DATA,
+            }),
+        );
+
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: groupKeys.invitations('DEFAULT', 'group-1') });
+    });
+
+    it('invalidates only members when an existing user is added directly', async () => {
+        mockInviteGroupMember.mockResolvedValue({ outcome: 'member-added' });
+        const { result } = renderHook(() => useInviteGroupMember(), { wrapper });
+
+        await act(() =>
+            result.current.mutateAsync({
+                groupId: 'group-1',
+                data: INVITATION_DATA,
+            }),
+        );
+
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: groupKeys.members('DEFAULT', 'group-1') });
+    });
+
+    it('does not invalidate group data when the invitation only returns ambiguous user matches', async () => {
+        mockInviteGroupMember.mockResolvedValue({ outcome: 'ambiguous' });
+        const { result } = renderHook(() => useInviteGroupMember(), { wrapper });
+
+        await act(() =>
+            result.current.mutateAsync({
+                groupId: 'group-1',
+                data: INVITATION_DATA,
+            }),
+        );
+
+        expect(invalidateQueries).not.toHaveBeenCalled();
+    });
+
+    it('invalidates only invitations after deleting an invitation', async () => {
+        const { result } = renderHook(() => useDeleteGroupInvitation(), { wrapper });
+
+        await act(() => result.current.mutateAsync({ groupId: 'group-1', invitationId: 'invitation-1' }));
+
+        expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: groupKeys.invitations('DEFAULT', 'group-1') });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/hooks/useGroupMutations.ts
@@ -17,11 +17,23 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { addGroupMembers, createGroup, deleteGroup, updateGroup } from '../services/groups';
-import type { Group, GroupMembershipPayload, NewGroupPayload, UpdateGroupPayload } from '../types/group';
+import { addGroupMembers, createGroup, deleteGroup, deleteGroupInvitation, inviteGroupMember, updateGroup } from '../services/groups';
+import type {
+    Group,
+    GroupInvitationPayload,
+    GroupMembershipPayload,
+    InviteGroupMemberResult,
+    NewGroupPayload,
+    UpdateGroupPayload,
+} from '../types/group';
 import { groupKeys } from '../utils/queryKeys';
 
-function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TData) => Promise<TResult>) {
+type InvalidationKeys<TData, TResult> = (environmentId: string, data: TData, result: TResult) => readonly (readonly unknown[])[];
+
+function useGroupMutation<TData, TResult>(
+    mutationFn: (envId: string, data: TData) => Promise<TResult>,
+    invalidationKeys: InvalidationKeys<TData, TResult> = () => [groupKeys.all],
+) {
     const env = useEnvironment();
     const queryClient = useQueryClient();
 
@@ -32,9 +44,11 @@ function useGroupMutation<TData, TResult>(mutationFn: (envId: string, data: TDat
             }
             return mutationFn(env.id, data);
         },
-        onSuccess: () => {
+        onSuccess: (result, data) => {
             if (env?.id) {
-                void queryClient.invalidateQueries({ queryKey: groupKeys.all });
+                invalidationKeys(env.id, data, result).forEach(queryKey => {
+                    void queryClient.invalidateQueries({ queryKey });
+                });
             }
         },
     });
@@ -55,7 +69,31 @@ export function useDeleteGroup() {
 }
 
 export function useAddGroupMembers() {
-    return useGroupMutation<{ groupId: string; memberships: GroupMembershipPayload[] }, void>((envId, { groupId, memberships }) =>
-        addGroupMembers(envId, groupId, memberships),
+    return useGroupMutation<{ groupId: string; memberships: GroupMembershipPayload[] }, void>(
+        (envId, { groupId, memberships }) => addGroupMembers(envId, groupId, memberships),
+        (envId, { groupId }) => [groupKeys.members(envId, groupId)],
+    );
+}
+
+export function useInviteGroupMember() {
+    return useGroupMutation<{ groupId: string; data: GroupInvitationPayload }, InviteGroupMemberResult>(
+        (envId, { groupId, data }) => inviteGroupMember(envId, groupId, data),
+        (envId, { groupId }, result) => {
+            switch (result.outcome) {
+                case 'ambiguous':
+                    return [];
+                case 'member-added':
+                    return [groupKeys.members(envId, groupId)];
+                case 'invitation-created':
+                    return [groupKeys.invitations(envId, groupId)];
+            }
+        },
+    );
+}
+
+export function useDeleteGroupInvitation() {
+    return useGroupMutation<{ groupId: string; invitationId: string }, void>(
+        (envId, { groupId, invitationId }) => deleteGroupInvitation(envId, groupId, invitationId),
+        (envId, { groupId }) => [groupKeys.invitations(envId, groupId)],
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { deleteGroupInvitation, inviteGroupMember, listGroupInvitations } from './groups';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { GroupInvitationPayload } from '../types/group';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonOrg: jest.fn(),
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+const INVITATION: GroupInvitationPayload = {
+    reference_type: 'GROUP',
+    reference_id: 'group/1',
+    email: 'user@example.com',
+    api_role: 'USER',
+    application_role: 'USER',
+};
+
+describe('groups invitation service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns invitation-created when the backend persists an invitation', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue({ id: 'invitation-1' });
+
+        await expect(inviteGroupMember('DEFAULT', 'group/1', INVITATION)).resolves.toEqual({ outcome: 'invitation-created' });
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/configuration/groups/group%2F1/invitations', {
+            method: 'POST',
+            body: JSON.stringify(INVITATION),
+        });
+    });
+
+    it.each([null, undefined])('returns member-added when the backend response body is %s', async responseBody => {
+        mockApimFetchJsonV1Env.mockResolvedValue(responseBody);
+
+        await expect(inviteGroupMember('DEFAULT', 'group-1', INVITATION)).resolves.toEqual({ outcome: 'member-added' });
+    });
+
+    it('treats the backend user list response as an ambiguous email match', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue([{ id: 'user-1' }, { id: 'user-2' }]);
+
+        await expect(inviteGroupMember('DEFAULT', 'group-1', INVITATION)).resolves.toEqual({ outcome: 'ambiguous' });
+    });
+
+    it('rejects an unexpected invitation response shape', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue({});
+
+        await expect(inviteGroupMember('DEFAULT', 'group-1', INVITATION)).rejects.toThrow('Unexpected group invitation response');
+    });
+
+    it('lists group invitations', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue([]);
+
+        await expect(listGroupInvitations('DEFAULT', 'group/1')).resolves.toEqual([]);
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/configuration/groups/group%2F1/invitations');
+    });
+
+    it('deletes an invitation using encoded identifiers', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+
+        await deleteGroupInvitation('DEFAULT', 'group/1', 'invitation/1');
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/configuration/groups/group%2F1/invitations/invitation%2F1', {
+            method: 'DELETE',
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/services/groups.ts
@@ -17,12 +17,15 @@
 import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../../shared/api/apimClient';
 import type {
     Group,
+    GroupInvitation,
+    GroupInvitationPayload,
     GroupMember,
     GroupMembershipItem,
     GroupMembershipPayload,
     GroupMembershipType,
     GroupRole,
     GroupsPagedResponse,
+    InviteGroupMemberResult,
     NewGroupPayload,
     UpdateGroupPayload,
 } from '../types/group';
@@ -106,4 +109,37 @@ export async function addGroupMembers(environmentId: string, groupId: string, me
         method: 'POST',
         body: JSON.stringify(memberships),
     });
+}
+
+export async function inviteGroupMember(
+    environmentId: string,
+    groupId: string,
+    data: GroupInvitationPayload,
+): Promise<InviteGroupMemberResult> {
+    const result = await apimFetchJsonV1Env<unknown>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+    if (Array.isArray(result)) {
+        return { outcome: 'ambiguous' };
+    }
+    if (result === null || result === undefined) {
+        return { outcome: 'member-added' };
+    }
+    if (typeof result === 'object' && 'id' in result && typeof result.id === 'string') {
+        return { outcome: 'invitation-created' };
+    }
+    throw new Error('Unexpected group invitation response');
+}
+
+export async function listGroupInvitations(environmentId: string, groupId: string): Promise<GroupInvitation[]> {
+    return apimFetchJsonV1Env<GroupInvitation[]>(environmentId, `/configuration/groups/${encodeURIComponent(groupId)}/invitations`);
+}
+
+export async function deleteGroupInvitation(environmentId: string, groupId: string, invitationId: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(
+        environmentId,
+        `/configuration/groups/${encodeURIComponent(groupId)}/invitations/${encodeURIComponent(invitationId)}`,
+        { method: 'DELETE' },
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/types/group.ts
@@ -134,3 +134,23 @@ export interface GroupMembershipPayload {
     reference?: string;
     roles: GroupMembershipRole[];
 }
+
+export interface GroupInvitationPayload {
+    reference_type: 'GROUP';
+    reference_id: string;
+    email: string;
+    api_role?: string;
+    application_role?: string;
+}
+
+export type InviteGroupMemberResult = { outcome: 'ambiguous' } | { outcome: 'invitation-created' } | { outcome: 'member-added' };
+
+export interface GroupInvitation {
+    id: string;
+    reference_type?: string;
+    reference_id: string;
+    email: string;
+    api_role?: string;
+    application_role?: string;
+    created_at?: number;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/memberRoles.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/memberRoles.ts
@@ -17,6 +17,8 @@
 import { isRoleLocked } from './groupPermissions';
 import type { GroupMembershipRole } from '../types/group';
 
+const PRIMARY_OWNER_MODE_USER = 'USER';
+
 export type MemberRoleSelections = {
     apiRole: string;
     apiProductRole: string;
@@ -36,6 +38,11 @@ export type MemberRoleLockFlags = {
     cluster: boolean;
     explorer: boolean;
 };
+
+/** Fail closed: until the mode is known and is not USER, PRIMARY_OWNER must stay unavailable. */
+export function isPrimaryOwnerUnavailable(mode: string | undefined): boolean {
+    return mode === undefined || mode.toUpperCase() === PRIMARY_OWNER_MODE_USER;
+}
 
 export function getMemberRoleLockFlags(
     locks: {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/groups/utils/queryKeys.ts
@@ -21,6 +21,7 @@ export const groupKeys = {
     list: (envId: string, query: string, page: number, size: number) => [...groupKeys.all, 'list', envId, query, page, size] as const,
     detail: (envId: string, groupId: string) => [...groupKeys.all, 'detail', envId, groupId] as const,
     members: (envId: string, groupId: string) => [...groupKeys.all, 'members', envId, groupId] as const,
+    invitations: (envId: string, groupId: string) => [...groupKeys.all, 'invitations', envId, groupId] as const,
     memberships: (envId: string, groupId: string, type: GroupMembershipType) =>
         [...groupKeys.all, 'memberships', envId, groupId, type] as const,
     roles: (scope: 'API' | 'APPLICATION' | 'API_PRODUCT' | 'INTEGRATION' | 'CLUSTER' | 'EXPLORER') => ['org-roles', scope] as const,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/ClientSideTableSearchField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/ClientSideTableSearchField.tsx
@@ -13,29 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@gravitee/graphene-core';
-import { SearchIcon } from '@gravitee/graphene-core/icons';
-
-interface ClientSideTableSearchFieldProps {
-    readonly id: string;
-    readonly label: string;
-    readonly value: string;
-    readonly onChange: (value: string) => void;
-    readonly placeholder?: string;
-}
-
-export function ClientSideTableSearchField({ id, label, value, onChange, placeholder = 'Search' }: ClientSideTableSearchFieldProps) {
-    return (
-        <div className="w-64">
-            <label htmlFor={id} className="sr-only">
-                {label}
-            </label>
-            <InputGroup>
-                <InputGroupAddon align="inline-start">
-                    <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
-                </InputGroupAddon>
-                <InputGroupInput id={id} placeholder={placeholder} value={value} onChange={event => onChange(event.target.value)} />
-            </InputGroup>
-        </div>
-    );
-}
+export { ClientSideTableSearchField } from '../../../shared/components/ClientSideTableSearchField';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.spec.ts
@@ -21,7 +21,6 @@ import {
     isDuplicateUserError,
     isOrganizationServiceAccount,
     isStillPrimaryOwnerError,
-    isValidEmail,
     sanitizeTextInput,
     statusBadgeVariant,
 } from './userDisplay';
@@ -29,11 +28,6 @@ import {
 describe('userDisplay utilities', () => {
     it('sanitizes HTML from text inputs', () => {
         expect(sanitizeTextInput('<b>Jane</b>')).toBe('Jane');
-    });
-
-    it('accepts well-formed emails and rejects malformed ones', () => {
-        expect(isValidEmail('jane@company.com')).toBe(true);
-        expect(isValidEmail('jane@company')).toBe(false);
     });
 
     it('labels the archived status as deletion in progress', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 import type { OrganizationUser } from '../types/user';
+export { isValidEmail } from '../../../shared/utils/email';
 
 /** Strips HTML tags from user-provided name fields before submit. */
 export function sanitizeTextInput(value: string): string {
     return value.replace(/<[^>]*>/g, '').trim();
-}
-
-const EMAIL_REGEX =
-    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-export function isValidEmail(value: string): boolean {
-    return EMAIL_REGEX.test(value.trim());
 }
 
 function roleDisplayNames(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.spec.tsx
@@ -15,6 +15,7 @@
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { GroupDetailPage } from './GroupDetailPage';
@@ -24,9 +25,16 @@ import {
     useGroupApplications,
     useGroupApiProducts,
     useGroupDetail,
+    useGroupInvitations,
     useGroupMembers,
 } from '../features/groups/hooks/useGroupDetail';
-import { useAddGroupMembers, useDeleteGroup, useUpdateGroup } from '../features/groups/hooks/useGroupMutations';
+import {
+    useAddGroupMembers,
+    useDeleteGroup,
+    useDeleteGroupInvitation,
+    useInviteGroupMember,
+    useUpdateGroup,
+} from '../features/groups/hooks/useGroupMutations';
 import {
     useGroupApiProductRoles,
     useGroupApiRoles,
@@ -35,7 +43,7 @@ import {
     useGroupExplorerRoles,
     useGroupIntegrationRoles,
 } from '../features/groups/hooks/useGroupRoles';
-import type { Group, GroupMembershipItem, GroupMembershipPayload } from '../features/groups/types/group';
+import type { Group, GroupInvitation, GroupMembershipItem, GroupMembershipPayload } from '../features/groups/types/group';
 import { notify } from '../shared/notify';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
@@ -56,6 +64,23 @@ jest.mock('../features/groups/components/GroupMembersTable', () => ({
         <div data-testid="members-table">{members.map(m => m.displayName).join(', ')}</div>
     ),
 }));
+jest.mock('../features/groups/components/GroupInvitationsTable', () => ({
+    GroupInvitationsTable: ({
+        invitations,
+        onDelete,
+    }: {
+        invitations: GroupInvitation[];
+        onDelete: (invitation: GroupInvitation) => void;
+    }) => (
+        <div data-testid="invitations-table">
+            {invitations.map(invitation => (
+                <button type="button" key={invitation.id} onClick={() => onDelete(invitation)}>
+                    {invitation.email}
+                </button>
+            ))}
+        </div>
+    ),
+}));
 jest.mock('../features/groups/components/GroupMembershipTable', () => ({
     GroupMembershipTable: ({ items, ariaLabel }: { items: GroupMembershipItem[]; ariaLabel: string }) => (
         <div data-testid={`membership-table-${ariaLabel}`}>{items.map(i => i.name).join(', ')}</div>
@@ -64,11 +89,36 @@ jest.mock('../features/groups/components/GroupMembershipTable', () => ({
 // GroupAddMembersSheet has its own spec covering its internals (search, role selects, selection);
 // here we only need to verify the page wires it to the add-members mutation.
 jest.mock('../features/groups/components/GroupAddMembersSheet', () => ({
-    GroupAddMembersSheet: ({ open, onSubmit }: { open: boolean; onSubmit: (m: GroupMembershipPayload[]) => void }) =>
+    GroupAddMembersSheet: ({
+        open,
+        initialSearch,
+        onSubmit,
+    }: {
+        open: boolean;
+        initialSearch?: string;
+        onSubmit: (m: GroupMembershipPayload[]) => Promise<void>;
+    }) =>
         open ? (
             <div data-testid="add-members-sheet">
+                {initialSearch ? <span>{initialSearch}</span> : null}
                 <button type="button" onClick={() => onSubmit([{ id: 'user-1', roles: [{ scope: 'API', name: 'USER' }] }])}>
                     Submit add members
+                </button>
+            </div>
+        ) : null,
+}));
+jest.mock('../features/groups/components/GroupInviteMemberSheet', () => ({
+    GroupInviteMemberSheet: ({
+        open,
+        onSubmit,
+    }: {
+        open: boolean;
+        onSubmit: (values: { email: string; apiRole: string; applicationRole: string }) => Promise<void>;
+    }) =>
+        open ? (
+            <div data-testid="invite-member-sheet">
+                <button type="button" onClick={() => onSubmit({ email: 'user@example.com', apiRole: 'USER', applicationRole: 'USER' })}>
+                    Submit invitation
                 </button>
             </div>
         ) : null,
@@ -87,6 +137,7 @@ beforeAll(() => {
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseGroupDetail = jest.mocked(useGroupDetail);
 const mockUseGroupMembers = jest.mocked(useGroupMembers);
+const mockUseGroupInvitations = jest.mocked(useGroupInvitations);
 const mockUseEnvironmentSettings = jest.mocked(useEnvironmentSettings);
 const mockUseGroupApis = jest.mocked(useGroupApis);
 const mockUseGroupApplications = jest.mocked(useGroupApplications);
@@ -100,6 +151,8 @@ const mockUseGroupExplorerRoles = jest.mocked(useGroupExplorerRoles);
 const mockUseUpdateGroup = jest.mocked(useUpdateGroup);
 const mockUseDeleteGroup = jest.mocked(useDeleteGroup);
 const mockUseAddGroupMembers = jest.mocked(useAddGroupMembers);
+const mockUseInviteGroupMember = jest.mocked(useInviteGroupMember);
+const mockUseDeleteGroupInvitation = jest.mocked(useDeleteGroupInvitation);
 
 const GROUP: Group = { id: 'group-1', name: 'Support Team', event_rules: [{ event: 'API_CREATE' }], system_invitation: true };
 
@@ -121,6 +174,18 @@ function renderPage(initialGroupId = 'group-1') {
     );
 }
 
+async function openAddMembersViaSearch() {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Add members/i }));
+    await user.click(await screen.findByRole('menuitem', { name: 'User search' }));
+}
+
+async function openEmailInvitation() {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Add members/i }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Email invitation' }));
+}
+
 describe('GroupDetailPage', () => {
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
@@ -130,6 +195,11 @@ describe('GroupDetailPage', () => {
             isLoading: false,
             isError: false,
         } as ReturnType<typeof useGroupMembers>);
+        mockUseGroupInvitations.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+        } as unknown as ReturnType<typeof useGroupInvitations>);
         mockUseEnvironmentSettings.mockReturnValue({ data: undefined } as ReturnType<typeof useEnvironmentSettings>);
         mockUseGroupApis.mockReturnValue({
             data: [{ id: 'api-1', name: 'Billing API', version: '1.0' }],
@@ -141,7 +211,11 @@ describe('GroupDetailPage', () => {
             isLoading: false,
             isError: false,
         } as ReturnType<typeof useGroupApplications>);
-        mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<typeof useGroupApiProducts>);
+        mockUseGroupApiProducts.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+        } as unknown as ReturnType<typeof useGroupApiProducts>);
         mockUseGroupApiRoles.mockReturnValue({ data: [{ name: 'USER', scope: 'API', default: true }], isLoading: false } as ReturnType<
             typeof useGroupApiRoles
         >);
@@ -153,8 +227,14 @@ describe('GroupDetailPage', () => {
             data: [{ name: 'USER', scope: 'API_PRODUCT', default: true }],
             isLoading: false,
         } as ReturnType<typeof useGroupApiProductRoles>);
-        mockUseGroupIntegrationRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupIntegrationRoles>);
-        mockUseGroupClusterRoles.mockReturnValue({ data: [], isLoading: false } as ReturnType<typeof useGroupClusterRoles>);
+        mockUseGroupIntegrationRoles.mockReturnValue({
+            data: [],
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGroupIntegrationRoles>);
+        mockUseGroupClusterRoles.mockReturnValue({
+            data: [],
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGroupClusterRoles>);
         mockUseGroupExplorerRoles.mockReturnValue({
             data: [],
             isLoading: false,
@@ -162,6 +242,8 @@ describe('GroupDetailPage', () => {
         mockUseUpdateGroup.mockReturnValue(makeMutation());
         mockUseDeleteGroup.mockReturnValue(makeMutation());
         mockUseAddGroupMembers.mockReturnValue(makeMutation());
+        mockUseInviteGroupMember.mockReturnValue(makeMutation());
+        mockUseDeleteGroupInvitation.mockReturnValue(makeMutation());
     });
 
     afterEach(() => {
@@ -219,9 +301,9 @@ describe('GroupDetailPage', () => {
             expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: false });
         });
 
-        it('fetches all six role catalogs once the Add members sheet is open', () => {
+        it('fetches all six role catalogs once the Add members sheet is open', async () => {
             renderPage();
-            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+            await openAddMembersViaSearch();
 
             expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: true });
             expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: true });
@@ -229,6 +311,23 @@ describe('GroupDetailPage', () => {
             expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: true });
             expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: true });
             expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: true });
+        });
+
+        it('fetches only API and application roles once the Email invitation sheet is open', async () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, email_invitation: true },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+            await openEmailInvitation();
+
+            expect(mockUseGroupApiRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupApplicationRoles).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseGroupApiProductRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupIntegrationRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupClusterRoles).toHaveBeenCalledWith({ enabled: false });
+            expect(mockUseGroupExplorerRoles).toHaveBeenCalledWith({ enabled: false });
         });
 
         it('skips fetching role catalogs when the user cannot edit or add members, since no sheet can open', () => {
@@ -353,7 +452,11 @@ describe('GroupDetailPage', () => {
 
     describe('per-section errors', () => {
         it('shows a section error instead of the members table when members fail to load', () => {
-            mockUseGroupMembers.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupMembers>);
+            mockUseGroupMembers.mockReturnValue({
+                data: [],
+                isLoading: false,
+                isError: true,
+            } as unknown as ReturnType<typeof useGroupMembers>);
             renderPage();
 
             expect(screen.getByText('Failed to load members. Please refresh and try again.')).not.toBeNull();
@@ -361,7 +464,11 @@ describe('GroupDetailPage', () => {
         });
 
         it('shows a section error instead of the APIs table when APIs fail to load', () => {
-            mockUseGroupApis.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<typeof useGroupApis>);
+            mockUseGroupApis.mockReturnValue({
+                data: [],
+                isLoading: false,
+                isError: true,
+            } as unknown as ReturnType<typeof useGroupApis>);
             renderPage();
 
             expect(screen.getByText('Failed to load associated APIs. Please refresh and try again.')).not.toBeNull();
@@ -369,7 +476,7 @@ describe('GroupDetailPage', () => {
         });
 
         it('shows a section error instead of the API Products table when API Products fail to load', () => {
-            mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+            mockUseGroupApiProducts.mockReturnValue({ data: [], isLoading: false, isError: true } as unknown as ReturnType<
                 typeof useGroupApiProducts
             >);
             renderPage();
@@ -379,7 +486,7 @@ describe('GroupDetailPage', () => {
         });
 
         it('shows a section error instead of the Applications table when Applications fail to load', () => {
-            mockUseGroupApplications.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+            mockUseGroupApplications.mockReturnValue({ data: [], isLoading: false, isError: true } as unknown as ReturnType<
                 typeof useGroupApplications
             >);
             renderPage();
@@ -433,9 +540,9 @@ describe('GroupDetailPage', () => {
             expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: false });
         });
 
-        it('hides Add members when the group does not allow adding users via search, even with update permission', () => {
+        it('hides Add members when both invitation methods are disabled, even with update permission', () => {
             mockUseGroupDetail.mockReturnValue({
-                data: { ...GROUP, system_invitation: false },
+                data: { ...GROUP, system_invitation: false, email_invitation: false },
                 isLoading: false,
                 isError: false,
             } as ReturnType<typeof useGroupDetail>);
@@ -445,12 +552,40 @@ describe('GroupDetailPage', () => {
             expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: false });
         });
 
+        it('shows Add members when only email invitations are enabled', () => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, system_invitation: false, email_invitation: true },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+
+            renderPage();
+
+            expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
+        });
+
+        it.each([
+            ['User search', { system_invitation: false, email_invitation: true }],
+            ['Email invitation', { system_invitation: true, email_invitation: false }],
+        ] as const)('disables %s when its group setting is disabled', async (menuItemName, invitationSettings) => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, ...invitationSettings },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+            renderPage();
+
+            await userEvent.setup().click(screen.getByRole('button', { name: /Add members/i }));
+
+            expect((await screen.findByRole('menuitem', { name: menuItemName })).getAttribute('aria-disabled')).toBe('true');
+        });
+
         it('opens the Add members sheet, submits, and shows a success toast', async () => {
             const addMutateAsync = jest.fn().mockResolvedValue(undefined);
             mockUseAddGroupMembers.mockReturnValue(makeMutation(addMutateAsync));
             renderPage();
 
-            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+            await openAddMembersViaSearch();
             expect(screen.getByTestId('add-members-sheet')).not.toBeNull();
 
             fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
@@ -470,11 +605,109 @@ describe('GroupDetailPage', () => {
             mockUseAddGroupMembers.mockReturnValue(makeMutation(jest.fn().mockRejectedValue(error)));
             renderPage();
 
-            fireEvent.click(screen.getByRole('button', { name: /Add members/i }));
+            await openAddMembersViaSearch();
             fireEvent.click(screen.getByRole('button', { name: 'Submit add members' }));
 
             await waitFor(() => expect(notify.error).toHaveBeenCalledWith(error, 'Failed to add members'));
             expect(screen.queryByTestId('add-members-sheet')).not.toBeNull();
+        });
+    });
+
+    describe('Email invitations', () => {
+        beforeEach(() => {
+            mockUseGroupDetail.mockReturnValue({
+                data: { ...GROUP, email_invitation: true },
+                isLoading: false,
+                isError: false,
+            } as ReturnType<typeof useGroupDetail>);
+        });
+
+        it('switches to Invitations after creating a pending invitation', async () => {
+            const inviteMutateAsync = jest.fn().mockResolvedValue({ outcome: 'invitation-created' });
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(inviteMutateAsync));
+            renderPage();
+
+            await openEmailInvitation();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invitation' }));
+
+            await waitFor(() =>
+                expect(inviteMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    data: {
+                        reference_type: 'GROUP',
+                        reference_id: 'group-1',
+                        email: 'user@example.com',
+                        api_role: 'USER',
+                        application_role: 'USER',
+                    },
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Successfully invited user to the group.');
+            await waitFor(() => expect(screen.getByRole('tab', { name: 'Invitations' }).getAttribute('data-state')).toBe('active'));
+        });
+
+        it('switches to Members when the email belongs to one existing user', async () => {
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(jest.fn().mockResolvedValue({ outcome: 'member-added' })));
+            renderPage();
+            await userEvent.setup().click(screen.getByRole('tab', { name: 'Invitations' }));
+
+            await openEmailInvitation();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invitation' }));
+
+            await waitFor(() => expect(notify.success).toHaveBeenCalledWith('Member added successfully'));
+            expect(screen.getByRole('tab', { name: 'Members' }).getAttribute('data-state')).toBe('active');
+        });
+
+        it('continues an ambiguous email response in user search with the email prefilled', async () => {
+            mockUseInviteGroupMember.mockReturnValue(makeMutation(jest.fn().mockResolvedValue({ outcome: 'ambiguous' })));
+            renderPage();
+
+            await openEmailInvitation();
+            fireEvent.click(screen.getByRole('button', { name: 'Submit invitation' }));
+
+            expect(await screen.findByRole('heading', { name: 'Many Users Found' })).not.toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+            expect(screen.getByTestId('add-members-sheet').textContent).toContain('user@example.com');
+        });
+
+        it('loads invitations only after the invitations tab is selected', async () => {
+            renderPage();
+
+            expect(mockUseGroupInvitations).toHaveBeenLastCalledWith(undefined);
+            await userEvent.setup().click(screen.getByRole('tab', { name: 'Invitations' }));
+
+            expect(mockUseGroupInvitations).toHaveBeenLastCalledWith('group-1');
+        });
+
+        it('confirms and deletes an invitation', async () => {
+            const user = userEvent.setup();
+            const invitation: GroupInvitation = {
+                id: 'invitation-1',
+                reference_id: 'group-1',
+                email: 'user@example.com',
+            };
+            const deleteMutateAsync = jest.fn().mockResolvedValue(undefined);
+            mockUseGroupInvitations.mockReturnValue({
+                data: [invitation],
+                isLoading: false,
+                isError: false,
+            } as unknown as ReturnType<typeof useGroupInvitations>);
+            mockUseDeleteGroupInvitation.mockReturnValue(makeMutation(deleteMutateAsync));
+            renderPage();
+
+            await user.click(screen.getByRole('tab', { name: 'Invitations' }));
+            await user.click(screen.getByRole('button', { name: 'user@example.com' }));
+            expect(screen.getByRole('heading', { name: 'Delete Invitation' })).not.toBeNull();
+            await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+            await waitFor(() =>
+                expect(deleteMutateAsync).toHaveBeenCalledWith({
+                    groupId: 'group-1',
+                    invitationId: 'invitation-1',
+                }),
+            );
+            expect(notify.success).toHaveBeenCalledWith('Invitation deleted successfully');
         });
     });
 
@@ -489,7 +722,7 @@ describe('GroupDetailPage', () => {
             renderPage();
 
             expect(screen.queryByRole('button', { name: /Add members/i })).not.toBeNull();
-            expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: true });
+            expect(mockUseEnvironmentSettings).toHaveBeenCalledWith({ enabled: false });
         });
 
         it('hides Add members when manageable but system invitation is disabled', () => {
@@ -532,7 +765,9 @@ describe('GroupDetailPage', () => {
             renderPage();
 
             expect(
-                screen.getByText('The number of members in this group has reached maximum allowed. Adding users has been disabled.'),
+                screen.getByText(
+                    'The number of members in this group has reached maximum allowed. Adding users via search and email invitation have been disabled.',
+                ),
             ).not.toBeNull();
             expect(screen.queryByRole('button', { name: /Add members/i })).toBeNull();
         });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GroupDetailPage.tsx
@@ -15,17 +15,44 @@
  */
 
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Alert, AlertDescription, Badge, Button, DateCell, Skeleton } from '@gravitee/graphene-core';
-import { ArrowLeftIcon, InfoIcon, PencilIcon, PlusIcon, Trash2Icon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
-import { useState } from 'react';
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    DateCell,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Skeleton,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+} from '@gravitee/graphene-core';
+import {
+    ArrowLeftIcon,
+    InfoIcon,
+    MailIcon,
+    PencilIcon,
+    PlusIcon,
+    SearchIcon,
+    Trash2Icon,
+    UsersRoundIcon,
+} from '@gravitee/graphene-core/icons';
+import { useState, useTransition } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { GroupAddMembersSheet } from '../features/groups/components/GroupAddMembersSheet';
 import { GroupAssociationSection } from '../features/groups/components/GroupAssociationSection';
 import { GroupDeleteSheet } from '../features/groups/components/GroupDeleteSheet';
+import { GroupInvitationsTable } from '../features/groups/components/GroupInvitationsTable';
+import { GroupInviteMemberSheet } from '../features/groups/components/GroupInviteMemberSheet';
 import { GroupMembersTable } from '../features/groups/components/GroupMembersTable';
 import { GroupSettingsSection } from '../features/groups/components/GroupSettingsSection';
 import { GroupSheet, type GroupFormValues } from '../features/groups/components/GroupSheet';
+import { GroupTooManyUsersDialog } from '../features/groups/components/GroupTooManyUsersDialog';
 import { SectionError } from '../features/groups/components/SectionError';
 import {
     useEnvironmentSettings,
@@ -47,6 +74,7 @@ import {
 } from '../features/groups/hooks/useGroupRoles';
 import { buildEventRules, buildRolesMap, hasEventRule, parseMaxInvitation } from '../features/groups/utils/groupPayload';
 import { ENVIRONMENT_GROUP_DELETE_PERMISSION, ENVIRONMENT_GROUP_UPDATE_PERMISSION } from '../features/groups/utils/groupPermissions';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
 import { notify } from '../shared/notify';
 
 export function GroupDetailPage() {
@@ -57,6 +85,7 @@ export function GroupDetailPage() {
 
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
+    const [isMemberTabPending, startMemberTabTransition] = useTransition();
 
     const { data: group, isLoading, isError } = useGroupDetail(groupId);
     const { data: members = [], isLoading: membersLoading, isError: membersError } = useGroupMembers(groupId);
@@ -64,27 +93,50 @@ export function GroupDetailPage() {
     const { data: applications = [], isLoading: applicationsLoading, isError: applicationsError } = useGroupApplications(groupId);
     const { data: apiProducts = [], isLoading: apiProductsLoading, isError: apiProductsError } = useGroupApiProducts(groupId);
 
-    const { memberSheet, setMemberSheet, closeMemberSheet, addMembersMutation, handleAddMembers } = useGroupMemberActions(groupId);
+    const {
+        memberTab,
+        setMemberTab,
+        memberSheet,
+        setMemberSheet,
+        closeMemberSheet,
+        tooManyUsersEmail,
+        setTooManyUsersEmail,
+        searchSeed,
+        deletingInvitation,
+        setDeletingInvitation,
+        invitations,
+        invitationsLoading,
+        invitationsError,
+        deleteInvitationMutation,
+        handleAddMembers,
+        handleInviteMember,
+        handleTooManyUsersContinue,
+        handleDeleteInvitation,
+    } = useGroupMemberActions(groupId);
 
-    // Edit Group only needs API / application / API product catalogs. Add members needs all six.
-    const addMemberRolesNeeded = memberSheet !== 'closed';
-    const defaultGroupRolesNeeded = editOpen || addMemberRolesNeeded;
-    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: defaultGroupRolesNeeded });
+    const addMemberRolesNeeded = memberSheet === 'search';
+    const inviteMemberRolesNeeded = memberSheet === 'invite';
+    const apiAndApplicationRolesNeeded = editOpen || addMemberRolesNeeded || inviteMemberRolesNeeded;
+    const apiProductRolesNeeded = editOpen || addMemberRolesNeeded;
+    const { data: apiRoles = [], isLoading: apiRolesLoading } = useGroupApiRoles({ enabled: apiAndApplicationRolesNeeded });
     const { data: applicationRoles = [], isLoading: applicationRolesLoading } = useGroupApplicationRoles({
-        enabled: defaultGroupRolesNeeded,
+        enabled: apiAndApplicationRolesNeeded,
     });
     const { data: apiProductRoles = [], isLoading: apiProductRolesLoading } = useGroupApiProductRoles({
-        enabled: defaultGroupRolesNeeded,
+        enabled: apiProductRolesNeeded,
     });
     const { data: integrationRoles = [] } = useGroupIntegrationRoles({ enabled: addMemberRolesNeeded });
     const { data: clusterRoles = [] } = useGroupClusterRoles({ enabled: addMemberRolesNeeded });
     const { data: explorerRoles = [] } = useGroupExplorerRoles({ enabled: addMemberRolesNeeded });
 
     const maxInvitationsLimitReached = typeof group?.max_invitation === 'number' && group.max_invitation <= members.length;
+    const canManageMembers = canEdit || Boolean(group?.manageable);
     const canAddMembers =
-        group !== undefined && Boolean(group.system_invitation) && (canEdit || Boolean(group.manageable)) && !maxInvitationsLimitReached;
-    // Portal settings only matter for add-members PRIMARY_OWNER gating; skip when the user cannot open the sheet.
-    const { data: environmentSettings } = useEnvironmentSettings({ enabled: canAddMembers });
+        group !== undefined &&
+        canManageMembers &&
+        Boolean(group.system_invitation || group.email_invitation) &&
+        !maxInvitationsLimitReached;
+    const { data: environmentSettings } = useEnvironmentSettings({ enabled: memberSheet !== 'closed' });
 
     const updateMutation = useUpdateGroup();
     const deleteMutation = useDeleteGroup();
@@ -128,6 +180,15 @@ export function GroupDetailPage() {
         } catch (error) {
             notify.error(error, 'Failed to delete group');
         }
+    }
+
+    function handleDeleteInvitationDialogOpenChange(isOpen: boolean) {
+        if (isOpen || deleteInvitationMutation.isPending) return;
+        setDeletingInvitation(null);
+    }
+
+    function handleMemberTabChange(value: string) {
+        startMemberTabTransition(() => setMemberTab(value as 'members' | 'invitations'));
     }
 
     if (isLoading) {
@@ -236,25 +297,60 @@ export function GroupDetailPage() {
                             <p className="text-sm text-muted-foreground">Direct members of this group and their scoped roles.</p>
                         </div>
                         {canAddMembers && (
-                            <Button type="button" className="shrink-0 gap-1.5" onClick={() => setMemberSheet('search')}>
-                                <PlusIcon className="size-4" aria-hidden />
-                                Add members
-                            </Button>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button type="button" className="shrink-0 gap-1.5">
+                                        <PlusIcon className="size-4" aria-hidden />
+                                        Add members
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    <DropdownMenuItem onSelect={() => setMemberSheet('search')} disabled={!group.system_invitation}>
+                                        <SearchIcon className="mr-2 size-4" aria-hidden />
+                                        User search
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem onSelect={() => setMemberSheet('invite')} disabled={!group.email_invitation}>
+                                        <MailIcon className="mr-2 size-4" aria-hidden />
+                                        Email invitation
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
                         )}
                     </div>
                     {maxInvitationsLimitReached && (
                         <Alert variant="default">
                             <InfoIcon className="size-4" aria-hidden />
                             <AlertDescription>
-                                The number of members in this group has reached maximum allowed. Adding users has been disabled.
+                                The number of members in this group has reached maximum allowed. Adding users via search and email
+                                invitation have been disabled.
                             </AlertDescription>
                         </Alert>
                     )}
-                    {membersError ? (
-                        <SectionError message="Failed to load members. Please refresh and try again." />
-                    ) : (
-                        <GroupMembersTable members={members} loading={membersLoading} canAddMembers={canAddMembers} />
-                    )}
+                    <Tabs value={memberTab} onValueChange={handleMemberTabChange} aria-busy={isMemberTabPending}>
+                        <TabsList variant="line">
+                            <TabsTrigger value="members">Members</TabsTrigger>
+                            <TabsTrigger value="invitations">Invitations</TabsTrigger>
+                        </TabsList>
+                        <TabsContent value="members">
+                            {membersError ? (
+                                <SectionError message="Failed to load members. Please refresh and try again." />
+                            ) : (
+                                <GroupMembersTable members={members} loading={membersLoading} canAddMembers={canAddMembers} />
+                            )}
+                        </TabsContent>
+                        <TabsContent value="invitations">
+                            {invitationsError ? (
+                                <SectionError message="Failed to load invitations. Please refresh and try again." />
+                            ) : (
+                                <GroupInvitationsTable
+                                    invitations={invitations}
+                                    loading={invitationsLoading}
+                                    canManageMembers={canManageMembers}
+                                    onDelete={setDeletingInvitation}
+                                />
+                            )}
+                        </TabsContent>
+                    </Tabs>
                 </section>
 
                 <GroupAssociationSection
@@ -331,9 +427,42 @@ export function GroupDetailPage() {
                 maxInvitation={group.max_invitation ?? null}
                 apiPrimaryOwnerMode={environmentSettings?.api?.primaryOwnerMode}
                 apiProductPrimaryOwnerMode={environmentSettings?.apiProduct?.primaryOwnerMode}
+                initialSearch={searchSeed ?? undefined}
                 onClose={closeMemberSheet}
                 onSubmit={handleAddMembers}
-                isSaving={addMembersMutation.isPending}
+            />
+
+            <GroupInviteMemberSheet
+                open={memberSheet === 'invite'}
+                groupName={group.name}
+                groupRoles={group.roles}
+                members={members}
+                apiRoles={apiRoles}
+                applicationRoles={applicationRoles}
+                lockApiRole={Boolean(group.lock_api_role)}
+                lockApplicationRole={Boolean(group.lock_application_role)}
+                canOverrideLocks={canEdit}
+                apiPrimaryOwnerMode={environmentSettings?.api?.primaryOwnerMode}
+                onClose={closeMemberSheet}
+                onSubmit={handleInviteMember}
+            />
+
+            <GroupTooManyUsersDialog
+                open={tooManyUsersEmail !== null}
+                email={tooManyUsersEmail}
+                onClose={() => setTooManyUsersEmail(null)}
+                onContinue={handleTooManyUsersContinue}
+            />
+
+            <ConfirmDialog
+                open={deletingInvitation !== null}
+                onOpenChange={handleDeleteInvitationDialogOpenChange}
+                title="Delete Invitation"
+                description={`You are trying to delete an invitation sent to ${deletingInvitation?.email}. Do you want to continue?`}
+                confirmLabel="Continue"
+                pendingLabel="Deleting…"
+                isPending={deleteInvitationMutation.isPending}
+                onConfirm={handleDeleteInvitation}
             />
         </>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ClientSideTableSearchField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/ClientSideTableSearchField.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+
+interface ClientSideTableSearchFieldProps {
+    readonly id: string;
+    readonly label: string;
+    readonly value: string;
+    readonly onChange: (value: string) => void;
+    readonly placeholder?: string;
+}
+
+export function ClientSideTableSearchField({ id, label, value, onChange, placeholder = 'Search' }: ClientSideTableSearchFieldProps) {
+    return (
+        <div className="w-64">
+            <label htmlFor={id} className="sr-only">
+                {label}
+            </label>
+            <InputGroup>
+                <InputGroupAddon align="inline-start">
+                    <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden />
+                </InputGroupAddon>
+                <InputGroupInput id={id} placeholder={placeholder} value={value} onChange={event => onChange(event.target.value)} />
+            </InputGroup>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/FormActionSubmitButton.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/FormActionSubmitButton.tsx
@@ -14,4 +14,23 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+import { Button } from '@gravitee/graphene-core';
+import { useFormStatus } from 'react-dom';
+
+export function FormActionSubmitButton({
+    disabled,
+    label,
+    pendingLabel,
+}: Readonly<{
+    disabled: boolean;
+    label: string;
+    pendingLabel: string;
+}>) {
+    const { pending } = useFormStatus();
+
+    return (
+        <Button type="submit" disabled={disabled || pending}>
+            {pending ? pendingLabel : label}
+        </Button>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useOpenRemountKey.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useOpenRemountKey.ts
@@ -14,4 +14,20 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+import { useRef } from 'react';
+
+/**
+ * React key that bumps only when `open` goes false → true (and when `identity` changes).
+ * Use for sheet content remount-on-open without remounting during the close animation.
+ */
+export function useOpenRemountKey(open: boolean, identity: string): string {
+    const wasOpenRef = useRef(false);
+    const openEpochRef = useRef(0);
+
+    if (open && !wasOpenRef.current) {
+        openEpochRef.current += 1;
+    }
+    wasOpenRef.current = open;
+
+    return `${openEpochRef.current}-${identity}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/layout/sheetLayout.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/layout/sheetLayout.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+/** Default right sheet width (30rem / 480px). */
+export const STANDARD_SHEET_WIDTH = '480px';
+
+/** Wider sheet for multi-column forms or category sections (48rem / 768px). */
+export const WIDE_SHEET_WIDTH = '48rem';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/testing/formAction.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/testing/formAction.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function installFormActionTestEnvironment(): () => void {
+    const nativeFormData = global.FormData;
+    const nativeResizeObserver = global.ResizeObserver;
+    global.FormData = class TestFormData extends nativeFormData {
+        constructor(_form?: HTMLFormElement) {
+            super();
+        }
+    };
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+
+    return () => {
+        global.FormData = nativeFormData;
+        if (nativeResizeObserver) {
+            global.ResizeObserver = nativeResizeObserver;
+        } else {
+            Reflect.deleteProperty(global, 'ResizeObserver');
+        }
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/clientPagination.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/clientPagination.ts
@@ -14,4 +14,11 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+export function paginate<T>(items: readonly T[], page: number, pageSize: number): T[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+export function totalPagesFor(totalCount: number, pageSize: number): number {
+    return pageSize > 0 ? Math.max(1, Math.ceil(totalCount / pageSize)) : 1;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/dataTableTypes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/dataTableTypes.ts
@@ -13,5 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { DataTableColumnHeaderProps } from '@gravitee/graphene-core';
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+/** Column header render props for Graphene `DataTable` column definitions. */
+export type ColHeader<T> = { column: DataTableColumnHeaderProps<T, unknown>['column'] };
+
+/** Column cell render props for Graphene `DataTable` column definitions. */
+export type ColCell<T> = { row: { original: T } };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/email.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/email.spec.ts
@@ -14,4 +14,11 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+import { isValidEmail } from './email';
+
+describe('isValidEmail', () => {
+    it('accepts well-formed emails and rejects malformed ones', () => {
+        expect(isValidEmail('jane@company.com')).toBe(true);
+        expect(isValidEmail('jane@company')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/email.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/email.ts
@@ -14,4 +14,9 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+const EMAIL_REGEX =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+export function isValidEmail(value: string): boolean {
+    return EMAIL_REGEX.test(value.trim());
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/paginationConstants.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
-export { paginate, totalPagesFor } from '../../../shared/utils/clientPagination';
+/** Shared page-size options for DataTable pagination (UI-COMP-12). */
+export const TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;


### PR DESCRIPTION
hem instead of duplicating the applications-feature copies.

## Issue

https://gravitee.atlassian.net/browse/FOUND-109

## Summary

Adds **email invitation** and **pending-invitation management** to Gamma group detail. User search already existed; this PR is the classic Console invite path that was still missing.

This is **FOUND-109 only**. Edit roles, remove member, ownership transfer, Explorer column, and delete-dialog rename stay on the stacked FOUND-107 branch.

## What this covers

On the group detail page:

- **Add members** is a dropdown, matching classic:
  - **User search** — disabled when `system_invitation` is false
  - **Email invitation** — disabled when `email_invitation` is false
- The button is shown when the user can update the group **or** the group is `manageable`, and at least one of search/email is enabled, and `max_invitation` is not already reached.
- **Members / Invitations** tabs. Invitations load **only after** the Invitations tab is selected (classic `onTabChange` / lazy tab).
- **Invite sheet:** email + default API role + default application role.
- **Invitations table:** email, API role, application role, invitation date, delete (when the user can manage).
- **Ambiguous email (HTTP 202):** “Many users found” dialog → Continue opens user search with that email prefilled (`initialSearch`).
- Delete invitation uses the shared `ConfirmDialog`.

## Classic Console alignment

Source of truth: `gravitee-apim-console-webui/.../groups/group/` (`group.component.ts` / `.html`, `invite-member-dialog`).

| Classic | Gamma |
| --- | --- |
| Add Members menu: User Search / Email Invitation | Same dropdown + disable flags |
| `canAddMembers = (canUpdate \|\| canInvite) && !maxReached` | Same, with `manageable` as the invite-admin path |
| Invite form: API role, application role, required email | `GroupInviteMemberSheet` — same three fields |
| Defaults: `group.roles.API/APPLICATION ?? USER` | Same |
| Locks: API/application locked unless `environment-group-u` | `getMemberRoleLockFlags` + `canOverrideLocks={canEdit}` |
| API: disable PRIMARY_OWNER when USER mode **or** an API PO already exists; other system roles disabled | `isPrimaryOwnerUnavailable` + `disableSystemRoles="except-primary-owner"` |
| Application: all system roles disabled | `disableSystemRoles="all"` |
| Invite has **no** API Product / Integration / Cluster / Explorer roles | Invite sheet stays API + Application only |
| POST `/invitations` → 200 success, 202 ambiguous users | `inviteGroupMember` treats an array body as `{ ambiguous: true }` |
| 202 → TooManyUsers → add-members dialog | `GroupTooManyUsersDialog` → search sheet + `searchSeed` |
| Invitations tab: email, API role, application role, date, delete | `GroupInvitationsTable` |
| Delete copy: “You are trying to delete an invitation sent to {email}…” | Same via `ConfirmDialog` |
| Unpaged invitations list, client search/pagination | Same; fetch gated on the tab to avoid the extra call on every detail load |

Intentionally **not** in this PR (classic has them; FOUND-107 will): edit member, remove member, ownership transfer, Explorer column on the members table.

## Code map for reviewers

**Page / orchestration**

- `pages/GroupDetailPage.tsx` — dropdown, tabs, sheets, dialogs. Does not own the mutations.
- `hooks/useGroupMemberActions.ts` — sheet/tab state, invite/add/delete invitation handlers, invitations query enabled only when `memberTab === 'invitations'`.
- `hooks/useGroupDetail.ts` — `useGroupInvitations`.
- `hooks/useGroupMutations.ts` — `useInviteGroupMember`, `useDeleteGroupInvitation`.
- `services/groups.ts` — POST/GET/DELETE `.../configuration/groups/{id}/invitations`. Ambiguous invite is detected as `Array.isArray(result)` because the 202 body is a user list (classic checks `response.status === 202`; `apimFetchJsonV1Env` only returns JSON).

**Invite UI**

- `components/GroupInviteMemberSheet.tsx` — Graphene `Sheet` / `Input` / `Label` / `GroupRoleSelect`. `aria-invalid` + “Enter a valid email”. Submit disabled until `isValidEmail`.
- `shared/utils/email.ts` — shared validator (also used from users).
- `components/GroupTooManyUsersDialog.tsx` — Graphene `Dialog` + `Alert` (classic Material dialog).
- `components/GroupInvitationsTable.tsx` — Graphene `DataTable`, client pagination, search, empty states. Single-action delete is an icon button (Graphene single-action exception).

**Reuse / DRY**

- `shared/layout/sheetLayout.ts`, `shared/utils/{clientPagination,dataTableTypes,paginationConstants,email}.ts`
- Applications feature files re-export those so existing imports keep working.
- `groups/utils/clientPagination.ts` re-exports the shared helpers.
- `isPrimaryOwnerUnavailable` lives in `memberRoles.ts` (invite + add-members). Edit/remove ownership helpers are **not** here.

**Add-members continuation**

- `useGroupAddMembersForm` / `GroupAddMembersSheet` accept `initialSearch` so Continue from 202 seeds the search field.

## Security

Invitation create/list/delete and membership add. Gating is the same as classic (env group update **or** `manageable`, plus `email_invitation` / `system_invitation` and max members). Backend still enforces `GROUP_INVITATION` / `ENVIRONMENT_GROUP` on the v1 resources.

## Out of scope

- Edit member roles, remove member, ownership transfer
- Explorer column on members
- Renaming `GroupDeleteSheet` → `GroupDeleteDialog`
- Paged invitations API (classic is unpaged too)

## Test plan

- `GroupInviteMemberSheet.spec.tsx` — validation, locks, PO / system-role disable, no “None” option
- `GroupInvitationsTable.spec.tsx` — columns, empty, delete
- `GroupDetailPage.spec.tsx` — dropdown wiring, invite success → Invitations tab, 202 → search seed, invitations query only after tab select
- `useGroupAddMembersForm.spec.tsx` — `initialSearch`
- `shared/utils/email.spec.ts`

Manual: invite a unique email (200 + row in Invitations), invite an email with multiple org users (202 → Continue → search), delete invitation, max members banner disables both menu items.

---

Classic has **no** invitation status (pending / accepted / rejected), **no** resend, **no** invitation history, and **no** invitation audit UI. The invitation entity is the same shape: `id`, email, roles, `created_at`.

FOUND-109 still lists those extras as acceptance criteria. They go beyond Console and need backend/API work, so they are **follow-ups** unless product explicitly reduces FOUND-109 to Console parity or expands this story beyond it.

| FOUND-109 AC | Classic Console | This PR |
| --- | --- | --- |
| Send invitations | Yes | Yes |
| Cancel pending invitations | Yes (delete) | Yes |
| Track status (pending / accepted / rejected) | No | Follow-up |
| Resend invitations | No | Follow-up |
| Display invitation history | No | Follow-up |
| Audit event for invitations | No | Follow-up |