### PR TITLE
feat(console): import portal page content from a file

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
@@ -32,4 +32,6 @@ export interface NewPortalPageContent {
 export interface UpdatePortalPageContent {
   content: string;
   configuration?: OpenApiViewerConfiguration;
+  /** When set and different from the current content type, the content is converted to this type (file import). */
+  type?: PortalPageContentType;
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -126,6 +126,20 @@
         @if (currentPageContentType() === 'OPENAPI') {
           <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onConfigure()">Configure</button>
         }
+        @if (selectedNavigationItem()?.type === 'PAGE') {
+          <button [disabled]="importFileDisabled()" mat-stroked-button data-testid="import-file-button" (click)="importFileInput.click()">
+            Import file
+          </button>
+          <input
+            #importFileInput
+            hidden
+            type="file"
+            aria-label="Import file"
+            [accept]="importFileAccept"
+            data-testid="import-file-input"
+            (change)="onImportFileSelected($event)"
+          />
+        }
         <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onEdit()">Edit</button>
         <span [matTooltip]="publishDisabledTooltip()" [matTooltipDisabled]="!publishDisabled()">
           <button [disabled]="publishActionDisabled()" mat-stroked-button (click)="onPublishToggle()">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -284,6 +284,43 @@ describe('PortalNavigationItemsComponent', () => {
         );
         await expectGetNavigationItems(fakeResponse);
       });
+      it('should push the file content to the created page when importing from a file', async () => {
+        // Back to the source choice: this suite lands on the "Fill in content" step
+        await dialogHarness.clickBackButton();
+        fixture.detectChanges();
+        await dialogHarness.selectContentSource('IMPORT_FILE');
+        fixture.detectChanges();
+        await dialogHarness.clickContinueButton();
+        fixture.detectChanges();
+
+        await dialogHarness.pickFile(new File(['openapi: 3.0.3\ninfo:\n  title: Imported'], 'spec.yaml'));
+        for (let tick = 0; tick < 5; tick++) {
+          await new Promise(resolve => setTimeout(resolve));
+        }
+        fixture.detectChanges();
+
+        await dialogHarness.clickSubmitButton();
+
+        expectCreateNavigationItem(
+          fakeNewPagePortalNavigationItem({ title: 'spec', area: 'TOP_NAVBAR', type: 'PAGE', contentType: 'OPENAPI' }),
+          fakePortalNavigationPage({
+            title: 'spec',
+            area: 'TOP_NAVBAR',
+            type: 'PAGE',
+            portalPageContentId: 'created-content-id',
+          }),
+        );
+
+        const contentReq = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/created-content-id`,
+        });
+        expect(contentReq.request.body).toEqual({ content: 'openapi: 3.0.3\ninfo:\n  title: Imported', type: 'OPENAPI' });
+        contentReq.flush({ id: 'created-content-id', type: 'OPENAPI', content: 'openapi: 3.0.3\ninfo:\n  title: Imported' });
+
+        await expectGetNavigationItems(fakeResponse);
+      });
+
       it('should navigate to the created page after creation', async () => {
         const title = 'New Page Title';
         await dialogHarness.setTitleInputValue(title);
@@ -1483,6 +1520,255 @@ describe('PortalNavigationItemsComponent', () => {
       expect(document.body.textContent).not.toContain('Failed to update page content');
       expect(await harness.getEditorContentText()).toBe('Edited content with ${api.invalid}');
       expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
+  });
+
+  describe('importing content from a file', () => {
+    // The FileReader used by the component completes on macrotasks: yield a few ticks so the read settles
+    async function waitForFileRead() {
+      for (let tick = 0; tick < 5; tick++) {
+        await new Promise(resolve => setTimeout(resolve));
+      }
+      fixture.detectChanges();
+    }
+
+    async function selectImportFile(name: string, content: string) {
+      component.onImportFileSelected({ target: { files: [new File([content], name)], value: '' } } as unknown as Event);
+      fixture.detectChanges();
+    }
+
+    async function confirmImportDialog() {
+      const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+      await confirmDialog.confirm();
+      await waitForFileRead();
+    }
+
+    describe('on an editable page', () => {
+      beforeEach(async () => {
+        snackBarErrorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+        await expectGetNavigationItems(
+          fakePortalNavigationItemsResponse({
+            items: [fakePortalNavigationPage({ id: 'nav-item-1', title: 'Nav Item 1', portalPageContentId: 'content-1' })],
+          }),
+        );
+        expectGetPageContent('content-1', 'Initial content');
+      });
+
+      it('shows an enabled Import file button', async () => {
+        expect(await harness.isImportFileButtonVisible()).toBe(true);
+        expect(await harness.isImportFileButtonDisabled()).toBe(false);
+      });
+
+      it('imports a markdown file after confirmation and replaces the content, keeping the page editable', async () => {
+        await selectImportFile('doc.md', '# Imported');
+        await confirmImportDialog();
+        await fixture.whenStable();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(req.request.body).toEqual({ content: '# Imported', type: 'GRAVITEE_MARKDOWN' });
+        req.flush({ id: 'content-1', type: 'GRAVITEE_MARKDOWN', content: '# Imported' });
+        fixture.detectChanges();
+
+        expect(await harness.getEditorContentText()).toBe('# Imported');
+        expect(await harness.isSaveButtonDisabled()).toBe(true);
+        expect(await harness.isContentEditorReadOnly()).toBe(false);
+      });
+
+      it('imports an OpenAPI yaml file and switches to the OpenAPI editor', async () => {
+        await selectImportFile('spec.yaml', 'openapi: 3.0.3\ninfo:\n  title: Imported');
+        await confirmImportDialog();
+        await fixture.whenStable();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(req.request.body).toEqual(expect.objectContaining({ type: 'OPENAPI' }));
+        req.flush({ id: 'content-1', type: 'OPENAPI', content: 'openapi: 3.0.3\ninfo:\n  title: Imported' });
+        fixture.detectChanges();
+
+        expect(await harness.getOpenApiEditor()).not.toBeNull();
+      });
+
+      it('imports an AsyncAPI yaml file as ASYNCAPI, not OpenAPI', async () => {
+        await selectImportFile('spec.yaml', 'asyncapi: 3.0.0\ninfo:\n  title: Imported');
+        await confirmImportDialog();
+        await fixture.whenStable();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(req.request.body).toEqual(expect.objectContaining({ type: 'ASYNCAPI' }));
+        req.flush({ id: 'content-1', type: 'ASYNCAPI', content: 'asyncapi: 3.0.0\ninfo:\n  title: Imported' });
+      });
+
+      it('imports an OpenAPI json file as OPENAPI', async () => {
+        const content = '{"openapi": "3.0.3", "info": {"title": "Imported"}}';
+        await selectImportFile('spec.json', content);
+        await confirmImportDialog();
+        await fixture.whenStable();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(req.request.body).toEqual(expect.objectContaining({ type: 'OPENAPI' }));
+        req.flush({ id: 'content-1', type: 'OPENAPI', content });
+      });
+
+      it('shows a clear error and does not call the backend when a spec file has no root spec property', async () => {
+        await selectImportFile('spec.yaml', 'title: Not a spec');
+        await confirmImportDialog();
+        await fixture.whenStable();
+
+        httpTestingController.expectNone({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('asyncapi'));
+      });
+
+      it('shows a clear error and does not call the backend for an unsupported extension', async () => {
+        await selectImportFile('image.png', 'binary');
+        await fixture.whenStable();
+
+        httpTestingController.expectNone({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('.png'));
+      });
+
+      it('rejects an .adoc file: AsciiDoc has no matching content type', async () => {
+        await selectImportFile('doc.adoc', '= Imported');
+        await fixture.whenStable();
+
+        httpTestingController.expectNone({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('.adoc'));
+      });
+
+      it('rejects a file above the import size limit before reading it', async () => {
+        const oversized = new File(['# Imported'], 'big.md');
+        Object.defineProperty(oversized, 'size', { value: 10 * 1024 * 1024 + 1 });
+
+        component.onImportFileSelected({ target: { files: [oversized], value: '' } } as unknown as Event);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        httpTestingController.expectNone({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('10 MB'));
+      });
+
+      it('does not touch the content when the confirmation is cancelled', async () => {
+        await selectImportFile('doc.md', '# Imported');
+
+        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        await confirmDialog.cancel();
+        await waitForFileRead();
+
+        httpTestingController.expectNone({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(await harness.getEditorContentText()).toBe('Initial content');
+      });
+
+      it('asks the same confirmation when there are unsaved changes, then imports over them', async () => {
+        await harness.setEditorContentText('Edited but not saved');
+        await selectImportFile('doc.md', '# Imported');
+        await confirmImportDialog();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        req.flush({ id: 'content-1', type: 'GRAVITEE_MARKDOWN', content: '# Imported' });
+        fixture.detectChanges();
+
+        expect(await harness.getEditorContentText()).toBe('# Imported');
+      });
+
+      it('wires the Import file button to the hidden file input', async () => {
+        const input: HTMLInputElement = fixture.nativeElement.querySelector('[data-testid="import-file-input"]');
+        const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+
+        await harness.clickImportFileButton();
+        expect(clickSpy).toHaveBeenCalled();
+
+        Object.defineProperty(input, 'files', { value: [new File(['# Imported'], 'doc.md')] });
+        input.dispatchEvent(new Event('change'));
+        fixture.detectChanges();
+        await confirmImportDialog();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        });
+        expect(req.request.body).toEqual({ content: '# Imported', type: 'GRAVITEE_MARKDOWN' });
+        req.flush({ id: 'content-1', type: 'GRAVITEE_MARKDOWN', content: '# Imported' });
+      });
+    });
+
+    it('does not overwrite the editor of another page selected while the import response is pending', async () => {
+      const snackBarSuccessSpy = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({
+          items: [
+            fakePortalNavigationPage({ id: 'nav-item-1', title: 'Page A', portalPageContentId: 'content-1' }),
+            fakePortalNavigationPage({ id: 'nav-item-2', title: 'Page B', portalPageContentId: 'content-2' }),
+          ],
+        }),
+      );
+      expectGetPageContent('content-1', 'Page A content');
+
+      await selectImportFile('doc.md', '# Imported');
+      await confirmImportDialog();
+
+      await harness.selectNavigationItemByTitle('Page B');
+      expectGetPageContent('content-2', 'Page B content');
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-1`,
+        })
+        .flush({ id: 'content-1', type: 'GRAVITEE_MARKDOWN', content: '# Imported' });
+      fixture.detectChanges();
+
+      expect(await harness.getEditorContentText()).toBe('Page B content');
+      expect(snackBarSuccessSpy).toHaveBeenCalledWith(expect.stringContaining('Page A'));
+    });
+
+    it('disables the Import file button when the page is managed by an external source', async () => {
+      const sourcedPage = fakePortalNavigationPage({
+        id: 'nav-item-1',
+        title: 'Nav Item 1',
+        portalPageContentId: 'content-1',
+        source: { type: 'github-fetcher', configuration: {} },
+      });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [sourcedPage] }));
+      expectGetPageContent('content-1', 'Fetched content');
+
+      expect(await harness.isImportFileButtonDisabled()).toBe(true);
+    });
+
+    it('does not show the Import file button for a folder', async () => {
+      const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR' });
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+      expect(await harness.isImportFileButtonVisible()).toBe(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -22,6 +22,8 @@ import {
   GioCardEmptyStateModule,
   GioConfirmAndValidateDialogComponent,
   GioConfirmAndValidateDialogData,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
 } from '@gravitee/ui-particles-angular';
 import { Component, computed, DestroyRef, effect, HostListener, inject, NgZone, Signal, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -63,6 +65,7 @@ import {
   PublishNavigationItemDialogData,
   PublishNavigationItemDialogResult,
 } from './publish-navigation-item-dialog/publish-navigation-item-dialog.component';
+import { ImportFileError, IMPORTABLE_FILE_EXTENSIONS, readImportedFile, validateImportFile } from './portal-page-content-import.util';
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
@@ -278,6 +281,8 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       ? !!getPortalNavigationItemSource(navItem)
       : collectNodeIdsWithSourcedPageDescendants(this.menuLinks()).has(navItem.id);
   });
+  readonly importFileDisabled = computed(() => this.actionsDisabled() || this.isContentEditingLocked());
+  protected readonly importFileAccept = IMPORTABLE_FILE_EXTENSIONS.join(',');
 
   // --- Resize Configuration ---
   private readonly ngZone = inject(NgZone);
@@ -760,7 +765,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
               visibility: result.visibility,
               ...(type === 'PAGE' && result.contentType ? { contentType: result.contentType } : {}),
               ...(type === 'PAGE' && result.source ? { source: result.source } : {}),
-            });
+            }).pipe(switchMap(created => this.pushImportedContent(created, result.content, result.contentType)));
           } else {
             if (!existingItem) {
               return EMPTY;
@@ -802,6 +807,26 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  /** A page created from a file is created empty, then filled: only the content endpoint carries content. */
+  private pushImportedContent(
+    createdItem: PortalNavigationItem,
+    content: string | undefined,
+    contentType: PortalPageContentType | undefined,
+  ): Observable<PortalNavigationItem> {
+    if (!content || createdItem.type !== 'PAGE') {
+      return of(createdItem);
+    }
+    return this.portalPageContentService.updatePageContent(createdItem.portalPageContentId, { content, type: contentType }).pipe(
+      map(() => createdItem),
+      catchError(error => {
+        if (!(error instanceof HttpErrorResponse)) {
+          this.snackBarService.error('Failed to import the file content into the new page');
+        }
+        return of(createdItem);
+      }),
+    );
   }
 
   private create(newPortalNavigationItem: NewPortalNavigationItem): Observable<PortalNavigationItem> {
@@ -951,6 +976,81 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     if (navId) {
       this.checkUnsavedChangesAndRun(() => this.executeFetch(navId));
     }
+  }
+
+  onImportFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    // Reset so selecting the same file again re-triggers the change event
+    input.value = '';
+    if (!file) {
+      return;
+    }
+
+    const validationError = validateImportFile(file);
+    if (validationError) {
+      this.snackBarService.error(validationError);
+      return;
+    }
+
+    // The import overwrites the saved content with no way back: always confirm, unsaved edits or not
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: GIO_DIALOG_WIDTH.SMALL,
+        data: {
+          title: 'Replace page content',
+          content: `Importing "${file.name}" will replace the content of this page, including what is already saved. This cannot be undone.`,
+          confirmButton: 'Replace content',
+          cancelButton: 'Cancel',
+        },
+        role: 'alertdialog',
+        id: 'importFileConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirmed => !!confirmed),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.importFileContent(file));
+  }
+
+  private importFileContent(file: File): void {
+    const navItem = this.selectedNavigationItem()?.data;
+    if (!navItem || navItem.type !== 'PAGE') {
+      return;
+    }
+
+    readImportedFile(file)
+      .pipe(
+        switchMap(({ content, contentType }) =>
+          this.portalPageContentService.updatePageContent(navItem.portalPageContentId, { content, type: contentType }),
+        ),
+        catchError(error => {
+          // HTTP errors are already caught by HttpErrorInterceptor and displayed in the snackbar
+          if (error instanceof ImportFileError) {
+            this.snackBarService.error(error.message);
+          } else if (!(error instanceof HttpErrorResponse)) {
+            this.snackBarService.error(`Failed to import content from "${file.name}"`);
+          }
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(updatedContent => {
+        // The user may have navigated away while the PUT was in flight: the import did succeed
+        // server-side, but this response must not overwrite the now-selected page's editor state
+        const selected = this.selectedNavigationItem()?.data;
+        if (!selected || selected.type !== 'PAGE' || selected.portalPageContentId !== navItem.portalPageContentId) {
+          this.snackBarService.success(`Content imported into "${navItem.title}"`);
+          return;
+        }
+        this.currentPageContentType.set(updatedContent.type);
+        this.currentPageConfiguration.set(updatedContent.configuration ?? {});
+        this.contentControl.reset(updatedContent.content);
+        this.contentControl.updateValueAndValidity();
+        this.initialContent.set(updatedContent.content);
+        this.snackBarService.success(`Content imported from "${file.name}"`);
+      });
   }
 
   private executeFetch(navigationItemId: string): void {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -57,6 +57,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
     }),
   );
   private readonly getFetchNowButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="fetch-now-button"]' }));
+  private readonly getImportFileButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="import-file-button"]' }));
   private readonly getContentManagedBySourceBanner = this.locatorForOptional('[data-testid="content-managed-by-source-banner"]');
   private readonly getContentManagedByParentBanner = this.locatorForOptional('[data-testid="content-managed-by-parent-banner"]');
   private readonly getContentFetchErrorBanner = this.locatorForOptional('[data-testid="content-fetch-error-banner"]');
