### PR TITLE
feat: manage API Products in Portal categories

### DIFF
--- a/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.html
@@ -1,0 +1,54 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<span mat-dialog-title>{{ data.title }}</span>
+<form autocomplete="off" (ngSubmit)="submit()">
+  <mat-dialog-content>
+    <mat-form-field appearance="outline" class="form-field">
+      <mat-icon matPrefix>search</mat-icon>
+      <mat-label id="api-product-search-label">Search API Products...</mat-label>
+      <input
+        id="api-product-select-input"
+        aria-labelledby="api-product-search-label"
+        matInput
+        type="search"
+        [matAutocomplete]="auto"
+        [formControl]="searchApiProductControl"
+        data-testid="api-product-select-input"
+      />
+      @if (searchApiProductControl.value) {
+        <button type="button" matSuffix mat-icon-button aria-label="Clear input" (click)="resetSearchTerm()">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
+        @for (option of filteredOptions(); track option.navigationItem.id) {
+          <mat-option [value]="option" data-testid="api-product-select-option">{{ option.name }} ({{ option.version }})</mat-option>
+        }
+        @if (filteredOptions().length === 0) {
+          <mat-option disabled>No API Products matching search criteria</mat-option>
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button type="button" mat-flat-button (click)="onCancelClick()" data-testid="cancel-button">Cancel</button>
+    <button type="submit" [disabled]="!isApiProductSelected()" mat-raised-button color="primary" data-testid="submit-button">Add</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.scss
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.form-field {
+  width: 100%;
+}

--- a/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import {
+  AddApiProductToCategoryDialogComponent,
+  AddApiProductToCategoryDialogData,
+  ApiProductCategoryCandidate,
+} from './add-api-product-to-category-dialog.component';
+import { AddApiProductToCategoryDialogHarness } from './add-api-product-to-category-dialog.harness';
+
+import { fakePortalNavigationApiProduct } from '../../../../entities/management-api-v2';
+
+describe('AddApiProductToCategoryDialogComponent', () => {
+  let fixture: ComponentFixture<AddApiProductToCategoryDialogComponent>;
+  let harness: AddApiProductToCategoryDialogHarness;
+  let dialogRefClose: jest.Mock;
+  let dialogData: AddApiProductToCategoryDialogData;
+
+  const PRODUCT_1: ApiProductCategoryCandidate = {
+    navigationItem: fakePortalNavigationApiProduct({ id: 'nav-product-1', apiProductId: 'product-1' }),
+    name: 'Commerce Product',
+    version: '1.0',
+  };
+  const PRODUCT_2: ApiProductCategoryCandidate = {
+    navigationItem: fakePortalNavigationApiProduct({ id: 'nav-product-2', apiProductId: 'product-2' }),
+    name: 'Banking Bundle',
+    version: '2.0',
+  };
+
+  beforeEach(async () => {
+    dialogRefClose = jest.fn();
+    dialogData = { title: 'Add API Product to Category', candidates: [PRODUCT_1, PRODUCT_2] };
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, AddApiProductToCategoryDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+        { provide: MAT_DIALOG_DATA, useFactory: () => dialogData },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddApiProductToCategoryDialogComponent);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AddApiProductToCategoryDialogHarness);
+  });
+
+  it('should list candidate API Products with their versions', async () => {
+    expect(await harness.getOptionLabels()).toEqual(['Commerce Product (1.0)', 'Banking Bundle (2.0)']);
+  });
+
+  it('should explicitly associate the search input with its label', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('#api-product-select-input');
+    const label: HTMLElement = fixture.nativeElement.querySelector('#api-product-search-label');
+
+    expect(input.getAttribute('aria-labelledby')).toEqual(label.id);
+  });
+
+  it('should filter candidates by API Product name', async () => {
+    expect(await harness.getOptionLabels('Banking')).toEqual(['Banking Bundle (2.0)']);
+  });
+
+  it('should close with the selected API Product candidate', async () => {
+    await harness.fillFormAndSubmit('Banking Bundle');
+
+    expect(dialogRefClose).toHaveBeenCalledWith(PRODUCT_2);
+  });
+
+  it('should close with undefined on cancel', async () => {
+    await harness.cancel();
+
+    expect(dialogRefClose).toHaveBeenCalledWith();
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.component.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+
+import { PortalNavigationApiProduct } from '../../../../entities/management-api-v2';
+
+export interface ApiProductCategoryCandidate {
+  navigationItem: PortalNavigationApiProduct;
+  name: string;
+  version: string;
+}
+
+export interface AddApiProductToCategoryDialogData {
+  title: string;
+  candidates: ApiProductCategoryCandidate[];
+}
+
+export type AddApiProductToCategoryDialogResult = ApiProductCategoryCandidate;
+
+@Component({
+  selector: 'add-api-product-to-category-dialog',
+  templateUrl: './add-api-product-to-category-dialog.component.html',
+  styleUrl: './add-api-product-to-category-dialog.component.scss',
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
+})
+export class AddApiProductToCategoryDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<AddApiProductToCategoryDialogComponent, AddApiProductToCategoryDialogResult>);
+  protected readonly data = inject<AddApiProductToCategoryDialogData>(MAT_DIALOG_DATA);
+
+  protected readonly searchApiProductControl = new FormControl<string | ApiProductCategoryCandidate>('', { nonNullable: true });
+
+  private readonly searchValue = toSignal(this.searchApiProductControl.valueChanges, {
+    initialValue: this.searchApiProductControl.value,
+  });
+
+  protected readonly isApiProductSelected = computed(() => this.isApiProductCandidate(this.searchValue()));
+
+  protected readonly filteredOptions = computed(() => {
+    const value = this.searchValue();
+    const term = (this.isApiProductCandidate(value) ? value.name : value).trim().toLowerCase();
+    return this.data.candidates.filter(candidate => candidate.name.toLowerCase().includes(term));
+  });
+
+  protected displayFn(option: ApiProductCategoryCandidate): string {
+    return option?.name ?? '';
+  }
+
+  protected resetSearchTerm(): void {
+    this.searchApiProductControl.setValue('');
+  }
+
+  protected onCancelClick(): void {
+    this.dialogRef.close();
+  }
+
+  protected submit(): void {
+    const value = this.searchApiProductControl.getRawValue();
+    if (this.isApiProductCandidate(value)) {
+      this.dialogRef.close(value);
+    }
+  }
+
+  private isApiProductCandidate(value: string | ApiProductCategoryCandidate): value is ApiProductCategoryCandidate {
+    return typeof value !== 'string';
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/add-api-product-to-category-dialog/add-api-product-to-category-dialog.harness.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncFactoryFn, ComponentHarness } from '@angular/cdk/testing';
+import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class AddApiProductToCategoryDialogHarness extends ComponentHarness {
+  public static readonly hostSelector = 'add-api-product-to-category-dialog';
+
+  private readonly inputLocator: AsyncFactoryFn<MatAutocompleteHarness> = this.locatorFor(
+    MatAutocompleteHarness.with({ selector: '[data-testid=api-product-select-input]' }),
+  );
+  private readonly addButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid=submit-button]' }),
+  );
+  private readonly cancelButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid=cancel-button]' }),
+  );
+
+  public async getOptionLabels(filter?: string): Promise<string[]> {
+    const inputAutocomplete = await this.inputLocator();
+    await inputAutocomplete.focus();
+    if (filter) {
+      await inputAutocomplete.enterText(filter);
+    }
+    const options = await inputAutocomplete.getOptions();
+    return Promise.all(options.map(option => option.getText()));
+  }
+
+  public async fillFormAndSubmit(value: string): Promise<void> {
+    const inputAutocomplete = await this.inputLocator();
+    await inputAutocomplete.enterText(value);
+    await inputAutocomplete.selectOption({ text: new RegExp(value) });
+    await this.addButtonLocator().then(button => button.click());
+  }
+
+  public async cancel(): Promise<void> {
+    await this.cancelButtonLocator().then(button => button.click());
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.html
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.html
@@ -45,14 +45,14 @@
     @if (mode === 'edit') {
       <mat-card *gioPermission="{ anyOf: ['environment-documentation-r'] }">
         <mat-card-content class="category__content">
-          <div class="category__apis__title">
+          <div class="category__assignments__title">
             <div class="category__content__header">
               <h3>APIs</h3>
             </div>
             <button
-              class="add-button"
               mat-raised-button
               color="primary"
+              data-testid="add-api-button"
               (click)="addApiToCategory()"
               *gioPermission="{ anyOf: ['environment-documentation-u'] }"
             >
@@ -61,7 +61,14 @@
             </button>
           </div>
           @if (apis$ | async; as apis) {
-            <table mat-table class="gio-table-light" [dataSource]="apis" id="categoriesTable" aria-label="Categories table">
+            <table
+              mat-table
+              class="gio-table-light"
+              [dataSource]="apis"
+              id="categoriesTable"
+              aria-label="APIs assigned to category"
+              data-testid="api-table"
+            >
               <!-- Display Name Column -->
               <ng-container matColumnDef="name">
                 <th mat-header-cell *matHeaderCellDef id="name">Name</th>
@@ -110,6 +117,75 @@
               <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
                 <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
                   There are no APIs for this category.
+                </td>
+              </tr>
+            </table>
+          }
+        </mat-card-content>
+      </mat-card>
+      <mat-card *gioPermission="{ anyOf: ['environment-documentation-r'] }">
+        <mat-card-content class="category__content">
+          <div class="category__assignments__title">
+            <div class="category__content__header">
+              <h3>API Products</h3>
+            </div>
+            <button
+              mat-raised-button
+              color="primary"
+              data-testid="add-api-product-button"
+              [disabled]="isLoadingApiProductCandidates()"
+              (click)="addApiProductToCategory()"
+              *gioPermission="{ anyOf: ['environment-documentation-u'] }"
+            >
+              <mat-icon>add</mat-icon>
+              Add API Product to Category
+            </button>
+          </div>
+          @if (apiProducts$ | async; as apiProducts) {
+            <table
+              mat-table
+              class="gio-table-light"
+              [dataSource]="apiProducts"
+              aria-label="API Products assigned to category"
+              data-testid="api-product-table"
+            >
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef id="api-product-name">Name</th>
+                <td mat-cell *matCellDef="let element">
+                  <div class="category__table__name">
+                    {{ element.name }}
+                  </div>
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="version">
+                <th mat-header-cell *matHeaderCellDef id="api-product-version">Version</th>
+                <td mat-cell *matCellDef="let element">
+                  {{ element.version }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="actions">
+                <th mat-header-cell *matHeaderCellDef id="api-product-list-actions"></th>
+                <td mat-cell *matCellDef="let element">
+                  <button
+                    mat-button
+                    (click)="removeApiProductFromCategory(element)"
+                    matTooltip="Remove API Product"
+                    aria-label="Remove {{ element.name }} from category"
+                    *gioPermission="{ anyOf: ['environment-documentation-u'] }"
+                  >
+                    <mat-icon svgIcon="gio:trash"></mat-icon>
+                  </button>
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="apiProductDisplayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: apiProductDisplayedColumns"></tr>
+
+              <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+                <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="apiProductDisplayedColumns.length">
+                  There are no API Products for this category.
                 </td>
               </tr>
             </table>

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.scss
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.scss
@@ -52,7 +52,7 @@
     }
   }
 
-  &__apis {
+  &__assignments {
     &__title {
       display: flex;
       justify-content: space-between;

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.spec.ts
@@ -27,17 +27,22 @@ import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { CategoryCatalogComponent } from './category.component';
 import { CategoryHarness } from './category.harness';
 import { AddApiToCategoryDialogHarness } from './add-api-to-category-dialog/add-api-to-category-dialog.harness';
+import { AddApiProductToCategoryDialogHarness } from './add-api-product-to-category-dialog/add-api-product-to-category-dialog.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import {
   fakePortalCategory,
   fakePortalNavigationApi,
+  fakePortalNavigationApiProduct,
   fakePortalNavigationItemsResponse,
   PortalCategory,
   PortalNavigationApi,
+  PortalNavigationApiProduct,
   PortalNavigationItemApiSummary,
   UpdateApiPortalNavigationItem,
+  UpdateApiProductPortalNavigationItem,
 } from '../../../entities/management-api-v2';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { PortalCatalogComponent } from '../portal-catalog.component';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -57,8 +62,15 @@ describe('CategoryCatalogComponent', () => {
   let componentHarness: CategoryHarness;
 
   const CATEGORY: PortalCategory = fakePortalCategory({ id: 'cat', title: 'cat title', description: 'cat desc', visible: true });
+  const DEFAULT_PERMISSIONS = [
+    'environment-category-u',
+    'environment-category-d',
+    'environment-category-c',
+    'environment-documentation-u',
+    'environment-documentation-r',
+  ];
 
-  const init = async (categoryId: string) => {
+  const init = async (categoryId: string, permissions = DEFAULT_PERMISSIONS) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, PortalCatalogComponent, CategoryCatalogComponent],
       providers: [
@@ -68,13 +80,7 @@ describe('CategoryCatalogComponent', () => {
         },
         {
           provide: GioTestingPermissionProvider,
-          useValue: [
-            'environment-category-u',
-            'environment-category-d',
-            'environment-category-c',
-            'environment-documentation-u',
-            'environment-documentation-r',
-          ],
+          useValue: permissions,
         },
       ],
     })
@@ -96,7 +102,7 @@ describe('CategoryCatalogComponent', () => {
     fixture.detectChanges();
   };
 
-  const expectGetPortalNavigationItems = (items: PortalNavigationApi[] = []) => {
+  const expectGetPortalNavigationItems = (items: (PortalNavigationApi | PortalNavigationApiProduct)[] = []) => {
     const req = httpTestingController.expectOne({
       method: 'GET',
       url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR`,
@@ -105,7 +111,7 @@ describe('CategoryCatalogComponent', () => {
   };
 
   const expectGetPortalNavigationItemsWithApis = (
-    items: PortalNavigationApi[] = [],
+    items: (PortalNavigationApi | PortalNavigationApiProduct)[] = [],
     apisById: Record<string, PortalNavigationItemApiSummary> = {},
   ) => {
     const req = httpTestingController.expectOne({
@@ -115,13 +121,26 @@ describe('CategoryCatalogComponent', () => {
     req.flush(fakePortalNavigationItemsResponse({ items, metadata: { apis: apisById } }));
   };
 
-  const expectUpdateNavigationItem = (navItemId: string, expectedBody: UpdateApiPortalNavigationItem, response: PortalNavigationApi) => {
+  const expectUpdateNavigationItem = (
+    navItemId: string,
+    expectedBody: UpdateApiPortalNavigationItem | UpdateApiProductPortalNavigationItem,
+    response: PortalNavigationApi | PortalNavigationApiProduct,
+  ) => {
     const req = httpTestingController.expectOne({
       method: 'PUT',
       url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${navItemId}`,
     });
     expect(req.request.body).toEqual(expectedBody);
     req.flush(response);
+  };
+
+  const expectSearchApiProducts = (ids: string[], products: ApiProduct[]) => {
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search?page=1&perPage=100`,
+    });
+    expect(req.request.body).toEqual({ ids });
+    req.flush({ data: products, pagination: { totalCount: products.length } });
   };
 
   afterEach(() => {
@@ -225,6 +244,62 @@ describe('CategoryCatalogComponent', () => {
 
       expect(snackBarErrorSpy).toHaveBeenCalledWith('Category not found');
       expect(navigateSpy).toHaveBeenCalledWith(['..', '..'], expect.anything());
+    });
+  });
+
+  describe('Navigation item loading', () => {
+    it('should recover the API and API Product lists after the initial request fails', async () => {
+      await init(CATEGORY.id);
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
+      fixture.detectChanges();
+
+      const failedRequest = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR&includes=apis`,
+      });
+      failedRequest.flush({ message: 'Navigation items unavailable' }, { status: 500, statusText: 'Server Error' });
+      fixture.detectChanges();
+
+      expect(errorSpy).toHaveBeenCalledWith('Navigation items unavailable');
+      expect(await componentHarness.getApiProductTable(harnessLoader)).toBeTruthy();
+
+      const navigationItem = fakePortalNavigationApi({
+        id: 'nav-api-1',
+        apiId: 'api-1',
+        title: 'Planets API',
+        categoryIds: [],
+      });
+      const addApiButton = await componentHarness.getAddApiButton(harnessLoader);
+      await addApiButton!.click();
+      expectGetPortalNavigationItems([navigationItem]);
+
+      const dialog = await rootLoader.getHarness(AddApiToCategoryDialogHarness);
+      await dialog.fillFormAndSubmit(navigationItem.title);
+
+      const updatedNavigationItem = { ...navigationItem, categoryIds: [CATEGORY.id] };
+      expectUpdateNavigationItem(
+        navigationItem.id,
+        {
+          type: 'API',
+          title: navigationItem.title,
+          published: navigationItem.published,
+          visibility: navigationItem.visibility,
+          parentId: navigationItem.parentId,
+          order: navigationItem.order,
+          apiId: navigationItem.apiId,
+          categoryIds: [CATEGORY.id],
+        },
+        updatedNavigationItem,
+      );
+      expectGetPortalNavigationItemsWithApis([updatedNavigationItem], {
+        [navigationItem.id]: { id: navigationItem.apiId, name: navigationItem.title, apiVersion: '1.0', contextPath: '/planets' },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await componentHarness.getNameByRowIndex(harnessLoader, 0)).toEqual(navigationItem.title);
     });
   });
 
@@ -417,6 +492,319 @@ describe('CategoryCatalogComponent', () => {
 
         expect(await componentHarness.getNameByRowIndex(harnessLoader, 0)).toEqual('Planets API');
       });
+    });
+  });
+
+  describe('API Product List', () => {
+    const commerceProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Commerce Product',
+      version: '1.0',
+    };
+
+    beforeEach(async () => {
+      await init(CATEGORY.id);
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
+      fixture.detectChanges();
+    });
+
+    it('should show an empty state when no API Products are assigned to the category', async () => {
+      expectGetPortalNavigationItemsWithApis([]);
+      fixture.detectChanges();
+
+      const table = await componentHarness.getApiProductTable(harnessLoader);
+      expect(await table.host().then(host => host.text())).toContain('There are no API Products for this category.');
+    });
+
+    it('should list an assigned API Product with its name and version', async () => {
+      const navigationItem = fakePortalNavigationApiProduct({
+        id: 'nav-product-1',
+        apiProductId: commerceProduct.id,
+        categoryIds: [CATEGORY.id],
+      });
+
+      expectGetPortalNavigationItemsWithApis([navigationItem]);
+      expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await componentHarness.getApiProductNameByRowIndex(harnessLoader, 0)).toEqual(commerceProduct.name);
+      expect(await componentHarness.getApiProductTextByColumnNameAndRowIndex(harnessLoader, 'version', 0)).toEqual(commerceProduct.version);
+    });
+
+    it('should search each API Product id only once', async () => {
+      const firstNavigationItem = fakePortalNavigationApiProduct({
+        id: 'nav-product-1',
+        apiProductId: commerceProduct.id,
+        categoryIds: [CATEGORY.id],
+      });
+      const secondNavigationItem = fakePortalNavigationApiProduct({
+        id: 'nav-product-2',
+        apiProductId: commerceProduct.id,
+        categoryIds: [CATEGORY.id],
+      });
+
+      expectGetPortalNavigationItemsWithApis([firstNavigationItem, secondNavigationItem]);
+      expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await componentHarness.getApiProductNameByRowIndex(harnessLoader, 0)).toEqual(commerceProduct.name);
+      expect(await componentHarness.getApiProductNameByRowIndex(harnessLoader, 1)).toEqual(commerceProduct.name);
+    });
+
+    it('should still list an assigned API Product after it was unpublished', async () => {
+      const navigationItem = fakePortalNavigationApiProduct({
+        id: 'nav-product-1',
+        apiProductId: commerceProduct.id,
+        categoryIds: [CATEGORY.id],
+        published: false,
+      });
+
+      expectGetPortalNavigationItemsWithApis([navigationItem]);
+      expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(await componentHarness.getApiProductNameByRowIndex(harnessLoader, 0)).toEqual(commerceProduct.name);
+    });
+
+    it('should show an error when assigned API Products cannot be loaded', () => {
+      const navigationItem = fakePortalNavigationApiProduct({
+        apiProductId: commerceProduct.id,
+        categoryIds: [CATEGORY.id],
+      });
+      const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+
+      expectGetPortalNavigationItemsWithApis([navigationItem]);
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_search?page=1&perPage=100`,
+      });
+      req.flush({ message: 'Products unavailable' }, { status: 500, statusText: 'Server Error' });
+
+      expect(errorSpy).toHaveBeenCalledWith('Products unavailable');
+    });
+
+    describe('Add API Product to Category', () => {
+      beforeEach(() => {
+        expectGetPortalNavigationItemsWithApis([]);
+        fixture.detectChanges();
+      });
+
+      it('should add the selected API Product while retaining its existing categories', async () => {
+        const navigationItem = fakePortalNavigationApiProduct({
+          id: 'nav-product-1',
+          apiProductId: commerceProduct.id,
+          title: 'Commerce documentation',
+          published: true,
+          categoryIds: ['existing-category'],
+        });
+        const successSpy = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+
+        const addButton = await componentHarness.getAddApiProductButton(harnessLoader);
+        await addButton!.click();
+        expectGetPortalNavigationItems([navigationItem]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+
+        const dialog = await rootLoader.getHarness(AddApiProductToCategoryDialogHarness);
+        await dialog.fillFormAndSubmit(commerceProduct.name);
+
+        const updatedNavigationItem = { ...navigationItem, categoryIds: ['existing-category', CATEGORY.id] };
+        expectUpdateNavigationItem(
+          navigationItem.id,
+          {
+            type: 'API_PRODUCT',
+            title: navigationItem.title,
+            published: navigationItem.published,
+            visibility: navigationItem.visibility,
+            parentId: navigationItem.parentId,
+            order: navigationItem.order,
+            categoryIds: ['existing-category', CATEGORY.id],
+          },
+          updatedNavigationItem,
+        );
+
+        expect(successSpy).toHaveBeenCalledWith(`API Product [${commerceProduct.name}] has been added to the category.`);
+        expectGetPortalNavigationItemsWithApis([updatedNavigationItem]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+      });
+
+      it('should offer only published API Products not yet assigned to the category', async () => {
+        const assigned = fakePortalNavigationApiProduct({
+          apiProductId: 'assigned-product',
+          published: true,
+          categoryIds: [CATEGORY.id],
+        });
+        const unpublished = fakePortalNavigationApiProduct({
+          apiProductId: 'unpublished-product',
+          published: false,
+          categoryIds: [],
+        });
+        const selectable = fakePortalNavigationApiProduct({
+          apiProductId: commerceProduct.id,
+          published: true,
+          categoryIds: [],
+        });
+
+        const addButton = await componentHarness.getAddApiProductButton(harnessLoader);
+        await addButton!.click();
+        expectGetPortalNavigationItems([assigned, unpublished, selectable]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+
+        const dialog = await rootLoader.getHarness(AddApiProductToCategoryDialogHarness);
+        expect(await dialog.getOptionLabels()).toEqual(['Commerce Product (1.0)']);
+      });
+
+      it('should prevent opening multiple dialogs while API Product candidates are loading', async () => {
+        const navigationItem = fakePortalNavigationApiProduct({
+          apiProductId: commerceProduct.id,
+          published: true,
+          categoryIds: [],
+        });
+        const addButton = await componentHarness.getAddApiProductButton(harnessLoader);
+
+        await addButton!.click();
+        expect(await addButton!.isDisabled()).toBe(true);
+        await addButton!.click();
+        expectGetPortalNavigationItems([navigationItem]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+
+        const dialog = await rootLoader.getHarness(AddApiProductToCategoryDialogHarness);
+        await dialog.cancel();
+        fixture.detectChanges();
+
+        expect(await addButton!.isDisabled()).toBe(false);
+      });
+
+      it('should show a load-specific error and re-enable the button when candidates cannot be loaded', async () => {
+        const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+        const addButton = await componentHarness.getAddApiProductButton(harnessLoader);
+
+        await addButton!.click();
+        const request = httpTestingController.expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=TOP_NAVBAR`,
+        });
+        request.flush({}, { status: 500, statusText: 'Server Error' });
+        fixture.detectChanges();
+
+        expect(errorSpy).toHaveBeenCalledWith('Unable to load API Products');
+        expect(await addButton!.isDisabled()).toBe(false);
+      });
+
+      it('should show an error when the API Product update fails', async () => {
+        const navigationItem = fakePortalNavigationApiProduct({
+          apiProductId: commerceProduct.id,
+          title: 'Commerce documentation',
+          published: true,
+          categoryIds: [],
+        });
+        const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+
+        const addButton = await componentHarness.getAddApiProductButton(harnessLoader);
+        await addButton!.click();
+        expectGetPortalNavigationItems([navigationItem]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+
+        const dialog = await rootLoader.getHarness(AddApiProductToCategoryDialogHarness);
+        await dialog.fillFormAndSubmit(commerceProduct.name);
+
+        const request = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${navigationItem.id}`,
+        });
+        request.flush({ message: 'Update rejected' }, { status: 400, statusText: 'Bad Request' });
+
+        expect(errorSpy).toHaveBeenCalledWith('Update rejected');
+      });
+    });
+
+    describe('Remove API Product from Category', () => {
+      const navigationItem = fakePortalNavigationApiProduct({
+        id: 'nav-product-1',
+        apiProductId: commerceProduct.id,
+        title: 'Commerce documentation',
+        published: false,
+        categoryIds: ['another-category', CATEGORY.id],
+      });
+
+      beforeEach(async () => {
+        expectGetPortalNavigationItemsWithApis([navigationItem]);
+        expectSearchApiProducts([commerceProduct.id], [commerceProduct]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+      });
+
+      it('should remove only the current category after confirmation', async () => {
+        const successSpy = jest.spyOn(TestBed.inject(SnackBarService), 'success');
+
+        const removeButton = await componentHarness.getRemoveApiProductButtonByRowIndex(harnessLoader, 0);
+        await removeButton!.click();
+        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        await confirmDialog.confirm();
+
+        expectUpdateNavigationItem(
+          navigationItem.id,
+          {
+            type: 'API_PRODUCT',
+            title: navigationItem.title,
+            published: false,
+            visibility: navigationItem.visibility,
+            parentId: navigationItem.parentId,
+            order: navigationItem.order,
+            categoryIds: ['another-category'],
+          },
+          { ...navigationItem, categoryIds: ['another-category'] },
+        );
+
+        expect(successSpy).toHaveBeenCalledWith(`'${commerceProduct.name}' removed successfully`);
+        expectGetPortalNavigationItemsWithApis([]);
+      });
+
+      it('should not remove the API Product when confirmation is cancelled', async () => {
+        const removeButton = await componentHarness.getRemoveApiProductButtonByRowIndex(harnessLoader, 0);
+        await removeButton!.click();
+
+        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        await confirmDialog.cancel();
+
+        expect(await componentHarness.getApiProductNameByRowIndex(harnessLoader, 0)).toEqual(commerceProduct.name);
+      });
+
+      it('should show an error when the API Product removal fails', async () => {
+        const errorSpy = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+        const removeButton = await componentHarness.getRemoveApiProductButtonByRowIndex(harnessLoader, 0);
+        await removeButton!.click();
+
+        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        await confirmDialog.confirm();
+
+        const request = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${navigationItem.id}`,
+        });
+        request.flush({ message: 'Removal rejected' }, { status: 400, statusText: 'Bad Request' });
+
+        expect(errorSpy).toHaveBeenCalledWith('Removal rejected');
+      });
+    });
+  });
+
+  describe('Permissions', () => {
+    it('should hide API and API Product update actions without documentation update permission', async () => {
+      await init(CATEGORY.id, ['environment-category-u', 'environment-documentation-r']);
+      expectListPortalCategoriesRequest(httpTestingController, [CATEGORY]);
+      fixture.detectChanges();
+      expectGetPortalNavigationItemsWithApis([]);
+      fixture.detectChanges();
+
+      expect(await componentHarness.getAddApiButton(harnessLoader)).toBeNull();
+      expect(await componentHarness.getAddApiProductButton(harnessLoader)).toBeNull();
     });
   });
 });

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.component.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject, EMPTY, forkJoin, Observable, of } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, filter, finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { chunk } from 'lodash';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   GIO_DIALOG_WIDTH,
@@ -44,6 +45,12 @@ import {
   AddApiToCategoryDialogData,
   AddApiToCategoryDialogResult,
 } from './add-api-to-category-dialog/add-api-to-category-dialog.component';
