### PR TITLE
fix(console): edit portal source auto-fetch frequency with the cron builder

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.html
@@ -51,11 +51,10 @@
     <mat-slide-toggle data-testid="auto-fetch-toggle" [formControl]="useAutoFetchControl">Auto-fetch</mat-slide-toggle>
 
     @if (useAutoFetch()) {
-      <mat-form-field appearance="outline" class="source-editor__auto-fetch__cron">
-        <mat-label>Update frequency (cron expression)</mat-label>
-        <input matInput data-testid="fetch-cron-input" [formControl]="fetchCronControl" placeholder="0 */10 * * * *" />
-        <mat-hint>Example: "0 */10 * * * *" fetches every 10 minutes</mat-hint>
-      </mat-form-field>
+      <gio-form-cron data-testid="fetch-cron-input" class="source-editor__auto-fetch__cron" [formControl]="fetchCronControl">
+        <gio-form-cron-label>Update frequency</gio-form-cron-label>
+        <gio-form-cron-hint>Required when auto-fetch is enabled</gio-form-cron-hint>
+      </gio-form-cron>
     }
   </div>
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.spec.ts
@@ -130,4 +130,23 @@ describe('NavigationItemSourceEditorComponent', () => {
       }),
     ]);
   });
+
+  it('disables save when the persisted cron of an auto-fetch source is invalid', async () => {
+    await createComponent({ ...githubSource, useAutoFetch: true, fetchCron: 'not a cron' }, false);
+
+    expect(await harness.isSaveDisabled()).toBe(true);
+  });
+
+  it('edits the auto-fetch frequency with the cron builder and blocks save on an invalid expression', async () => {
+    await createComponent(githubSource, false);
+
+    await harness.toggleAutoFetch();
+    fixture.detectChanges();
+
+    await harness.setCron('not a cron');
+    expect(await harness.isSaveDisabled()).toBe(true);
+
+    await harness.setCron('0 */10 * * * *');
+    expect(await harness.isSaveDisabled()).toBe(false);
+  });
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
@@ -21,7 +21,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { GioBannerModule, GioFormJsonSchemaModule, GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormCronModule, GioFormJsonSchemaModule, GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { catchError, debounceTime, map, tap } from 'rxjs/operators';
 import { of, Subject, Subscription } from 'rxjs';
 import { DatePipe } from '@angular/common';
@@ -76,6 +76,7 @@ export function stripLegacyAutoFetchFromSchema(schema: GioJsonSchema): GioJsonSc
     MatSelectModule,
     MatSlideToggleModule,
     GioBannerModule,
+    GioFormCronModule,
     GioFormJsonSchemaModule,
     DatePipe,
   ],
@@ -101,6 +102,7 @@ export class NavigationItemSourceEditorComponent {
   readonly selectedType = toSignal(this.typeControl.valueChanges, { initialValue: this.typeControl.value });
   readonly useAutoFetch = toSignal(this.useAutoFetchControl.valueChanges, { initialValue: this.useAutoFetchControl.value });
   readonly fetchCron = toSignal(this.fetchCronControl.valueChanges, { initialValue: this.fetchCronControl.value });
+  private readonly fetchCronStatus = toSignal(this.fetchCronControl.statusChanges, { initialValue: this.fetchCronControl.status });
   private readonly configurationInvalid = signal(false);
   private readonly rebuildConfiguration$ = new Subject<string | null>();
   private configurationSubscription?: Subscription;
@@ -129,7 +131,10 @@ export class NavigationItemSourceEditorComponent {
     if (this.disabled() || !this.selectedType() || !this.selectedSchema() || this.configurationInvalid()) {
       return true;
     }
-    return this.useAutoFetch() && !this.fetchCron()?.trim();
+    if (!this.useAutoFetch()) {
+      return false;
+    }
+    return !this.fetchCron()?.trim() || this.fetchCronStatus() === 'INVALID';
   });
 
   private readonly rebuildConfigurationSubscription = this.rebuildConfiguration$
@@ -159,6 +164,14 @@ export class NavigationItemSourceEditorComponent {
       this.resetFormFromSource(source);
     } else if (fetchers.length > 0 && this.selectedType() && !this.selectedSchema()) {
       this.rebuildConfiguration$.next(this.selectedType());
+    }
+  });
+
+  // The cron field renders only while auto-fetch is on, and its validator attaches with
+  // emitEvent: false — statusChanges misses that recalculation, so re-run it once rendered
+  private readonly observeCronValidityOnRender = effect(() => {
+    if (this.useAutoFetch()) {
+      queueMicrotask(() => this.fetchCronControl.updateValueAndValidity());
     }
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.harness.ts
@@ -18,13 +18,14 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { GioFormCronHarness } from '@gravitee/ui-particles-angular';
 
 export class NavigationItemSourceEditorHarness extends ComponentHarness {
   static readonly hostSelector = 'navigation-item-source-editor';
 
   private readonly locateTypeSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="source-type-select"]' }));
   private readonly locateAutoFetchToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid="auto-fetch-toggle"]' }));
-  private readonly locateCronInput = this.locatorForOptional(MatInputHarness.with({ selector: '[data-testid="fetch-cron-input"]' }));
+  private readonly locateCronInput = this.locatorForOptional(GioFormCronHarness.with({ selector: '[data-testid="fetch-cron-input"]' }));
   private readonly locateSaveButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="save-source-button"]' }));
   private readonly locateRemoveButton = this.locatorForOptional(
     MatButtonHarness.with({ selector: '[data-testid="remove-source-button"]' }),
@@ -72,7 +73,7 @@ export class NavigationItemSourceEditorHarness extends ComponentHarness {
 
   async setCron(cron: string): Promise<void> {
     const input = await this.locateCronInput();
-    await input?.setValue(cron);
+    await input?.setCustomValue(cron);
   }
 
   async getCron(): Promise<string | null> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-89

## Description

The source editor rendered the auto-fetch frequency as a raw cron text input, while fetcher plugin schemas declare `fetchCron` with format: "`gio-cron`" — losing the frequency builder UI users had in the v4 documentation screens.

The raw input is replaced with the `GioFormCron` widget (same as health-check). As a bonus, the widget validates the expression, so saving is now blocked on an invalid cron instead of sending any string to the backend.

## Additional context

<img width="1496" height="820" alt="Capture d’écran 2026-08-20 à 10 52 22" src="https://github.com/user-attachments/assets/0449b109-a256-4693-bfc8-09511e490cbe" />