@@ -286,6 +287,26 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async isPageNotFoundDisplayed(): Promise<boolean> {
     const emptyState = await this.getPageNotFoundEmptyState();
     return emptyState !== null;
+  }
+
+  async isImportFileButtonVisible(): Promise<boolean> {
+    return (await this.getImportFileButton()) !== null;
+  }
+
+  async isImportFileButtonDisabled(): Promise<boolean> {
+    const button = await this.getImportFileButton();
+    if (!button) {
+      throw new Error('Import file button not found');
+    }
+    return button.isDisabled();
+  }
+
+  async clickImportFileButton(): Promise<void> {
+    const button = await this.getImportFileButton();
+    if (!button) {
+      throw new Error('Import file button not found');
+    }
+    return button.click();
   }
 
   async isFetchNowButtonVisible(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-page-content-import.util.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-page-content-import.util.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { load } from 'js-yaml';
+import { map, Observable } from 'rxjs';
+
+import { PortalPageContentType } from '../../entities/management-api-v2';
+
+export const IMPORTABLE_FILE_EXTENSIONS: readonly string[] = ['.md', '.yaml', '.yml', '.json'];
+
+export const MAX_IMPORT_FILE_SIZE_MB = 10;
+const MAX_IMPORT_FILE_SIZE_BYTES = MAX_IMPORT_FILE_SIZE_MB * 1024 * 1024;
+
+export interface ImportedFileContent {
+  content: string;
+  contentType: PortalPageContentType;
+}
+
+export class ImportFileError extends Error {}
+
+export function validateImportFile(file: File): string | null {
+  const extension = extractExtension(file.name);
+  if (!IMPORTABLE_FILE_EXTENSIONS.includes(extension)) {
+    return `Unsupported file type "${extension}". Supported extensions: ${IMPORTABLE_FILE_EXTENSIONS.join(', ')}`;
+  }
+  if (file.size > MAX_IMPORT_FILE_SIZE_BYTES) {
+    return `"${file.name}" exceeds the ${MAX_IMPORT_FILE_SIZE_MB} MB import limit`;
+  }
+  return null;
+}
+
+export function readImportedFile(file: File): Observable<ImportedFileContent> {
+  return readFileAsText(file).pipe(
+    map(content => {
+      const contentType = detectContentType(file.name, content);
+      if (!contentType) {
+        throw new ImportFileError(
+          `Cannot determine the API type of "${file.name}": the document needs a root "openapi", "swagger" or "asyncapi" property`,
+        );
+      }
+      return { content, contentType };
+    }),
+  );
+}
+
+export function detectContentType(fileName: string, content: string): PortalPageContentType | null {
+  if (fileName.toLowerCase().endsWith('.md')) {
+    return 'GRAVITEE_MARKDOWN';
+  }
+  // .yaml/.yml/.json can hold either spec type: only the document's root property tells them apart
+  let document: unknown;
+  try {
+    document = load(content);
+  } catch {
+    return null;
+  }
+  if (!(document instanceof Object)) {
+    return null;
+  }
+  if ('asyncapi' in document) {
+    return 'ASYNCAPI';
+  }
+  return 'openapi' in document || 'swagger' in document ? 'OPENAPI' : null;
+}
+
+export function extractTitleFromFileName(fileName: string): string {
+  const extension = extractExtension(fileName);
+  return fileName.toLowerCase().endsWith(extension) ? fileName.slice(0, -extension.length) : fileName;
+}
+
+function extractExtension(fileName: string): string {
+  return fileName.includes('.') ? `.${fileName.split('.').pop()!.toLowerCase()}` : fileName;
+}
+
+function readFileAsText(file: File): Observable<string> {
+  return new Observable<string>(subscriber => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      subscriber.next(reader.result as string);
+      subscriber.complete();
+    };
+    reader.onerror = () => subscriber.error(reader.error);
+    reader.readAsText(file);
+    return () => reader.abort();
+  });
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -29,10 +29,10 @@
             <gio-card-content-subtitle>Write Markdown or OpenAPI directly in the editor</gio-card-content-subtitle>
           </gio-form-selection-inline-card-content>
         </gio-form-selection-inline-card>