+import {
+  AddApiProductToCategoryDialogComponent,
+  AddApiProductToCategoryDialogData,
+  AddApiProductToCategoryDialogResult,
+  ApiProductCategoryCandidate,
+} from './add-api-product-to-category-dialog/add-api-product-to-category-dialog.component';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioGoBackButtonModule } from '../../../shared/components/gio-go-back-button/gio-go-back-button.module';
@@ -51,14 +58,19 @@ import { GioPermissionService } from '../../../shared/components/gio-permission/
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { PortalCategoryService } from '../../../services-ngx/portal-category.service';
 import { PortalNavigationItemService } from '../../../services-ngx/portal-navigation-item.service';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import {
   CreatePortalCategory,
   PortalCategory,
   PortalNavigationApi,
+  PortalNavigationApiProduct,
   PortalNavigationItemApiSummary,
+  PortalNavigationItemsResponse,
   UpdateApiPortalNavigationItem,
+  UpdateApiProductPortalNavigationItem,
   UpdatePortalCategory,
 } from '../../../entities/management-api-v2';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 
 interface ApiVM {
   id: string;
@@ -66,6 +78,10 @@ interface ApiVM {
   version: string;
   contextPath: string;
   navigationItem: PortalNavigationApi;
+}
+
+interface ApiProductVM extends ApiProductCategoryCandidate {
+  id: string;
 }
 
 @Component({
@@ -110,14 +126,19 @@ export class CategoryCatalogComponent implements OnInit {
 
   category$: Observable<PortalCategory>;
   apis$: Observable<ApiVM[]>;
+  apiProducts$: Observable<ApiProductVM[]>;
 
   displayedColumns = ['name', 'version', 'contextPath', 'actions'];
+  apiProductDisplayedColumns = ['name', 'version', 'actions'];
+  readonly isLoadingApiProductCandidates = signal(false);
 
   private refreshData = new BehaviorSubject(1);
-  private refreshApis = new BehaviorSubject(1);
+  private refreshNavigationItems = new BehaviorSubject(1);
   private destroyRef = inject(DestroyRef);
   private readonly portalNavigationItemService = inject(PortalNavigationItemService);
+  private readonly apiProductService = inject(ApiProductV2Service);
   private readonly matDialog = inject(MatDialog);
+  private navigationItemsResponse$: Observable<PortalNavigationItemsResponse>;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -157,21 +178,44 @@ export class CategoryCatalogComponent implements OnInit {
       }),
     );
 
-    this.apis$ = this.refreshApis.pipe(
-      switchMap(() => {
-        if (this.mode !== 'edit') {
-          return of([]);
-        }
-        return this.apiNavigationItemsWithSummaries$().pipe(
-          map(({ navItems, apisById }) =>
-            navItems
-              .filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId))
-              .map(navItem => this.toApiVM(navItem, apisById[navItem.id]))
-              .filter((apiVM): apiVM is ApiVM => !!apiVM),
-          ),
-          catchError(() => of([])),
-        );
-      }),
+    this.navigationItemsResponse$ = this.refreshNavigationItems.pipe(
+      switchMap(() =>
+        this.mode === 'edit'
+          ? this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR', ['apis']).pipe(
+              catchError(({ error }) => {
+                this.snackBarService.error(error?.message ?? 'Unable to load navigation items');
+                return of({ items: [] } satisfies PortalNavigationItemsResponse);
+              }),
+            )
+          : of({ items: [] } satisfies PortalNavigationItemsResponse),
+      ),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+
+    this.apis$ = this.navigationItemsResponse$.pipe(
+      map(response =>
+        response.items
+          .filter((item): item is PortalNavigationApi => item.type === 'API')
+          .filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId))
+          .map(navItem => this.toApiVM(navItem, response.metadata?.apis?.[navItem.id]))
+          .filter((apiVM): apiVM is ApiVM => !!apiVM),
+      ),
+    );
+
+    this.apiProducts$ = this.navigationItemsResponse$.pipe(
+      map(response =>
+        response.items
+          .filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT')
+          .filter(navItem => (navItem.categoryIds ?? []).includes(this.categoryId)),
+      ),
+      switchMap(navItems =>
+        this.toApiProductVMs$(navItems).pipe(
+          catchError(({ error }) => {
+            this.snackBarService.error(error?.message ?? 'Unable to load API Products');
+            return of([]);
+          }),
+        ),
+      ),
     );
   }
 
