### PR TITLE
feat(automation): api-referenced links automation - openApi and resources

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalLinkMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalLinkMapper.java
@@ -39,7 +39,17 @@ public interface PortalLinkMapper {
         AuditInfo audit,
         String portalHrid
     ) {
-        var state = new PortalLinkState(id, audit.environmentId(), audit.organizationId(), toErrors(errors), portalHrid);
+        var state = new PortalLinkState(id, audit.environmentId(), audit.organizationId(), toErrors(errors), portalHrid, null);
+        state.setHrid(spec.getHrid());
+        state.setName(spec.getName());
+        state.setHref(spec.getHref());
+        state.setLocation(spec.getLocation());
+        state.setOrder(spec.getOrder());
+        return state;
+    }
+
+    default PortalLinkState toApiLinkState(PortalLinkSpec spec, String id, List<Validator.Error> errors, AuditInfo audit, String apiHrid) {
+        var state = new PortalLinkState(id, audit.environmentId(), audit.organizationId(), toErrors(errors), null, apiHrid);
         state.setHrid(spec.getHrid());
         state.setName(spec.getName());
         state.setHref(spec.getHref());
@@ -54,7 +64,25 @@ public interface PortalLinkMapper {
             link.getEnvironmentId(),
             link.getOrganizationId(),
             null,
-            portalHrid
+            portalHrid,
+            null
+        );
+        state.setHrid(hrid);
+        state.setName(link.getTitle());
+        state.setHref(link.getUrl());
+        state.setOrder(link.getOrder());
+        state.setLocation(link.getAutomationMetadata() != null ? link.getAutomationMetadata().location().orElse(null) : null);
+        return state;
+    }
+
+    default PortalLinkState toApiLinkState(PortalNavigationLink link, String hrid, String apiHrid) {
+        var state = new PortalLinkState(
+            link.getId() != null ? link.getId().toString() : null,
+            link.getEnvironmentId(),
+            link.getOrganizationId(),
+            null,
+            null,
+            apiHrid
         );
         state.setHrid(hrid);
         state.setName(link.getTitle());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.use_case.DeleteApiLinkUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetApiLinkUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.PortalLinkMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApiLinkResource extends AbstractResource {
+
+    @Inject
+    private GetApiLinkUseCase getApiLinkUseCase;
+
+    @Inject
+    private DeleteApiLinkUseCase deleteApiLinkUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.READ) })
+    public Response getApiLinkByHRID(@PathParam("apiHrid") String apiHrid, @PathParam("linkHrid") String linkHrid) {
+        var auditInfo = getAuditInfo();
+        var apiId = HRIDToUUID.api().context(auditInfo).hrid(apiHrid).id();
+        var linkId = PortalNavigationItemId.forApiLink(auditInfo, apiId, linkHrid);
+        try {
+            var output = getApiLinkUseCase.execute(new GetApiLinkUseCase.Input(auditInfo, linkId));
+            return Response.ok(PortalLinkMapper.INSTANCE.toApiLinkState(output.link(), linkHrid, apiHrid)).build();
+        } catch (PortalLinkNotFoundException e) {
+            throw new HRIDNotFoundException(linkHrid);
+        }
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.DELETE) })
+    public Response deleteApiLinkByHrid(@PathParam("apiHrid") String apiHrid, @PathParam("linkHrid") String linkHrid) {
+        var auditInfo = getAuditInfo();
+        var apiId = HRIDToUUID.api().context(auditInfo).hrid(apiHrid).id();
+        var linkId = PortalNavigationItemId.forApiLink(auditInfo, apiId, linkHrid);
+        try {
+            deleteApiLinkUseCase.execute(new DeleteApiLinkUseCase.Input(auditInfo, linkId));
+        } catch (PortalLinkNotFoundException e) {
+            throw new HRIDNotFoundException(linkHrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinksResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinksResource.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiLinkUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidateApiLinkUseCase;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.mapper.PortalLinkMapper;
+import io.gravitee.apim.rest.api.automation.model.PortalLinkSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApiLinksResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreateOrUpdateApiLinkUseCase createOrUpdateApiLinkUseCase;
+
+    @Inject
+    private ValidateApiLinkUseCase validateApiLinkUseCase;
+
+    @Path("/{linkHrid}")
+    public ApiLinkResource getApiLinkResource() {
+        return resourceContext.getResource(ApiLinkResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(
+        @PathParam("apiHrid") String apiHrid,
+        @Valid @NotNull PortalLinkSpec spec,
+        @QueryParam("dryRun") boolean dryRun
+    ) {
+        var auditInfo = getAuditInfo();
+        var apiId = HRIDToUUID.api().context(auditInfo).hrid(apiHrid).id();
+        var linkId = PortalNavigationItemId.forApiLink(auditInfo, apiId, spec.getHrid());
+
+        var input = new CreateOrUpdateApiLinkUseCase.Input(
+            auditInfo,
+            apiId,
+            spec.getHrid(),
+            spec.getName(),
+            spec.getHref(),
+            spec.getLocation(),
+            spec.getOrder()
+        );
+        var output = dryRun ? validateApiLinkUseCase.execute(input) : createOrUpdateApiLinkUseCase.execute(input);
+
+        var state = PortalLinkMapper.INSTANCE.toApiLinkState(spec, linkId.toString(), output.errors(), auditInfo, apiHrid);
+
+        // A dry run is a preview: severe findings are its payload, so it always answers 200.
+        // A real apply that produced severe errors persisted nothing — it must not report success.
+        var applyFailed = !dryRun && output.errors().stream().anyMatch(Validator.Error::isSevere);
+
+        return Response.status(applyFailed ? Response.Status.BAD_REQUEST : Response.Status.OK).entity(state).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiResource.java
@@ -88,6 +88,11 @@ public class ApiResource extends AbstractResource {
         return resourceContext.getResource(ApiDocumentationsResource.class);
     }
 
+    @Path("links")
+    public ApiLinksResource getLinksResource() {
+        return resourceContext.getResource(ApiLinksResource.class);
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1054,6 +1054,86 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  # API Links
+  /organizations/{orgId}/environments/{envId}/apis/{apiHrid}/links:
+    put:
+      operationId: createOrUpdateApiLink
+      tags:
+        - API Links
+      summary: Create or update an API Link
+      description: Create or update a Link attached to an API
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/apiHridParam"
+        - $ref: "#/components/parameters/dryRunQueryParam"
+      requestBody:
+        description: Portal Link specification
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/PortalLinkSpec"
+        required: true
+      responses:
+        "200":
+          description: State of the successfully created/updated Link
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalLinkState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/Error"
+  /organizations/{orgId}/environments/{envId}/apis/{apiHrid}/links/{hrid}:
+    parameters:
+      - $ref: "#/components/parameters/orgIdParam"
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiHridParam"
+      - $ref: "#/components/parameters/hridParam"
+    get:
+      operationId: getApiLink
+      tags:
+        - API Links
+      summary: Get one API Link
+      description: Get an API Link using HRID
+      responses:
+        "200":
+          description: Link successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalLinkState"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      operationId: deleteApiLink
+      tags:
+        - API Links
+      summary: Delete one API Link
+      description: Delete an API Link using HRID
+      responses:
+        "204":
+          description: Link successfully deleted
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+
 components:
   schemas:
     Hrid:
@@ -3542,6 +3622,7 @@ components:
       description: |
         Specification of a Portal Link.
         An external navigation entry placed in a portal's navigation — a thin wrapper around a URL, with no separate content of its own.
+        A link is attached to either a portal or an API, determined by the endpoint used.
       type: object
       properties:
         hrid:
@@ -3560,6 +3641,9 @@ components:
           type: string
           description: |
             The path in the navigation hierarchy where this link should appear.
+            Resolved against the portal's navigation for a portal-attached link, and against the API's own
+            navigation for an API-attached link — the same path string therefore denotes a different tree
+            depending on which endpoint was used.
           examples:
             - /projects/alpha
         order:
@@ -3570,14 +3654,20 @@ components:
         - name
         - href
     PortalLinkStatus:
-      description: Status information for a Portal Link after import.
+      description: |
+        Status information for a Portal Link after import.
+        Exactly one of `portalHrid` / `apiHrid` is populated depending on the parent endpoint used.
       allOf:
         - $ref: "#/components/schemas/BaseStatus"
         - type: object
           properties:
             portalHrid:
               type: string
-              description: The HRID of the portal this link belongs to.
+              description: The HRID of the portal this link belongs to (when attached to a portal).
+              readOnly: true
+            apiHrid:
+              type: string
+              description: The HRID of the API this link belongs to (when attached to an API).
               readOnly: true
     PortalLinkState:
       description: State of a Portal Link that has been created/updated.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/PortalLinkMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/PortalLinkMapperTest.java
@@ -150,6 +150,26 @@ class PortalLinkMapperTest {
         assertThat(state.getLocation()).isNull();
     }
 
+    @Test
+    void api_link_state_populates_api_hrid_and_leaves_portal_hrid_null() {
+        var state = PortalLinkMapper.INSTANCE.toApiLinkState(aSpec(), LINK_ID.toString(), List.of(), AUDIT, "my-api");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(state.getApiHrid()).isEqualTo("my-api");
+            soft.assertThat(state.getPortalHrid()).isNull();
+        });
+    }
+
+    @Test
+    void portal_link_state_still_populates_portal_hrid_and_leaves_api_hrid_null() {
+        var state = PortalLinkMapper.INSTANCE.toPortalLinkState(aSpec(), LINK_ID.toString(), List.of(), AUDIT, "default-portal");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(state.getPortalHrid()).isEqualTo("default-portal");
+            soft.assertThat(state.getApiHrid()).isNull();
+        });
+    }
+
     private static PortalLinkSpec aSpec() {
         var spec = new PortalLinkSpec();
         spec.setHrid("external-docs");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiLinkUseCase;
+import io.gravitee.apim.core.portal_page.use_case.DeleteApiLinkUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetApiLinkUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidateApiLinkUseCase;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.PortalLinkState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiLinkResourceTest extends AbstractResourceTest {
+
+    private static final String API_HRID = "my-api";
+    private static final String LINK_HRID = "external-docs";
+
+    @Inject
+    private CreateOrUpdateApiLinkUseCase createOrUpdateApiLinkUseCase;
+
+    @Inject
+    private ValidateApiLinkUseCase validateApiLinkUseCase;
+
+    @Inject
+    private GetApiLinkUseCase getApiLinkUseCase;
+
+    @Inject
+    private DeleteApiLinkUseCase deleteApiLinkUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdateApiLinkUseCase, validateApiLinkUseCase, getApiLinkUseCase, deleteApiLinkUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/apis/" + API_HRID + "/links";
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_apply_and_return_the_api_link_state() {
+            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(new CreateOrUpdateApiLinkUseCase.Output(null, List.of()));
+
+            try (
+                var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdateApiLinkUseCase).execute(any(CreateOrUpdateApiLinkUseCase.Input.class));
+
+                var state = response.readEntity(PortalLinkState.class);
+                assertThat(state.getApiHrid()).isEqualTo(API_HRID);
+                assertThat(state.getPortalHrid()).isNull();
+            }
+        }
+
+        @Test
+        void should_return_400_with_severe_errors_when_apply_fails_validation() {
+            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
+            );
+
+            try (
+                var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+
+                var state = response.readEntity(PortalLinkState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("href");
+            }
+        }
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_when_validation_passes() {
+            when(validateApiLinkUseCase.execute(any())).thenReturn(new CreateOrUpdateApiLinkUseCase.Output(null, List.of()));
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(validateApiLinkUseCase).execute(any(CreateOrUpdateApiLinkUseCase.Input.class));
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+
+                var state = response.readEntity(PortalLinkState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("External Docs");
+                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
+                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
+                    soft.assertThat(state.getPortalHrid()).isNull();
+                    soft.assertThat(state.getErrors()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_state_with_errors_when_validation_fails() {
+            when(validateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
+            );
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+
+                var state = response.readEntity(PortalLinkState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("href");
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(validateApiLinkUseCase);
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_the_link() {
+            when(getApiLinkUseCase.execute(any())).thenReturn(new GetApiLinkUseCase.Output(aLink()));
+
+            try (var response = rootTarget(LINK_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getApiLinkUseCase).execute(any(GetApiLinkUseCase.Input.class));
+
+                var state = response.readEntity(PortalLinkState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("External Docs");
+                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
+                    soft.assertThat(state.getOrder()).isEqualTo(3);
+                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
+                    soft.assertThat(state.getPortalHrid()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_the_link_does_not_exist() {
+            when(getApiLinkUseCase.execute(any())).thenThrow(new PortalLinkNotFoundException(LINK_HRID));
+
+            try (var response = rootTarget(LINK_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_the_link() {
+            try (var response = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deleteApiLinkUseCase).execute(any(DeleteApiLinkUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_return_404_when_the_link_does_not_exist() {
+            doThrow(new PortalLinkNotFoundException(LINK_HRID)).when(deleteApiLinkUseCase).execute(any());
+
+            try (var response = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    private static PortalNavigationLink aLink() {
+        return PortalNavigationLink.builder()
+            .id(PortalNavigationItemId.of("11111111-1111-1111-1111-111111111111"))
+            .organizationId(ORGANIZATION)
+            .environmentId(ENVIRONMENT)
+            .title("External Docs")
+            .segment(LINK_HRID)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(3)
+            .url("https://docs.example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .automationMetadata(
+                new AutomationMetadata(AutomationMetadata.ReferenceType.API, "api-1", null, Optional.empty(), Optional.empty())
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -161,19 +161,23 @@ import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQuerySer
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.DeleteApiDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.DeleteApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.DeletePortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.DeletePortalLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetApiDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidateApiDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidateApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidatePortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidatePortalLinkUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
@@ -1442,6 +1446,26 @@ public class ResourceContextConfiguration {
     @Bean
     public DeletePortalLinkUseCase deletePortalLinkUseCase() {
         return mock(DeletePortalLinkUseCase.class);
+    }
+
+    @Bean
+    public CreateOrUpdateApiLinkUseCase createOrUpdateApiLinkUseCase() {
+        return mock(CreateOrUpdateApiLinkUseCase.class);
+    }
+
+    @Bean
+    public ValidateApiLinkUseCase validateApiLinkUseCase() {
+        return mock(ValidateApiLinkUseCase.class);
+    }
+
+    @Bean
+    public GetApiLinkUseCase getApiLinkUseCase() {
+        return mock(GetApiLinkUseCase.class);
+    }
+
+    @Bean
+    public DeleteApiLinkUseCase deleteApiLinkUseCase() {
+        return mock(DeleteApiLinkUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-link.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-link.json
@@ -1,0 +1,5 @@
+{
+  "hrid": "external-docs",
+  "name": "External Docs",
+  "href": "https://docs.example.com"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-api-link.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-api-link.json
@@ -1,0 +1,4 @@
+{
+  "name": "Missing HRID",
+  "href": "https://docs.example.com"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -31,6 +31,7 @@ import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
@@ -100,6 +101,7 @@ public class PortalNavigationSyncDomainService {
             auditInfo,
             area,
             null,
+            NavigationItemReference.defaultReference(),
             portalIdFolderFactory(auditInfo, portalId),
             ctx.ownership().asDeleteStrategy()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -53,13 +54,14 @@ public final class NavigationSyncPlanExecutor {
         PortalArea area,
         // null for top-level portal navigation; the nav-api row for api-folder subtrees
         @Nullable PortalNavigationItemContainer root,
+        NavigationItemReference reference,
         Function<String, PortalNavigationItemId> idFactory,
         DeleteStrategy strategy
     ) {
         final var byPath = new HashMap<String, PortalNavigationItemContainer>();
         for (var action : plan.actions()) {
             switch (action) {
-                case FolderActions.FolderMutation m -> applyMutation(m, byPath, auditInfo, area, root, idFactory);
+                case FolderActions.FolderMutation m -> applyMutation(m, byPath, auditInfo, area, root, reference, idFactory);
                 case FolderActions.DeleteFolder d -> applyDelete(d, auditInfo.environmentId(), strategy);
             }
         }
@@ -71,12 +73,13 @@ public final class NavigationSyncPlanExecutor {
         AuditInfo auditInfo,
         PortalArea area,
         PortalNavigationItemContainer root,
+        NavigationItemReference reference,
         Function<String, PortalNavigationItemId> idFactory
     ) {
         final var df = mutation.desired();
         final var parent = df.parentPath() == null ? root : byPath.get(df.parentPath());
         final PortalNavigationFolder result = switch (mutation) {
-            case FolderActions.CreateFolder c -> createFolder(c.desired(), parent, auditInfo, area, idFactory);
+            case FolderActions.CreateFolder c -> createFolder(c.desired(), parent, auditInfo, area, reference, idFactory);
             case FolderActions.UpdateFolder u -> applyUpdate(u.existing(), u.desired(), parent);
         };
         byPath.put(df.path(), result);
@@ -110,11 +113,12 @@ public final class NavigationSyncPlanExecutor {
         PortalNavigationItemContainer parent,
         AuditInfo auditInfo,
         PortalArea area,
+        NavigationItemReference reference,
         Function<String, PortalNavigationItemId> idFactory
     ) {
         final var folderId = idFactory.apply(df.path());
         final var parentId = parent == null ? null : parent.getId();
-        rejectIfSegmentTakenByForeignItem(auditInfo, parentId, df.segment().value(), folderId, df.path());
+        rejectIfSegmentTakenByForeignItem(auditInfo, parentId, df.segment().value(), folderId, df.path(), reference);
         final var create = CreatePortalNavigationItem.builder()
             .id(folderId)
             .title(df.title())
@@ -122,6 +126,7 @@ public final class NavigationSyncPlanExecutor {
             .area(area)
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
+            .reference(reference)
             .published(true)
             .build();
         return (PortalNavigationFolder) crudService.create(
@@ -134,10 +139,11 @@ public final class NavigationSyncPlanExecutor {
         @Nullable PortalNavigationItemId parentId,
         String segment,
         PortalNavigationItemId expectedId,
-        String path
+        String path,
+        NavigationItemReference reference
     ) {
         queryService
-            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
+            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment, reference)
             .filter(sibling -> !sibling.getId().equals(expectedId))
             .ifPresent(squatter -> {
                 throw PathConflictException.folderPath(path);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryService.java
@@ -24,7 +24,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,6 @@ import lombok.RequiredArgsConstructor;
 public class AutomationManagedNavigationItemsQueryService {
 
     private final PortalListingCrudService portalListingCrudService;
-    private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
 
     public Set<PortalNavigationItemId> activeListingApiRows(AuditInfo auditInfo, PortalId portalId) {
@@ -61,16 +59,26 @@ public class AutomationManagedNavigationItemsQueryService {
     }
 
     public Set<PortalNavigationItemId> automationManagedApiDocPages(AuditInfo auditInfo, String apiId) {
-        return portalPageContentQueryService
-            .findByReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
+        return portalNavigationItemsQueryService
+            .findByAutomationReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
             .stream()
-            .map(pc -> PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, pc.getId()))
+            .filter(item -> item.getType() == PortalNavigationItemType.PAGE)
+            .map(PortalNavigationItem::getId)
             .collect(Collectors.toSet());
     }
 
     public Set<PortalNavigationItemId> automationManagedPortalLinks(AuditInfo auditInfo, PortalId portalId) {
         return portalNavigationItemsQueryService
             .findByAutomationReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.PORTAL, portalId.toString())
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItemType.LINK)
+            .map(PortalNavigationItem::getId)
+            .collect(Collectors.toSet());
+    }
+
+    public Set<PortalNavigationItemId> automationManagedApiLinks(AuditInfo auditInfo, String apiId) {
+        return portalNavigationItemsQueryService
+            .findByAutomationReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
             .stream()
             .filter(item -> item.getType() == PortalNavigationItemType.LINK)
             .map(PortalNavigationItem::getId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -30,7 +30,7 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -45,7 +45,7 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
-/** Reconciles the api-folder subtree under a {@link PortalNavigationApi} row against the api's {@code portalNavigation}. */
+/** Reconciles the api-folder subtree for an API, keyed on the API itself, against the api's {@code portalNavigation}. */
 @DomainService
 @RequiredArgsConstructor
 class ApiFolderSubtreeReconciler {
@@ -55,36 +55,30 @@ class ApiFolderSubtreeReconciler {
     private final NavigationSyncPlanExecutor planExecutor;
     private final AutomationManagedNavigationItemsQueryService automationManagedNavigationItemsQueryService;
 
-    void sync(
-        AuditInfo auditInfo,
-        PortalNavigationApi navApi,
-        String apiId,
-        List<NavigationPath> previousPaths,
-        List<PortalNavigationItem> currentFolders
-    ) {
+    void sync(AuditInfo auditInfo, String apiId, List<NavigationPath> previousPaths, List<PortalNavigationItem> currentFolders) {
         var desired = desiredPaths(apiId);
         var ownership = ownership(auditInfo, apiId, desired);
         var plan = NavigationSyncPlanner.plan(desired, currentFolders, previousPaths, ownership);
         Function<String, PortalNavigationItemId> idMapper = path -> apiFolderId(auditInfo, apiId, path);
         var deleteStrategy = ownership.asDeleteStrategy();
-        planExecutor.execute(plan, auditInfo, navApi.getArea(), navApi, idMapper, deleteStrategy);
+        planExecutor.execute(
+            plan,
+            auditInfo,
+            PortalArea.TOP_NAVBAR,
+            null,
+            new NavigationItemReference.ApiReference(apiId),
+            idMapper,
+            deleteStrategy
+        );
+    }
+
+    ValidationItems itemsForValidation(AuditInfo auditInfo, String apiId, List<PortalNavigationItem> currentFolders) {
+        return itemsForValidation(auditInfo, apiId, desiredPaths(apiId), currentFolders);
     }
 
     ValidationItems itemsForValidation(
         AuditInfo auditInfo,
         String apiId,
-        PortalNavigationItemId navApiId,
-        PortalArea area,
-        List<PortalNavigationItem> currentFolders
-    ) {
-        return itemsForValidation(auditInfo, apiId, navApiId, area, desiredPaths(apiId), currentFolders);
-    }
-
-    ValidationItems itemsForValidation(
-        AuditInfo auditInfo,
-        String apiId,
-        PortalNavigationItemId navApiId,
-        PortalArea area,
         List<NavigationPath> desired,
         List<PortalNavigationItem> currentFolders
     ) {
@@ -97,14 +91,14 @@ class ApiFolderSubtreeReconciler {
             .filter(FolderActions.CreateFolder.class::isInstance)
             .map(FolderActions.CreateFolder.class::cast)
             .map(FolderActions.CreateFolder::desired)
-            .map(df -> toCreateItem(df, area, idFactory, navApiId, apiId))
+            .map(df -> toCreateItem(df, idFactory, apiId))
             .toList();
         var updates = plan
             .actions()
             .stream()
             .filter(FolderActions.UpdateFolder.class::isInstance)
             .map(FolderActions.UpdateFolder.class::cast)
-            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory, navApiId), action.existing()))
+            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory), action.existing()))
             .toList();
         return new ValidationItems(creates, updates);
     }
@@ -113,19 +107,18 @@ class ApiFolderSubtreeReconciler {
 
     private static CreatePortalNavigationItem toCreateItem(
         FolderActions.DesiredFolder df,
-        PortalArea area,
         Function<String, PortalNavigationItemId> idFactory,
-        PortalNavigationItemId navApiId,
         String apiId
     ) {
         return CreatePortalNavigationItem.builder()
             .id(idFactory.apply(df.path()))
             .title(df.title())
             .segment(df.segment().value())
-            .area(area)
+            .area(PortalArea.TOP_NAVBAR)
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
-            .parentId(df.parentPath() == null ? navApiId : idFactory.apply(df.parentPath()))
+            .parentId(df.parentPath() == null ? null : idFactory.apply(df.parentPath()))
+            .reference(new NavigationItemReference.ApiReference(apiId))
             .published(true)
             .automationMetadata(
                 new AutomationMetadata(AutomationMetadata.ReferenceType.API, apiId, null, Optional.of(df.path()), Optional.empty())
@@ -135,15 +128,14 @@ class ApiFolderSubtreeReconciler {
 
     private static UpdatePortalNavigationItem toUpdateItem(
         FolderActions.DesiredFolder df,
-        Function<String, PortalNavigationItemId> idFactory,
-        PortalNavigationItemId navApiId
+        Function<String, PortalNavigationItemId> idFactory
     ) {
         return UpdatePortalNavigationItem.builder()
             .title(df.title())
             .segment(df.segment().value())
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
-            .parentId(df.parentPath() == null ? navApiId : idFactory.apply(df.parentPath()))
+            .parentId(df.parentPath() == null ? null : idFactory.apply(df.parentPath()))
             .build();
     }
 
@@ -153,25 +145,20 @@ class ApiFolderSubtreeReconciler {
         );
     }
 
-    List<PortalNavigationItem> collectFolderDescendantsFrom(List<PortalNavigationItem> envFolders, PortalNavigationItemId rootId) {
-        var collector = new FolderCollector();
-        PortalNavigationTreeWalker.walkFrom(envFolders, rootId, collector);
-        return collector.collected();
-    }
-
-    List<PortalNavigationApi> navApiRowsFor(AuditInfo auditInfo, String apiId) {
-        return navigationItemsQueryService
-            .search(
-                PortalNavigationItemQueryCriteria.builder()
-                    .environmentId(auditInfo.environmentId())
-                    .type(PortalNavigationItemType.API)
-                    .apiIds(Set.of(apiId))
-                    .build()
-            )
+    List<PortalNavigationItem> collectFolderDescendantsFrom(List<PortalNavigationItem> envFolders, String apiId) {
+        var reference = new NavigationItemReference.ApiReference(apiId);
+        var collected = new ArrayList<PortalNavigationItem>();
+        envFolders
             .stream()
-            .filter(PortalNavigationApi.class::isInstance)
-            .map(PortalNavigationApi.class::cast)
-            .toList();
+            .filter(folder -> reference.equals(folder.getReference()))
+            .filter(PortalNavigationItem::isRoot)
+            .forEach(root -> {
+                collected.add(root);
+                var walker = new FolderCollector();
+                PortalNavigationTreeWalker.walkFrom(envFolders, root.getId(), walker);
+                collected.addAll(walker.collected());
+            });
+        return collected;
     }
 
     List<NavigationPath> desiredPaths(String apiId) {
@@ -187,7 +174,7 @@ class ApiFolderSubtreeReconciler {
             path -> apiFolderId(auditInfo, apiId, path),
             automationManagedNavigationItemsQueryService.automationManagedApiDocPages(auditInfo, apiId),
             Set.of(),
-            Set.of()
+            automationManagedNavigationItemsQueryService.automationManagedApiLinks(auditInfo, apiId)
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudSe
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -39,7 +40,7 @@ import io.gravitee.apim.core.slug.model.Slug;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
-/** Owns the {@link PortalNavigationApi} row lifecycle (upsert at the deterministic id, cascade-dematerialize). */
+/** Owns the {@link PortalNavigationApi} row lifecycle (upsert at the deterministic id, row-only dematerialize). */
 @DomainService
 @RequiredArgsConstructor
 class NavigationItemEntryMaterializer {
@@ -136,7 +137,7 @@ class NavigationItemEntryMaterializer {
     ) {
         var parentId = Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
         navigationItemsQueryService
-            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
+            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment, NavigationItemReference.defaultReference())
             .filter(sibling -> !sibling.getId().equals(expectedId))
             .ifPresent(squatter -> {
                 throw PathConflictException.segmentTaken(PathConflictException.EntryKind.LISTING, location);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -21,7 +21,6 @@ import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationVa
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
-import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.domain_service.ApiFolderSubtreeReconciler.ValidationItems;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
@@ -68,24 +67,19 @@ public class PortalListingSyncDomainService {
             var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
             for (var entry : listing.getApis()) {
                 var apiId = entry.apiId(auditInfo);
-                var navApi = navigationItemEntryMaterializer.upsert(auditInfo, portalId, apiId, entry);
-                var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-                apiFolderSubtreeReconciler.sync(auditInfo, navApi, apiId, List.of(), currentFolders);
+                navigationItemEntryMaterializer.upsert(auditInfo, portalId, apiId, entry);
+                var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, apiId);
+                apiFolderSubtreeReconciler.sync(auditInfo, apiId, List.of(), currentFolders);
                 materializeApiDocs(auditInfo, apiId);
             }
         }
     }
 
-    /** Reconciles the api-folder subtree under every nav-api row for this api, then re-materializes its doc pages. */
+    /** Reconciles the api-folder subtree for this api, then re-materializes its doc pages. */
     public void syncApiFolders(AuditInfo auditInfo, String apiId, List<NavigationPath> previousPaths) {
-        var navApis = apiFolderSubtreeReconciler.navApiRowsFor(auditInfo, apiId);
-        if (!navApis.isEmpty()) {
-            var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
-            for (var navApi : navApis) {
-                var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-                apiFolderSubtreeReconciler.sync(auditInfo, navApi, apiId, previousPaths, currentFolders);
-            }
-        }
+        var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
+        var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, apiId);
+        apiFolderSubtreeReconciler.sync(auditInfo, apiId, previousPaths, currentFolders);
         materializeApiDocs(auditInfo, apiId);
     }
 
@@ -132,8 +126,7 @@ public class PortalListingSyncDomainService {
 
     private ValidationItems validationItemsForNewRow(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
         var rowCreate = navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry);
-        var navApiId = navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId);
-        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApiId, PortalArea.TOP_NAVBAR, List.of());
+        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, List.of());
         var creates = new ArrayList<CreatePortalNavigationItem>(subtree.creates().size() + 1);
         creates.add(rowCreate);
         creates.addAll(subtree.creates());
@@ -148,8 +141,8 @@ public class PortalListingSyncDomainService {
         PortalNavigationApi navApi,
         List<PortalNavigationItem> envFolders
     ) {
-        var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi.getId(), navApi.getArea(), currentFolders);
+        var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, apiId);
+        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, currentFolders);
         var rowUpdate = navigationItemEntryMaterializer.updateForValidation(auditInfo, portalId, entry, navApi);
         var updates = new ArrayList<>(subtree.updates());
         updates.add(rowUpdate);
@@ -157,26 +150,11 @@ public class PortalListingSyncDomainService {
     }
 
     public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, @Nullable List<NavigationPath> desired) {
-        var navApis = apiFolderSubtreeReconciler.navApiRowsFor(auditInfo, apiId);
-        if (navApis.isEmpty()) return;
         var safeDesired = desired == null ? List.<NavigationPath>of() : desired;
         var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
-        List<CreatePortalNavigationItem> creates = new ArrayList<>();
-        List<PendingUpdate> updates = new ArrayList<>();
-        for (var navApi : navApis) {
-            var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-            var items = apiFolderSubtreeReconciler.itemsForValidation(
-                auditInfo,
-                apiId,
-                navApi.getId(),
-                navApi.getArea(),
-                safeDesired,
-                currentFolders
-            );
-            creates.addAll(items.creates());
-            updates.addAll(items.updates());
-        }
-        validatorService.validate(creates, updates, auditInfo.environmentId());
+        var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, apiId);
+        var items = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, safeDesired, currentFolders);
+        validatorService.validate(items.creates(), items.updates(), auditInfo.environmentId());
     }
 
     private void materializeApiDocs(AuditInfo auditInfo, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -33,7 +34,6 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.slug.model.Slug;
 import java.util.List;
 import java.util.Set;
@@ -41,17 +41,13 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Materializes an API-attached Documentation into the navigation tree.
+ * Materializes an API-attached Documentation into the navigation tree, keyed on the API itself.
  *
- * <p>For every {@link PortalNavigationApi} row that exists for the API in the environment (created by a
- * {@code PortalListing}), creates/updates a {@link PortalNavigationPage}. When the doc's {@code location}
- * points to a folder materialized from {@code api.portalNavigation}, the page parents there; otherwise the
- * page parents directly under the nav-api row (orphan-tolerant: a phantom parent is set so the page
- * reconnects once the folder is materialized).
- *
- * <p>If no listing exists yet, the scan returns zero rows and the doc sits idle in {@code portal_page_contents}.
- * When a listing later creates a nav-api row, {@code PortalListingSyncDomainService} calls {@link #materialize}
- * again (Rule 2 backfill) so the new rows get populated regardless of apply order.
+ * <p>The nav page is upserted unconditionally — no portal or listing needs to exist. When the doc's
+ * {@code location} points to a folder materialized from {@code api.portalNavigation}, the page parents
+ * there (orphan-tolerant: a phantom parent is set so the page reconnects once the folder is
+ * materialized); an absent, blank, or {@code "/"} location makes the page a root of the API's own
+ * subtree instead.
  *
  * @author GraviteeSource Team
  */
@@ -67,28 +63,18 @@ public class ApiDocumentationSyncDomainService {
 
     private final PortalNavigationItemCrudService navigationItemCrudService;
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
-    private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalNavigationItemValidatorService validatorService;
 
     public void materialize(AuditInfo auditInfo, PortalPageContent<?> pageContent) {
         var meta = pageContent.getAutomationMetadata();
         var apiId = meta.referenceId();
         var contentId = pageContent.getId();
-        var navApiRows = findNavApiRows(auditInfo.environmentId(), apiId);
-        if (navApiRows.isEmpty()) {
-            return;
-        }
-        for (var navApi : navApiRows) {
-            var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, contentId);
-            var parent = resolveParent(auditInfo, navApi, meta.location().orElse(null));
-            upsertNavPage(auditInfo, pageId, contentId, parent, meta);
-        }
+        var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, contentId);
+        var parent = resolveParent(auditInfo, apiId, meta.location().orElse(null));
+        upsertNavPage(auditInfo, pageId, contentId, parent, meta);
     }
 
     public void dematerialize(AuditInfo auditInfo, String apiId, PortalPageContentId contentId) {
-        if (findNavApiRows(auditInfo.environmentId(), apiId).isEmpty()) {
-            return;
-        }
         var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, contentId);
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId);
         if (existing != null) {
@@ -97,43 +83,40 @@ public class ApiDocumentationSyncDomainService {
     }
 
     /**
-     * Cleans up navigation rows materialized by the API itself (api-folder subtree + phantom-parented doc pages).
-     * Nav-api rows are owned by their {@code PortalListing} and {@code PortalPageContent} rows by their
-     * {@code Documentation}, so neither is touched here.
+     * Cleans up the API's own subtree — its folder subtree, its documentation pages, and its links, wherever
+     * they are rooted — enumerated by reference rather than by iterating nav-api rows: the subtree belongs to
+     * the API, not to any listing. Nav-api rows are owned by their {@code PortalListing}, so none are touched here.
      */
     public void cleanupForApi(AuditInfo auditInfo, String apiId) {
-        for (var navApi : findNavApiRows(auditInfo.environmentId(), apiId)) {
-            cascadeDeleteNavApiDescendants(auditInfo, navApi.getId(), apiId);
-        }
+        var reference = new NavigationItemReference.ApiReference(apiId);
+        var envFolders = navigationItemsQueryService.search(
+            PortalNavigationItemQueryCriteria.builder()
+                .environmentId(auditInfo.environmentId())
+                .type(PortalNavigationItemType.FOLDER)
+                .build()
+        );
+        envFolders
+            .stream()
+            .filter(folder -> reference.equals(folder.getReference()))
+            .filter(PortalNavigationItem::isRoot)
+            .forEach(root -> {
+                cascadeDeleteDescendants(auditInfo.environmentId(), root.getId(), 0);
+                navigationItemCrudService.delete(root.getId());
+            });
+        navigationItemsQueryService
+            .findByAutomationReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItemType.PAGE || item.getType() == PortalNavigationItemType.LINK)
+            .forEach(item -> navigationItemCrudService.delete(item.getId()));
     }
 
     /**
-     * Cleans up a single {@link PortalNavigationApi} row and every descendant underneath it. Used by listing
-     * sync when an entry is removed from a listing spec, and indirectly by {@link #cleanupForApi}.
+     * Cleans up a single {@link PortalNavigationApi} row. The API's own subtree is not a descendant of this
+     * row — it belongs to the API (see {@link #cleanupForApi}) — so removing a listing entry never takes it.
      */
     public void cleanupNavApi(AuditInfo auditInfo, PortalNavigationItemId navApiId) {
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId);
-        if (!(existing instanceof PortalNavigationApi navApi)) {
-            return;
-        }
-        cascadeDeleteNavApi(auditInfo, navApiId, navApi.getApiId());
-    }
-
-    private void cascadeDeleteNavApiDescendants(AuditInfo auditInfo, PortalNavigationItemId navApiId, String apiId) {
-        portalPageContentQueryService
-            .findByReference(auditInfo.environmentId(), AutomationMetadata.ReferenceType.API, apiId)
-            .forEach(pc -> {
-                var pageId = PortalNavigationItemId.forApiDocumentation(auditInfo, apiId, pc.getId());
-                if (navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), pageId) != null) {
-                    navigationItemCrudService.delete(pageId);
-                }
-            });
-        cascadeDeleteDescendants(auditInfo.environmentId(), navApiId, 0);
-    }
-
-    private void cascadeDeleteNavApi(AuditInfo auditInfo, PortalNavigationItemId navApiId, String apiId) {
-        cascadeDeleteNavApiDescendants(auditInfo, navApiId, apiId);
-        if (navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId) != null) {
+        if (existing instanceof PortalNavigationApi) {
             navigationItemCrudService.delete(navApiId);
         }
     }
@@ -148,31 +131,16 @@ public class ApiDocumentationSyncDomainService {
         }
     }
 
-    private PortalNavigationItemContainer resolveParent(AuditInfo auditInfo, PortalNavigationApi navApi, String location) {
+    private PortalNavigationItemContainer resolveParent(AuditInfo auditInfo, String apiId, String location) {
         if (location == null || location.isBlank() || "/".equals(location)) {
-            return navApi;
+            return null;
         }
-        var folderId = PortalNavigationItemId.forApiFolder(auditInfo, navApi.getApiId(), location);
+        var folderId = PortalNavigationItemId.forApiFolder(auditInfo, apiId, location);
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), folderId);
         if (existing instanceof PortalNavigationItemContainer container) {
             return container;
         }
         return PortalNavigationItemContainer.phantom(folderId);
-    }
-
-    private List<PortalNavigationApi> findNavApiRows(String environmentId, String apiId) {
-        return navigationItemsQueryService
-            .search(
-                PortalNavigationItemQueryCriteria.builder()
-                    .environmentId(environmentId)
-                    .type(PortalNavigationItemType.API)
-                    .apiIds(Set.of(apiId))
-                    .build()
-            )
-            .stream()
-            .filter(PortalNavigationApi.class::isInstance)
-            .map(PortalNavigationApi.class::cast)
-            .toList();
     }
 
     private void upsertNavPage(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
@@ -19,9 +19,11 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -95,7 +97,7 @@ public class PortalLinkSyncDomainService {
         // is safe: if this link already legitimately owns (parent, segment), no foreign item could have
         // taken that same slot in the meantime without failing this same check itself.
         if (existingLink == null || !Objects.equals(existingLink.getParentId(), parentId)) {
-            rejectIfSegmentTakenByForeignItem(auditInfo, parent, segment, linkId, location);
+            rejectIfSegmentTakenByForeignItem(auditInfo, parent, segment, linkId, location, automationMetadata.reference());
         }
 
         if (existingLink != null) {
@@ -141,7 +143,8 @@ public class PortalLinkSyncDomainService {
             resolveParent(auditInfo, location, portalId),
             Slug.from(linkHrid).value(),
             PortalNavigationItemId.forPortalLink(auditInfo, portalId, linkHrid),
-            location
+            location,
+            new NavigationItemReference.PortalReference(PortalId.of(portalId))
         );
     }
 
@@ -178,7 +181,8 @@ public class PortalLinkSyncDomainService {
             resolveApiParent(auditInfo, location, apiId),
             Slug.from(linkHrid).value(),
             PortalNavigationItemId.forApiLink(auditInfo, apiId, linkHrid),
-            location
+            location,
+            new NavigationItemReference.ApiReference(apiId)
         );
     }
 
@@ -222,11 +226,12 @@ public class PortalLinkSyncDomainService {
         PortalNavigationItemContainer parent,
         String segment,
         PortalNavigationItemId expectedId,
-        String location
+        String location,
+        NavigationItemReference reference
     ) {
         var parentId = Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
         navigationItemsQueryService
-            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
+            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment, reference)
             .filter(sibling -> !sibling.getId().equals(expectedId))
             .ifPresent(squatter -> {
                 throw PathConflictException.segmentTaken(PathConflictException.EntryKind.LINK, location);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -32,6 +33,9 @@ public class PortalNavigationEnclosingApiDomainService {
     private final PortalNavigationItemsQueryService queryService;
 
     public Optional<String> findEnclosingApiId(String environmentId, PortalNavigationItem item) {
+        if (item.getReference() instanceof NavigationItemReference.ApiReference apiReference) {
+            return Optional.of(apiReference.apiId());
+        }
         PortalNavigationItem current = item;
         while (current != null && current.getParentId() != null) {
             current = queryService.findByIdAndEnvironmentId(environmentId, current.getParentId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudServi
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -68,7 +69,8 @@ public class PortalNavigationItemDomainService {
             createPortalNavigationItem.getParentId(),
             environmentId,
             createPortalNavigationItem.getArea(),
-            createPortalNavigationItem.getOrder()
+            createPortalNavigationItem.getOrder(),
+            createPortalNavigationItem.getReference()
         );
         createPortalNavigationItem.setOrder(sanitizedOrder);
 
@@ -93,7 +95,12 @@ public class PortalNavigationItemDomainService {
         var parent = parentId != null ? resolveParentContainer(parentId, environmentId) : null;
 
         if (createPortalNavigationItem.getSegment() == null) {
-            var usedSegments = retrieveSiblingItems(parentId, environmentId, createPortalNavigationItem.getArea())
+            var usedSegments = retrieveSiblingItems(
+                parentId,
+                environmentId,
+                createPortalNavigationItem.getArea(),
+                createPortalNavigationItem.getReference()
+            )
                 .stream()
                 .map(item -> new Slug(item.getSegment()))
                 .collect(Collectors.toSet());
@@ -107,7 +114,8 @@ public class PortalNavigationItemDomainService {
         this.retrieveSiblingItems(
                 portalNavigationItem.getParentId(),
                 portalNavigationItem.getEnvironmentId(),
-                createPortalNavigationItem.getArea()
+                createPortalNavigationItem.getArea(),
+                portalNavigationItem.getReference()
             )
             .stream()
             .filter(item -> !Objects.equals(item.getId(), portalNavigationItem.getId()))
@@ -163,10 +171,15 @@ public class PortalNavigationItemDomainService {
         return crudService.update(page);
     }
 
-    private List<PortalNavigationItem> retrieveSiblingItems(PortalNavigationItemId parentId, String environmentId, PortalArea area) {
+    private List<PortalNavigationItem> retrieveSiblingItems(
+        PortalNavigationItemId parentId,
+        String environmentId,
+        PortalArea area,
+        NavigationItemReference reference
+    ) {
         return parentId != null
             ? queryService.findByParentIdAndEnvironmentId(environmentId, parentId)
-            : queryService.findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, area);
+            : queryService.findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(environmentId, area, reference);
     }
 
     public void delete(PortalNavigationItem item) {
@@ -178,7 +191,7 @@ public class PortalNavigationItemDomainService {
         // Reorder siblings at the deleted item's parent level: decrement order for siblings with order > deleted order
         var parentId = item.getParentId();
         var deletedOrder = item.getOrder();
-        var siblings = retrieveSiblingItems(parentId, item.getEnvironmentId(), item.getArea());
+        var siblings = retrieveSiblingItems(parentId, item.getEnvironmentId(), item.getArea(), item.getReference());
         var siblingsToUpdate = siblings
             .stream()
             .filter(sibling -> !sibling.getId().equals(item.getId()))
@@ -274,20 +287,27 @@ public class PortalNavigationItemDomainService {
                 toUpdate.getParentId(),
                 originalItem.getEnvironmentId(),
                 originalItem.getArea(),
-                toUpdate.getOrder()
+                toUpdate.getOrder(),
+                originalItem.getReference()
             )
             : this.sanitizeOrderForReordering(
                 toUpdate.getParentId(),
                 originalItem.getEnvironmentId(),
                 originalItem.getArea(),
-                toUpdate.getOrder()
+                toUpdate.getOrder(),
+                originalItem.getReference()
             );
 
         toUpdate.setOrder(sanitizedOrder);
 
         if (toUpdate.getSegment() == null) {
             var targetParentId = isMoveToNewParent ? toUpdate.getParentId() : originalItem.getParentId();
-            var usedSegments = retrieveSiblingItems(targetParentId, originalItem.getEnvironmentId(), originalItem.getArea())
+            var usedSegments = retrieveSiblingItems(
+                targetParentId,
+                originalItem.getEnvironmentId(),
+                originalItem.getArea(),
+                originalItem.getReference()
+            )
                 .stream()
                 .filter(sibling -> !Objects.equals(sibling.getId(), originalItem.getId()))
                 .map(sibling -> new Slug(sibling.getSegment()))
@@ -427,15 +447,27 @@ public class PortalNavigationItemDomainService {
         }
     }
 
-    private int sanitizeOrderForReordering(PortalNavigationItemId parentId, String environmentId, PortalArea area, Integer order) {
-        final var siblingItems = this.retrieveSiblingItems(parentId, environmentId, area);
+    private int sanitizeOrderForReordering(
+        PortalNavigationItemId parentId,
+        String environmentId,
+        PortalArea area,
+        Integer order,
+        NavigationItemReference reference
+    ) {
+        final var siblingItems = this.retrieveSiblingItems(parentId, environmentId, area, reference);
         final var maxOrder = Math.max(0, siblingItems.size() - 1);
         if (Objects.isNull(order)) return maxOrder;
         return Math.min(order, maxOrder);
     }
 
-    private int sanitizeOrderForInsertion(PortalNavigationItemId parentId, String environmentId, PortalArea area, Integer order) {
-        final var newMaxOrder = this.retrieveSiblingItems(parentId, environmentId, area).size();
+    private int sanitizeOrderForInsertion(
+        PortalNavigationItemId parentId,
+        String environmentId,
+        PortalArea area,
+        Integer order,
+        NavigationItemReference reference
+    ) {
+        final var newMaxOrder = this.retrieveSiblingItems(parentId, environmentId, area, reference).size();
         if (Objects.isNull(order)) return newMaxOrder;
 
         return Math.min(order, newMaxOrder);
@@ -446,7 +478,12 @@ public class PortalNavigationItemDomainService {
         PortalNavigationItem updatedItem,
         PortalNavigationItemId originalParentId
     ) {
-        return this.retrieveSiblingItems(originalParentId, updatedItem.getEnvironmentId(), updatedItem.getArea())
+        return this.retrieveSiblingItems(
+                originalParentId,
+                updatedItem.getEnvironmentId(),
+                updatedItem.getArea(),
+                updatedItem.getReference()
+            )
             .stream()
             .filter(sibling -> sibling.getOrder() > originalOrder)
             .peek(sibling -> {
@@ -456,7 +493,12 @@ public class PortalNavigationItemDomainService {
     }
 
     private List<PortalNavigationItem> reorderDestinationSiblingsOnInsertion(PortalNavigationItem updatedItem) {
-        return this.retrieveSiblingItems(updatedItem.getParentId(), updatedItem.getEnvironmentId(), updatedItem.getArea())
+        return this.retrieveSiblingItems(
+                updatedItem.getParentId(),
+                updatedItem.getEnvironmentId(),
+                updatedItem.getArea(),
+                updatedItem.getReference()
+            )
             .stream()
             .filter(sibling -> !Objects.equals(sibling.getId(), updatedItem.getId()) && sibling.getOrder() >= updatedItem.getOrder())
             .peek(sibling -> {
@@ -472,7 +514,12 @@ public class PortalNavigationItemDomainService {
         Predicate<PortalNavigationItem> shouldBeIncremented = sibling ->
             sibling.getOrder() >= updatedItem.getOrder() && sibling.getOrder() < originalOrder;
 
-        return this.retrieveSiblingItems(updatedItem.getParentId(), updatedItem.getEnvironmentId(), updatedItem.getArea())
+        return this.retrieveSiblingItems(
+                updatedItem.getParentId(),
+                updatedItem.getEnvironmentId(),
+                updatedItem.getArea(),
+                updatedItem.getReference()
+            )
             .stream()
             .filter(
                 sibling ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconciler.java
@@ -37,7 +37,7 @@ public class HomepageReconciler {
 
     public void dropStaleHomepages(String environmentId, String portalId, PortalNavigationItemId activeHomepageId) {
         dropHomepagesMatching(environmentId, new NavigationItemReference.PortalReference(PortalId.of(portalId)), activeHomepageId);
-        dropHomepagesMatching(environmentId, NavigationItemReference.DEFAULT, activeHomepageId);
+        dropHomepagesMatching(environmentId, NavigationItemReference.defaultReference(), activeHomepageId);
     }
 
     private void dropHomepagesMatching(String environmentId, NavigationItemReference reference, PortalNavigationItemId activeHomepageId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -54,7 +55,14 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
     public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
         if (
             collidesWithPendingBatch(item.getId(), item.getParentId(), item.getSegment(), ctx.pendingSegmentClaims()) ||
-            collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId, ctx.pendingSegmentClaims())
+            collidesWithPersistedSibling(
+                item.getId(),
+                item.getParentId(),
+                item.getSegment(),
+                item.getReference(),
+                environmentId,
+                ctx.pendingSegmentClaims()
+            )
         ) {
             throw exceptionFor(item);
         }
@@ -76,6 +84,7 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
                 existingItem.getId(),
                 toUpdate.getParentId(),
                 toUpdate.getSegment(),
+                existingItem.getReference(),
                 existingItem.getEnvironmentId(),
                 ctx.pendingSegmentClaims()
             )
@@ -105,11 +114,12 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
         PortalNavigationItemId itemId,
         PortalNavigationItemId parentId,
         String segment,
+        NavigationItemReference reference,
         String environmentId,
         List<PendingSegmentClaim> claims
     ) {
         return navigationItemsQueryService
-            .findByParentIdAndSegment(environmentId, parentId, segment)
+            .findByParentIdAndSegment(environmentId, parentId, segment, reference)
             .filter(sibling -> !sibling.getId().equals(itemId))
             .filter(sibling -> !isVacatedInBatch(sibling.getId(), parentId, segment, claims))
             .isPresent();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
@@ -36,7 +36,7 @@ public final class CreatePortalNavigationItem {
     private PortalArea area;
 
     @Builder.Default
-    private NavigationItemReference reference = NavigationItemReference.DEFAULT;
+    private NavigationItemReference reference = NavigationItemReference.defaultReference();
 
     private Integer order;
     private PortalNavigationItemType type;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/NavigationItemReference.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/NavigationItemReference.java
@@ -18,7 +18,22 @@ package io.gravitee.apim.core.portal_page.model;
 import io.gravitee.apim.core.portal.model.PortalId;
 
 public sealed interface NavigationItemReference {
-    NavigationItemReference DEFAULT = PortalReference.DEFAULT;
+    /**
+     * Deliberately a method, not an eagerly-initialized field: a field initializer here would read
+     * {@code PortalReference.DEFAULT} as part of this interface's own class initialization, coupling
+     * the two classes' {@code <clinit>} together. A method defers that read to first call, so this
+     * interface's own initialization has no dependency on {@link PortalReference} at all.
+     */
+    static NavigationItemReference defaultReference() {
+        return PortalReference.DEFAULT;
+    }
+
+    default boolean sharesRootNamespaceWith(NavigationItemReference other) {
+        return switch (this) {
+            case ApiReference api -> other instanceof ApiReference otherApi && api.apiId().equals(otherApi.apiId());
+            case PortalReference ignored -> !(other instanceof ApiReference);
+        };
+    }
 
     record PortalReference(PortalId portalId) implements NavigationItemReference {
         public static final PortalReference DEFAULT = new PortalReference(PortalId.ZERO);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -44,7 +44,7 @@ public abstract sealed class PortalNavigationItem
 
     @Builder.Default
     @Nonnull
-    private NavigationItemReference reference = NavigationItemReference.DEFAULT;
+    private NavigationItemReference reference = NavigationItemReference.defaultReference();
 
     @Setter
     @Nonnull
@@ -207,7 +207,7 @@ public abstract sealed class PortalNavigationItem
             );
         };
         newItem.setSegment(segmentFor(item));
-        newItem.reference = Objects.requireNonNullElse(item.getReference(), NavigationItemReference.DEFAULT);
+        newItem.reference = Objects.requireNonNullElse(item.getReference(), NavigationItemReference.defaultReference());
         newItem.source = item.getSource();
         newItem.automationMetadata = item.getAutomationMetadata();
         if (parent == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,10 +40,16 @@ public interface PortalNavigationItemsQueryService {
         String referenceId
     );
 
-    default Optional<PortalNavigationItem> findByParentIdAndSegment(String environmentId, PortalNavigationItemId parentId, String segment) {
+    default Optional<PortalNavigationItem> findByParentIdAndSegment(
+        String environmentId,
+        @Nullable PortalNavigationItemId parentId,
+        String segment,
+        NavigationItemReference reference
+    ) {
         return findByParentIdAndEnvironmentId(environmentId, parentId)
             .stream()
             .filter(it -> segment.equals(it.getSegment()))
+            .filter(it -> parentId != null || reference.sharesRootNamespaceWith(it.getReference()))
             .findFirst();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -190,7 +190,12 @@ public final class HRIDToUUID {
     public static class NavigationBuilder {
 
         public NavigationWithContext context(AuditInfo audit) {
-            return new NavigationWithContext(audit.organizationId(), audit.environmentId());
+            return context(audit.organizationId(), audit.environmentId());
+        }
+
+        /** For callers with no {@link AuditInfo} to construct — an upgrader migrating stored rows, for example. */
+        public NavigationWithContext context(String organizationId, String environmentId) {
+            return new NavigationWithContext(organizationId, environmentId);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiNavigationSubtreePaths.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiNavigationSubtreePaths.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.CustomLog;
+
+/**
+ * Reconstructs the {@code portalNavigation} path of every legacy, automation-owned {@code FOLDER}
+ * descendant of a nav-api row — the path {@code PortalNavigationItemId#forApiFolder} needs to derive
+ * that same folder's id in the API-owned key space.
+ * <p>
+ * "Automation-owned" is decided the way the runtime itself decides it when rejecting a conflicting
+ * foreign item ({@code NavigationSyncPlanExecutor#rejectIfSegmentTakenByForeignItem}): by id, not by
+ * metadata. Folders never carried {@code automationMetadata}, and pre-re-key folders never carried a
+ * stamped {@code reference} either, so a hand-created folder is indistinguishable from a legacy
+ * automation folder on metadata alone. A legacy folder's id is deterministic — the pre-re-key
+ * {@code forApiFolder} formula, keyed on the nav-api row rather than on the API — so a candidate whose
+ * stored id does not match that formula for its own reconstructed path was never written by automation,
+ * whatever it is. Its subtree is left alone, exactly as a hand-created folder standing where automation
+ * planned to write one is left alone today.
+ * <p>
+ * This is also why paths are not chained through parent folder ids: the legacy formula takes one full
+ * path string per folder, computed straight from the nav-api row, never nested per ancestor.
+ */
+@CustomLog
+final class ApiNavigationSubtreePaths {
+
+    private ApiNavigationSubtreePaths() {}
+
+    record PathedFolder(PortalNavigationItem folder, String path) {}
+
+    static List<PathedFolder> collect(
+        String organizationId,
+        String environmentId,
+        String navApiRowId,
+        Map<String, List<PortalNavigationItem>> childrenByParentId
+    ) {
+        var result = new ArrayList<PathedFolder>();
+        walk(organizationId, environmentId, navApiRowId, navApiRowId, "", childrenByParentId, result);
+        return result;
+    }
+
+    private static void walk(
+        String organizationId,
+        String environmentId,
+        String navApiRowId,
+        String parentId,
+        String parentPath,
+        Map<String, List<PortalNavigationItem>> childrenByParentId,
+        List<PathedFolder> result
+    ) {
+        var matches = childrenByParentId
+            .getOrDefault(parentId, List.of())
+            .stream()
+            .filter(child -> child.getType() == PortalNavigationItem.Type.FOLDER)
+            .map(child -> matchLegacyFolder(organizationId, environmentId, navApiRowId, parentPath, child))
+            .flatMap(Optional::stream)
+            .toList();
+
+        for (var match : matches) {
+            result.add(match);
+            walk(organizationId, environmentId, navApiRowId, match.folder().getId(), match.path(), childrenByParentId, result);
+        }
+    }
+
+    private static Optional<PathedFolder> matchLegacyFolder(
+        String organizationId,
+        String environmentId,
+        String navApiRowId,
+        String parentPath,
+        PortalNavigationItem child
+    ) {
+        var segment = child.getSegment();
+        if (segment == null || segment.isBlank()) {
+            log.warn(
+                "Navigation folder [id={}] under legacy nav-api row [id={}] has a blank segment; not re-keying it or its descendants",
+                child.getId(),
+                navApiRowId
+            );
+            return Optional.empty();
+        }
+        var path = parentPath + "/" + segment;
+        var legacyId = HRIDToUUID.navigation().context(organizationId, environmentId).api(navApiRowId).folder(path).id();
+        return legacyId.equals(child.getId()) ? Optional.of(new PathedFolder(child, path)) : Optional.empty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgrader.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.PORTAL_NAVIGATION_ITEM_API_OWNED_REKEY_UPGRADER;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalNavigationItemRepository;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import io.gravitee.repository.management.model.PortalNavigationReferenceType;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * One-time re-key of API-attached navigation rows created before their identity moved off the
+ * per-listing {@code PortalNavigationApi} row and onto the API itself. Folders, doc pages and
+ * links keyed on a nav-api row are moved into the API-owned key space; a legacy link's id never changed
+ * (it was already keyed on the API), so it is only re-parented and re-referenced in place.
+ * <p>
+ * Folders have no reliable automation-ownership signal of their own — they never carried
+ * {@code automationMetadata} — so a folder is treated as legacy-automation-owned only if its stored id
+ * matches the pre-re-key {@code forApiFolder} formula for its own reconstructed path, the same identity
+ * test the runtime itself uses to reject a foreign item. See {@link ApiNavigationSubtreePaths}. Doc
+ * pages and links carry {@code automationMetadata} whenever automation created them and never otherwise,
+ * so they are found by a direct scan instead of a tree walk — which also finds a page phantom-parented
+ * at a folder id with no row behind it, unreachable by any walk.
+ * <p>
+ * Must run after {@link PortalNavigationItemAutomationMetadataUpgrader}: doc-page discovery here relies
+ * on {@code automationMetadata} already being backfilled onto every automation-managed page.
+ */
+@Component
+@CustomLog
+public class PortalNavigationItemApiOwnedRekeyUpgrader implements Upgrader {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String PORTAL_PAGE_CONTENT_ID = "portalPageContentId";
+
+    private final PortalNavigationItemRepository portalNavigationItemRepository;
+
+    public PortalNavigationItemApiOwnedRekeyUpgrader(@Lazy PortalNavigationItemRepository portalNavigationItemRepository) {
+        this.portalNavigationItemRepository = portalNavigationItemRepository;
+    }
+
+    @Override
+    public int getOrder() {
+        return PORTAL_NAVIGATION_ITEM_API_OWNED_REKEY_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::migrate);
+    }
+
+    private boolean migrate() throws TechnicalException {
+        // One full scan, grouped by (organizationId, environmentId) below, rather than looping
+        // environments and re-querying: navigation items are few enough that this is simpler and
+        // cheaper, mirroring PortalNavigationItemAutomationMetadataUpgrader#migrate.
+        Map<Map.Entry<String, String>, List<PortalNavigationItem>> byOrgAndEnv = portalNavigationItemRepository
+            .findAll()
+            .stream()
+            .collect(Collectors.groupingBy(item -> Map.entry(item.getOrganizationId(), item.getEnvironmentId())));
+
+        for (var entry : byOrgAndEnv.entrySet()) {
+            migrateEnvironment(entry.getKey().getKey(), entry.getKey().getValue(), entry.getValue());
+        }
+        return true;
+    }
+
+    private void migrateEnvironment(String organizationId, String environmentId, List<PortalNavigationItem> items)
+        throws TechnicalException {
+        Map<String, List<PortalNavigationItem>> childrenByParentId = items
+            .stream()
+            .filter(item -> item.getParentId() != null)
+            .collect(Collectors.groupingBy(PortalNavigationItem::getParentId));
+
+        Map<String, String> folderNewIdToRootId = new HashMap<>();
+
+        var apiRows = items
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItem.Type.API)
+            .toList();
+        for (var apiRow : apiRows) {
+            rekeyFolders(organizationId, environmentId, apiRow, childrenByParentId, folderNewIdToRootId);
+        }
+
+        rekeyDocPages(organizationId, environmentId, items, folderNewIdToRootId);
+        realignApiLinkReferences(organizationId, environmentId, items, folderNewIdToRootId);
+    }
+
+    private void rekeyFolders(
+        String organizationId,
+        String environmentId,
+        PortalNavigationItem apiRow,
+        Map<String, List<PortalNavigationItem>> childrenByParentId,
+        Map<String, String> folderNewIdToRootId
+    ) throws TechnicalException {
+        var apiId = apiRow.getApiId();
+        var pathedFolders = ApiNavigationSubtreePaths.collect(organizationId, environmentId, apiRow.getId(), childrenByParentId);
+
+        // Pre-order: every ancestor of a folder appears earlier in this list, so its new root is
+        // already in folderNewIdToRootId by the time a descendant needs it.
+        for (var pathed : pathedFolders) {
+            var path = pathed.path();
+            var newId = folderId(organizationId, environmentId, apiId, path);
+
+            String newParentId = null;
+            String newRootId = newId;
+            var lastSlash = path.lastIndexOf('/');
+            if (lastSlash > 0) {
+                var parentPath = path.substring(0, lastSlash);
+                newParentId = folderId(organizationId, environmentId, apiId, parentPath);
+                newRootId = folderNewIdToRootId.getOrDefault(newParentId, newParentId);
+            }
+            folderNewIdToRootId.put(newId, newRootId);
+
+            rekeyItem(pathed.folder(), newId, newParentId, newRootId, PortalNavigationReferenceType.API, apiId);
+        }
+    }
+
+    private record DocPageCandidate(PortalNavigationItem page, String apiId, String location, String contentId) {}
+
+    private void rekeyDocPages(
+        String organizationId,
+        String environmentId,
+        List<PortalNavigationItem> items,
+        Map<String, String> folderNewIdToRootId
+    ) throws TechnicalException {
+        var candidates = items
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItem.Type.PAGE)
+            .filter(page -> {
+                var metadata = page.getAutomationMetadata();
+                return metadata != null && metadata.getReferenceType() == AutomationTargetReferenceType.API;
+            })
+            .map(page -> {
+                var metadata = page.getAutomationMetadata();
+                return new DocPageCandidate(page, metadata.getReferenceId(), metadata.getLocation(), extractContentId(page));
+            })
+            .filter(candidate -> candidate.contentId() != null)
+            .toList();
+
+        for (var candidate : candidates) {
+            var newId = HRIDToUUID.navigation()
+                .context(organizationId, environmentId)
+                .api(candidate.apiId())
+                .documentation(candidate.contentId())
+                .id();
+            var parentAndRoot = resolveNewParentAndRoot(
+                organizationId,
+                environmentId,
+                candidate.apiId(),
+                candidate.location(),
+                newId,
+                folderNewIdToRootId
+            );
+
+            rekeyItem(
+                candidate.page(),
+                newId,
+                parentAndRoot.parentId(),
+                parentAndRoot.rootId(),
+                PortalNavigationReferenceType.API,
+                candidate.apiId()
+            );
+        }
+    }
+
+    private record LinkCandidate(PortalNavigationItem link, String apiId, ParentAndRoot parentAndRoot) {}
+
+    private void realignApiLinkReferences(
+        String organizationId,
+        String environmentId,
+        List<PortalNavigationItem> items,
+        Map<String, String> folderNewIdToRootId
+    ) throws TechnicalException {
+        var candidates = items
+            .stream()
+            .filter(item -> item.getType() == PortalNavigationItem.Type.LINK)
+            .filter(link -> {
+                var metadata = link.getAutomationMetadata();
+                return metadata != null && metadata.getReferenceType() == AutomationTargetReferenceType.API;
+            })
+            .map(link -> {
+                var metadata = link.getAutomationMetadata();
+                var apiId = metadata.getReferenceId();
+                var parentAndRoot = resolveNewParentAndRoot(
+                    organizationId,
+                    environmentId,
+                    apiId,
+                    metadata.getLocation(),
+                    link.getId(),
+                    folderNewIdToRootId
+                );
+                return new LinkCandidate(link, apiId, parentAndRoot);
+            })
+            .filter(candidate -> !isAlreadyCorrect(candidate))
+            .toList();
+
+        for (var candidate : candidates) {
+            var link = candidate.link();
+            var parentAndRoot = candidate.parentAndRoot();
+            link.setParentId(parentAndRoot.parentId());
+            link.setRootId(parentAndRoot.rootId());
+            link.setReferenceType(PortalNavigationReferenceType.API);
+            link.setReferenceId(candidate.apiId());
+            portalNavigationItemRepository.update(link);
+        }
+    }
+
+    private static boolean isAlreadyCorrect(LinkCandidate candidate) {
+        var link = candidate.link();
+        var parentAndRoot = candidate.parentAndRoot();
+        if (!Objects.equals(link.getParentId(), parentAndRoot.parentId())) {
+            return false;
+        }
+        if (!Objects.equals(link.getRootId(), parentAndRoot.rootId())) {
+            return false;
+        }
+        if (link.getReferenceType() != PortalNavigationReferenceType.API) {
+            return false;
+        }
+        return candidate.apiId().equals(link.getReferenceId());
+    }
+
+    /**
+     * Applied to folders and doc pages, where the identity itself changes. If {@code newId} already
+     * matches, nothing was ever legacy-keyed here and there is nothing to do — the write paths that
+     * create these rows already set parent/root/reference correctly together whenever they set the id
+     * correctly. If a row
+     * already exists at {@code newId}, this source is a duplicate that lost the race — created by a
+     * different, already-processed nav-api row's copy of the same subtree — so only the source is
+     * deleted; skipping the redundant insert and always deleting the source is what makes two legacy
+     * duplicates converge on one new row, and what makes a run that died mid-migration converge on retry.
+     */
+    private void rekeyItem(
+        PortalNavigationItem original,
+        String newId,
+        String newParentId,
+        String newRootId,
+        PortalNavigationReferenceType referenceType,
+        String referenceId
+    ) throws TechnicalException {
+        if (newId.equals(original.getId())) {
+            return;
+        }
+        if (portalNavigationItemRepository.findById(newId).isEmpty()) {
+            portalNavigationItemRepository.create(copyWithNewIdentity(original, newId, newParentId, newRootId, referenceType, referenceId));
+        }
+        portalNavigationItemRepository.delete(original.getId());
+    }
+
+    private static PortalNavigationItem copyWithNewIdentity(
+        PortalNavigationItem original,
+        String newId,
+        String newParentId,
+        String newRootId,
+        PortalNavigationReferenceType referenceType,
+        String referenceId
+    ) {
+        return PortalNavigationItem.builder()
+            .id(newId)
+            .organizationId(original.getOrganizationId())
+            .environmentId(original.getEnvironmentId())
+            .referenceType(referenceType)
+            .referenceId(referenceId)
+            .title(original.getTitle())
+            .segment(original.getSegment())
+            .type(original.getType())
+            .area(original.getArea())
+            .parentId(newParentId)
+            .rootId(newRootId)
+            .order(original.getOrder())
+            .configuration(original.getConfiguration())
+            .published(original.isPublished())
+            .visibility(original.getVisibility())
+            .apiId(original.getApiId())
+            .apiProductId(original.getApiProductId())
+            .useAutoFetch(original.isUseAutoFetch())
+            .categoryIds(original.getCategoryIds())
+            .automationMetadata(original.getAutomationMetadata())
+            .build();
+    }
+
+    private record ParentAndRoot(String parentId, String rootId) {}
+
+    /**
+     * A blank/null/"/" location makes the item a root of its own — matching
+     * {@code ApiDocumentationSyncDomainService#resolveParent}'s same three-way check. Otherwise the
+     * parent is the deterministic folder id for that location; if that folder was re-keyed earlier in
+     * this same pass its real root is known, and if not — the folder does not exist, exactly the phantom
+     * case the runtime itself tolerates — the item's root is the folder id itself, mirroring
+     * {@code PortalNavigationItemContainer#phantom}, whose root is its own placeholder id.
+     */
+    private static ParentAndRoot resolveNewParentAndRoot(
+        String organizationId,
+        String environmentId,
+        String apiId,
+        String location,
+        String ownNewId,
+        Map<String, String> folderNewIdToRootId
+    ) {
+        if (location == null || location.isBlank() || "/".equals(location)) {
+            return new ParentAndRoot(null, ownNewId);
+        }
+        var folderId = folderId(organizationId, environmentId, apiId, normalizeLocation(location));
+        return new ParentAndRoot(folderId, folderNewIdToRootId.getOrDefault(folderId, folderId));
+    }
+
+    private static String folderId(String organizationId, String environmentId, String apiId, String path) {
+        return HRIDToUUID.navigation().context(organizationId, environmentId).api(apiId).folder(path).id();
+    }
+
+    /** Mirrors {@code PortalNavigationItemId#normalizeLocation}, which is private and not reusable from here. */
+    private static String normalizeLocation(String location) {
+        return location.endsWith("/") && location.length() > 1 ? location.substring(0, location.length() - 1) : location;
+    }
+
+    // Mirrors PortalNavigationItemAutomationMetadataUpgrader#extractContentId.
+    private String extractContentId(PortalNavigationItem item) {
+        try {
+            JsonNode node = JSON.readTree(item.getConfiguration()).get(PORTAL_PAGE_CONTENT_ID);
+            return node == null ? null : node.asText();
+        } catch (Exception e) {
+            log.warn("Unable to parse configuration for portal navigation item {}; skipping api-owned re-key for it", item.getId(), e);
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -71,6 +71,7 @@ public class UpgraderOrder {
     public static final int CLASSIC_CATEGORIES_MIGRATION_UPGRADER = 722;
     public static final int PORTAL_NAVIGATION_STRUCTURE_UPGRADER = 723;
     public static final int PORTAL_NAVIGATION_ITEM_AUTOMATION_METADATA_UPGRADER = 724;
+    public static final int PORTAL_NAVIGATION_ITEM_API_OWNED_REKEY_UPGRADER = 725;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
@@ -65,7 +65,7 @@ class PortalNavigationListingDomainServiceTest {
         portalListingCrud.reset();
         syncService = new PortalNavigationSyncDomainService(
             query,
-            new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, query),
+            new AutomationManagedNavigationItemsQueryService(portalListingCrud, query),
             new NavigationSyncPlanExecutor(crud, query, pageContentCrud),
             mock(PortalNavigationValidator.class)
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -82,7 +82,7 @@ class PortalNavigationSyncDomainServiceTest {
         validator = mock(PortalNavigationValidator.class);
         syncService = new PortalNavigationSyncDomainService(
             query,
-            new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, query),
+            new AutomationManagedNavigationItemsQueryService(portalListingCrud, query),
             new NavigationSyncPlanExecutor(crud, query, pageContentCrud),
             validator
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutorTest.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -47,6 +48,7 @@ class NavigationSyncPlanExecutorTest {
         .build();
 
     private static final PortalNavigationItemId FIXED_ID = PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
 
     private final PortalNavigationItemsCrudServiceInMemory crud = new PortalNavigationItemsCrudServiceInMemory();
     private final PortalNavigationItemsQueryServiceInMemory query = new PortalNavigationItemsQueryServiceInMemory(crud.storage());
@@ -60,6 +62,24 @@ class NavigationSyncPlanExecutorTest {
     }
 
     @Test
+    void created_folders_carry_the_reference_they_were_planned_under() {
+        var plan = new NavigationSyncPlan(List.of(new FolderActions.CreateFolder(desired("/guides", null, "guides", 0))));
+        var reference = new NavigationItemReference.ApiReference(API_ID);
+
+        executor.execute(
+            plan,
+            AUDIT_INFO,
+            PortalArea.TOP_NAVBAR,
+            null,
+            reference,
+            path -> PortalNavigationItemId.random(),
+            new DeleteStrategy(item -> false, false)
+        );
+
+        assertThat(crud.storage()).singleElement().extracting(PortalNavigationItem::getReference).isEqualTo(reference);
+    }
+
+    @Test
     void create_folder_under_root_when_parent_path_is_null() {
         var plan = new NavigationSyncPlan(List.of(new FolderActions.CreateFolder(desired("/a", null, "a", 0))));
 
@@ -68,6 +88,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -95,6 +116,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -109,7 +131,15 @@ class NavigationSyncPlanExecutorTest {
     void id_comes_from_id_factory() {
         var plan = new NavigationSyncPlan(List.of(new FolderActions.CreateFolder(desired("/a", null, "a", 0))));
 
-        executor.execute(plan, AUDIT_INFO, PortalArea.TOP_NAVBAR, null, path -> FIXED_ID, new DeleteStrategy(item -> false, false));
+        executor.execute(
+            plan,
+            AUDIT_INFO,
+            PortalArea.TOP_NAVBAR,
+            null,
+            NavigationItemReference.defaultReference(),
+            path -> FIXED_ID,
+            new DeleteStrategy(item -> false, false)
+        );
 
         assertThat(crud.storage()).hasSize(1);
         assertThat(crud.storage().get(0).getId()).isEqualTo(FIXED_ID);
@@ -127,6 +157,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -147,6 +178,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -168,6 +200,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -182,7 +215,15 @@ class NavigationSyncPlanExecutorTest {
         crud.initWith(List.of(privateRoot));
         var plan = new NavigationSyncPlan(List.of(new FolderActions.CreateFolder(desired("/a", null, "a", 0))));
 
-        executor.execute(plan, AUDIT_INFO, PortalArea.TOP_NAVBAR, privateRoot, path -> FIXED_ID, new DeleteStrategy(item -> false, false));
+        executor.execute(
+            plan,
+            AUDIT_INFO,
+            PortalArea.TOP_NAVBAR,
+            privateRoot,
+            NavigationItemReference.defaultReference(),
+            path -> FIXED_ID,
+            new DeleteStrategy(item -> false, false)
+        );
 
         var created = (PortalNavigationFolder) crud
             .storage()
@@ -206,6 +247,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             privateParent,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> false, false)
         );
@@ -234,6 +276,7 @@ class NavigationSyncPlanExecutorTest {
             AUDIT_INFO,
             PortalArea.TOP_NAVBAR,
             null,
+            NavigationItemReference.defaultReference(),
             path -> PortalNavigationItemId.random(),
             new DeleteStrategy(item -> skipIds.contains(item.getId()), false)
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/query_service/AutomationManagedNavigationItemsQueryServiceTest.java
@@ -19,17 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.PortalListingCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
-import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_listing.model.PortalListingId;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
-import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
@@ -52,6 +49,7 @@ class AutomationManagedNavigationItemsQueryServiceTest {
         .actor(AuditActor.builder().userId("user-id").build())
         .build();
 
+    private static final String API_ID = "00000000-0000-0000-0000-0000000000a1";
     private static final String PORTAL_HRID = "default-portal";
     private static final PortalId PORTAL_ID = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
     private static final PortalListingId LISTING_ID = PortalListingId.of(
@@ -59,18 +57,15 @@ class AutomationManagedNavigationItemsQueryServiceTest {
     );
 
     private final PortalListingCrudServiceInMemory listingCrud = new PortalListingCrudServiceInMemory();
-    private final PortalPageContentQueryServiceInMemory pageContentQuery = new PortalPageContentQueryServiceInMemory();
     private final PortalNavigationItemsQueryServiceInMemory navigationItemsQuery = new PortalNavigationItemsQueryServiceInMemory();
     private final AutomationManagedNavigationItemsQueryService queryService = new AutomationManagedNavigationItemsQueryService(
         listingCrud,
-        pageContentQuery,
         navigationItemsQuery
     );
 
     @BeforeEach
     void setUp() {
         listingCrud.reset();
-        pageContentQuery.reset();
         navigationItemsQuery.reset();
     }
 
@@ -130,15 +125,26 @@ class AutomationManagedNavigationItemsQueryServiceTest {
     }
 
     @Test
-    void automation_managed_api_doc_pages_returns_page_ids_under_the_specific_nav_api_row() {
-        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid("pets-api").id();
-        var contentId = PortalPageContentId.of(
-            HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api("pets-api").hrid("getting-started").id()
-        );
-        pageContentQuery.initWith(List.of(apiDoc(contentId, apiId)));
-        var result = queryService.automationManagedApiDocPages(AUDIT_INFO, apiId);
+    void automation_managed_api_doc_pages_returns_pages_with_matching_automation_metadata() {
+        var managedPage = pageRow("getting-started", automationMetadata(AutomationMetadata.ReferenceType.API, API_ID));
+        var unmanagedPage = pageRow("manual", null);
+        navigationItemsQuery.initWith(List.of(managedPage, unmanagedPage));
 
-        assertThat(result).containsExactly(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, apiId, contentId));
+        var result = queryService.automationManagedApiDocPages(AUDIT_INFO, API_ID);
+
+        assertThat(result).containsExactly(managedPage.getId());
+    }
+
+    @Test
+    void automation_managed_api_doc_pages_excludes_links_with_the_same_automation_reference() {
+        var meta = automationMetadata(AutomationMetadata.ReferenceType.API, API_ID);
+        var managedPage = pageRow("managed-page", meta);
+        var managedLink = linkRow("managed-link", meta);
+        navigationItemsQuery.initWith(List.of(managedPage, managedLink));
+
+        var result = queryService.automationManagedApiDocPages(AUDIT_INFO, API_ID);
+
+        assertThat(result).containsExactly(managedPage.getId());
     }
 
     @Test
@@ -167,6 +173,17 @@ class AutomationManagedNavigationItemsQueryServiceTest {
     @Test
     void automation_managed_portal_links_returns_empty_when_no_links_exist() {
         assertThat(queryService.automationManagedPortalLinks(AUDIT_INFO, PORTAL_ID)).isEmpty();
+    }
+
+    @Test
+    void automation_managed_api_links_returns_only_link_items_referencing_the_api() {
+        var link = linkRow("external-docs", automationMetadata(AutomationMetadata.ReferenceType.API, API_ID));
+        var page = pageRow("a-page", automationMetadata(AutomationMetadata.ReferenceType.API, API_ID));
+        navigationItemsQuery.initWith(List.of(link, page));
+
+        var result = queryService.automationManagedApiLinks(AUDIT_INFO, API_ID);
+
+        assertThat(result).containsExactly(link.getId());
     }
 
     private static PortalNavigationLink linkRow(String title, AutomationMetadata metadata) {
@@ -203,16 +220,6 @@ class AutomationManagedNavigationItemsQueryServiceTest {
             .build();
         page.markAsRoot();
         return page;
-    }
-
-    private static GraviteeMarkdownPageContent apiDoc(PortalPageContentId id, String apiId) {
-        return new GraviteeMarkdownPageContent(
-            id,
-            AUDIT_INFO.organizationId(),
-            AUDIT_INFO.environmentId(),
-            GraviteeMarkdown.of("# x"),
-            automationMetadata(AutomationMetadata.ReferenceType.API, apiId)
-        );
     }
 
     private static AutomationMetadata automationMetadata(AutomationMetadata.ReferenceType type, String refId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -84,7 +84,7 @@ class CreateOrUpdatePortalUseCaseTest {
             portalCrudService,
             new PortalNavigationSyncDomainService(
                 navQueryService,
-                new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService, navQueryService),
+                new AutomationManagedNavigationItemsQueryService(portalListingCrudService, navQueryService),
                 new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService),
                 mock(PortalNavigationItemValidatorService.class)
             ),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -89,7 +89,7 @@ class DeletePortalUseCaseTest {
     void setUp() {
         var navSync = new PortalNavigationSyncDomainService(
             navQueryService,
-            new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService, navQueryService),
+            new AutomationManagedNavigationItemsQueryService(portalListingCrudService, navQueryService),
             new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService),
             new PortalNavigationItemValidatorService(
                 navQueryService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 
 import inmemory.ApiCrudServiceInMemory;
@@ -35,6 +36,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
+import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
@@ -46,9 +48,12 @@ import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDoma
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
@@ -95,13 +100,8 @@ class PortalListingSyncDomainServiceTest {
         pageContentCrud.reset();
         apiCrud.reset();
         var portalListingCrud = new PortalListingCrudServiceInMemory();
-        var apiDocSync = new ApiDocumentationSyncDomainService(
-            navItemCrud,
-            navItemQuery,
-            pageContentQuery,
-            mock(PortalNavigationItemValidatorService.class)
-        );
-        var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
+        var apiDocSync = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, mock(PortalNavigationItemValidatorService.class));
+        var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, navItemQuery);
         validator = mock(PortalNavigationValidator.class);
         syncService = new PortalListingSyncDomainService(
             pageContentQuery,
@@ -221,38 +221,183 @@ class PortalListingSyncDomainServiceTest {
     }
 
     @Test
-    void should_cascade_remove_api_doc_pages_when_listing_entry_is_removed() {
+    void removing_the_only_listing_entry_keeps_the_apis_documentation_and_folders() {
         var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
         var docContentId = PortalPageContentId.of(
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api(API_HRID).hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(anApiDocPageContent(docContentId, apiId)));
-        apiCrud.initWith(List.of(anApi(API_HRID)));
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of(new NavigationPath("/getting-started", null))).build()));
 
         var initial = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), initial);
 
+        var navApiId = PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).listingApi(apiId).id()
+        );
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, apiId, "/getting-started");
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, apiId, docContentId);
+
         var empty = aListing(List.of());
         syncService.sync(AUDIT_INFO, PORTAL_ID, initial.getApis(), empty);
 
-        assertThat(navItemCrud.storage()).isEmpty();
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(navApiId).contains(folderId, pageId);
     }
 
     @Test
-    void dematerialize_removes_every_nav_row_for_listing() {
+    void dematerialize_removes_only_the_nav_api_row_and_keeps_documentation_and_folders() {
         var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
         var docContentId = PortalPageContentId.of(
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api(API_HRID).hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(anApiDocPageContent(docContentId, apiId)));
-        apiCrud.initWith(List.of(anApi(API_HRID)));
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of(new NavigationPath("/getting-started", null))).build()));
 
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
 
+        var navApiId = PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).listingApi(apiId).id()
+        );
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, apiId, "/getting-started");
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, apiId, docContentId);
+
         syncService.dematerialize(AUDIT_INFO, PORTAL_ID, listing);
 
-        assertThat(navItemCrud.storage()).isEmpty();
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(navApiId).contains(folderId, pageId);
+    }
+
+    @Test
+    void reconciles_the_api_folder_subtree_when_no_portal_lists_the_api() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var guidesPath = new NavigationPath("/guides", null);
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of(guidesPath)).build()));
+
+        syncService.syncApiFolders(AUDIT_INFO, apiId, List.of());
+
+        assertThat(navItemCrud.storage())
+            .singleElement()
+            .satisfies(folder -> {
+                assertThat(folder.getId()).isEqualTo(PortalNavigationItemId.forApiFolder(AUDIT_INFO, apiId, "/guides"));
+                assertThat(folder.getReference()).isEqualTo(new NavigationItemReference.ApiReference(apiId));
+                assertThat(folder.isRoot()).isTrue();
+            });
+    }
+
+    @Test
+    void an_api_folder_may_take_a_root_segment_already_owned_by_a_portal_root() {
+        // Every environment is seeded with a TOP_NAVBAR root folder titled "Guides" (segment "guides"),
+        // and "/guides" is the ordinary thing to put in an API's portalNavigation. The API's folder is a
+        // root of the API's own subtree, rendered under the nav-api row, so it never becomes a sibling of
+        // the portal's own root and the two may share a segment.
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var portalRoot = portalRootFolder("Guides", "guides");
+        navItemCrud.create(portalRoot);
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of(new NavigationPath("/guides", null))).build()));
+
+        syncService.syncApiFolders(AUDIT_INFO, apiId, List.of());
+
+        assertThat(navItemCrud.storage())
+            .extracting(PortalNavigationItem::getId)
+            .contains(PortalNavigationItemId.forApiFolder(AUDIT_INFO, apiId, "/guides"), portalRoot.getId());
+    }
+
+    @Test
+    void two_apis_may_each_own_a_root_folder_with_the_same_segment() {
+        var firstApiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var secondApiId = HRIDToUUID.api().context(AUDIT_INFO).hrid("other-api").id();
+        var guides = List.of(new NavigationPath("/guides", null));
+        apiCrud.initWith(
+            List.of(
+                Api.builder().id(firstApiId).portalNavigation(guides).build(),
+                Api.builder().id(secondApiId).portalNavigation(guides).build()
+            )
+        );
+
+        syncService.syncApiFolders(AUDIT_INFO, firstApiId, List.of());
+        syncService.syncApiFolders(AUDIT_INFO, secondApiId, List.of());
+
+        assertThat(navItemCrud.storage())
+            .extracting(PortalNavigationItem::getId)
+            .contains(
+                PortalNavigationItemId.forApiFolder(AUDIT_INFO, firstApiId, "/guides"),
+                PortalNavigationItemId.forApiFolder(AUDIT_INFO, secondApiId, "/guides")
+            );
+    }
+
+    @Test
+    void validates_api_folder_conflicts_with_zero_listings() {
+        // A conflict is a conflict whether or not a portal currently lists the API: the impostor's
+        // segment resolves to the same "/guides" path automation would create, but its id isn't the
+        // deterministic one, so it fails the id check even though nothing lists this API yet.
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var impostor = PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("guides")
+            .segment("guides")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .reference(new NavigationItemReference.ApiReference(apiId))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        navItemCrud.create(impostor);
+
+        var throwable = catchThrowable(() ->
+            syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, List.of(new NavigationPath("/guides", null)))
+        );
+
+        assertThat(throwable).isInstanceOf(PathConflictException.class);
+    }
+
+    @Test
+    void an_automation_managed_api_link_survives_its_folder_being_dropped_from_the_api_navigation() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var guidesPath = new NavigationPath("/guides", null);
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of(guidesPath)).build()));
+
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
+
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, apiId, "/guides");
+        var link = PortalNavigationLink.builder()
+            .id(PortalNavigationItemId.forApiLink(AUDIT_INFO, apiId, "external-docs"))
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("External Docs")
+            .segment("external-docs")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .url("https://docs.example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .parentId(folderId)
+            .automationMetadata(
+                new AutomationMetadata(AutomationMetadata.ReferenceType.API, apiId, null, Optional.of("/guides"), Optional.empty())
+            )
+            .build();
+        navItemCrud.create(link);
+
+        apiCrud.initWith(List.of(Api.builder().id(apiId).portalNavigation(List.of()).build()));
+        syncService.syncApiFolders(AUDIT_INFO, apiId, List.of(guidesPath));
+
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).contains(link.getId()).doesNotContain(folderId);
+    }
+
+    private static PortalNavigationFolder portalRootFolder(String title, String segment) {
+        return PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(segment)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
     }
 
     private static Api anApi(String hrid) {
@@ -293,7 +438,6 @@ class PortalListingSyncDomainServiceTest {
 
     @Test
     void validate_api_folder_conflicts_routes_desired_paths_through_the_shared_validator() {
-        // First materialize a nav-api row for this api so validateApiFolderConflictsForApi finds a target navApi
         apiCrud.initWith(List.of(anApi(API_HRID)));
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
@@ -332,9 +476,6 @@ class PortalListingSyncDomainServiceTest {
 
         syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, listing);
 
-        var expectedNavigationApiId = PortalNavigationItemId.of(
-            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).listingApi(apiId).id()
-        );
         var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
         var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
         org.mockito.Mockito.verify(validator).validate(
@@ -347,20 +488,11 @@ class PortalListingSyncDomainServiceTest {
             .contains(
                 org.assertj.core.groups.Tuple.tuple(
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.FOLDER,
-                    expectedNavigationApiId,
+                    null,
                     "reports"
                 )
             );
         assertThat(updatesCaptor.getValue()).isEmpty();
-    }
-
-    @Test
-    void validate_api_folder_conflicts_is_a_noop_when_no_nav_api_row_exists_for_the_api() {
-        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
-
-        syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, List.of(new NavigationPath("/guides", null)));
-
-        org.mockito.Mockito.verifyNoInteractions(validator);
     }
 
     @Nested
@@ -378,10 +510,9 @@ class PortalListingSyncDomainServiceTest {
             var apiDocSync = new ApiDocumentationSyncDomainService(
                 navItemCrud,
                 navItemQuery,
-                pageContentQuery,
                 mock(PortalNavigationItemValidatorService.class)
             );
-            var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
+            var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, navItemQuery);
             syncService = new PortalListingSyncDomainService(
                 pageContentQuery,
                 apiDocSync,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
@@ -31,7 +31,9 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -70,14 +72,35 @@ class ApiDocumentationSyncDomainServiceTest {
         navItemCrud.reset();
         pageContentQuery.reset();
         validatorService = mock(PortalNavigationItemValidatorService.class);
-        syncService = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, pageContentQuery, validatorService);
+        syncService = new ApiDocumentationSyncDomainService(navItemCrud, navItemQuery, validatorService);
     }
 
     @Test
-    void should_be_noop_when_no_nav_api_row_exists_for_this_api() {
-        syncService.materialize(AUDIT_INFO, aDocumentation());
+    void materializes_a_nav_page_when_no_portal_lists_the_api() {
+        var meta = new AutomationMetadata(
+            AutomationMetadata.ReferenceType.API,
+            API_ID,
+            "Getting Started",
+            Optional.empty(),
+            Optional.of(1)
+        );
+        var doc = new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello"),
+            meta
+        );
 
-        assertThat(navItemCrud.storage()).isEmpty();
+        syncService.materialize(AUDIT_INFO, doc);
+
+        assertThat(navItemCrud.storage())
+            .singleElement()
+            .satisfies(page -> {
+                assertThat(page.getId()).isEqualTo(PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID));
+                assertThat(page.isRoot()).isTrue();
+                assertThat(page.getReference()).isEqualTo(new NavigationItemReference.ApiReference(API_ID));
+            });
     }
 
     @Test
@@ -186,6 +209,62 @@ class ApiDocumentationSyncDomainServiceTest {
     }
 
     @Test
+    void cleanupForApi_also_removes_the_apis_folder_subtree() {
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides");
+        var folder = PortalNavigationFolder.builder()
+            .id(folderId)
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("guides")
+            .segment("guides")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .reference(new NavigationItemReference.ApiReference(API_ID))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        navItemCrud.create(folder);
+
+        syncService.cleanupForApi(AUDIT_INFO, API_ID);
+
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(folderId);
+    }
+
+    @Test
+    void cleanupForApi_removes_root_level_link() {
+        var linkSyncService = new PortalLinkSyncDomainService(navItemCrud, navItemQuery);
+        var link = linkSyncService.materializeForApi(AUDIT_INFO, API_ID, "docs-link", "Docs", "https://example.com", null, 0);
+
+        syncService.cleanupForApi(AUDIT_INFO, API_ID);
+
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(link.getId());
+    }
+
+    @Test
+    void cleanupForApi_removes_nested_link_under_folder() {
+        var folderId = PortalNavigationItemId.forApiFolder(AUDIT_INFO, API_ID, "/guides");
+        var folder = PortalNavigationFolder.builder()
+            .id(folderId)
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("guides")
+            .segment("guides")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .reference(new NavigationItemReference.ApiReference(API_ID))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        navItemCrud.create(folder);
+        var linkSyncService = new PortalLinkSyncDomainService(navItemCrud, navItemQuery);
+        var link = linkSyncService.materializeForApi(AUDIT_INFO, API_ID, "docs-link", "Docs", "https://example.com", "/guides", 0);
+
+        syncService.cleanupForApi(AUDIT_INFO, API_ID);
+
+        assertThat(navItemCrud.storage()).extracting(PortalNavigationItem::getId).doesNotContain(link.getId());
+    }
+
+    @Test
     void cleanupForApi_leaves_other_api_rows_untouched() {
         var ownNavApiId = PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var otherApiNavId = PortalNavigationItemId.of("cccccccc-cccc-cccc-cccc-cccccccccccc");
@@ -198,7 +277,7 @@ class ApiDocumentationSyncDomainServiceTest {
     }
 
     @Test
-    void cleanupNavApi_removes_the_nav_api_row_and_the_api_page_it_still_owns() {
+    void cleanupNavApi_removes_only_the_row_and_leaves_the_apis_page_intact() {
         var keptNavApiId = PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var removedNavApiId = PortalNavigationItemId.of("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         seedNavApi(keptNavApiId);
@@ -209,41 +288,13 @@ class ApiDocumentationSyncDomainServiceTest {
 
         syncService.cleanupNavApi(AUDIT_INFO, removedNavApiId);
 
+        // The API's page is not a descendant of the row — it belongs to the API — so removing one of two
+        // nav-api rows takes only that row.
         var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
         assertThat(navItemCrud.storage())
             .extracting(PortalNavigationItem::getId)
-            .containsExactly(keptNavApiId)
-            .doesNotContain(removedNavApiId, pageId);
-    }
-
-    @Test
-    void materialize_inherits_private_visibility_from_private_nav_api_row() {
-        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), API_ID, PortalVisibility.PRIVATE);
-
-        var meta = new AutomationMetadata(
-            AutomationMetadata.ReferenceType.API,
-            API_ID,
-            "Getting Started",
-            Optional.empty(),
-            Optional.of(1)
-        );
-        var doc = new GraviteeMarkdownPageContent(
-            DOC_ID,
-            AUDIT_INFO.organizationId(),
-            AUDIT_INFO.environmentId(),
-            GraviteeMarkdown.of("# Hello"),
-            meta
-        );
-        syncService.materialize(AUDIT_INFO, doc);
-
-        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
-        var page = (PortalNavigationPage) navItemCrud
-            .storage()
-            .stream()
-            .filter(item -> item.getId().equals(pageId))
-            .findFirst()
-            .orElseThrow();
-        assertThat(page.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            .containsExactlyInAnyOrder(keptNavApiId, pageId)
+            .doesNotContain(removedNavApiId);
     }
 
     private PortalNavigationApi seedNavApi(PortalNavigationItemId id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
@@ -368,7 +368,7 @@ class PortalDocumentationSyncDomainServiceTest {
             .id(PortalNavigationItemId.of("00000000-0000-0000-0000-00000000c0d2"))
             .organizationId(AUDIT_INFO.organizationId())
             .environmentId(AUDIT_INFO.environmentId())
-            .reference(NavigationItemReference.DEFAULT)
+            .reference(NavigationItemReference.defaultReference())
             .title("Seeded")
             .segment("seeded")
             .area(PortalArea.HOMEPAGE)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
@@ -289,6 +289,31 @@ class PortalLinkSyncDomainServiceTest {
     }
 
     @Test
+    void materialize_for_api_allows_a_root_segment_already_owned_by_a_portal_root() {
+        // An API-attached item with no location is a root of the API's own subtree, spliced in under
+        // every nav-api row that lists the API. It never renders as a sibling of a portal root, so the
+        // two may hold the same segment: /docs under the API is not the portal's own "docs".
+        navItemCrud.create(linkRow("docs", null, 0));
+
+        var link = syncService.materializeForApi(AUDIT_INFO, API_ID, "docs", "Docs", "https://d.example", null, 0);
+
+        assertThat(link.isRoot()).isTrue();
+        assertThat(link.getReference()).isEqualTo(new NavigationItemReference.ApiReference(API_ID));
+    }
+
+    @Test
+    void materialize_still_rejects_a_portal_attached_link_whose_root_segment_is_owned_by_another_portal_item() {
+        // Console-created and seeded roots carry PortalReference(ZERO) while an automation portal link
+        // carries PortalReference(portalId). Both render at the portal's top level, so they do clash —
+        // scoping the root check by exact reference equality would wrongly let this through.
+        navItemCrud.create(linkRow("docs", null, 0));
+
+        var throwable = catchThrowable(() -> syncService.materialize(AUDIT_INFO, PORTAL_ID, "docs", "Docs", "https://d.example", null, 0));
+
+        assertThat(throwable).isInstanceOf(PathConflictException.class);
+    }
+
+    @Test
     void materialize_for_api_stamps_an_api_reference_on_the_nav_item() {
         var link = syncService.materializeForApi(AUDIT_INFO, API_ID, "external-docs", "External Docs", "https://d.example", null, 0);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainServiceTest.java
@@ -20,7 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +64,27 @@ class PortalNavigationEnclosingApiDomainServiceTest {
         var page = PortalNavigationItemFixtures.aPage(DOC_PAGE_ID, "Doc", folder.getId(), contentId);
         page.updateParent(folder);
         itemsQueryService.initWith(List.of(api, folder, page));
+
+        assertThat(enclosingApiDomainService.findEnclosingApiId(ENV_ID, page)).contains("api-x");
+    }
+
+    @Test
+    void should_find_api_from_the_items_own_reference_when_it_is_a_spliced_subtree_root() {
+        var page = PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.of(DOC_PAGE_ID))
+            .organizationId(PortalNavigationItemFixtures.ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Doc")
+            .segment("doc")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.random())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .reference(new NavigationItemReference.ApiReference("api-x"))
+            .build();
+        page.markAsRoot();
+        itemsQueryService.initWith(List.of(page));
 
         assertThat(enclosingApiDomainService.findEnclosingApiId(ENV_ID, page)).contains("api-x");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
@@ -28,11 +28,14 @@ import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
@@ -408,6 +411,65 @@ public class PortalNavigationItemDomainServiceTest {
             )
                 .containsOnlyKeys(expected.keySet())
                 .containsAllEntriesOf(expected);
+        }
+
+        @Test
+        void deleting_a_portal_root_does_not_reorder_api_subtree_roots() {
+            var portalRoot = PortalNavigationPage.builder()
+                .id(PortalNavigationItemId.of("00000000-0000-0000-0000-00000000a010"))
+                .organizationId(PortalNavigationItemFixtures.ORG_ID)
+                .environmentId(PortalNavigationItemFixtures.ENV_ID)
+                .title("Portal Root")
+                .segment("portal-root")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .portalPageContentId(PortalPageContentId.random())
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .build();
+            portalRoot.markAsRoot();
+
+            var apiRoot1 = PortalNavigationPage.builder()
+                .id(PortalNavigationItemId.of("00000000-0000-0000-0000-00000000a011"))
+                .organizationId(PortalNavigationItemFixtures.ORG_ID)
+                .environmentId(PortalNavigationItemFixtures.ENV_ID)
+                .title("API 1 Root")
+                .segment("api-1-root")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(1)
+                .portalPageContentId(PortalPageContentId.random())
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .reference(new NavigationItemReference.ApiReference("api-1"))
+                .build();
+            apiRoot1.markAsRoot();
+
+            var apiRoot2 = PortalNavigationPage.builder()
+                .id(PortalNavigationItemId.of("00000000-0000-0000-0000-00000000a012"))
+                .organizationId(PortalNavigationItemFixtures.ORG_ID)
+                .environmentId(PortalNavigationItemFixtures.ENV_ID)
+                .title("API 2 Root")
+                .segment("api-2-root")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(2)
+                .portalPageContentId(PortalPageContentId.random())
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .reference(new NavigationItemReference.ApiReference("api-2"))
+                .build();
+            apiRoot2.markAsRoot();
+
+            portalNavigationItemsCrudService.initWith(List.of(portalRoot, apiRoot1, apiRoot2));
+            portalNavigationItemsQueryService.initWith(List.copyOf(portalNavigationItemsCrudService.storage()));
+
+            domainService.delete(portalRoot);
+
+            var reloaded = portalNavigationItemsCrudService
+                .storage()
+                .stream()
+                .collect(Collectors.toMap(PortalNavigationItem::getId, item -> item));
+            assertThat(reloaded.get(apiRoot1.getId()).getOrder()).isEqualTo(1);
+            assertThat(reloaded.get(apiRoot2.getId()).getOrder()).isEqualTo(2);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconcilerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/reconciliation/HomepageReconcilerTest.java
@@ -94,7 +94,7 @@ class HomepageReconcilerTest {
     @Test
     void drops_unattached_sentinel_homepage_and_its_content() {
         var seededContentId = PortalPageContentId.of("00000000-0000-0000-0000-0000000000c3");
-        navItemCrud.create(homepage(UNATTACHED_ID, NavigationItemReference.DEFAULT, seededContentId));
+        navItemCrud.create(homepage(UNATTACHED_ID, NavigationItemReference.defaultReference(), seededContentId));
         pageContentCrud.create(content(seededContentId));
 
         reconciler.dropStaleHomepages(ENV_ID, PORTAL_ID, ACTIVE_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/NavigationItemReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/NavigationItemReferenceTest.java
@@ -26,12 +26,12 @@ import org.junit.jupiter.api.Test;
 class NavigationItemReferenceTest {
 
     @Test
-    void DEFAULT_is_a_PortalReference_wrapping_PortalId_ZERO() {
-        assertThat(NavigationItemReference.DEFAULT).isEqualTo(new NavigationItemReference.PortalReference(PortalId.ZERO));
+    void defaultReference_is_a_PortalReference_wrapping_PortalId_ZERO() {
+        assertThat(NavigationItemReference.defaultReference()).isEqualTo(new NavigationItemReference.PortalReference(PortalId.ZERO));
     }
 
     @Test
-    void DEFAULT_is_the_same_instance_as_PortalReference_DEFAULT() {
-        assertThat(NavigationItemReference.DEFAULT).isSameAs(NavigationItemReference.PortalReference.DEFAULT);
+    void defaultReference_returns_the_same_instance_as_PortalReference_DEFAULT() {
+        assertThat(NavigationItemReference.defaultReference()).isSameAs(NavigationItemReference.PortalReference.DEFAULT);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdateApiDocumentationUseCaseTest.java
@@ -88,12 +88,7 @@ class CreateOrUpdateApiDocumentationUseCaseTest {
             crudService,
             queryService,
             new PortalPageContentValidatorService(List.of(gmdContentValidator)),
-            new ApiDocumentationSyncDomainService(
-                navCrudService,
-                navQueryService,
-                queryService,
-                mock(PortalNavigationItemValidatorService.class)
-            )
+            new ApiDocumentationSyncDomainService(navCrudService, navQueryService, mock(PortalNavigationItemValidatorService.class))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeleteApiDocumentationUseCaseTest.java
@@ -64,12 +64,7 @@ class DeleteApiDocumentationUseCaseTest {
         useCase = new DeleteApiDocumentationUseCase(
             crudService,
             queryService,
-            new ApiDocumentationSyncDomainService(
-                navCrudService,
-                navQueryService,
-                queryService,
-                mock(PortalNavigationItemValidatorService.class)
-            )
+            new ApiDocumentationSyncDomainService(navCrudService, navQueryService, mock(PortalNavigationItemValidatorService.class))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
@@ -445,4 +445,15 @@ class HRIDToUUIDTest {
             assertThat(planId).isEqualTo(pageId).isEqualTo(subId);
         }
     }
+
+    @Nested
+    class Navigation {
+
+        @Test
+        void should_produce_same_result_from_audit_info_and_org_env_strings() {
+            assertThat(HRIDToUUID.navigation().context(AUDIT).api("api").folder("/guides").id()).isEqualTo(
+                HRIDToUUID.navigation().context("org", "env").api("api").folder("/guides").id()
+            );
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiNavigationSubtreePathsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiNavigationSubtreePathsTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiNavigationSubtreePathsTest {
+
+    private static final String ORG = "org";
+    private static final String ENV = "env";
+    private static final String NAV_API_ROW_ID = "11111111-1111-1111-1111-111111111111";
+
+    @Test
+    void collects_a_single_folder_directly_under_the_row() {
+        var guides = legacyFolder("/guides");
+
+        var result = ApiNavigationSubtreePaths.collect(ORG, ENV, NAV_API_ROW_ID, Map.of(NAV_API_ROW_ID, List.of(guides)));
+
+        assertThat(result).extracting(ApiNavigationSubtreePaths.PathedFolder::path).containsExactly("/guides");
+        assertThat(result)
+            .extracting(f -> f.folder().getId())
+            .containsExactly(guides.getId());
+    }
+
+    @Test
+    void collects_a_folder_nested_two_deep() {
+        var guides = legacyFolder("/guides");
+        var advanced = legacyFolder("/guides/advanced");
+        advanced.setParentId(guides.getId());
+
+        var byParent = new HashMap<String, List<PortalNavigationItem>>();
+        byParent.put(NAV_API_ROW_ID, List.of(guides));
+        byParent.put(guides.getId(), List.of(advanced));
+
+        var result = ApiNavigationSubtreePaths.collect(ORG, ENV, NAV_API_ROW_ID, byParent);
+
+        assertThat(result).extracting(ApiNavigationSubtreePaths.PathedFolder::path).containsExactly("/guides", "/guides/advanced");
+    }
+
+    @Test
+    void does_not_re_key_or_descend_into_a_hand_created_folder() {
+        // Its id is not the deterministic legacy id for "/notes" — an ordinary folder someone made by
+        // hand happens to sit where automation would have written one. The child beneath it would only
+        // be reachable if the walk (wrongly) descended anyway.
+        var handCreated = PortalNavigationItem.builder()
+            .id("22222222-2222-2222-2222-222222222222")
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .parentId(NAV_API_ROW_ID)
+            .segment("notes")
+            .rootId("22222222-2222-2222-2222-222222222222")
+            .build();
+        var wouldBeChild = legacyFolder("/notes/nested");
+        wouldBeChild.setParentId(handCreated.getId());
+
+        var byParent = new HashMap<String, List<PortalNavigationItem>>();
+        byParent.put(NAV_API_ROW_ID, List.of(handCreated));
+        byParent.put(handCreated.getId(), List.of(wouldBeChild));
+
+        var result = ApiNavigationSubtreePaths.collect(ORG, ENV, NAV_API_ROW_ID, byParent);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void gives_up_on_a_branch_with_a_blank_segment_instead_of_emitting_a_double_slash() {
+        var blank = PortalNavigationItem.builder()
+            .id("33333333-3333-3333-3333-333333333333")
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .parentId(NAV_API_ROW_ID)
+            .segment("")
+            .rootId("33333333-3333-3333-3333-333333333333")
+            .build();
+
+        var result = ApiNavigationSubtreePaths.collect(ORG, ENV, NAV_API_ROW_ID, Map.of(NAV_API_ROW_ID, List.of(blank)));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void ignores_non_folder_children() {
+        var page = PortalNavigationItem.builder()
+            .id("44444444-4444-4444-4444-444444444444")
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.PAGE)
+            .parentId(NAV_API_ROW_ID)
+            .segment("getting-started")
+            .rootId("44444444-4444-4444-4444-444444444444")
+            .build();
+
+        var result = ApiNavigationSubtreePaths.collect(ORG, ENV, NAV_API_ROW_ID, Map.of(NAV_API_ROW_ID, List.of(page)));
+
+        assertThat(result).isEmpty();
+    }
+
+    private static PortalNavigationItem legacyFolder(String path) {
+        var segment = path.substring(path.lastIndexOf('/') + 1);
+        var id = HRIDToUUID.navigation().context(ORG, ENV).api(NAV_API_ROW_ID).folder(path).id();
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .segment(segment)
+            .rootId(NAV_API_ROW_ID)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgraderTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.PortalNavigationItemRepository;
+import io.gravitee.repository.management.api.search.PortalNavigationItemCriteria;
+import io.gravitee.repository.management.model.AutomationMetadata;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import io.gravitee.repository.management.model.PortalNavigationReferenceType;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemApiOwnedRekeyUpgraderTest {
+
+    private static final String ORG = "org";
+    private static final String ENV = "env";
+    private static final String API_ID = "api-1";
+    // apiLink()'s builder has no String-context overload — that overload exists only on
+    // NavigationBuilder, for production code that never computes a link id at all (a legacy link's id
+    // never changes). Test fixtures still need to derive it, so they use a real AuditInfo like every
+    // other navigation test.
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId(ORG)
+        .environmentId(ENV)
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private FakePortalNavigationItemRepository repository;
+    private PortalNavigationItemApiOwnedRekeyUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        repository = new FakePortalNavigationItemRepository();
+        upgrader = new PortalNavigationItemApiOwnedRekeyUpgrader(repository);
+    }
+
+    @Test
+    void rekeys_a_two_level_legacy_folder_tree_and_keeps_its_paths() throws UpgraderException {
+        var navApiRowId = "nav-api-row-1";
+        var apiRow = apiRow(navApiRowId, API_ID);
+        var guides = legacyFolder(navApiRowId, "/guides");
+        guides.setParentId(navApiRowId);
+        var advanced = legacyFolder(navApiRowId, "/guides/advanced");
+        advanced.setParentId(guides.getId());
+        repository.initWith(List.of(apiRow, guides, advanced));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var newGuidesId = newFolderId(API_ID, "/guides");
+        var newAdvancedId = newFolderId(API_ID, "/guides/advanced");
+
+        var newGuides = repository.get(newGuidesId);
+        assertThat(newGuides.getParentId()).isNull();
+        assertThat(newGuides.getRootId()).isEqualTo(newGuidesId);
+        assertThat(newGuides.getReferenceType()).isEqualTo(PortalNavigationReferenceType.API);
+        assertThat(newGuides.getReferenceId()).isEqualTo(API_ID);
+
+        var newAdvanced = repository.get(newAdvancedId);
+        assertThat(newAdvanced.getParentId()).isEqualTo(newGuidesId);
+        assertThat(newAdvanced.getRootId()).isEqualTo(newGuidesId);
+        assertThat(newAdvanced.getReferenceType()).isEqualTo(PortalNavigationReferenceType.API);
+
+        assertThat(repository.findById(guides.getId())).isEmpty();
+        assertThat(repository.findById(advanced.getId())).isEmpty();
+    }
+
+    @Test
+    void rekeys_a_legacy_doc_page_onto_the_api_and_keeps_its_phantom_parent_when_the_folder_is_absent() throws UpgraderException {
+        var contentId = "content-1";
+        var page = PortalNavigationItem.builder()
+            .id("old-page-id")
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.PAGE)
+            .parentId("some-legacy-parent-placeholder")
+            .rootId("old-page-id")
+            .configuration("{\"portalPageContentId\":\"" + contentId + "\"}")
+            .automationMetadata(
+                AutomationMetadata.builder()
+                    .referenceType(AutomationTargetReferenceType.API)
+                    .referenceId(API_ID)
+                    .location("/missing")
+                    .build()
+            )
+            .build();
+        repository.initWith(List.of(page));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var newPageId = HRIDToUUID.navigation().context(ORG, ENV).api(API_ID).documentation(contentId).id();
+        var phantomFolderId = newFolderId(API_ID, "/missing");
+
+        var newPage = repository.get(newPageId);
+        assertThat(newPage.getParentId()).isEqualTo(phantomFolderId);
+        assertThat(newPage.getRootId()).isEqualTo(phantomFolderId);
+        assertThat(newPage.getReferenceType()).isEqualTo(PortalNavigationReferenceType.API);
+        assertThat(newPage.getReferenceId()).isEqualTo(API_ID);
+
+        assertThat(repository.findById("old-page-id")).isEmpty();
+    }
+
+    @Test
+    void re_parents_a_legacy_api_link_without_changing_its_id() throws UpgraderException {
+        var linkId = HRIDToUUID.apiLink().context(AUDIT_INFO).api(API_ID).hrid("external-docs").id();
+        var link = PortalNavigationItem.builder()
+            .id(linkId)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.LINK)
+            .parentId("stale-parent-id")
+            .rootId("stale-parent-id")
+            // referenceType/referenceId left at their PORTAL/ZERO builder defaults, as a legacy row would have them.
+            .automationMetadata(AutomationMetadata.builder().referenceType(AutomationTargetReferenceType.API).referenceId(API_ID).build())
+            .build();
+        repository.initWith(List.of(link));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var updated = repository.get(linkId);
+        assertThat(updated.getParentId()).isNull();
+        assertThat(updated.getRootId()).isEqualTo(linkId);
+        assertThat(updated.getReferenceType()).isEqualTo(PortalNavigationReferenceType.API);
+        assertThat(updated.getReferenceId()).isEqualTo(API_ID);
+        assertThat(repository.storage()).hasSize(1);
+    }
+
+    @Test
+    void leaves_a_hand_created_folder_under_the_nav_api_row_untouched() throws UpgraderException {
+        var navApiRowId = "nav-api-row-1";
+        var apiRow = apiRow(navApiRowId, API_ID);
+        var handCreated = PortalNavigationItem.builder()
+            .id("hand-created-folder")
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .parentId(navApiRowId)
+            .segment("notes")
+            .rootId("hand-created-folder")
+            .build();
+        repository.initWith(List.of(apiRow, handCreated));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(repository.storage()).containsExactlyInAnyOrder(apiRow, handCreated);
+    }
+
+    @Test
+    void a_second_run_changes_nothing() throws UpgraderException {
+        var navApiRowId = "nav-api-row-1";
+        var apiRow = apiRow(navApiRowId, API_ID);
+
+        var folderNewId = newFolderId(API_ID, "/guides");
+        var folder = PortalNavigationItem.builder()
+            .id(folderNewId)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .segment("guides")
+            .rootId(folderNewId)
+            .referenceType(PortalNavigationReferenceType.API)
+            .referenceId(API_ID)
+            .build();
+
+        var contentId = "content-1";
+        var pageNewId = HRIDToUUID.navigation().context(ORG, ENV).api(API_ID).documentation(contentId).id();
+        var page = PortalNavigationItem.builder()
+            .id(pageNewId)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.PAGE)
+            .parentId(folderNewId)
+            .rootId(folderNewId)
+            .referenceType(PortalNavigationReferenceType.API)
+            .referenceId(API_ID)
+            .configuration("{\"portalPageContentId\":\"" + contentId + "\"}")
+            .automationMetadata(
+                AutomationMetadata.builder()
+                    .referenceType(AutomationTargetReferenceType.API)
+                    .referenceId(API_ID)
+                    .location("/guides")
+                    .build()
+            )
+            .build();
+
+        var linkId = HRIDToUUID.apiLink().context(AUDIT_INFO).api(API_ID).hrid("external-docs").id();
+        var link = PortalNavigationItem.builder()
+            .id(linkId)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.LINK)
+            .rootId(linkId)
+            .referenceType(PortalNavigationReferenceType.API)
+            .referenceId(API_ID)
+            .automationMetadata(AutomationMetadata.builder().referenceType(AutomationTargetReferenceType.API).referenceId(API_ID).build())
+            .build();
+
+        repository.initWith(List.of(apiRow, folder, page, link));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(repository.storage()).containsExactlyInAnyOrder(apiRow, folder, page, link);
+        assertThat(repository.updateCount()).isZero();
+    }
+
+    @Test
+    void two_portals_listing_the_same_api_converge_on_one_subtree() throws UpgraderException {
+        var apiRowA = apiRow("nav-api-row-a", API_ID);
+        var apiRowB = apiRow("nav-api-row-b", API_ID);
+        var guidesA = legacyFolder("nav-api-row-a", "/guides");
+        guidesA.setParentId("nav-api-row-a");
+        var guidesB = legacyFolder("nav-api-row-b", "/guides");
+        guidesB.setParentId("nav-api-row-b");
+        repository.initWith(List.of(apiRowA, apiRowB, guidesA, guidesB));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var newGuidesId = newFolderId(API_ID, "/guides");
+
+        assertThat(repository.storage())
+            .filteredOn(item -> item.getId().equals(newGuidesId))
+            .hasSize(1);
+        assertThat(repository.findById(guidesA.getId())).isEmpty();
+        assertThat(repository.findById(guidesB.getId())).isEmpty();
+    }
+
+    private static PortalNavigationItem apiRow(String id, String apiId) {
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.API)
+            .apiId(apiId)
+            .rootId(id)
+            .build();
+    }
+
+    private static PortalNavigationItem legacyFolder(String navApiRowId, String path) {
+        var segment = path.substring(path.lastIndexOf('/') + 1);
+        var id = HRIDToUUID.navigation().context(ORG, ENV).api(navApiRowId).folder(path).id();
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId(ORG)
+            .environmentId(ENV)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .segment(segment)
+            .rootId(navApiRowId)
+            .build();
+    }
+
+    private static String newFolderId(String apiId, String path) {
+        return HRIDToUUID.navigation().context(ORG, ENV).api(apiId).folder(path).id();
+    }
+
+    private static class FakePortalNavigationItemRepository implements PortalNavigationItemRepository {
+
+        private final List<PortalNavigationItem> items = new ArrayList<>();
+        private int updateCount;
+
+        void initWith(List<PortalNavigationItem> initial) {
+            items.clear();
+            items.addAll(initial);
+            updateCount = 0;
+        }
+
+        List<PortalNavigationItem> storage() {
+            return items;
+        }
+
+        int updateCount() {
+            return updateCount;
+        }
+
+        PortalNavigationItem get(String id) {
+            return findById(id).orElseThrow(() -> new AssertionError("No item at id " + id));
+        }
+
+        @Override
+        public Set<PortalNavigationItem> findAll() {
+            return Set.copyOf(items);
+        }
+
+        @Override
+        public Optional<PortalNavigationItem> findById(String id) {
+            return items
+                .stream()
+                .filter(item -> item.getId().equals(id))
+                .findFirst();
+        }
+
+        @Override
+        public PortalNavigationItem create(PortalNavigationItem item) {
+            items.add(item);
+            return item;
+        }
+
+        @Override
+        public PortalNavigationItem update(PortalNavigationItem item) {
+            updateCount++;
+            items.removeIf(existing -> existing.getId().equals(item.getId()));
+            items.add(item);
+            return item;
+        }
+
+        @Override
+        public void delete(String id) {
+            items.removeIf(item -> item.getId().equals(id));
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllByOrganizationIdAndEnvironmentId(String organizationId, String environmentId) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findByAutomationReference(
+            String environmentId,
+            AutomationTargetReferenceType referenceType,
+            String referenceId
+        ) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllByParentIdAndEnvironmentId(String parentId, String environmentId) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllByAreaAndEnvironmentIdAndParentIdIsNull(
+            PortalNavigationItem.Area area,
+            String environmentId
+        ) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllTopLevelByAreaAndEnvironmentAndReference(
+            PortalNavigationItem.Area area,
+            String environmentId,
+            PortalNavigationReferenceType referenceType,
+            String referenceId
+        ) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllByAreaAndEnvironmentId(PortalNavigationItem.Area area, String environmentId) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> searchByCriteria(PortalNavigationItemCriteria criteria) {
+            return List.of();
+        }
+
+        @Override
+        public List<PortalNavigationItem> findAllByRootId(String rootId, String environmentId) {
+            return List.of();
+        }
+
+        @Override
+        public void deleteByIds(List<String> ids) {
+            items.removeIf(item -> ids.contains(item.getId()));
+        }
+
+        @Override
+        public void deleteByOrganizationId(String organizationId) {
+            items.removeIf(item -> item.getOrganizationId().equals(organizationId));
+        }
+
+        @Override
+        public void deleteByEnvironmentId(String environmentId) {
+            items.removeIf(item -> item.getEnvironmentId().equals(environmentId));
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-180

## Description

### What this branch does

This branch exposes the API-referenced link feature (introduced in `part1`) through the **Automation REST API**, and completes a structural change part1 started: an API's navigation content — its folders, its documentation pages, and now its links — is materialized exactly once, owned by the API itself, instead of being duplicated per portal listing. Existing deployments are migrated to that model automatically on upgrade.

### REST layer & OpenAPI contract

New resources let automation config declare and read back an API's own link(s) through the Automation API:

- New endpoints for reading and managing a single API-referenced link, and listing an API's links
- The `open-api.yaml` contract extended with the corresponding schemas and operations
- A mapper translating between the REST/automation model and the domain model
- Resource wiring updated so the new endpoints are reachable from the existing API resource tree

### API-owned navigation: materialize once, not per listing

Previously, an API's folder subtree and documentation pages were each reconciled and materialized **per portal listing** — an API listed in two portals produced two independent copies of the same subtree, keyed to that listing rather than to the API. This branch removes that fan-out:

- The folder subtree reconciler now reconciles an API's `portalNavigation` **once per API**, regardless of how many portals list it, or whether any currently do
- Documentation pages drop the per-listing materialization loop entirely — one page per API and content, materialized with no listing and no portal required
- Ownership queries (used to protect automation-managed rows from an unrelated cascade delete) move onto the item's own API reference instead of enumerating by listing row
- Removing an API from a listing no longer deletes its automation-managed documentation, folders or links — only deleting the API itself does. Re-adding the listing simply re-renders what was never actually removed
- The walks that resolve an item's owning API (for documentation-template scoping) and that order or validate siblings at the root level now recognize an API-owned root directly, rather than assuming every top-level item belongs to a portal

### Fixing a root-level segment conflict

An API declaring an ordinary navigation path like `/guides` could never actually be reconciled: the check that rejects a segment already taken by a foreign item was scoped across the *entire* environment rather than by the item's own reference, so it collided with the portal's own seeded "Guides" folder — a false conflict on the most common input there is. Fixed by scoping that check the same way sibling ordering was already scoped: by reference, not environment-wide, so an API's own navigation and a portal's own navigation stop competing for the same segment names.

### Migrating existing navigation data

Rows materialized under the old, per-listing model don't disappear just because the code changed. A new boot-time upgrader re-keys every pre-existing folder, documentation page and link into the API-owned model in place: legacy folders and pages are identified by matching their stored id against the old id formula — the same check the runtime itself already uses to detect a foreign row — then migrated to their new identity, with any duplicate left behind by the old per-listing fan-out converging onto a single row. Links, whose identity never depended on the listing, are simply re-parented and re-tagged in place. The migration runs once, requires no downtime and no manual step, and replaces an earlier runtime-sweep approach that turned out not to work for folders at all.

### Outcome

With this branch, operators can declare an API's links via the Automation API/GitOps config exactly like they already do for documentation and listing, and have them reliably created, updated, retracted and exposed for reading. An API's navigation content is now owned by the API rather than by any one listing, existing deployments migrate to that model automatically on upgrade, and a class of root-level path collisions between an API's own declared navigation and a portal's seeded folders is closed.