-        <gio-form-selection-inline-card value="IMPORT_FILE" [disabled]="true">
+        <gio-form-selection-inline-card value="IMPORT_FILE">
           <gio-form-selection-inline-card-content icon="gio:upload">
             <gio-card-content-title>Import from file</gio-card-content-title>
-            <gio-card-content-subtitle>Upload a .md or .yaml file from your machine (coming soon)</gio-card-content-subtitle>
+            <gio-card-content-subtitle>Upload a Markdown, OpenAPI or AsyncAPI file from your machine</gio-card-content-subtitle>
           </gio-form-selection-inline-card-content>
         </gio-form-selection-inline-card>
         <gio-form-selection-inline-card value="EXTERNAL">
@@ -64,6 +64,24 @@
           }
         </gio-form-selection-inline>
       }
+      @if (showFileImport()) {
+        <div class="form-field-title">File</div>
+        <gio-form-file-picker class="section-editor-dialog__file-picker" [accept]="importFileAccept" [formControl]="importFileControl">
+          <gio-form-file-picker-add-button>
+            <div class="section-editor-dialog__file-picker__prompt">
+              <mat-icon svgIcon="gio:upload"></mat-icon>
+              <p class="mat-body-strong">Drag and drop a file, or click here to choose one.</p>
+              <p>Supported formats: {{ importFileAccept }}</p>
+            </div>
+          </gio-form-file-picker-add-button>
+        </gio-form-file-picker>
+        @if (importedFileName(); as fileName) {
+          <gio-banner-info data-testid="imported-file-banner">
+            {{ fileName }} will be imported as {{ importedContentTypeLabel() }}.
+          </gio-banner-info>
+        }
+      }
+
       <div class="form-field-title">Title</div>
       <mat-form-field>
         <mat-label>{{ titleFieldLabel }}</mat-label>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.scss