@@ -220,7 +264,7 @@ export class CategoryCatalogComponent implements OnInit {
       .subscribe({
         next: navItem => {
           this.snackBarService.success(`API [${navItem.title}] has been added to the category.`);
-          this.refreshApis.next(1);
+          this.refreshNavigationItems.next(1);
         },
         error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during API addition'),
       });
@@ -254,9 +298,88 @@ export class CategoryCatalogComponent implements OnInit {
       .subscribe({
         next: () => {
           this.snackBarService.success(`'${apiVM.name}' removed successfully`);
-          this.refreshApis.next(1);
+          this.refreshNavigationItems.next(1);
         },
         error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during API removal'),
+      });
+  }
+
+  addApiProductToCategory(): void {
+    if (this.isLoadingApiProductCandidates()) {
+      return;
+    }
+    this.isLoadingApiProductCandidates.set(true);
+
+    this.selectableApiProductCandidates$()
+      .pipe(
+        catchError(({ error }) => {
+          this.snackBarService.error(error?.message ?? 'Unable to load API Products');
+          return EMPTY;
+        }),
+        switchMap(candidates =>
+          this.matDialog
+            .open<AddApiProductToCategoryDialogComponent, AddApiProductToCategoryDialogData, AddApiProductToCategoryDialogResult>(
+              AddApiProductToCategoryDialogComponent,
+              {
+                data: { title: 'Add API Product to Category', candidates },
+                width: GIO_DIALOG_WIDTH.SMALL,
+              },
+            )
+            .afterClosed(),
+        ),
+        filter(candidate => !!candidate),
+        switchMap(candidate => {
+          const navigationItem = candidate.navigationItem;
+          return this.portalNavigationItemService
+            .updateNavigationItem(
+              navigationItem.id,
+              this.toApiProductUpdatePayload(navigationItem, [...(navigationItem.categoryIds ?? []), this.categoryId]),
+            )
+            .pipe(map(() => candidate.name));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.isLoadingApiProductCandidates.set(false)),
+      )
+      .subscribe({
+        next: apiProductName => {
+          this.snackBarService.success(`API Product [${apiProductName}] has been added to the category.`);
+          this.refreshNavigationItems.next(1);
+        },
+        error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during API Product addition'),
+      });
+  }
+
+  removeApiProductFromCategory(apiProductVM: ApiProductVM): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Remove API Product',
+          content: `Are you sure you want to remove API Product '${apiProductVM.name}' from this category?`,
+          confirmButton: 'Remove',
+        },
+        role: 'alertdialog',
+        id: 'confirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirmed => !!confirmed),
+        switchMap(() =>
+          this.portalNavigationItemService.updateNavigationItem(
+            apiProductVM.navigationItem.id,
+            this.toApiProductUpdatePayload(
+              apiProductVM.navigationItem,
+              (apiProductVM.navigationItem.categoryIds ?? []).filter(categoryId => categoryId !== this.categoryId),
+            ),
+          ),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.snackBarService.success(`'${apiProductVM.name}' removed successfully`);
+          this.refreshNavigationItems.next(1);
+        },
+        error: ({ error }) => this.snackBarService.error(error?.message ?? 'Error during API Product removal'),
       });
   }
 
