### PR TITLE
fix(ci): restore the S3 upload for es-mapping and jdbc-migration resources

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -82,18 +82,20 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-
 
       steps.push(
         /**
-         * In order to upload repositories, endpoints and entrypoints embedded in APIM mono-repository, we browse for all ZIP files in the project and check if they have a "publish folder path" property in pom.xml.
-         * Because we don't want to publish EVERY plugins (we don't want, apim-services or rest-api-idp-memory for instance), we only rely on this publish-folder-path maven property to determine if a ZIP has to be published or not.
-         * Each plugins is uploaded into a folder based on its name.
+         * We browse the distribution reactor for ZIP files and check if they have a "publish folder path" property in
+         * pom.xml. Because we don't want to publish every artefact, we only rely on that maven property to determine
+         * whether a ZIP has to be published. Each artefact is uploaded into a folder based on its name.
          * Example:
-         *   gravitee-apim-repository-mongodb-x.x.x.zip is published into graviteeio-apim/plugins/repositories/gravitee-apim-repository-mongodb
+         *   gravitee-apim-jdbc-migrations-x.x.x.zip is published into graviteeio-apim/resources/gravitee-apim-jdbc-migrations
          *
-         *
+         * The search is scoped to gravitee-apim-distribution on purpose. Repositories, reporters, endpoints and
+         * entrypoints also carry publish-folder-path, and have not been published since 4.8 — widening the search
+         * here would silently resume publishing thirteen more artefacts, which is a product decision of its own.
          */
         new commands.Run({
           name: 'Prepare plugin zip to upload',
           command: `workingDir=$(pwd)
-for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
   # Extract folder of the artefact to publish
   # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
   artefactFolder=\${pathToArtefactFile%/target*}
@@ -126,6 +128,9 @@ for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
     cd $workingDir
   fi
 done`,
+        }),
+        new reusable.ReusedCommand(syncFolderToS3Cmd, {
+          'folder-to-sync': 'folder_to_sync',
         }),
       );
     }

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -510,7 +510,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -543,6 +543,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -282,7 +282,7 @@ jobs:
           name: Prepare plugin zip to upload
           command: |-
             workingDir=$(pwd)
-            for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
               # Extract folder of the artefact to publish
               # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
               artefactFolder=${pathToArtefactFile%/target*}
@@ -315,6 +315,8 @@ jobs:
                 cd $workingDir
               fi
             done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-183

## What

Restores the `cmd-sync-folder-to-s3` step in `job-backend-build-and-publish-on-download-website`, and scopes the artefact search to the distribution reactor so that only `gravitee-apim-distribution-es-index-mappings` and `gravitee-apim-distribution-jdbc-migrations` are published.

## Why

The job has two halves: shell steps that *stage* zips and checksums into a local `folder_to_sync/`, and one reusable command that *uploads* that folder to S3.

`d9c7d3dbdb` ("chore: remove backend standalone zip and sync on S3", March 2025) legitimately removed the two staging steps for the mAPI and Gateway standalone zips, replaced by the Docker images. But the four entries were contiguous in the same `steps.push(...)`, and the deletion took the fourth with them:

```diff
-        new reusable.ReusedCommand(syncFolderToS3Cmd, {
-          'folder-to-sync': 'folder_to_sync',
-        }),
```

That one was not specific to the standalone zips: it was the shared upload, serving also the generic `publish-folder-path` loop, which survived.

Since then the job stages everything correctly and the container dies with the folder. Nothing fails and the logs look clean. Two things kept it hidden. Lines 80-81 still register the reusable command, so it keeps appearing under `commands:` in the generated YAML and a grep looks reassuring. And the download website does not look empty, because `job-package-bundle` builds its own `folder_to_sync` and calls the sync itself; it is currently the only caller left in the repo.

Confirmed against the bucket:

| Prefix | Newest object | |
|---|---|---|
| `graviteeio-apim/distributions/` | `graviteeio-full-4.12.15.zip`, 2026-08-12 | alive, published by `job-package-bundle` |
| `graviteeio-apim/plugins/repositories/` | `...elasticsearch-4.4.23.zip`, 2025-03-27 | dead since `d9c7d3dbdb` |
| `graviteeio-apim/resources/` | 0 objects | `es-index-mappings` never landed |

No plugin zip exists for 4.8, 4.9, 4.10, 4.11 or 4.12, checked prefix by prefix.

## Scope of the search

The `find` is narrowed to `./gravitee-apim-distribution`. Restoring the upload without narrowing it would silently resume publishing thirteen plugin artefacts (repositories, reporters, endpoints, entrypoints) that have been absent from the download website for a year and a half.

Whether to resume them, or instead to drop the now-inert `publish-folder-path` properties, is a product decision, and one to backport across 4.8.x to 4.12.x. This PR deliberately keeps master's current behaviour and only adds the two distribution archives.

## What will be published

Replayed the job's shell script against a local build:

```
gravitee-apim-distribution-es-index-mappings-4.13.0.zip -> graviteeio-apim/resources/gravitee-apim-distribution-es-index-mappings/
gravitee-apim-jdbc-migrations-4.13.0.zip                -> graviteeio-apim/resources/gravitee-apim-jdbc-migrations/
```

These two and nothing else. Three filters stack up:

- the narrowed `find` returns 2 zips instead of 40;
- `publish-folder-path` is declared by only those two poms in the reactor, and the script reads each module's own `pom.xml`, so nothing inherits it by accident;
- `gravitee-apim-distribution-integration-tests` is profile-gated and produces no zip.

The case worth noting: `target/distribution/plugins/` under the two standalone modules holds 372 plugin zips. They do not match, because the pattern requires the literal `target/gravitee-apim` and here `target/` is followed by `distribution/`. Even if they did, `${pathToArtefactFile%/target*}` would attribute them to the standalone module, whose pom carries no `publish-folder-path`. The guard holds at two levels.

No double upload: nothing persists `folder_to_sync` to the workspace, so `job-package-bundle`'s `attach_workspace` cannot pick up the backend job's folder; the two prefixes are disjoint anyway; and `aws s3 sync` runs without `--delete`, so re-running a release overwrites the same keys rather than accumulating.

The restored step needs no companion. The reusable command already carries the two `keeper/env-export` for the AWS credentials and the `aws-cli/setup`, and the job already runs with `context: cicd-orchestrator`, the same context `job-package-bundle` uses and the one this job already relies on for GPG.

## Tested

- `npx jest`: 153 tests, 29 suites, green
- `npm run validate:test`: 52 configs valid, 0 invalid
- the 7 regenerated fixtures were diffed: they contain the two changes replicated 7 times, with no absorbed drift

Dry-run is safe to try: the sync targets `s3://gravitee-dry-releases-downloads`, and a qualified version goes under `/pre-releases`.

## Note

`npm run build` fails on `circleci-config/config.ts:103` (`lineWidth` missing from `Options`). Verified pre-existing by stashing, unrelated to this change, likely a `yaml` version drift.

Backport policy: none (master only). The published modules only exist from 4.10.x (es-index-mappings) and master (jdbc-migrations). On 4.8.x/4.9.x the narrowed find would match nothing and the sync step would fail on a missing directory, so this must not be cherry-picked there.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