@@ -34,3 +34,12 @@ mat-dialog-content {
 .section-editor-dialog__source-toggle {
   margin-bottom: 8px;
 }
+
+.section-editor-dialog__file-picker__prompt {
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  text-align: center;
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.spec.ts
@@ -39,6 +39,7 @@ import {
   PortalNavigationItemType,
 } from '../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 @Component({
   selector: 'test-host-component',
@@ -93,6 +94,7 @@ describe('SectionEditorDialogComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let rootLoader: HarnessLoader;
   let apiResolveNameById: jest.Mock;
+  let snackBarErrorSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     apiResolveNameById = jest.fn().mockReturnValue(of('api-1'));
@@ -105,6 +107,7 @@ describe('SectionEditorDialogComponent', () => {
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    snackBarErrorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
     fixture.detectChanges();
   });
 
@@ -202,6 +205,111 @@ describe('SectionEditorDialogComponent', () => {
         expect(component.dialogValue).toBeUndefined();
       });
     });
+    describe('when adding a page from a file', () => {
+      async function openImportStep(): Promise<SectionEditorDialogHarness> {
+        fixture.componentRef.setInput('type', 'PAGE');
+        fixture.detectChanges();
+        component.clicked();
+        fixture.detectChanges();
+        const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+        await dialog.selectContentSource('IMPORT_FILE');
+        fixture.detectChanges();
+        await dialog.clickContinueButton();
+        fixture.detectChanges();
+        return dialog;
+      }
+
+      // The picker reads the file asynchronously: yield a few ticks so the read settles
+      async function waitForFileRead(): Promise<void> {
+        for (let tick = 0; tick < 5; tick++) {
+          await new Promise(resolve => setTimeout(resolve));
+        }
+        fixture.detectChanges();
+      }
+
+      it('offers a file picker instead of the page type selection', async () => {
+        const dialog = await openImportStep();
+
+        expect(await dialog.isFilePickerVisible()).toBe(true);
+        expect(await dialog.isPageTypeSelectionVisible()).toBe(false);
+        expect(await dialog.getFilePickerAccept()).toBe('.md,.yaml,.yml,.json');
+      });
+
+      it('cannot be submitted until a file is picked', async () => {
+        const dialog = await openImportStep();
+        await dialog.setTitleInputValue('My imported page');
+
+        expect(await dialog.isSubmitButtonDisabled()).toBe(true);
+      });
+
+      it('creates a markdown page carrying the file content', async () => {
+        const dialog = await openImportStep();
+        await dialog.pickFile(new File(['# Imported'], 'doc.md'));
+        await waitForFileRead();
+
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual({
+          title: 'doc',
+          visibility: 'PUBLIC',
+          contentType: 'GRAVITEE_MARKDOWN',
+          content: '# Imported',
+        });
+      });
+
+      it('derives the OpenAPI type from the document, not the extension', async () => {
+        const dialog = await openImportStep();
+        await dialog.pickFile(new File(['openapi: 3.0.3\ninfo:\n  title: Imported'], 'spec.yaml'));
+        await waitForFileRead();
+
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual(expect.objectContaining({ contentType: 'OPENAPI' }));
+      });
+
+      it('derives the AsyncAPI type from the document, not the extension', async () => {
+        const dialog = await openImportStep();
+        await dialog.pickFile(new File(['asyncapi: 3.0.0\ninfo:\n  title: Imported'], 'spec.yaml'));
+        await waitForFileRead();
+
+        await dialog.clickSubmitButton();
+        fixture.detectChanges();
+
+        expect(component.dialogValue).toEqual(expect.objectContaining({ contentType: 'ASYNCAPI' }));
+      });
+
+      it('keeps a title the user already typed', async () => {
+        const dialog = await openImportStep();
+        await dialog.setTitleInputValue('My own title');
+        await dialog.pickFile(new File(['# Imported'], 'doc.md'));
+        await waitForFileRead();
+
+        expect(await dialog.getTitleInputValue()).toBe('My own title');
+      });
+
+      it('rejects a document with no recognizable root property', async () => {
+        const dialog = await openImportStep();
+        await dialog.pickFile(new File(['title: Not a spec'], 'spec.yaml'));
+        await waitForFileRead();
+
+        expect(await dialog.isSubmitButtonDisabled()).toBe(true);
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('asyncapi'));
+      });
+
+      it('rejects a file above the import size limit', async () => {
+        const dialog = await openImportStep();
+        const oversized = new File(['# Imported'], 'big.md');
+        Object.defineProperty(oversized, 'size', { value: 10 * 1024 * 1024 + 1 });
+        await dialog.pickFile(oversized);
+        await waitForFileRead();
+
+        expect(await dialog.isSubmitButtonDisabled()).toBe(true);
+        expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('10 MB'));
+      });
+    });
+
     describe('when adding a page with PRIVATE parent', () => {
       beforeEach(async () => {
         fixture.componentRef.setInput('type', 'PAGE');

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -19,15 +19,16 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconRegistry } from '@angular/material/icon';
+import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { LowerCasePipe } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
-import { GioBannerModule, GioFormSelectionInlineModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormFilePickerModule, GioFormSelectionInlineModule, NewFile } from '@gravitee/ui-particles-angular';
 import { isEqual, pick } from 'lodash';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import {
   PortalNavigationApi,
@@ -44,6 +45,15 @@ import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { urlValidator } from '../../../shared/validators/url.validator';
 import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 import { NavigationItemSourceEditorComponent } from '../navigation-item-source-editor/navigation-item-source-editor.component';
+import {
+  extractTitleFromFileName,
+  ImportedFileContent,
+  ImportFileError,
+  IMPORTABLE_FILE_EXTENSIONS,
+  readImportedFile,
+  validateImportFile,
+} from '../portal-page-content-import.util';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 export type SectionEditorDialogMode = 'create' | 'edit';
 
@@ -70,6 +80,7 @@ export interface SectionEditorDialogResult {
   url?: string;
   contentType?: PortalPageContentType;
   source?: PortalNavigationItemSource;
+  content?: string;
 }
 
 export type SectionContentSource = 'FILL' | 'IMPORT_FILE' | 'EXTERNAL';
@@ -125,6 +136,8 @@ type SectionForm = FormGroup<SectionFormControls>;
     LowerCasePipe,
     MatTooltipModule,
     NavigationItemSourceEditorComponent,
+    GioFormFilePickerModule,
+    MatIconModule,
   ],
   templateUrl: './section-editor-dialog.component.html',
   styleUrls: ['./section-editor-dialog.component.scss'],
@@ -152,8 +165,22 @@ export class SectionEditorDialogComponent implements OnInit {
   public initialSource: PortalNavigationItemSource | undefined;
   private readonly sourceEditor = viewChild(NavigationItemSourceEditorComponent);
 
+  // --- File import state ---
+  readonly importFileControl = new FormControl<(NewFile | string)[]>([]);
+  readonly importFileAccept = IMPORTABLE_FILE_EXTENSIONS.join(',');
+  readonly importedFile = signal<ImportedFileContent | null>(null);
+  readonly importedFileName = signal<string | null>(null);
+  readonly importedContentTypeLabel = computed(() => {
+    const contentType = this.importedFile()?.contentType;
+    return PORTAL_PAGE_CONTENT_TYPE_OPTIONS.find(option => option.value === contentType)?.label ?? '';
+  });
+
+  showFileImport(): boolean {
+    return this.isCreatePageFlow() && this.contentSource() === 'IMPORT_FILE';
+  }
+
   showPageTypeSelection(): boolean {
-    return this.mode === 'create' && this.type === 'PAGE';
+    return this.mode === 'create' && this.type === 'PAGE' && this.contentSource() !== 'IMPORT_FILE';
   }
 
   isCreatePageFlow(): boolean {
@@ -176,6 +203,7 @@ export class SectionEditorDialogComponent implements OnInit {
   private readonly iconRegistry = inject(MatIconRegistry);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly apiService = inject(ApiV2Service);
+  private readonly snackBarService = inject(SnackBarService);
   private readonly destroyRef = inject(DestroyRef);
   readonly publicDisabled: Signal<boolean> = computed(() => {
     return isPublicVisibilityDisabled(this.data.parentItem);
@@ -218,6 +246,8 @@ export class SectionEditorDialogComponent implements OnInit {
       this.isSourceChoiceStep.set(true);
     }
 
+    this.importFileControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(files => this.onFilePicked(files ?? []));
+
     this.useExternalSourceControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(useSource => {
       if (!this.initialSource) {
         return;
@@ -235,6 +265,40 @@ export class SectionEditorDialogComponent implements OnInit {
 
   continueToDetails(): void {
     this.isSourceChoiceStep.set(false);
+  }
+
+  private onFilePicked(files: (NewFile | string)[]): void {
+    this.importedFile.set(null);
+    this.importedFileName.set(null);
+
+    const picked = files.find(file => file instanceof NewFile);
+    if (!picked?.file) {
+      return;
+    }
+    const file = picked.file;
+
+    const validationError = validateImportFile(file);
+    if (validationError) {
+      this.snackBarService.error(validationError);
+      return;
+    }
+
+    readImportedFile(file)
+      .pipe(
+        catchError(error => {
+          this.snackBarService.error(error instanceof ImportFileError ? error.message : `Failed to read "${file.name}"`);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(imported => {
+        this.importedFile.set(imported);
+        this.importedFileName.set(file.name);
+        this.form.controls.contentType?.setValue(imported.contentType);
+        if (!this.form.controls.title.value.trim()) {
+          this.form.controls.title.setValue(extractTitleFromFileName(file.name));
+        }
+      });
   }
 
   backToSourceChoice(): void {
@@ -263,7 +327,7 @@ export class SectionEditorDialogComponent implements OnInit {
         }),
       );
     }
-    if (this.showPageTypeSelection()) {
+    if (this.isCreatePageFlow()) {
       this.form.addControl('contentType', new FormControl<PortalPageContentType>('GRAVITEE_MARKDOWN', { nonNullable: true }));
     }
   }
@@ -297,8 +361,9 @@ export class SectionEditorDialogComponent implements OnInit {
       title: formValues.title,
       visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
       ...(this.type === 'LINK' ? { url: formValues.url! } : {}),
-      ...(this.showPageTypeSelection() && formValues.contentType ? { contentType: formValues.contentType } : {}),
+      ...(this.isCreatePageFlow() && formValues.contentType ? { contentType: formValues.contentType } : {}),
       ...(this.isExternalSourceActive() ? { source: this.sourceEditor()?.buildSource() ?? undefined } : {}),
+      ...(this.showFileImport() && this.importedFile() ? { content: this.importedFile()!.content } : {}),
     });
   }
 
@@ -309,6 +374,9 @@ export class SectionEditorDialogComponent implements OnInit {
   isSubmitDisabled(): boolean {
     if (!this.form.valid) {
       return true;
+    }
+    if (this.showFileImport()) {
+      return !this.importedFile();
     }
     if (this.isExternalSourceActive()) {
       const editor = this.sourceEditor();

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.harness.ts
@@ -17,7 +17,7 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
-import { GioFormSelectionInlineCardHarness } from '@gravitee/ui-particles-angular';
+import { GioFormFilePickerInputHarness, GioFormSelectionInlineCardHarness } from '@gravitee/ui-particles-angular';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 import { NavigationItemSourceEditorHarness } from '../navigation-item-source-editor/navigation-item-source-editor.harness';
@@ -51,6 +51,7 @@ export class SectionEditorDialogHarness extends ComponentHarness {
     GioFormSelectionInlineCardHarness.with({ ancestor: '.section-editor-dialog__page-types' }),
   );
   private locatePageTypeSection = this.locatorForOptional('.section-editor-dialog__page-types');
+  private readonly locateFilePicker = this.locatorForOptional(GioFormFilePickerInputHarness);
 
   async getTitleInput(): Promise<MatInputHarness> {
     return this.locateTitleInput();
@@ -191,5 +192,27 @@ export class SectionEditorDialogHarness extends ComponentHarness {
 
   async isSourceRemovalWarningDisplayed(): Promise<boolean> {
     return (await this.locateSourceRemovalWarning()) !== null;
+  }
+
+  // --- File import ---
+
+  async isFilePickerVisible(): Promise<boolean> {
+    return (await this.locateFilePicker()) !== null;
+  }
+
+  async getFilePickerAccept(): Promise<string | null> {
+    const picker = await this.locateFilePicker();
+    if (!picker) {
+      throw new Error('File picker not found');
+    }
+    return picker.getInputFileAccept();
+  }
+
+  async pickFile(file: File): Promise<void> {
+    const picker = await this.locateFilePicker();
+    if (!picker) {
+      throw new Error('File picker not found');
+    }
+    return picker.dropFiles([file]);
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -3075,6 +3075,12 @@ components:
           description: The updated content for the page
         configuration:
           $ref: "#/components/schemas/PortalPageOpenApiConfiguration"
+        type:
+          allOf:
+            - $ref: "#/components/schemas/PortalPageContentType"
+          description: >
+            When set and different from the current content type, the content is converted to this type.
+            Used by the file import, where the type is derived from the uploaded file extension.
       required: [ content ]
 
     # Subscription Forms

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -181,6 +181,30 @@ class PortalPageContentMapperTest {
     }
 
     @Test
+    void should_map_update_portal_page_content_type_to_core_type() {
+        // Given
+        var content = new UpdatePortalPageContent().content("openapi: 3.0.0").type(PortalPageContentType.OPENAPI);
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalPageContentType.OPENAPI);
+    }
+
+    @Test
+    void should_keep_core_type_null_when_update_has_no_type() {
+        // Given
+        var content = new UpdatePortalPageContent().content("# Hello");
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getType()).isNull();
+    }
+
+    @Test
     void should_map_update_portal_page_content_configuration_to_core_configuration() {
         // Given
         var content = new UpdatePortalPageContent()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
@@ -16,14 +16,19 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTooLargeException;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
 public class PortalPageContentValidatorService {
+
+    private static final int MAX_CONTENT_SIZE_IN_MEGA_BYTES = 10;
+    private static final int MAX_CONTENT_SIZE_IN_BYTES = MAX_CONTENT_SIZE_IN_MEGA_BYTES * 1024 * 1024;
 
     private final List<PortalPageContentValidator> validators;
 
@@ -32,5 +37,15 @@ public class PortalPageContentValidatorService {
             .stream()
             .filter(validator -> validator.appliesTo(existingContent))
             .forEach(validator -> validator.validate(existingContent, updateContent));
+    }
+
+    /**
+     * Deliberately not part of {@link #validateForUpdate}: the cap constrains the Management API update
+     * endpoint (file import) only, so Automation API flows keep accepting existing definitions unchanged.
+     */
+    public void validateContentSize(String content) {
+        if (content != null && content.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_SIZE_IN_BYTES) {
+            throw new PortalPageContentTooLargeException(MAX_CONTENT_SIZE_IN_MEGA_BYTES);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalPageContentTooLargeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalPageContentTooLargeException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public class PortalPageContentTooLargeException extends ValidationDomainException {
+
+    public PortalPageContentTooLargeException(int maxSizeInMegaBytes) {
+        super("Content must not exceed " + maxSizeInMegaBytes + " MB");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -15,12 +15,43 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import io.gravitee.apim.core.async_api.AsyncApi;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.open_api.OpenApi;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import lombok.Getter;
 
 @Getter
 public abstract sealed class PortalPageContent<T> permits GraviteeMarkdownPageContent, OpenApiPageContent, AsyncApiPageContent {
+
+    public static PortalPageContent<?> of(
+        @Nonnull PortalPageContentType type,
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull String content,
+        @Nullable AutomationMetadata automationMetadata
+    ) {
+        return switch (type) {
+            case GRAVITEE_MARKDOWN -> new GraviteeMarkdownPageContent(
+                id,
+                organizationId,
+                environmentId,
+                GraviteeMarkdown.of(content),
+                automationMetadata
+            );
+            case OPENAPI -> new OpenApiPageContent(
+                id,
+                organizationId,
+                environmentId,
+                OpenApi.of(content),
+                new RedocConfiguration(),
+                automationMetadata
+            );
+            case ASYNCAPI -> new AsyncApiPageContent(id, organizationId, environmentId, AsyncApi.of(content), automationMetadata);
+        };
+    }
 
     @Nonnull
     private final PortalPageContentId id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/UpdatePortalPageContent.java
@@ -28,4 +28,7 @@ public final class UpdatePortalPageContent {
 
     private String content;
     private OpenApiConfiguration configuration;
+
+    /** When set and different from the current type, the content is converted to this type (file import). */
+    private PortalPageContentType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCase.java
@@ -103,7 +103,7 @@ public class CreateOrUpdateApiDocumentationUseCase {
                 portalPageContentCrudService.delete(current.getId());
                 saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
             } else {
-                var updateContent = new UpdatePortalPageContent(sanitized.content(), null);
+                var updateContent = UpdatePortalPageContent.builder().content(sanitized.content()).build();
                 pageContentValidatorService.validateForUpdate(current, updateContent);
                 current.update(updateContent, meta);
                 saved = portalPageContentCrudService.update(current);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
@@ -109,7 +109,7 @@ public class CreateOrUpdatePortalDocumentationUseCase {
                 portalPageContentCrudService.delete(current.getId());
                 saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
             } else {
-                var updateContent = new UpdatePortalPageContent(sanitized.content(), null);
+                var updateContent = UpdatePortalPageContent.builder().content(sanitized.content()).build();
                 pageContentValidatorService.validateForUpdate(current, updateContent);
                 current.update(updateContent, meta);
                 saved = portalPageContentCrudService.update(current);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
@@ -62,11 +62,29 @@ public class UpdatePortalPageContentUseCase {
             throw InvalidPortalNavigationItemDataException.sourcedPageContentIsReadOnly(input.portalPageContentId());
         }
 
-        validatorService.validateForUpdate(existingContent, input.updatePortalPageContent());
+        PortalPageContent<?> targetContent = withRequestedType(existingContent, input.updatePortalPageContent());
 
-        existingContent.update(input.updatePortalPageContent());
+        validatorService.validateForUpdate(targetContent, input.updatePortalPageContent());
 
-        return new Output(portalPageContentCrudService.update(existingContent));
+        targetContent.update(input.updatePortalPageContent());
+
+        return new Output(portalPageContentCrudService.update(targetContent));
+    }
+
+    /** File import can change the content type: rebuild the content under its new type, keeping the same id. */
+    private PortalPageContent<?> withRequestedType(PortalPageContent<?> existingContent, UpdatePortalPageContent update) {
+        var requestedType = update.getType();
+        if (requestedType == null || requestedType == existingContent.getType()) {
+            return existingContent;
+        }
+        return PortalPageContent.of(
+            requestedType,
+            existingContent.getId(),
+            existingContent.getOrganizationId(),
+            existingContent.getEnvironmentId(),
+            update.getContent(),
+            existingContent.getAutomationMetadata()
+        );
     }
 
     private boolean isSourced(PortalNavigationPage page, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCase.java
@@ -64,6 +64,7 @@ public class UpdatePortalPageContentUseCase {
 
         PortalPageContent<?> targetContent = withRequestedType(existingContent, input.updatePortalPageContent());
 
+        validatorService.validateContentSize(input.updatePortalPageContent().getContent());
         validatorService.validateForUpdate(targetContent, input.updatePortalPageContent());
 
         targetContent.update(input.updatePortalPageContent());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTooLargeException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
@@ -54,6 +57,32 @@ class PortalPageContentValidatorServiceTest {
 
         // Then
         verify(mockValidator).appliesTo(existingContent);
+        verify(mockValidator).validate(existingContent, updateContent);
+    }
+
+    @Test
+    void should_throw_when_content_exceeds_the_max_size() {
+        assertThatThrownBy(() -> service.validateContentSize("a".repeat(10 * 1024 * 1024 + 1)))
+            .isInstanceOf(PortalPageContentTooLargeException.class)
+            .hasMessage("Content must not exceed 10 MB");
+    }
+
+    @Test
+    void should_accept_content_at_the_max_size() {
+        assertThatCode(() -> service.validateContentSize("a".repeat(10 * 1024 * 1024))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_not_check_the_size_on_update_validation() {
+        // Automation API flows go through validateForUpdate: the cap must not apply to them
+        PortalPageContent existingContent = GraviteeMarkdownPageContent.create("org", "env", "old");
+        UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("a".repeat(10 * 1024 * 1024 + 1)).build();
+        when(mockValidator.appliesTo(existingContent)).thenReturn(true);
+
+        // When
+        service.validateForUpdate(existingContent, updateContent);
+
+        // Then
         verify(mockValidator).validate(existingContent, updateContent);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -229,6 +230,80 @@ class UpdatePortalPageContentUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PageContentNotFoundException.class)
             .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_replace_content_type_when_requested_type_differs() {
+        // Given: CONTENT_ID holds a GRAVITEE_MARKDOWN content
+        final var updateContent = UpdatePortalPageContent.builder()
+            .content("openapi: 3.0.3\ninfo:\n  title: Imported")
+            .type(PortalPageContentType.OPENAPI)
+            .build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When
+        final var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent()).isInstanceOf(OpenApiPageContent.class);
+        assertThat(output.portalPageContent().getId()).isEqualTo(PortalPageContentId.of(CONTENT_ID));
+        final var updatedContent = (OpenApiPageContent) output.portalPageContent();
+        assertThat(updatedContent.getContent().value()).contains("title: Imported");
+    }
+
+    @Test
+    void should_keep_existing_type_when_requested_type_matches() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder()
+            .content("Updated content")
+            .type(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When
+        final var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent()).isInstanceOf(GraviteeMarkdownPageContent.class);
+        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("Updated content");
+    }
+
+    @Test
+    void should_validate_against_the_requested_type_when_type_changes() {
+        // Given: an OPENAPI content updated towards GRAVITEE_MARKDOWN with empty content
+        final var contentId = PortalPageContentId.of("00000000-0000-0000-0000-000000000003");
+        final var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "openapi: 3.0.3\ninfo:\n  title: Initial",
+            aSwaggerUiConfiguration()
+        );
+        queryService.initWith(List.of(openApiContent));
+        crudService.initWith(List.of(openApiContent));
+
+        final var updateContent = UpdatePortalPageContent.builder().content("").type(PortalPageContentType.GRAVITEE_MARKDOWN).build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(contentId.toString())
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(GraviteeMarkdownContentEmptyException.class)
+            .hasMessage("Content must not be null or empty");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosin
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTooLargeException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
@@ -147,6 +148,21 @@ class UpdatePortalPageContentUseCaseTest {
         final var updatedContent = (GraviteeMarkdownPageContent) output.portalPageContent();
         assertThat(updatedContent.getContent().value()).isEqualTo("Updated content");
         assertThat(updatedContent.getId()).isEqualTo(PortalPageContentId.of(CONTENT_ID));
+    }
+
+    @Test
+    void should_reject_update_when_content_exceeds_the_max_size() {
+        // Given
+        final var updateContent = UpdatePortalPageContent.builder().content("a".repeat(10 * 1024 * 1024 + 1)).build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(PortalPageContentTooLargeException.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-91

## Description

Import portal page content from a local file, on both entry points: the "Import from file" option of the Add page dialog (until now a disabled placeholder) and a new Import file button on an existing page. Accepts `.md`, `.yaml`, `.yml`, `.json`.

The content type is derived from the document itself rather than its extension, so an AsyncAPI spec no longer lands as an OpenAPI page. On the backend, the page content update endpoint accepts an optional `type` to convert a page in place, and rejects content over 10 MB.

## Additional context

https://github.com/user-attachments/assets/05994638-a8c6-4ac2-9a97-d57b5dd4ae4f