### PR TITLE
fix(ci): fall back to git when the GitHub API cannot answer for the base branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,43 +78,47 @@ jobs:
                       - run:
                             name: Find base branch
                             command: |
-                                if [ "x${GITHUB_TOKEN}" == "x" ]; then
-                                  echo "[GITHUB_TOKEN] is not set, can't find the base branch. Use 'master'"
-                                  echo "export GIT_BASE_BRANCH=master" >> $BASH_ENV
-                                fi;
+                                # `--fail`, so that an error body -- a rate limited 403 included -- stops being
+                                # parsed like an answer: the jq defaults below used to turn it into `origin/master`.
+                                # Nothing here is fatal any more; a missing answer falls through to the history walk.
+                                if [ "x${CIRCLE_PULL_REQUEST}" != "x" ] && [ "x${GITHUB_TOKEN}" != "x" ]; then
+                                  PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
 
-                                if [ "x${CIRCLE_PULL_REQUEST}" == "x" ]; then
-                                  echo "No opened pull request for this branch -> try to find the base branch with commits."
-                                  # Loop over the last 100 commits maximum and find the first commit that is on a branch matching `origin/master` or `origin/[0-9].[0-9].x`
+                                  if PULL_REQUEST_RESPONSE_CONTENT=$(curl -sS --fail -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL}); then
+                                    PULL_REQUEST_BASE=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.ref // ""')
+                                    COMMON_COMMIT=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.sha // ""')
+
+                                    if [ "x${PULL_REQUEST_BASE}" != "x" ] && [ "x${COMMON_COMMIT}" != "x" ]; then
+                                      BASE_REF=origin/${PULL_REQUEST_BASE}
+                                    else
+                                      COMMON_COMMIT=""
+                                    fi
+                                  else
+                                    echo "The GitHub API did not answer, looking for the base branch in the history."
+                                  fi
+                                fi
+
+                                # No pull request, or no usable answer: find the first commit that is also on `origin/master`
+                                # or on a support branch.
+                                if [ "x${COMMON_COMMIT}" == "x" ]; then
                                   MAX_COMMITS=100
-
-                                  # Define the pattern for matching branch names: origin/master or origin/[0-9].[0-9].x
                                   PATTERN="origin/master|origin/[0-9]+\.[0-9]+\.x"
 
-                                  # Loop over the last $MAX_COMMITS commits
                                   for (( i = 0; i < MAX_COMMITS; i++ )); do
-                                    # Get the commit hash
                                     hash=$(git rev-parse HEAD~$i)
-                                  
-                                    # Get the branch name that contains the commit hash and matches the pattern
-                                    branch=$(git --no-pager branch -r --contains $hash | grep -oE $PATTERN || true)
-                                  
-                                    # If the branch name is not empty, then the matching branch has been found
+
+                                    # `head -1`: a commit usually sits on several branches, and `origin/HEAD -> origin/master`
+                                    # alone makes `origin/master` match twice. Several lines here means several lines in
+                                    # $BASH_ENV, which every later step sources under `bash -eo pipefail` before running.
+                                    branch=$(git --no-pager branch -r --contains $hash | grep -oE $PATTERN | head -1 || true)
+
                                     if [ -n "$branch" ]; then
                                       BASE_REF=$branch
                                       COMMON_COMMIT=$hash
                                       break
                                     fi
                                   done
-
-                                # else use the pull request info
-                                else
-                                  PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
-                                  PULL_REQUEST_RESPONSE_CONTENT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL})
-
-                                  BASE_REF=origin/$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.ref // "master"')
-                                  COMMON_COMMIT=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.sha // ""')
-                                fi;
+                                fi
 
                                 # if BASE_REF is empty just stop
                                 if [ "x${BASE_REF}" == "x" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,9 @@ jobs:
                                 if [ "x${CIRCLE_PULL_REQUEST}" != "x" ] && [ "x${GITHUB_TOKEN}" != "x" ]; then
                                   PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
 
-                                  if PULL_REQUEST_RESPONSE_CONTENT=$(curl -sS --fail -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL}); then
+                                  # `--max-time`, because a connection that never answers is the one failure
+                                  # `--fail` cannot turn into a fall through: it would sit here until the job times out.
+                                  if PULL_REQUEST_RESPONSE_CONTENT=$(curl -sS --fail --max-time 10 -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL}); then
                                     PULL_REQUEST_BASE=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.ref // ""')
                                     COMMON_COMMIT=$(echo $PULL_REQUEST_RESPONSE_CONTENT | jq -r '.base.sha // ""')
 
