### PR TITLE
chore(4.12.x): bump gravitee-reactor-mcp-proxy from 3.1.5 to 3.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.7</gravitee-reactor-native-kafka.version>
-    <gravitee-reactor-mcp-proxy.version>3.1.5</gravitee-reactor-mcp-proxy.version>
+    <gravitee-reactor-mcp-proxy.version>3.1.6</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-329

## Description

Bumps `gravitee-reactor-mcp-proxy` from `3.1.5` to `3.1.6` to pick up the fix for AIAM-329: with `upstreamAuth.type = "elicitation-oauth"`, the brokered upstream token was cached per OAuth client instead of per end user, so once one user completed the authorization flow, every other caller sharing that OAuth client silently reused that user's upstream token — including users who never consented and have no account with the upstream provider.

Plugin PRs: gravitee-io/gravitee-reactor-mcp-proxy#78 (main, released 3.3.1) and gravitee-io/gravitee-reactor-mcp-proxy#80 (backport, released **3.1.6**).

## Additional context

This single property drives all five MCP plugins in the distribution poms — `reactor-mcp-proxy`, `entrypoint-mcp-proxy`, `entrypoint-mcp-studio`, `endpoint-mcp-proxy` and `endpoint-tools-mcp` — since they release in lockstep from that monorepo.

The plugin-side change is confined to `McpCredentialResolver.resolveSubject`, which now keys the brokered token by end user *and* OAuth client. Callers with no end-user identity (client-credentials grants) keep the previous client-scoped behaviour, so there is no regression for machine-to-machine traffic.

4.11.x and 4.10.x are unaffected and need no equivalent bump: `McpCredentialResolver` does not exist at tags 2.2.3 or 1.2.0, so the `elicitation-oauth` feature predates them.

**Verified on a live stack** before release: APIM 4.12.17-SNAPSHOT gateway with this plugin build, an MCP studio on an OAuth2 plan, plus a mock IdP and MCP upstream. Before the fix, user B silently received user A's upstream token; after it, user B is prompted to authorize and makes zero upstream calls.