@@ -300,19 +423,52 @@ export class CategoryCatalogComponent implements OnInit {
     );
   }
 
-  /**
-   * Not filtered by `published`: an API assigned to this category before being unpublished must
-   * still appear here so its association can be seen and removed.
-   */
-  private apiNavigationItemsWithSummaries$(): Observable<{
-    navItems: PortalNavigationApi[];
-    apisById: Record<string, PortalNavigationItemApiSummary>;
-  }> {
-    return this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR', ['apis']).pipe(
-      map(response => ({
-        navItems: response.items.filter((item): item is PortalNavigationApi => item.type === 'API'),
-        apisById: response.metadata?.apis ?? {},
-      })),
+  private selectableApiProductCandidates$(): Observable<ApiProductCategoryCandidate[]> {
+    return this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR').pipe(
+      map(response =>
+        response.items
+          .filter((item): item is PortalNavigationApiProduct => item.type === 'API_PRODUCT' && item.published)
+          .filter(navItem => !(navItem.categoryIds ?? []).includes(this.categoryId)),
+      ),
+      switchMap(navItems => this.toApiProductVMs$(navItems)),
+      map(apiProducts =>
+        apiProducts.map(({ navigationItem, name, version }) => ({
+          navigationItem,
+          name,
+          version,
+        })),
+      ),
+    );
+  }
+
+  private toApiProductVMs$(navItems: PortalNavigationApiProduct[]): Observable<ApiProductVM[]> {
+    return this.findApiProductsByIds$(navItems.map(navItem => navItem.apiProductId)).pipe(
+      map(apiProductsById =>
+        navItems
+          .map(navItem => {
+            const apiProduct = apiProductsById.get(navItem.apiProductId);
+            return apiProduct
+              ? {
+                  id: apiProduct.id,
+                  name: apiProduct.name,
+                  version: apiProduct.version,
+                  navigationItem: navItem,
+                }
+              : null;
+          })
+          .filter((apiProductVM): apiProductVM is ApiProductVM => !!apiProductVM),
+      ),
+    );
+  }
+
+  private findApiProductsByIds$(apiProductIds: string[]): Observable<Map<string, ApiProduct>> {
+    const idBatches = chunk([...new Set(apiProductIds)], 100);
+    if (idBatches.length === 0) {
+      return of(new Map());
+    }
+
+    return forkJoin(idBatches.map(ids => this.apiProductService.search({ ids }, undefined, 1, 100))).pipe(
+      map(responses => new Map(responses.flatMap(response => response.data ?? []).map(apiProduct => [apiProduct.id, apiProduct] as const))),
     );
   }
 