@@ -126,10 +128,13 @@ jobs:
                                   circleci step halt
                                 fi;
 
-                                echo "export GIT_BASE_BRANCH=${BASE_REF}" >> $BASH_ENV
+                                # `%q`, because on the pull request path these values come from the API rather than from
+                                # the pattern above, and `git check-ref-format` allows `;`, `&` and backticks in a branch
+                                # name — which $BASH_ENV would hand to every later step.
+                                printf 'export GIT_BASE_BRANCH=%q\n' "${BASE_REF}" >> $BASH_ENV
                                 echo "The base branch is ${BASE_REF}"
 
-                                echo "export GIT_COMMON_COMMIT_HASH=${COMMON_COMMIT}" >> $BASH_ENV
+                                printf 'export GIT_COMMON_COMMIT_HASH=%q\n' "${COMMON_COMMIT}" >> $BASH_ENV
                                 echo "The common commit hash is ${COMMON_COMMIT}"
 
             - node/install-packages:


### PR DESCRIPTION
## Issue

No ticket: CI reliability fix.

## Description

When the GitHub API stopped returning `base.sha`, every pipeline with an open pull request
went red. The `generate-config` setup job resolves the base branch of the current branch,
and everything else depends on the answer: it is what the changed files are diffed against,
and therefore what decides which jobs get scheduled at all. That resolution had no way to
carry on without the API.

Three changes, and deliberately nothing else.

**The API call is allowed to fail.** It had no `--fail` and no status check, so an error
body — a rate limited 403 included — was parsed like a successful answer, and
`jq -r '.base.ref // "master"'` turned it into `origin/master` for every branch, silently. A
branch cut from `4.12.x` was then diffed against `master`. The call now fails properly, and
a response without a usable `base.ref` and `base.sha` — this morning's case exactly — falls
through to the path below instead of taking the pipeline down.

**The call is bounded in time.** A connection that never answers is the one failure `--fail`
cannot turn into a fall through: it does not return, so the fallback is never reached and
the job sits there until the pipeline times out. `--max-time 10` returns after 10.02s with
exit 28, and the fallback runs.

**The history walk it falls back to can no longer poison `$BASH_ENV`.** That path already
existed, for branches with no open pull request. It greps `git branch -r --contains`, which
returns *one line per containing branch*, and `origin/HEAD -> origin/master` alone makes
`origin/master` match twice. The result went straight into `$BASH_ENV`, so the file gained
lines that are not assignments; CircleCI sources it under `bash -eo pipefail` before every
step, so each later step died before it started. It was rarely hit while it only served
branches without a pull request. It is the fallback now, so it takes a `head -1`.

The two values written into `$BASH_ENV` are quoted with `printf '%q'` in the same spirit: on
the API path `BASE_REF` is `base.ref` verbatim, and `git check-ref-format` allows `;`, `&`
and backticks in a branch name.

## Additional context

Exercised locally against this repository, by extracting the step and running it under
`bash -eo pipefail` with a real `$BASH_ENV`:

| case | result |
|---|---|
| open pull request, API answering | base from the API, unchanged behaviour |
| API failing (`401`) | `curl: (56)`, then the history walk, pipeline carries on |
| API answering without `base.sha` — this morning | history walk, pipeline carries on |
| API never answering | `--max-time` returns at 10.02s, exit 28, history walk |
| no pull request | history walk |
| all of them | `$BASH_ENV` sources cleanly, one line per variable |

Measured on 8 local branches, the multi-line value the `head -1` fixes was produced by 6 of
them, and sourcing such a file under `bash -eo pipefail` exits 1 before the step body runs.

On the quoting, a branch named `feat;<command>` as the base of a pull request writes
`export GIT_BASE_BRANCH=origin/feat;<command>` into `$BASH_ENV`, and *every* later step of
the job runs `<command>` while sourcing it — verified locally. `%q` keeps the value intact
and inert. Creating such a branch takes write access to the repository, so this is
hardening rather than an open door.

Two known defects are left alone on purpose, since neither is what broke: the walk gives up
after 100 commits, and giving up calls `circleci step halt`, which leaves a green pipeline
that has run no test at all.

Backport labels are set for `4.12.x`, `4.11.x`, `4.10.x` and `4.9.x`: the block is
byte-identical on all of them.
