### PR TITLE
feat(portal-next): add automation theme use cases for PORTAL_NEXT themes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 public interface PortalRepository extends CrudRepository<Portal, String> {
     Optional<Portal> findByIdAndEnvironmentId(final String portalId, final String environmentId) throws TechnicalException;
     List<Portal> findByEnvironmentId(final String environmentId) throws TechnicalException;
+    List<Portal> findByActiveThemeIdAndEnvironmentId(final String activeThemeId, final String environmentId) throws TechnicalException;
     void deleteByEnvironmentId(final String environmentId) throws TechnicalException;
     void deleteByOrganizationId(final String organizationId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Theme.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Theme.java
@@ -48,6 +48,7 @@ public class Theme {
         this.backgroundImage = cloned.getBackgroundImage();
         this.definition = cloned.getDefinition();
         this.favicon = cloned.getFavicon();
+        this.automationMetadata = cloned.getAutomationMetadata();
     }
 
     public enum AuditEvent implements Audit.AuditEvent {
@@ -82,6 +83,8 @@ public class Theme {
     private String optionalLogo;
 
     private String favicon;
+
+    private ThemeAutomationMetadata automationMetadata;
 
     @Override
     public boolean equals(Object o) {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ThemeAutomationMetadata.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ThemeAutomationMetadata.java
@@ -13,31 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.theme.model;
+package io.gravitee.repository.management.model;
 
-import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
-import java.time.ZonedDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-public class NewTheme {
+@NoArgsConstructor
+@AllArgsConstructor
+public class ThemeAutomationMetadata {
 
-    private String name;
-    private String referenceId;
-    private Theme.ReferenceType referenceType;
-
-    private ThemeDefinition definitionPortal;
-    private io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition definitionPortalNext;
-
-    private ThemeType type;
-
-    private boolean enabled;
-    private String logo;
-    private String optionalLogo;
-    private String favicon;
-    private String backgroundImage;
-
-    private ThemeAutomationMetadata automationMetadata;
+    private String hrid;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
@@ -87,6 +87,27 @@ public class JdbcPortalRepository extends JdbcAbstractCrudRepository<Portal, Str
     }
 
     @Override
+    public List<Portal> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.findByActiveThemeIdAndEnvironmentId({}, {})", activeThemeId, environmentId);
+        try {
+            return jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " WHERE active_theme_id = ? AND environment_id = ?",
+                getOrm().getRowMapper(),
+                activeThemeId,
+                environmentId
+            );
+        } catch (final Exception ex) {
+            final String error = String.format(
+                "Failed to find portals by active theme id (%s) and environment id (%s)",
+                activeThemeId,
+                environmentId
+            );
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
     public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
         log.debug("JdbcPortalRepository.deleteByEnvironmentId({})", environmentId);
         try {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcThemeRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.jdbc.management;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.util.stream.Collectors.toSet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -25,6 +26,7 @@ import io.gravitee.repository.management.api.ThemeRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.ThemeCriteria;
 import io.gravitee.repository.management.model.Theme;
+import io.gravitee.repository.management.model.ThemeAutomationMetadata;
 import io.gravitee.repository.management.model.ThemeReferenceType;
 import io.gravitee.repository.management.model.ThemeType;
 import java.sql.PreparedStatement;
@@ -44,6 +46,8 @@ import org.springframework.stereotype.Repository;
 @CustomLog
 @Repository
 public class JdbcThemeRepository extends JdbcAbstractCrudRepository<Theme, String> implements ThemeRepository {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
 
     JdbcThemeRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "themes");
@@ -65,7 +69,30 @@ public class JdbcThemeRepository extends JdbcAbstractCrudRepository<Theme, Strin
             .addColumn("optional_logo", Types.NVARCHAR, String.class)
             .addColumn("background_image", Types.NVARCHAR, String.class)
             .addColumn("favicon", Types.NVARCHAR, String.class)
+            .addColumn(
+                "automation_metadata",
+                Types.NCLOB,
+                ThemeAutomationMetadata.class,
+                JdbcThemeRepository::serializeAutomationMetadata,
+                JdbcThemeRepository::deserializeAutomationMetadata
+            )
             .build();
+    }
+
+    static String serializeAutomationMetadata(ThemeAutomationMetadata meta) {
+        try {
+            return JSON.writeValueAsString(meta);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize automation metadata", e);
+        }
+    }
+
+    static ThemeAutomationMetadata deserializeAutomationMetadata(String json) {
+        try {
+            return JSON.readValue(json, ThemeAutomationMetadata.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize automation metadata", e);
+        }
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/17_add_automation_metadata_to_themes.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/17_add_automation_metadata_to_themes.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_17_add_automation_metadata_to_themes
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}themes
+            columns:
+              - column: {name: automation_metadata, type: nclob, constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -419,3 +419,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/15_add_automation_metadata_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/16_add_active_theme_id_to_portals.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/17_add_automation_metadata_to_themes.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcPortalRepositoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import java.lang.reflect.Field;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class JdbcPortalRepositoryTest {
+
+    private final JdbcPortalRepository repository = new JdbcPortalRepository("");
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    @SneakyThrows
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        Field field = JdbcAbstractRepository.class.getDeclaredField("jdbcTemplate");
+        field.setAccessible(true);
+        field.set(repository, jdbcTemplate);
+        field.setAccessible(false);
+    }
+
+    @Test
+    void findByActiveThemeIdAndEnvironmentId_wraps_exception_as_technical() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object.class), any(Object.class))).thenThrow(
+            new RuntimeException("boom")
+        );
+
+        var ex = catchThrowable(() -> repository.findByActiveThemeIdAndEnvironmentId("theme1", "env1"));
+
+        assertThat(ex)
+            .isInstanceOf(TechnicalException.class)
+            .hasMessageContaining("Failed to find portals by active theme id (theme1)")
+            .hasMessageContaining("environment id (env1)")
+            .hasCauseInstanceOf(RuntimeException.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcThemeRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcThemeRepositoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.gravitee.repository.management.model.ThemeAutomationMetadata;
+import org.junit.jupiter.api.Test;
+
+class JdbcThemeRepositoryTest {
+
+    @Test
+    void serializeAutomationMetadata_writes_hrid_field_as_json() {
+        var meta = ThemeAutomationMetadata.builder().hrid("brand-theme").build();
+
+        var json = JdbcThemeRepository.serializeAutomationMetadata(meta);
+
+        assertThat(json).contains("\"hrid\"").contains("brand-theme");
+    }
+
+    @Test
+    void deserializeAutomationMetadata_reads_hrid_field_from_json() {
+        var meta = JdbcThemeRepository.deserializeAutomationMetadata("{\"hrid\":\"brand-theme\"}");
+
+        assertThat(meta).isNotNull();
+        assertThat(meta.getHrid()).isEqualTo("brand-theme");
+    }
+
+    @Test
+    void serializeAutomationMetadata_wraps_exception_as_illegal_argument() {
+        var self = new ThemeAutomationMetadata();
+        // Force a Jackson failure by creating a value that references itself indirectly is hard;
+        // easier: pass a subclass overriding a getter to throw.
+        var throwing = new ThemeAutomationMetadata() {
+            @Override
+            public String getHrid() {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        var ex = catchThrowable(() -> JdbcThemeRepository.serializeAutomationMetadata(throwing));
+
+        assertThat(ex)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Failed to serialize automation metadata")
+            .hasCauseInstanceOf(Exception.class);
+    }
+
+    @Test
+    void deserializeAutomationMetadata_wraps_exception_as_illegal_argument() {
+        var ex = catchThrowable(() -> JdbcThemeRepository.deserializeAutomationMetadata("{not-valid-json"));
+
+        assertThat(ex)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Failed to deserialize automation metadata")
+            .hasCauseInstanceOf(Exception.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
@@ -55,6 +55,11 @@ public class MongoPortalRepository implements PortalRepository {
     }
 
     @Override
+    public List<Portal> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId) throws TechnicalException {
+        return mapper.mapPortals(internalPortalRepo.findByActiveThemeIdAndEnvironmentId(activeThemeId, environmentId));
+    }
+
+    @Override
     public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
         try {
             internalPortalRepo.deleteByEnvironmentId(environmentId);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ThemeMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ThemeMongo.java
@@ -64,4 +64,6 @@ public class ThemeMongo {
     private String loader;
 
     private String favicon;
+
+    private io.gravitee.repository.management.model.ThemeAutomationMetadata automationMetadata;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
@@ -33,6 +33,9 @@ public interface PortalMongoRepository extends MongoRepository<PortalMongo, Stri
     @Query("{ 'environmentId': ?0 }")
     List<PortalMongo> findByEnvironmentId(String environmentId);
 
+    @Query("{ 'activeThemeId': ?0, 'environmentId': ?1 }")
+    List<PortalMongo> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId);
+
     @Query(value = "{ 'environmentId': ?0 }", delete = true)
     void deleteByEnvironmentId(String environmentId);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
@@ -109,6 +109,20 @@ public class PortalRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void should_find_by_active_theme_id_and_environment() throws Exception {
+        List<Portal> portals = portalRepository.findByActiveThemeIdAndEnvironmentId("theme-portal2", "environment1");
+
+        assertThat(portals).extracting(Portal::getId).containsExactly("portal2");
+    }
+
+    @Test
+    public void should_find_nothing_by_active_theme_id_when_environment_differs() throws Exception {
+        List<Portal> portals = portalRepository.findByActiveThemeIdAndEnvironmentId("theme-portal2", "environment2");
+
+        assertThat(portals).isEmpty();
+    }
+
+    @Test
     public void should_create() throws Exception {
         Portal toCreate = Portal.builder()
             .id("new-portal")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -27,8 +27,15 @@ import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
 import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.domain_service.CurrentThemeDomainService;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeAutomationMetadata;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
@@ -42,14 +49,24 @@ public class CreateOrUpdatePortalUseCase {
     private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalDocumentationSyncDomainService portalDocumentationSyncDomainService;
     private final PortalAutomationScopeDomainService portalAutomationScopeEnforcer;
+    private final ThemeCrudService themeCrudService;
+    private final CurrentThemeDomainService currentThemeDomainService;
 
-    public record Input(AuditInfo auditInfo, Portal portal, PortalNavigationStructure structure) {
+    public record Input(AuditInfo auditInfo, Portal portal, PortalNavigationStructure structure, String activeThemeHrid) {
         public Input(AuditInfo auditInfo, Portal portal) {
-            this(auditInfo, portal, PortalNavigationStructure.empty());
+            this(auditInfo, portal, PortalNavigationStructure.empty(), null);
+        }
+
+        public Input(AuditInfo auditInfo, Portal portal, PortalNavigationStructure structure) {
+            this(auditInfo, portal, structure, null);
         }
     }
 
-    public record Output(Portal portal, PortalNavigationStructure structure, List<Validator.Error> errors) {}
+    public record Output(Portal portal, PortalNavigationStructure structure, String activeThemeHrid, List<Validator.Error> errors) {
+        public Output(Portal portal, PortalNavigationStructure structure, List<Validator.Error> errors) {
+            this(portal, structure, null, errors);
+        }
+    }
 
     public Output execute(Input input) {
         var validation = validator.validateAndSanitize(
@@ -73,7 +90,8 @@ public class CreateOrUpdatePortalUseCase {
             previouslyPersisted,
             sanitized.structure()
         );
-        var portalToSave = sanitized.portal().withNavigationStructure(sanitized.structure());
+        var resolvedActiveThemeId = resolveActiveThemeId(input, existing.map(Portal::getActiveThemeId).orElse(null));
+        var portalToSave = sanitized.portal().withNavigationStructure(sanitized.structure()).withActiveThemeId(resolvedActiveThemeId);
         var saved = existing.isPresent() ? portalCrudService.update(portalToSave) : portalCrudService.create(portalToSave);
         var isDefault = portalAutomationScopeEnforcer.isDefaultPortal(input.auditInfo(), saved.getId());
         // Skip nav-tree materialization for non-default portals — app is not ready for that.
@@ -83,6 +101,40 @@ public class CreateOrUpdatePortalUseCase {
                 .findByReference(input.auditInfo().environmentId(), AutomationMetadata.ReferenceType.PORTAL, saved.getId().toString())
                 .forEach(pc -> portalDocumentationSyncDomainService.materialize(input.auditInfo(), pc));
         }
-        return new Output(saved, saved.getNavigationStructure(), warnings);
+        var activeThemeHrid = reverseResolveActiveThemeHrid(input, saved.getActiveThemeId());
+        return new Output(saved, saved.getNavigationStructure(), activeThemeHrid, warnings);
+    }
+
+    private String reverseResolveActiveThemeHrid(Input input, String activeThemeId) {
+        if (activeThemeId == null) {
+            return null;
+        }
+        if (input.activeThemeHrid() != null) {
+            return input.activeThemeHrid();
+        }
+        return themeCrudService
+            .findByIdAndEnvironmentId(activeThemeId, input.auditInfo().environmentId())
+            .map(Theme::getAutomationMetadata)
+            .map(ThemeAutomationMetadata::hrid)
+            .orElse(null);
+    }
+
+    private String resolveActiveThemeId(Input input, String currentActiveThemeId) {
+        var targetThemeId = input.activeThemeHrid() == null
+            ? null
+            : HRIDToUUID.portalTheme().context(input.auditInfo()).hrid(input.activeThemeHrid()).id();
+        if (Objects.equals(targetThemeId, currentActiveThemeId)) {
+            return targetThemeId;
+        }
+        var environmentId = input.auditInfo().environmentId();
+        if (targetThemeId == null) {
+            themeCrudService.findByIdAndEnvironmentId(currentActiveThemeId, environmentId).ifPresent(currentThemeDomainService::deactivate);
+            return null;
+        }
+        var target = themeCrudService
+            .findByIdAndEnvironmentId(targetThemeId, environmentId)
+            .orElseThrow(() -> new ThemeNotFoundException(input.activeThemeHrid()));
+        currentThemeDomainService.activate(target);
+        return targetThemeId;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
@@ -22,6 +22,8 @@ import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainSer
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.domain_service.CurrentThemeDomainService;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -30,6 +32,8 @@ public class DeletePortalUseCase {
 
     private final PortalCrudService portalCrudService;
     private final PortalNavigationSyncDomainService navigationSyncDomainService;
+    private final ThemeCrudService themeCrudService;
+    private final CurrentThemeDomainService currentThemeDomainService;
 
     public record Input(AuditInfo auditInfo, PortalId portalId) {}
 
@@ -43,6 +47,11 @@ public class DeletePortalUseCase {
             portal.getNavigationStructure(),
             PortalNavigationStructure.empty()
         );
+        if (portal.getActiveThemeId() != null) {
+            themeCrudService
+                .findByIdAndEnvironmentId(portal.getActiveThemeId(), input.auditInfo().environmentId())
+                .ifPresent(currentThemeDomainService::deactivate);
+        }
         portalCrudService.delete(input.portalId());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -22,6 +22,9 @@ import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeAutomationMetadata;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -29,15 +32,32 @@ import lombok.RequiredArgsConstructor;
 public class GetPortalUseCase {
 
     private final PortalCrudService portalCrudService;
+    private final ThemeCrudService themeCrudService;
 
     public record Input(AuditInfo auditInfo, PortalId portalId) {}
 
-    public record Output(Portal portal, PortalNavigationStructure structure) {}
+    public record Output(Portal portal, PortalNavigationStructure structure, String activeThemeHrid) {
+        public Output(Portal portal, PortalNavigationStructure structure) {
+            this(portal, structure, null);
+        }
+    }
 
     public Output execute(Input input) {
         var portal = portalCrudService
             .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
             .orElseThrow(() -> new PortalNotFoundException(input.portalId().toString()));
-        return new Output(portal, portal.getNavigationStructure());
+        var activeThemeHrid = resolveActiveThemeHrid(portal.getActiveThemeId(), input.auditInfo().environmentId());
+        return new Output(portal, portal.getNavigationStructure(), activeThemeHrid);
+    }
+
+    private String resolveActiveThemeHrid(String activeThemeId, String environmentId) {
+        if (activeThemeId == null) {
+            return null;
+        }
+        return themeCrudService
+            .findByIdAndEnvironmentId(activeThemeId, environmentId)
+            .map(Theme::getAutomationMetadata)
+            .map(ThemeAutomationMetadata::hrid)
+            .orElse(null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCase.java
@@ -33,6 +33,6 @@ public class ValidatePortalUseCase {
         );
         List<Validator.Error> errors = result.errors().orElseGet(List::of);
         var sanitized = result.value().orElse(new ValidatePortalDomainService.Input(input.auditInfo(), input.portal(), input.structure()));
-        return new CreateOrUpdatePortalUseCase.Output(sanitized.portal(), sanitized.structure(), errors);
+        return new CreateOrUpdatePortalUseCase.Output(sanitized.portal(), sanitized.structure(), input.activeThemeHrid(), errors);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/crud_service/ThemeCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/crud_service/ThemeCrudService.java
@@ -16,9 +16,12 @@
 package io.gravitee.apim.core.theme.crud_service;
 
 import io.gravitee.apim.core.theme.model.Theme;
+import java.util.Optional;
 
 public interface ThemeCrudService {
     Theme create(Theme theme);
     Theme update(Theme theme);
     Theme get(String id);
+    Optional<Theme> findByIdAndEnvironmentId(String id, String environmentId);
+    void delete(String id);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/CurrentThemeDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/CurrentThemeDomainService.java
@@ -49,4 +49,17 @@ public class CurrentThemeDomainService {
                 this.themeCrudService.update(theme);
             });
     }
+
+    public void activate(Theme newActiveTheme) {
+        if (!newActiveTheme.isEnabled()) {
+            this.themeCrudService.update(newActiveTheme.toBuilder().enabled(true).updatedAt(ZonedDateTime.now()).build());
+        }
+        disablePreviousEnabledTheme(newActiveTheme);
+    }
+
+    public void deactivate(Theme theme) {
+        if (theme.isEnabled()) {
+            this.themeCrudService.update(theme.toBuilder().enabled(false).updatedAt(ZonedDateTime.now()).build());
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/ThemeDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/ThemeDomainService.java
@@ -31,6 +31,10 @@ public class ThemeDomainService {
     private final ThemeCrudService themeCrudService;
 
     public Theme create(NewTheme newTheme) {
+        return this.create(newTheme, UuidString.generateRandom());
+    }
+
+    public Theme create(NewTheme newTheme, String id) {
         var currentTime = ZonedDateTime.now();
 
         var themeToBeCreated = Theme.builder()
@@ -45,7 +49,8 @@ public class ThemeDomainService {
             .optionalLogo(newTheme.getOptionalLogo())
             .favicon(newTheme.getFavicon())
             .backgroundImage(newTheme.getBackgroundImage())
-            .id(UuidString.generateRandom())
+            .automationMetadata(newTheme.getAutomationMetadata())
+            .id(id)
             .createdAt(currentTime)
             .updatedAt(currentTime)
             .build();
@@ -64,6 +69,7 @@ public class ThemeDomainService {
             .optionalLogo(updateTheme.getOptionalLogo())
             .favicon(updateTheme.getFavicon())
             .backgroundImage(updateTheme.getBackgroundImage())
+            .automationMetadata(updateTheme.getAutomationMetadata())
             .updatedAt(ZonedDateTime.now())
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/ValidateThemeDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/ValidateThemeDomainService.java
@@ -16,26 +16,63 @@
 package io.gravitee.apim.core.theme.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
 import io.gravitee.apim.core.theme.exception.ThemeDefinitionInvalidException;
 import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
 import io.gravitee.apim.core.theme.exception.ThemeTypeInvalidException;
 import io.gravitee.apim.core.theme.model.Theme;
-import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
 import io.gravitee.apim.core.theme.model.ThemeType;
 import io.gravitee.apim.core.theme.model.UpdateTheme;
-import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
-import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
-public class ValidateThemeDomainService {
+public class ValidateThemeDomainService implements Validator<ValidateThemeDomainService.Input> {
 
     private final ThemeCrudService themeCrudService;
+
+    public record Input(
+        AuditInfo auditInfo,
+        String themeHrid,
+        String name,
+        ThemeDefinition definitionPortalNext,
+        String logo,
+        String optionalLogo,
+        String favicon,
+        String backgroundImage
+    ) implements Validator.Input {}
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+        var sanitizedName = input.name() == null ? null : input.name().trim();
+        if (sanitizedName == null || sanitizedName.isBlank()) {
+            errors.add(Error.severe("spec.name must not be blank"));
+        }
+        if (input.themeHrid() == null || input.themeHrid().isBlank()) {
+            errors.add(Error.severe("spec.hrid must not be blank"));
+        }
+        if (input.definitionPortalNext() == null) {
+            errors.add(Error.severe("spec.definitionPortalNext must not be null"));
+        }
+        var sanitized = new Input(
+            input.auditInfo(),
+            input.themeHrid(),
+            sanitizedName,
+            input.definitionPortalNext(),
+            input.logo(),
+            input.optionalLogo(),
+            input.favicon(),
+            input.backgroundImage()
+        );
+        return Result.ofBoth(sanitized, errors);
+    }
 
     public void validateUpdateTheme(UpdateTheme updateTheme, ExecutionContext executionContext) {
         var existingTheme = this.themeCrudService.get(updateTheme.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/exception/PortalThemeInUseException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/exception/PortalThemeInUseException.java
@@ -13,23 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal.crud_service;
+package io.gravitee.apim.core.theme.exception;
 
-import io.gravitee.apim.core.portal.model.Portal;
-import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
-public interface PortalCrudService {
-    Portal create(Portal portal);
+public class PortalThemeInUseException extends ValidationDomainException {
 
-    Portal update(Portal portal);
-
-    Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId);
-
-    List<Portal> findByEnvironmentId(String environmentId);
-
-    List<Portal> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId);
-
-    void delete(PortalId portalId);
+    public PortalThemeInUseException(String themeId, List<String> referencingPortalIds) {
+        super(
+            "Theme cannot be deleted as it is still referenced by portal(s).",
+            Map.of("themeId", themeId, "portalIds", String.join(",", referencingPortalIds))
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
@@ -43,6 +43,8 @@ public class Theme {
     private String favicon;
     private String backgroundImage;
 
+    private ThemeAutomationMetadata automationMetadata;
+
     public enum ReferenceType {
         ENVIRONMENT,
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeAutomationMetadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeAutomationMetadata.java
@@ -15,29 +15,4 @@
  */
 package io.gravitee.apim.core.theme.model;
 
-import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
-import java.time.ZonedDateTime;
-import lombok.Builder;
-import lombok.Data;
-
-@Data
-@Builder
-public class NewTheme {
-
-    private String name;
-    private String referenceId;
-    private Theme.ReferenceType referenceType;
-
-    private ThemeDefinition definitionPortal;
-    private io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition definitionPortalNext;
-
-    private ThemeType type;
-
-    private boolean enabled;
-    private String logo;
-    private String optionalLogo;
-    private String favicon;
-    private String backgroundImage;
-
-    private ThemeAutomationMetadata automationMetadata;
-}
+public record ThemeAutomationMetadata(String hrid) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/UpdateTheme.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/UpdateTheme.java
@@ -37,4 +37,6 @@ public class UpdateTheme {
     private String optionalLogo;
     private String favicon;
     private String backgroundImage;
+
+    private ThemeAutomationMetadata automationMetadata;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/CreateOrUpdatePortalThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/CreateOrUpdatePortalThemeUseCase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.domain_service.ThemeDomainService;
+import io.gravitee.apim.core.theme.domain_service.ValidateThemeDomainService;
+import io.gravitee.apim.core.theme.model.NewTheme;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeAutomationMetadata;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.apim.core.theme.model.UpdateTheme;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateOrUpdatePortalThemeUseCase {
+
+    private final ValidateThemeDomainService validator;
+    private final ThemeDomainService themeDomainService;
+    private final ThemeCrudService themeCrudService;
+
+    public record Output(Theme theme, List<Validator.Error> errors) {}
+
+    public Output execute(ValidateThemeDomainService.Input input) {
+        var validation = validator.validateAndSanitize(input);
+
+        validation
+            .severe()
+            .ifPresent(errors -> {
+                throw new ValidationDomainException(errors.stream().map(Validator.Error::getMessage).collect(Collectors.joining(", ")));
+            });
+
+        var warnings = validation.warning().orElseGet(List::of);
+        var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize theme"));
+
+        var envId = sanitized.auditInfo().environmentId();
+        var themeId = HRIDToUUID.portalTheme().context(sanitized.auditInfo()).hrid(sanitized.themeHrid()).id();
+        var automationMetadata = new ThemeAutomationMetadata(sanitized.themeHrid());
+        var existing = themeCrudService.findByIdAndEnvironmentId(themeId, envId);
+
+        Theme saved;
+        if (existing.isPresent()) {
+            var toUpdate = UpdateTheme.builder()
+                .id(themeId)
+                .type(ThemeType.PORTAL_NEXT)
+                .name(sanitized.name())
+                .definitionPortalNext(sanitized.definitionPortalNext())
+                .enabled(existing.get().isEnabled())
+                .logo(sanitized.logo())
+                .optionalLogo(sanitized.optionalLogo())
+                .favicon(sanitized.favicon())
+                .backgroundImage(sanitized.backgroundImage())
+                .automationMetadata(automationMetadata)
+                .build();
+            saved = themeDomainService.update(toUpdate, existing.get());
+        } else {
+            var toCreate = NewTheme.builder()
+                .name(sanitized.name())
+                .type(ThemeType.PORTAL_NEXT)
+                .referenceType(Theme.ReferenceType.ENVIRONMENT)
+                .referenceId(envId)
+                .definitionPortalNext(sanitized.definitionPortalNext())
+                .enabled(false)
+                .logo(sanitized.logo())
+                .optionalLogo(sanitized.optionalLogo())
+                .favicon(sanitized.favicon())
+                .backgroundImage(sanitized.backgroundImage())
+                .automationMetadata(automationMetadata)
+                .build();
+            saved = themeDomainService.create(toCreate, themeId);
+        }
+
+        return new Output(saved, warnings);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/DeletePortalThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/DeletePortalThemeUseCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.exception.PortalThemeInUseException;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeletePortalThemeUseCase {
+
+    private final ThemeCrudService themeCrudService;
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, String themeId) {}
+
+    public void execute(Input input) {
+        var envId = input.auditInfo().environmentId();
+        var theme = themeCrudService
+            .findByIdAndEnvironmentId(input.themeId(), envId)
+            .orElseThrow(() -> new ThemeNotFoundException(input.themeId()));
+
+        var referencingPortalIds = portalCrudService
+            .findByActiveThemeIdAndEnvironmentId(theme.getId(), envId)
+            .stream()
+            .map(Portal::getId)
+            .map(Object::toString)
+            .toList();
+
+        if (!referencingPortalIds.isEmpty()) {
+            throw new PortalThemeInUseException(theme.getId(), referencingPortalIds);
+        }
+
+        themeCrudService.delete(theme.getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetPortalThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetPortalThemeUseCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.model.Theme;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalThemeUseCase {
+
+    private final ThemeCrudService themeCrudService;
+
+    public record Input(AuditInfo auditInfo, String themeId) {}
+
+    public record Output(Theme theme) {}
+
+    public Output execute(Input input) {
+        var theme = themeCrudService
+            .findByIdAndEnvironmentId(input.themeId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new ThemeNotFoundException(input.themeId()));
+        return new Output(theme);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/ValidatePortalThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/ValidatePortalThemeUseCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.theme.domain_service.ValidateThemeDomainService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeAutomationMetadata;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ValidatePortalThemeUseCase {
+
+    private final ValidateThemeDomainService validator;
+
+    public CreateOrUpdatePortalThemeUseCase.Output execute(ValidateThemeDomainService.Input input) {
+        var result = validator.validateAndSanitize(input);
+        var sanitized = result.value().orElse(input);
+        List<Validator.Error> errors = result.errors().orElseGet(List::of);
+        return new CreateOrUpdatePortalThemeUseCase.Output(toTheme(sanitized), errors);
+    }
+
+    private static Theme toTheme(ValidateThemeDomainService.Input sanitized) {
+        var id = sanitized.themeHrid() == null || sanitized.themeHrid().isBlank()
+            ? null
+            : HRIDToUUID.portalTheme().context(sanitized.auditInfo()).hrid(sanitized.themeHrid()).id();
+        var automationMetadata = sanitized.themeHrid() == null || sanitized.themeHrid().isBlank()
+            ? null
+            : new ThemeAutomationMetadata(sanitized.themeHrid());
+        return Theme.builder()
+            .id(id)
+            .name(sanitized.name())
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(sanitized.auditInfo().environmentId())
+            .definitionPortalNext(sanitized.definitionPortalNext())
+            .enabled(false)
+            .logo(sanitized.logo())
+            .optionalLogo(sanitized.optionalLogo())
+            .favicon(sanitized.favicon())
+            .backgroundImage(sanitized.backgroundImage())
+            .automationMetadata(automationMetadata)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ThemeAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ThemeAdapter.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.infra.adapter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeAutomationMetadata;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.repository.management.model.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
@@ -41,10 +42,12 @@ public interface ThemeAdapter {
     ThemeAdapter INSTANCE = Mappers.getMapper(ThemeAdapter.class);
 
     @Mapping(target = "definition", expression = "java(serializeDefinition(theme))")
+    @Mapping(target = "automationMetadata", expression = "java(toRepoAutomationMetadata(theme))")
     io.gravitee.repository.management.model.Theme map(Theme theme);
 
     @Mapping(target = "definitionPortal", expression = "java(deserializeDefinitionPortal(theme))")
     @Mapping(target = "definitionPortalNext", expression = "java(deserializeDefinitionPortalNext(theme))")
+    @Mapping(target = "automationMetadata", expression = "java(toCoreAutomationMetadata(theme))")
     Theme map(io.gravitee.repository.management.model.Theme theme);
 
     @Mapping(target = "definitionPortal", source = "definition")
@@ -80,6 +83,16 @@ public interface ThemeAdapter {
         }
 
         return null;
+    }
+
+    default ThemeAutomationMetadata toCoreAutomationMetadata(io.gravitee.repository.management.model.Theme theme) {
+        var meta = theme.getAutomationMetadata();
+        return meta == null ? null : new ThemeAutomationMetadata(meta.getHrid());
+    }
+
+    default io.gravitee.repository.management.model.ThemeAutomationMetadata toRepoAutomationMetadata(Theme theme) {
+        var meta = theme.getAutomationMetadata();
+        return meta == null ? null : io.gravitee.repository.management.model.ThemeAutomationMetadata.builder().hrid(meta.hrid()).build();
     }
 
     default String serializeDefinition(Theme theme) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
@@ -88,6 +88,26 @@ public class PortalCrudServiceImpl implements PortalCrudService {
     }
 
     @Override
+    public List<Portal> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId) {
+        try {
+            return portalRepository
+                .findByActiveThemeIdAndEnvironmentId(activeThemeId, environmentId)
+                .stream()
+                .map(portalAdapter::toEntity)
+                .toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format(
+                    "An error occurred while trying to find Portals by active theme id (%s) and environment (%s)",
+                    activeThemeId,
+                    environmentId
+                ),
+                e
+            );
+        }
+    }
+
+    @Override
     public void delete(PortalId portalId) {
         try {
             portalRepository.delete(portalId.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/theme/ThemeCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/theme/ThemeCrudServiceImpl.java
@@ -22,7 +22,8 @@ import io.gravitee.apim.core.theme.model.Theme;
 import io.gravitee.apim.infra.adapter.ThemeAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ThemeRepository;
-import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
@@ -64,6 +65,28 @@ public class ThemeCrudServiceImpl implements ThemeCrudService {
                 .orElseThrow(() -> new ThemeNotFoundException(id));
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("Error during get", e);
+        }
+    }
+
+    @Override
+    public Optional<Theme> findByIdAndEnvironmentId(String id, String environmentId) {
+        try {
+            return themeRepository
+                .findById(id)
+                .map(ThemeAdapter.INSTANCE::map)
+                .filter(theme -> theme.getReferenceType() == Theme.ReferenceType.ENVIRONMENT)
+                .filter(theme -> Objects.equals(theme.getReferenceId(), environmentId));
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("Error during theme lookup", e);
+        }
+    }
+
+    @Override
+    public void delete(String id) {
+        try {
+            themeRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("Error during theme deletion", e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -20,7 +20,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 /**
  * Fluent DSL for generating deterministic UUIDs from HRIDs.
  * <p>
- * Top-level resources (API, Application, SharedPolicyGroup, Group, Portal) produce both {@code id()} and
+ * Top-level resources (API, Application, SharedPolicyGroup, Group, Portal, PortalTheme) produce both {@code id()} and
  * {@code crossId()}.
  * Sub-resources (Plan, Page, Subscription) are scoped to a parent API and only produce {@code id()}.
  * Portal sub-resources (Portal Listing, Portal Documentation) are scoped to a parent Portal and only produce
@@ -41,6 +41,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
  * HRIDToUUID.portalLink().context(audit).portal("my-portal").hrid("my-link").id()
  * HRIDToUUID.apiDocumentation().context(audit).api("my-api").hrid("my-doc").id()
  * HRIDToUUID.gamma().context(audit).module("aim").kind("catalog/mcp-servers").hrid("github").id()
+ * HRIDToUUID.portalTheme().context(audit).hrid("my-theme").id()
  * </pre>
  *
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -71,6 +72,10 @@ public final class HRIDToUUID {
     }
 
     public static TopLevelBuilder portal() {
+        return new TopLevelBuilder();
+    }
+
+    public static TopLevelBuilder portalTheme() {
         return new TopLevelBuilder();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.portal.model.PortalId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -58,6 +59,14 @@ public class PortalCrudServiceInMemory implements PortalCrudService, InMemoryAlt
         return storage
             .stream()
             .filter(p -> environmentId.equals(p.getEnvironmentId()))
+            .toList();
+    }
+
+    @Override
+    public List<Portal> findByActiveThemeIdAndEnvironmentId(String activeThemeId, String environmentId) {
+        return findByEnvironmentId(environmentId)
+            .stream()
+            .filter(p -> Objects.equals(activeThemeId, p.getActiveThemeId()))
             .toList();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ThemeCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ThemeCrudServiceInMemory.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 public class ThemeCrudServiceInMemory implements ThemeCrudService, InMemoryAlternative<Theme> {
@@ -69,5 +70,20 @@ public class ThemeCrudServiceInMemory implements ThemeCrudService, InMemoryAlter
             .filter(theme -> Objects.equals(id, theme.getId()))
             .findAny()
             .orElseThrow(() -> new ThemeNotFoundException(id));
+    }
+
+    @Override
+    public Optional<Theme> findByIdAndEnvironmentId(String id, String environmentId) {
+        return storage
+            .stream()
+            .filter(theme -> Objects.equals(id, theme.getId()))
+            .filter(theme -> theme.getReferenceType() == Theme.ReferenceType.ENVIRONMENT)
+            .filter(theme -> Objects.equals(environmentId, theme.getReferenceId()))
+            .findAny();
+    }
+
+    @Override
+    public void delete(String id) {
+        storage.removeIf(theme -> Objects.equals(id, theme.getId()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -26,6 +26,8 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import inmemory.ThemeCrudServiceInMemory;
+import inmemory.ThemeQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -42,6 +44,9 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncD
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.reconciliation.HomepageReconciler;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.theme.domain_service.CurrentThemeDomainService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +73,8 @@ class CreateOrUpdatePortalUseCaseTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
     private final PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory();
     private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
+    private final ThemeQueryServiceInMemory themeQueryService = new ThemeQueryServiceInMemory(themeCrudService);
     private CreateOrUpdatePortalUseCase useCase;
 
     @BeforeEach
@@ -87,7 +94,9 @@ class CreateOrUpdatePortalUseCaseTest {
                 new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService),
                 mock(PortalNavigationItemValidatorService.class)
             ),
-            scopeEnforcer
+            scopeEnforcer,
+            themeCrudService,
+            new CurrentThemeDomainService(themeQueryService, themeCrudService)
         );
     }
 
@@ -294,5 +303,76 @@ class CreateOrUpdatePortalUseCaseTest {
         var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
 
         assertThat(output.portal()).isEqualTo(portal);
+    }
+
+    @Test
+    void should_wire_active_theme_and_enable_it_when_active_theme_hrid_set() {
+        var themeHrid = "brand-theme";
+        var themeId = io.gravitee.rest.api.service.common.HRIDToUUID.portalTheme().context(AUDIT_INFO).hrid(themeHrid).id();
+        var otherThemeId = "11111111-1111-1111-1111-111111111111";
+        themeCrudService.initWith(
+            List.of(
+                io.gravitee.apim.core.theme.model.Theme.builder()
+                    .id(themeId)
+                    .name("Brand")
+                    .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL_NEXT)
+                    .referenceType(io.gravitee.apim.core.theme.model.Theme.ReferenceType.ENVIRONMENT)
+                    .referenceId(AUDIT_INFO.environmentId())
+                    .enabled(false)
+                    .build(),
+                io.gravitee.apim.core.theme.model.Theme.builder()
+                    .id(otherThemeId)
+                    .name("Other")
+                    .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL_NEXT)
+                    .referenceType(io.gravitee.apim.core.theme.model.Theme.ReferenceType.ENVIRONMENT)
+                    .referenceId(AUDIT_INFO.environmentId())
+                    .enabled(true)
+                    .build()
+            )
+        );
+        var portal = PortalFixtures.aPortal();
+
+        var output = useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, PortalNavigationStructure.empty(), themeHrid)
+        );
+
+        assertThat(output.portal().getActiveThemeId()).isEqualTo(themeId);
+        assertThat(themeCrudService.storage())
+            .filteredOn(t -> t.getId().equals(themeId))
+            .singleElement()
+            .extracting(t -> t.isEnabled())
+            .isEqualTo(true);
+        assertThat(themeCrudService.storage())
+            .filteredOn(t -> t.getId().equals(otherThemeId))
+            .singleElement()
+            .extracting(t -> t.isEnabled())
+            .isEqualTo(false);
+    }
+
+    @Test
+    void should_clear_active_theme_and_disable_previous_when_hrid_not_provided() {
+        var existingActiveThemeId = "22222222-2222-2222-2222-222222222222";
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal.withActiveThemeId(existingActiveThemeId)));
+        themeCrudService.initWith(
+            List.of(
+                Theme.builder()
+                    .id(existingActiveThemeId)
+                    .type(ThemeType.PORTAL_NEXT)
+                    .referenceType(Theme.ReferenceType.ENVIRONMENT)
+                    .referenceId(AUDIT_INFO.environmentId())
+                    .enabled(true)
+                    .build()
+            )
+        );
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+
+        assertThat(output.portal().getActiveThemeId()).isNull();
+        assertThat(themeCrudService.storage())
+            .filteredOn(t -> t.getId().equals(existingActiveThemeId))
+            .singleElement()
+            .extracting(Theme::isEnabled)
+            .isEqualTo(false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -26,6 +26,8 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import inmemory.ThemeCrudServiceInMemory;
+import inmemory.ThemeQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
@@ -48,6 +50,9 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.theme.domain_service.CurrentThemeDomainService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -73,6 +78,7 @@ class DeletePortalUseCaseTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
     private final PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory();
     private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
 
     private CreateOrUpdatePortalUseCase setupUseCase;
     private DeletePortalUseCase useCase;
@@ -85,6 +91,8 @@ class DeletePortalUseCaseTest {
             new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService)
         );
         var scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService, () -> false);
+        var themeQueryService = new ThemeQueryServiceInMemory(themeCrudService);
+        var currentThemeDomainService = new CurrentThemeDomainService(themeQueryService, themeCrudService);
         setupUseCase = new CreateOrUpdatePortalUseCase(
             new ValidatePortalDomainService(scopeEnforcer),
             portalCrudService,
@@ -96,9 +104,11 @@ class DeletePortalUseCaseTest {
                 new HomepageReconciler(navQueryService, navCrudService, pageContentCrudService),
                 mock(PortalNavigationItemValidatorService.class)
             ),
-            scopeEnforcer
+            scopeEnforcer,
+            themeCrudService,
+            currentThemeDomainService
         );
-        useCase = new DeletePortalUseCase(portalCrudService, navSync);
+        useCase = new DeletePortalUseCase(portalCrudService, navSync, themeCrudService, currentThemeDomainService);
     }
 
     @AfterEach
@@ -107,6 +117,7 @@ class DeletePortalUseCaseTest {
         navCrudService.reset();
         pageContentCrudService.reset();
         pageContentQueryService.reset();
+        themeCrudService.reset();
     }
 
     @Test
@@ -209,6 +220,33 @@ class DeletePortalUseCaseTest {
 
         assertThat(portalCrudService.storage()).isEmpty();
         assertThat(navCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_disable_active_theme_when_portal_is_deleted() {
+        var activeThemeId = "22222222-2222-2222-2222-222222222222";
+        var portal = PortalFixtures.aPortal().withActiveThemeId(activeThemeId);
+        portalCrudService.initWith(List.of(portal));
+        themeCrudService.initWith(
+            List.of(
+                Theme.builder()
+                    .id(activeThemeId)
+                    .type(ThemeType.PORTAL_NEXT)
+                    .referenceType(Theme.ReferenceType.ENVIRONMENT)
+                    .referenceId(AUDIT_INFO.environmentId())
+                    .enabled(true)
+                    .build()
+            )
+        );
+
+        useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(portalCrudService.storage()).isEmpty();
+        assertThat(themeCrudService.storage())
+            .filteredOn(t -> t.getId().equals(activeThemeId))
+            .singleElement()
+            .extracting(Theme::isEnabled)
+            .isEqualTo(false);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
+import inmemory.ThemeCrudServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
@@ -44,11 +45,12 @@ class GetPortalUseCaseTest {
         .build();
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
     private GetPortalUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new GetPortalUseCase(portalCrudService);
+        useCase = new GetPortalUseCase(portalCrudService, themeCrudService);
     }
 
     @AfterEach

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/CreateOrUpdatePortalThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/CreateOrUpdatePortalThemeUseCaseTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.ThemeCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.theme.domain_service.ThemeDomainService;
+import io.gravitee.apim.core.theme.domain_service.ValidateThemeDomainService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdatePortalThemeUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String THEME_HRID = "my-theme";
+
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
+    private CreateOrUpdatePortalThemeUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOrUpdatePortalThemeUseCase(
+            new ValidateThemeDomainService(themeCrudService),
+            new ThemeDomainService(themeCrudService),
+            themeCrudService
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        themeCrudService.reset();
+    }
+
+    @Test
+    void creates_theme_with_deterministic_id_when_absent() {
+        var definition = new ThemeDefinition();
+        var output = useCase.execute(specWith(THEME_HRID, "My Theme", definition));
+
+        var expectedId = HRIDToUUID.portalTheme().context(AUDIT_INFO).hrid(THEME_HRID).id();
+        assertThat(output.theme().getId()).isEqualTo(expectedId);
+        assertThat(output.theme().getName()).isEqualTo("My Theme");
+        assertThat(output.theme().getType()).isEqualTo(ThemeType.PORTAL_NEXT);
+        assertThat(output.theme().getReferenceType()).isEqualTo(Theme.ReferenceType.ENVIRONMENT);
+        assertThat(output.theme().getReferenceId()).isEqualTo(AUDIT_INFO.environmentId());
+        assertThat(output.theme().getDefinitionPortalNext()).isSameAs(definition);
+        assertThat(output.theme().isEnabled()).isFalse();
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void persists_assets_from_spec() {
+        var input = new ValidateThemeDomainService.Input(
+            AUDIT_INFO,
+            THEME_HRID,
+            "My Theme",
+            new ThemeDefinition(),
+            "data:image/png;base64,LOGO",
+            "data:image/png;base64,OPT",
+            "data:image/png;base64,FAV",
+            "data:image/png;base64,BG"
+        );
+
+        var output = useCase.execute(input);
+
+        assertThat(output.theme().getLogo()).isEqualTo("data:image/png;base64,LOGO");
+        assertThat(output.theme().getOptionalLogo()).isEqualTo("data:image/png;base64,OPT");
+        assertThat(output.theme().getFavicon()).isEqualTo("data:image/png;base64,FAV");
+        assertThat(output.theme().getBackgroundImage()).isEqualTo("data:image/png;base64,BG");
+    }
+
+    @Test
+    void updates_existing_theme_when_id_matches() {
+        var existing = anEnvironmentTheme("Old", false, HRIDToUUID.portalTheme().context(AUDIT_INFO).hrid(THEME_HRID).id());
+        themeCrudService.initWith(List.of(existing));
+
+        var newDefinition = new ThemeDefinition();
+        var output = useCase.execute(specWith(THEME_HRID, "New", newDefinition));
+
+        assertThat(output.theme().getId()).isEqualTo(existing.getId());
+        assertThat(output.theme().getName()).isEqualTo("New");
+        assertThat(output.theme().getDefinitionPortalNext()).isSameAs(newDefinition);
+        assertThat(output.theme().isEnabled()).isFalse();
+        assertThat(themeCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void does_not_touch_other_themes_when_applying() {
+        var otherEnabled = anEnvironmentTheme("Other", true, "11111111-1111-1111-1111-111111111111");
+        themeCrudService.initWith(List.of(otherEnabled));
+
+        useCase.execute(specWith(THEME_HRID, "New", new ThemeDefinition()));
+
+        assertThat(themeCrudService.storage())
+            .filteredOn(t -> t.getId().equals(otherEnabled.getId()))
+            .singleElement()
+            .extracting(Theme::isEnabled)
+            .isEqualTo(true);
+    }
+
+    @Test
+    void persists_automation_metadata_with_hrid() {
+        useCase.execute(specWith(THEME_HRID, "My Theme", new ThemeDefinition()));
+
+        assertThat(themeCrudService.storage())
+            .singleElement()
+            .satisfies(t -> assertThat(t.getAutomationMetadata().hrid()).isEqualTo(THEME_HRID));
+    }
+
+    @Test
+    void trims_name_before_persisting() {
+        useCase.execute(specWith(THEME_HRID, "  Padded  ", new ThemeDefinition()));
+
+        assertThat(themeCrudService.storage()).singleElement().extracting(Theme::getName).isEqualTo("Padded");
+    }
+
+    @Test
+    void throws_validation_error_when_name_is_blank() {
+        assertThatThrownBy(() -> useCase.execute(specWith(THEME_HRID, "  ", new ThemeDefinition())))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("spec.name");
+    }
+
+    @Test
+    void throws_validation_error_when_definition_is_null() {
+        assertThatThrownBy(() -> useCase.execute(specWith(THEME_HRID, "Ok", null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("spec.definitionPortalNext");
+    }
+
+    @Test
+    void throws_validation_error_when_hrid_is_blank() {
+        assertThatThrownBy(() -> useCase.execute(specWith("", "Ok", new ThemeDefinition())))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("spec.hrid");
+    }
+
+    private static ValidateThemeDomainService.Input specWith(String hrid, String name, ThemeDefinition definition) {
+        return new ValidateThemeDomainService.Input(AUDIT_INFO, hrid, name, definition, null, null, null, null);
+    }
+
+    private static Theme anEnvironmentTheme(String name, boolean enabled, String id) {
+        return Theme.builder()
+            .id(id)
+            .name(name)
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(AUDIT_INFO.environmentId())
+            .definitionPortalNext(new ThemeDefinition())
+            .enabled(enabled)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/DeletePortalThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/DeletePortalThemeUseCaseTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.PortalCrudServiceInMemory;
+import inmemory.ThemeCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.theme.exception.PortalThemeInUseException;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeletePortalThemeUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String THEME_ID = "theme-1";
+
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private DeletePortalThemeUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeletePortalThemeUseCase(themeCrudService, portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        themeCrudService.reset();
+        portalCrudService.reset();
+    }
+
+    @Test
+    void deletes_theme_when_not_referenced() {
+        themeCrudService.initWith(List.of(anEnvironmentTheme(THEME_ID)));
+
+        useCase.execute(new DeletePortalThemeUseCase.Input(AUDIT_INFO, THEME_ID));
+
+        assertThat(themeCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void rejects_delete_when_portal_active_theme_id_matches() {
+        themeCrudService.initWith(List.of(anEnvironmentTheme(THEME_ID)));
+        var portal = Portal.of(
+            PortalId.of("11111111-1111-1111-1111-111111111111"),
+            AUDIT_INFO.environmentId(),
+            AUDIT_INFO.organizationId(),
+            "Portal 1"
+        ).withActiveThemeId(THEME_ID);
+        portalCrudService.initWith(List.of(portal));
+
+        assertThatThrownBy(() -> useCase.execute(new DeletePortalThemeUseCase.Input(AUDIT_INFO, THEME_ID)))
+            .isInstanceOf(PortalThemeInUseException.class)
+            .hasMessageContaining("still referenced");
+
+        assertThat(themeCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void allows_delete_when_portals_reference_other_themes() {
+        themeCrudService.initWith(List.of(anEnvironmentTheme(THEME_ID), anEnvironmentTheme("other")));
+        var portal = Portal.of(
+            PortalId.of("11111111-1111-1111-1111-111111111111"),
+            AUDIT_INFO.environmentId(),
+            AUDIT_INFO.organizationId(),
+            "Portal 1"
+        ).withActiveThemeId("other");
+        portalCrudService.initWith(List.of(portal));
+
+        useCase.execute(new DeletePortalThemeUseCase.Input(AUDIT_INFO, THEME_ID));
+
+        assertThat(themeCrudService.storage()).extracting(Theme::getId).containsExactly("other");
+    }
+
+    @Test
+    void throws_when_theme_missing() {
+        assertThatThrownBy(() -> useCase.execute(new DeletePortalThemeUseCase.Input(AUDIT_INFO, "unknown"))).isInstanceOf(
+            ThemeNotFoundException.class
+        );
+    }
+
+    @Test
+    void throws_when_theme_belongs_to_another_environment() {
+        themeCrudService.initWith(List.of(anEnvironmentTheme(THEME_ID, "other-env")));
+
+        assertThatThrownBy(() -> useCase.execute(new DeletePortalThemeUseCase.Input(AUDIT_INFO, THEME_ID))).isInstanceOf(
+            ThemeNotFoundException.class
+        );
+    }
+
+    private static Theme anEnvironmentTheme(String id) {
+        return anEnvironmentTheme(id, AUDIT_INFO.environmentId());
+    }
+
+    private static Theme anEnvironmentTheme(String id, String envId) {
+        return Theme.builder()
+            .id(id)
+            .name("Theme " + id)
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(envId)
+            .enabled(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetPortalThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetPortalThemeUseCaseTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.ThemeCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalThemeUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final ThemeCrudServiceInMemory themeCrudService = new ThemeCrudServiceInMemory();
+    private GetPortalThemeUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalThemeUseCase(themeCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        themeCrudService.reset();
+    }
+
+    @Test
+    void returns_theme_when_it_belongs_to_environment() {
+        var theme = anEnvironmentTheme("theme-1", AUDIT_INFO.environmentId());
+        themeCrudService.initWith(List.of(theme));
+
+        var output = useCase.execute(new GetPortalThemeUseCase.Input(AUDIT_INFO, "theme-1"));
+
+        assertThat(output.theme()).isEqualTo(theme);
+    }
+
+    @Test
+    void throws_when_theme_is_in_a_different_environment() {
+        themeCrudService.initWith(List.of(anEnvironmentTheme("theme-1", "other-env")));
+
+        assertThatThrownBy(() -> useCase.execute(new GetPortalThemeUseCase.Input(AUDIT_INFO, "theme-1"))).isInstanceOf(
+            ThemeNotFoundException.class
+        );
+    }
+
+    @Test
+    void throws_when_theme_does_not_exist() {
+        assertThatThrownBy(() -> useCase.execute(new GetPortalThemeUseCase.Input(AUDIT_INFO, "unknown"))).isInstanceOf(
+            ThemeNotFoundException.class
+        );
+    }
+
+    private static Theme anEnvironmentTheme(String id, String envId) {
+        return Theme.builder()
+            .id(id)
+            .name("Theme " + id)
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(envId)
+            .enabled(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/ValidatePortalThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/ValidatePortalThemeUseCaseTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ThemeCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.domain_service.ValidateThemeDomainService;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidatePortalThemeUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private ValidatePortalThemeUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidatePortalThemeUseCase(new ValidateThemeDomainService(new ThemeCrudServiceInMemory()));
+    }
+
+    @Test
+    void returns_no_errors_and_previews_theme_for_well_formed_input() {
+        var output = useCase.execute(specWith("my-theme", "My Theme", new ThemeDefinition()));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(output.theme().getName()).isEqualTo("My Theme");
+        assertThat(output.theme().getId()).isNotBlank();
+        assertThat(output.theme().isEnabled()).isFalse();
+    }
+
+    @Test
+    void surfaces_severe_errors_for_blank_name() {
+        var output = useCase.execute(specWith("my-theme", "  ", new ThemeDefinition()));
+
+        assertThat(output.errors()).anyMatch(e -> e.isSevere() && e.getMessage().contains("spec.name"));
+    }
+
+    @Test
+    void surfaces_severe_error_when_definition_null() {
+        var output = useCase.execute(specWith("my-theme", "Ok", null));
+
+        assertThat(output.errors()).anyMatch(e -> e.isSevere() && e.getMessage().contains("spec.definitionPortalNext"));
+    }
+
+    private static ValidateThemeDomainService.Input specWith(String hrid, String name, ThemeDefinition definition) {
+        return new ValidateThemeDomainService.Input(AUDIT_INFO, hrid, name, definition, null, null, null, null);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
@@ -89,6 +89,24 @@ class HRIDToUUIDTest {
     }
 
     @Nested
+    class PortalTheme {
+
+        @Test
+        void should_generate_same_id_for_same_hrid() {
+            assertThat(HRIDToUUID.portalTheme().context(AUDIT).hrid("my-theme").id()).isEqualTo(
+                HRIDToUUID.portalTheme().context(AUDIT).hrid("my-theme").id()
+            );
+        }
+
+        @Test
+        void should_generate_different_id_for_different_hrid() {
+            assertThat(HRIDToUUID.portalTheme().context(AUDIT).hrid("light").id()).isNotEqualTo(
+                HRIDToUUID.portalTheme().context(AUDIT).hrid("dark").id()
+            );
+        }
+    }
+
+    @Nested
     class Plan {
 
         @Test


### PR DESCRIPTION
## Issue
  
https://gravitee.atlassian.net/browse/EXT-174

## Description
  
Adds use cases for portal themes - create-or-update, get, delete, validate.
Introduces metadata into themes to keep hrid which is automation api specific.

Scope is PORTAL_NEXT only. Automation-managed themes are identified by a deterministic HRID-derived id.
REST resource wiring is a follow-up PR;
  
### Design note

Added dedicated automation use cases (same as for other automation resources). The existing theme use cases serves the console and doesn't fit the automation contract (audit info, structured `errors[]` in the response, create-or-update dispatch, HRID resolution). Underlying domain services and persistence are fully reused.

### Automation-wins mechanic

Applying an automation theme flips every other env-scoped PORTAL_NEXT theme to disabled. Console does the same on activation; automation does it unconditionally - automation wins.

Under one portal per env this preserves the "one enabled theme per env" invariant. When multiportal lands and per-portal active-theme pointers become the source of truth, the enabled-flag mechanic can be dropped.

### Follow-ups

- The env-level "current theme" lookup will fall back to the per-portal pointer in a follow-up PR (right now its also fine, because it points to enabled theme which is the one recently updated by automation api).

### To be confirmed

- [x] Assets (logo, optional logo, favicon, background image) are accepted as inline data URIs, matching how the console handles them. Is URL-based fetcher needed? -> confirmed with @dev-marek that base64 content is enough