### PR TITLE
feat: support categories on API Product navigation items

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -65,6 +65,7 @@ export interface PortalNavigationApi extends BasePortalNavigationItem<'API'> {
 
 export interface PortalNavigationApiProduct extends BasePortalNavigationItem<'API_PRODUCT'> {
   apiProductId: string;
+  categoryIds?: string[];
 }
 
 export type PortalNavigationItem =
@@ -158,6 +159,7 @@ export interface NewApiPortalNavigationItem extends BaseNewPortalNavigationItem<
 
 export interface NewApiProductPortalNavigationItem extends BaseNewPortalNavigationItem<'API_PRODUCT'> {
   apiProductId: string;
+  categoryIds?: string[];
 }
 
 export type NewPortalNavigationItem =
@@ -193,7 +195,9 @@ export interface UpdateApiPortalNavigationItem extends BaseUpdatePortalNavigatio
   categoryIds?: string[];
 }
 
-export interface UpdateApiProductPortalNavigationItem extends BaseUpdatePortalNavigationItem<'API_PRODUCT'> {}
+export interface UpdateApiProductPortalNavigationItem extends BaseUpdatePortalNavigationItem<'API_PRODUCT'> {
+  categoryIds?: string[];
+}
 
 export type UpdatePortalNavigationItem =
   | UpdatePagePortalNavigationItem

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -4248,6 +4248,7 @@ describe('PortalNavigationItemsComponent', () => {
       order: 2,
       published: false,
       visibility: 'PUBLIC',
+      categoryIds: ['category-1', 'category-2'],
     });
 
     it('should display the linked API Product name and version in the selected item header', async () => {
@@ -4287,6 +4288,34 @@ describe('PortalNavigationItemsComponent', () => {
           order: apiProductItem.order,
           published: apiProductItem.published,
           visibility: apiProductItem.visibility,
+          categoryIds: apiProductItem.categoryIds,
+        }),
+        updatedItem,
+      );
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, updatedItem] }));
+    });
+
+    it('should preserve category IDs when changing the item position', async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, apiProductItem] }));
+      flushPendingLinkedApiProductRequests();
+
+      component.onNodeMoved({
+        node: fakeSectionNode({ id: apiProductItem.id, data: apiProductItem }),
+        newParentId: folder.id,
+        newOrder: 0,
+      });
+      fixture.detectChanges();
+
+      const updatedItem = fakePortalNavigationApiProduct({ ...apiProductItem, order: 0 });
+      expectPutPortalNavigationItem(
+        apiProductItem.id,
+        fakeUpdateApiProductPortalNavigationItem({
+          title: apiProductItem.title,
+          parentId: folder.id,
+          order: 0,
+          published: apiProductItem.published,
+          visibility: apiProductItem.visibility,
+          categoryIds: apiProductItem.categoryIds,
         }),
         updatedItem,
       );
@@ -4444,6 +4473,7 @@ describe('PortalNavigationItemsComponent', () => {
       title: 'API Product Item 1',
       apiProductId: 'api-product-1',
       published: false,
+      categoryIds: ['category-1', 'category-2'],
     });
     const fakeResponse = fakePortalNavigationItemsResponse({ items: [apiProduct] });
 
@@ -4471,6 +4501,7 @@ describe('PortalNavigationItemsComponent', () => {
           order: apiProduct.order,
           published: true,
           visibility: apiProduct.visibility,
+          categoryIds: apiProduct.categoryIds,
         }),
         apiProduct,
         { propagatePublishToChildren: true },

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -778,6 +778,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
                 order: existingItem.order,
                 published: existingItem.published,
                 visibility: result.visibility,
+                categoryIds: existingItem.categoryIds,
               });
             }
             return this.update(existingItem.id, {
@@ -1167,6 +1168,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         order: navItem.order,
         published: !navItem.published,
         visibility: navItem.visibility,
+        categoryIds: navItem.categoryIds,
       };
     }
 
@@ -1251,6 +1253,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
             type: 'API_PRODUCT',
             published: navItem.published,
             visibility: navItem.visibility,
+            categoryIds: navItem.categoryIds,
             parentId: newParentId ?? undefined,
             order: newOrder,
           }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -2563,6 +2563,13 @@ components:
               format: uuid
               description: API Product referenced by the navigation item
               example: 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API Product navigation item is assigned to
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiProductId ]
     PortalNavigationItem:
       oneOf:
@@ -2710,6 +2717,13 @@ components:
               format: uuid
               description: API Product referenced by the navigation item
               example: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API Product navigation item is assigned to. Defaults to an empty list if not provided.
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiProductId ]
     CreatePortalNavigationItem:
       oneOf:
@@ -2851,6 +2865,14 @@ components:
       description: Portal navigation API Product item to update. The linked API Product is immutable; an apiProductId property supplied in an update payload is ignored.
       allOf:
         - $ref: "#/components/schemas/BaseUpdatePortalNavigationItem"
+        - properties:
+            categoryIds:
+              type: array
+              description: The IDs of the Portal Next categories this API Product navigation item is assigned to. Defaults to an empty list if not provided.
+              items:
+                type: string
+                format: uuid
+              example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
     UpdatePortalNavigationItem:
       oneOf:
         - $ref: "#/components/schemas/UpdatePortalNavigationPage"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiProduct;
+import java.util.List;
 import java.util.UUID;
 
 public class PortalNavigationItemsFixtures {
@@ -104,16 +105,23 @@ public class PortalNavigationItemsFixtures {
             .visibility(PortalVisibility.PUBLIC);
     }
 
-    public static BaseCreatePortalNavigationItem aCreatePortalNavigationApiProduct() {
-        return new CreatePortalNavigationApiProduct()
-            .apiProductId(UUID.fromString("00000000-0000-0000-0000-000000000019"))
-            .type(PortalNavigationItemType.API_PRODUCT)
-            .id(UUID.fromString("00000000-0000-0000-0000-000000000018"))
-            .title("My API Product")
-            .area(io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR)
-            .order(4)
-            .parentId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-            .visibility(PortalVisibility.PUBLIC);
+    public static CreatePortalNavigationApiProduct aCreatePortalNavigationApiProduct() {
+        var apiProduct = new CreatePortalNavigationApiProduct();
+        apiProduct.setApiProductId(UUID.fromString("00000000-0000-0000-0000-000000000019"));
+        apiProduct.setType(PortalNavigationItemType.API_PRODUCT);
+        apiProduct.setId(UUID.fromString("00000000-0000-0000-0000-000000000018"));
+        apiProduct.setTitle("My API Product");
+        apiProduct.setArea(io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR);
+        apiProduct.setOrder(4);
+        apiProduct.setParentId(UUID.fromString("00000000-0000-0000-0000-000000000002"));
+        apiProduct.setVisibility(PortalVisibility.PUBLIC);
+        return apiProduct;
+    }
+
+    public static CreatePortalNavigationApiProduct aCreatePortalNavigationApiProduct(List<UUID> categoryIds) {
+        var apiProduct = aCreatePortalNavigationApiProduct();
+        apiProduct.setCategoryIds(categoryIds);
+        return apiProduct;
     }
 
     public static BaseUpdatePortalNavigationItem anUpdatePortalNavigationApi() {
@@ -125,13 +133,20 @@ public class PortalNavigationItemsFixtures {
             .visibility(PortalVisibility.PRIVATE);
     }
 
-    public static BaseUpdatePortalNavigationItem anUpdatePortalNavigationApiProduct() {
-        return new UpdatePortalNavigationApiProduct()
-            .type(PortalNavigationItemType.API_PRODUCT)
-            .title("Updated API Product")
-            .order(1)
-            .published(false)
-            .visibility(PortalVisibility.PRIVATE);
+    public static UpdatePortalNavigationApiProduct anUpdatePortalNavigationApiProduct() {
+        var apiProduct = new UpdatePortalNavigationApiProduct();
+        apiProduct.setType(PortalNavigationItemType.API_PRODUCT);
+        apiProduct.setTitle("Updated API Product");
+        apiProduct.setOrder(1);
+        apiProduct.setPublished(false);
+        apiProduct.setVisibility(PortalVisibility.PRIVATE);
+        return apiProduct;
+    }
+
+    public static UpdatePortalNavigationApiProduct anUpdatePortalNavigationApiProduct(List<UUID> categoryIds) {
+        var apiProduct = anUpdatePortalNavigationApiProduct();
+        apiProduct.setCategoryIds(categoryIds);
+        return apiProduct;
     }
 
     public static BaseCreatePortalNavigationItem aPrivateCreatePortalNavigationPage() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -24,7 +24,6 @@ import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BasePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
-import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
@@ -150,7 +149,9 @@ class PortalNavigationItemsMapperTest {
 
         @Test
         void should_map_portal_navigation_api_product() {
-            var apiProduct = PortalNavigationItemFixtures.anApiProduct();
+            var category1 = PortalCategoryId.random();
+            var category2 = PortalCategoryId.random();
+            var apiProduct = PortalNavigationItemFixtures.anApiProduct().toBuilder().categoryIds(List.of(category1, category2)).build();
 
             var result = mapper.map(apiProduct);
 
@@ -158,6 +159,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getId()).isEqualTo(UUID.fromString(PortalNavigationItemFixtures.API_PRODUCT_ID));
             assertThat(result.getType()).isEqualTo(PortalNavigationItemType.API_PRODUCT);
             assertThat(result.getApiProductId()).isEqualTo(UUID.fromString(apiProduct.getApiProductId()));
+            assertThat(result.getCategoryIds()).containsExactly(category1.id(), category2.id());
             assertThat(result.getRootId()).isEqualTo(apiProduct.getRootId().id());
         }
 
@@ -307,23 +309,28 @@ class PortalNavigationItemsMapperTest {
 
         @Test
         void should_map_create_portal_navigation_api_product() {
-            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
+            var category1 = UUID.randomUUID();
+            var category2 = UUID.randomUUID();
+            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct(List.of(category1, category2));
 
             var result = mapper.map(apiProduct);
 
             assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT);
-            assertThat(result.getApiProductId()).isEqualTo(((CreatePortalNavigationApiProduct) apiProduct).getApiProductId().toString());
+            assertThat(result.getApiProductId()).isEqualTo(apiProduct.getApiProductId().toString());
+            assertThat(result.getCategoryIds()).containsExactly(new PortalCategoryId(category1), new PortalCategoryId(category2));
         }
 
         @Test
         void should_map_update_portal_navigation_api_product_without_product_relinking_field() {
-            final var apiProduct = PortalNavigationItemsFixtures.anUpdatePortalNavigationApiProduct();
+            var categoryId = UUID.randomUUID();
+            final var apiProduct = PortalNavigationItemsFixtures.anUpdatePortalNavigationApiProduct(List.of(categoryId));
 
             var result = mapper.map(apiProduct);
 
             assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT);
             assertThat(result.getTitle()).isEqualTo("Updated API Product");
             assertThat(result.getPublished()).isFalse();
+            assertThat(result.getCategoryIds()).containsExactly(new PortalCategoryId(categoryId));
         }
 
         @Test
@@ -332,7 +339,8 @@ class PortalNavigationItemsMapperTest {
             final var folder = PortalNavigationItemsFixtures.aCreatePortalNavigationFolder();
             final var link = PortalNavigationItemsFixtures.aCreatePortalNavigationLink();
             final var api = PortalNavigationItemsFixtures.aCreatePortalNavigationApi();
-            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct();
+            var apiProductCategoryId = UUID.randomUUID();
+            final var apiProduct = PortalNavigationItemsFixtures.aCreatePortalNavigationApiProduct(List.of(apiProductCategoryId));
 
             final var requestItems = java.util.List.of(page, folder, link, api, apiProduct);
 
@@ -348,6 +356,7 @@ class PortalNavigationItemsMapperTest {
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API,
                     io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.API_PRODUCT
                 );
+            assertThat(result.get(4).getCategoryIds()).containsExactly(new PortalCategoryId(apiProductCategoryId));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -28,16 +28,19 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
+import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationPage;
@@ -200,6 +203,63 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
         assertThat(updated.getTitle()).isEqualTo("Updated Title");
+    }
+
+    @Test
+    void should_replace_api_product_category_ids() {
+        var existingCategoryId = PortalCategoryId.random();
+        var replacementCategoryIds = List.of(PortalCategoryId.random(), PortalCategoryId.random());
+        var parent = PortalNavigationItemFixtures.aFolder(APIS_ID, "APIs");
+        parent.markAsRoot();
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct().toBuilder().categoryIds(List.of(existingCategoryId)).build();
+        apiProduct.updateParent(parent);
+        initStorageWith(List.of(parent, apiProduct));
+
+        var payload = new UpdatePortalNavigationApiProduct().categoryIds(
+            replacementCategoryIds.stream().map(PortalCategoryId::id).toList()
+        );
+        payload
+            .title(apiProduct.getTitle())
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .order(apiProduct.getOrder())
+            .published(apiProduct.getPublished())
+            .parentId(parent.getId().id())
+            .visibility(PortalVisibility.PUBLIC);
+
+        Response response = target.path(apiProduct.getId().toString()).request().put(json(payload));
+
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationApiProduct body = response.readEntity(PortalNavigationApiProduct.class);
+        assertThat(body.getCategoryIds()).containsExactlyElementsOf(replacementCategoryIds.stream().map(PortalCategoryId::id).toList());
+
+        var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, apiProduct.getId());
+        assertThat(updated).hasFieldOrPropertyWithValue("categoryIds", replacementCategoryIds);
+    }
+
+    @Test
+    void should_reset_api_product_category_ids_when_omitted() {
+        var parent = PortalNavigationItemFixtures.aFolder(APIS_ID, "APIs");
+        parent.markAsRoot();
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct().toBuilder().categoryIds(List.of(PortalCategoryId.random())).build();
+        apiProduct.updateParent(parent);
+        initStorageWith(List.of(parent, apiProduct));
+
+        var payload = new UpdatePortalNavigationApiProduct()
+            .title(apiProduct.getTitle())
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .order(apiProduct.getOrder())
+            .published(apiProduct.getPublished())
+            .parentId(parent.getId().id())
+            .visibility(PortalVisibility.PUBLIC);
+
+        Response response = target.path(apiProduct.getId().toString()).request().put(json(payload));
+
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationApiProduct body = response.readEntity(PortalNavigationApiProduct.class);
+        assertThat(body.getCategoryIds()).isEmpty();
+
+        var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, apiProduct.getId());
+        assertThat(updated).hasFieldOrPropertyWithValue("categoryIds", List.of());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationApiProduct.java
@@ -16,7 +16,11 @@
 package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -29,6 +33,10 @@ public final class PortalNavigationApiProduct extends PortalNavigationItem imple
     @Nonnull
     private final String apiProductId;
 
+    @Builder.Default
+    @Nonnull
+    private List<PortalCategoryId> categoryIds = List.of();
+
     PortalNavigationApiProduct(
         @Nonnull PortalNavigationItemId id,
         @Nonnull String organizationId,
@@ -38,14 +46,26 @@ public final class PortalNavigationApiProduct extends PortalNavigationItem imple
         @Nonnull Integer order,
         @Nonnull String apiProductId,
         @Nonnull Boolean published,
-        @Nonnull PortalVisibility visibility
+        @Nonnull PortalVisibility visibility,
+        List<PortalCategoryId> categoryIds
     ) {
         super(id, organizationId, environmentId, title, area, order, published, visibility);
         this.apiProductId = apiProductId;
+        this.categoryIds = normalizeCategoryIds(categoryIds);
     }
 
     @Override
     public PortalNavigationItemType getType() {
         return TYPE;
+    }
+
+    @Override
+    public void update(UpdatePortalNavigationItem navItem) {
+        super.update(navItem);
+        this.categoryIds = normalizeCategoryIds(navItem.getCategoryIds());
+    }
+
+    private static List<PortalCategoryId> normalizeCategoryIds(List<PortalCategoryId> categoryIds) {
+        return Objects.requireNonNullElse(categoryIds, List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -202,7 +202,8 @@ public abstract sealed class PortalNavigationItem
                 order,
                 apiProductId,
                 published,
-                visibility
+                visibility,
+                categoryIds
             );
         };
         newItem.setSegment(segmentFor(item));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
@@ -112,7 +112,7 @@ public class GetVisiblePortalCatalogItemsUseCase {
             visibleApis,
             navigationItemsById
         );
-        // API products carry no category association, so a category-filtered catalog search never matches any of them.
+        // Category assignment and catalog filtering are delivered separately; exclude products until catalog filtering is implemented.
         List<PortalNavigationApiProduct> visibleApiProducts = input.categoryId().isPresent()
             ? List.of()
             : findVisibleApiProducts(navigationItems, input, navigationItemsById, accessibleApiNavigationItemIds, accessibleApiProductIds);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemTest.java
@@ -47,7 +47,28 @@ class PortalNavigationItemTest {
         assertThat(apiProduct.getApiProductId()).isEqualTo("00000000-0000-0000-0000-000000000020");
         assertThat(apiProduct.getPublished()).isFalse();
         assertThat(apiProduct.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+        assertThat(apiProduct.getCategoryIds()).isEmpty();
         assertThat(apiProduct.isRoot()).isTrue();
+    }
+
+    @Test
+    void should_create_api_product_with_category_ids() {
+        var categoryIds = List.of(PortalCategoryId.random(), PortalCategoryId.random());
+        var create = CreatePortalNavigationItem.builder()
+            .title("Product documentation")
+            .segment("product-documentation")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .apiProductId("00000000-0000-0000-0000-000000000020")
+            .categoryIds(categoryIds)
+            .build();
+
+        var item = PortalNavigationItem.from(create, "organization-id", "environment-id", null);
+
+        assertThat(item).isInstanceOf(PortalNavigationApiProduct.class);
+        assertThat(((PortalNavigationApiProduct) item).getCategoryIds()).containsExactlyElementsOf(categoryIds);
     }
 
     @Test
@@ -66,6 +87,50 @@ class PortalNavigationItemTest {
 
         assertThat(apiProduct.getApiProductId()).isEqualTo(originalApiProductId);
         assertThat(apiProduct.getTitle()).isEqualTo("Updated product documentation");
+    }
+
+    @Test
+    void should_update_api_product_category_ids() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct();
+        var categoryId = PortalCategoryId.random();
+        var update = UpdatePortalNavigationItem.builder()
+            .title("Updated product documentation")
+            .order(1)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .published(false)
+            .visibility(PortalVisibility.PRIVATE)
+            .categoryIds(List.of(categoryId))
+            .build();
+
+        apiProduct.update(update);
+
+        assertThat(apiProduct.getCategoryIds()).containsExactly(categoryId);
+    }
+
+    @Test
+    void should_reset_api_product_category_ids_to_empty_list_when_update_omits_them() {
+        var apiProduct = PortalNavigationItemFixtures.anApiProduct();
+        apiProduct.update(
+            UpdatePortalNavigationItem.builder()
+                .title("Updated product documentation")
+                .order(1)
+                .type(PortalNavigationItemType.API_PRODUCT)
+                .published(false)
+                .visibility(PortalVisibility.PRIVATE)
+                .categoryIds(List.of(PortalCategoryId.random()))
+                .build()
+        );
+        var update = UpdatePortalNavigationItem.builder()
+            .title("Updated product documentation")
+            .order(1)
+            .type(PortalNavigationItemType.API_PRODUCT)
+            .published(false)
+            .visibility(PortalVisibility.PRIVATE)
+            .build();
+
+        apiProduct.update(update);
+
+        assertThat(apiProduct.getCategoryIds()).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -145,12 +145,14 @@ class PortalNavigationItemAdapterTest {
 
         @Test
         void should_map_api_product_to_entity() {
+            var categoryId = PortalCategoryId.random();
             var repositoryItem = PortalNavigationItemsRepositoryFixtures.anApiProduct(
                 "550e8400-e29b-41d4-a716-446655440020",
                 "My API Product",
                 "550e8400-e29b-41d4-a716-446655440021",
                 null
             );
+            repositoryItem.setCategoryIds(List.of(categoryId.toString()));
 
             var entity = adapter.toEntity(repositoryItem);
 
@@ -158,6 +160,7 @@ class PortalNavigationItemAdapterTest {
             var apiProduct = (PortalNavigationApiProduct) entity;
             assertThat(apiProduct.getId()).isEqualTo(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440020"));
             assertThat(apiProduct.getApiProductId()).isEqualTo("550e8400-e29b-41d4-a716-446655440021");
+            assertThat(apiProduct.getCategoryIds()).containsExactly(categoryId);
             assertThat(apiProduct.getRootId()).isEqualTo(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440020"));
         }
 
@@ -385,18 +388,23 @@ class PortalNavigationItemAdapterTest {
 
         @Test
         void should_map_api_product_to_repository() {
+            var categoryId = PortalCategoryId.random();
             var entity = PortalNavigationItemFixtures.anApiProduct(
                 "550e8400-e29b-41d4-a716-446655440022",
                 "My API Product",
                 null,
                 "550e8400-e29b-41d4-a716-446655440023"
-            );
+            )
+                .toBuilder()
+                .categoryIds(List.of(categoryId))
+                .build();
 
             var repositoryItem = adapter.toRepository((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) entity);
 
             assertThat(repositoryItem.getId()).isEqualTo("550e8400-e29b-41d4-a716-446655440022");
             assertThat(repositoryItem.getType()).isEqualTo(PortalNavigationItem.Type.API_PRODUCT);
             assertThat(repositoryItem.getApiProductId()).isEqualTo("550e8400-e29b-41d4-a716-446655440023");
+            assertThat(repositoryItem.getCategoryIds()).containsExactly(categoryId.toString());
             assertThat(repositoryItem.getConfiguration()).isEqualTo("{}");
             assertThat(repositoryItem.getRootId()).isEqualTo("00000000-0000-0000-0000-000000000000");
         }


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/PORTAL-130

## Description

Adds Portal category support to `API_PRODUCT` navigation items.

- Adds `categoryIds` to Management v2 create, update, bulk-create, and response contracts.
- Supports category assignments in the API Product navigation domain model.
- Applies the existing replacement semantics when categories are updated.
- Reuses the existing Portal navigation category persistence.
- Extends Console Management API v2 models.
- Preserves `apiProductId` immutability.
- Adds focused domain, repository adapter, and Management v2 mapper tests.

No new endpoint or database migration is introduced.
