### PR TITLE
chore: bump up entrypoint-mcp-tool-server to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
     <gravitee-entrypoint-webhook.version>8.0.1</gravitee-entrypoint-webhook.version>
     <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
     <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
-    <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
+    <gravitee-entrypoint-mcp-tool-server.version>2.0.3</gravitee-entrypoint-mcp-tool-server.version>
     <gravitee-endpoint-jms.version>2.0.2</gravitee-endpoint-jms.version>
     <gravitee-endpoint-kafka.version>6.1.5</gravitee-endpoint-kafka.version>
     <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-900

## Description

bump up entrypoint-mcp-tool-server to 2.0.3