@@ -338,6 +494,18 @@ export class CategoryCatalogComponent implements OnInit {
       parentId: navItem.parentId,
       order: navItem.order,
       apiId: navItem.apiId,
+      categoryIds,
+    };
+  }
+
+  private toApiProductUpdatePayload(navItem: PortalNavigationApiProduct, categoryIds: string[]): UpdateApiProductPortalNavigationItem {
+    return {
+      type: 'API_PRODUCT',
+      title: navItem.title,
+      published: navItem.published,
+      visibility: navItem.visibility,
+      parentId: navItem.parentId,
+      order: navItem.order,
       categoryIds,
     };
   }

--- a/gravitee-apim-console-webui/src/portal/catalog/category/category.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/catalog/category/category.harness.ts
@@ -36,7 +36,11 @@ export class CategoryHarness extends ComponentHarness {
   }
 
   async getAddApiButton(harnessLoader: HarnessLoader): Promise<MatButtonHarness | null> {
-    return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '.add-button' }));
+    return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
+  }
+
+  async getAddApiProductButton(harnessLoader: HarnessLoader): Promise<MatButtonHarness | null> {
+    return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="add-api-product-button"]' }));
   }
 
   async getSaveBar(rootLoader: HarnessLoader): Promise<GioSaveBarHarness> {
@@ -44,7 +48,7 @@ export class CategoryHarness extends ComponentHarness {
   }
 
   async getTableRows(harnessLoader: HarnessLoader): Promise<MatRowHarness[]> {
-    return await harnessLoader.getHarness(MatTableHarness).then(table => table.getRows());
+    return await this.getApiTable(harnessLoader).then(table => table.getRows());
   }
 
   async getNameByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<string> {
@@ -52,8 +56,7 @@ export class CategoryHarness extends ComponentHarness {
   }
 
   async getTextByColumnNameAndRowIndex(harnessLoader: HarnessLoader, columnName: string, index: number): Promise<string> {
-    return await harnessLoader
-      .getHarness(MatTableHarness)
+    return await this.getApiTable(harnessLoader)
       .then(table => table.getRows())
       .then(rows => rows[index])
       .then(row => row.getCellTextByIndex({ columnName }).then(cell => cell[0]));
@@ -64,5 +67,32 @@ export class CategoryHarness extends ComponentHarness {
       .then(rows => rows[index].getCells({ columnName: 'actions' }))
       .then(cells => cells[0])
       .then(actionCell => actionCell.getHarnessOrNull(MatButtonHarness));
+  }
+
+  async getApiProductTable(harnessLoader: HarnessLoader): Promise<MatTableHarness> {
+    return await harnessLoader.getHarness(MatTableHarness.with({ selector: '[data-testid="api-product-table"]' }));
+  }
+
+  async getApiProductNameByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<string> {
+    return await this.getApiProductTextByColumnNameAndRowIndex(harnessLoader, 'name', index);
+  }
+
+  async getApiProductTextByColumnNameAndRowIndex(harnessLoader: HarnessLoader, columnName: string, index: number): Promise<string> {
+    return await this.getApiProductTable(harnessLoader)
+      .then(table => table.getRows())
+      .then(rows => rows[index])
+      .then(row => row.getCellTextByIndex({ columnName }).then(cell => cell[0]));
+  }
+
+  async getRemoveApiProductButtonByRowIndex(harnessLoader: HarnessLoader, index: number): Promise<MatButtonHarness | null> {
+    return await this.getApiProductTable(harnessLoader)
+      .then(table => table.getRows())
+      .then(rows => rows[index].getCells({ columnName: 'actions' }))
+      .then(cells => cells[0])
+      .then(actionCell => actionCell.getHarnessOrNull(MatButtonHarness));
+  }
+
+  private async getApiTable(harnessLoader: HarnessLoader): Promise<MatTableHarness> {
+    return await harnessLoader.getHarness(MatTableHarness.with({ selector: '[data-testid="api-table"]' }));
   }
 }


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/PORTAL-131

## Description

Adds API Product assignment management to the existing Console Portal category editor.

This PR:

- adds a separate API Products section,
- lists API Products assigned to the category, including unpublished assignments,
- allows searching for and adding published, unassigned API Products,
- preserves existing category assignments when adding a product,
- allows removing the current category assignment with confirmation,
- applies the existing documentation permissions,
- provides success and error notifications.

No HTTP contract changes are introduced.

## Dependency

This is a stacked PR based on `PORTAL-130-backend-support-api-product-navigation-categories`.


https://github.com/user-attachments/assets/4ec42117-92b5-40bf-98dd-c9af952e3f71

