### PR TITLE
chore(deps): bump gravitee-node to 9.7.0

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.6.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.6.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.6.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.6.1.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.7.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.7.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.7.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.7.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.6.1.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.6.1.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.7.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.7.0.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
     <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
     <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>
-    <gravitee-node.version>9.6.1</gravitee-node.version>
+    <gravitee-node.version>9.7.0</gravitee-node.version>
     <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
     <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
     <gravitee-plugin.version>5.1.5</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-4304

## Description

Picks up gravitee-node 9.7.0, which adds `services.opentelemetry.exporter.ssl.{keystore,truststore}.content` so the OTLP trace exporter can take a base64-encoded store instead of only a file path. Cockpit pushes OpenTelemetry reporter config (including mTLS client certificates) down to the gateways, and a path-only exporter has no way to consume it.

Also aligns the hazelcast node plugin pins in `helm/values.yaml` (and the federation helm test) with the same version.

## Additional context

Delta from the currently pinned 9.6.1 is two changes:

- gravitee-io/gravitee-node#601 — the OpenTelemetry exporter change above (9.7.0)
- gravitee-io/gravitee-node#602 — reuse of a single `NetClient` in `JettyHttpServerProbe` (9.6.2)

Labelled `apply-on-master` so mergify opens the master copy.
