### PR TITLE
feat(gamma): edit identity provider

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/consoleSettings/index.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/consoleSettings/index.ts
@@ -13,8 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const ROLE_LIST_TOOLTIP_CONTENT_CLASS = 'block max-w-xs items-start p-1 text-left text-xs';
 
-export function RoleListTooltipContent({ labels }: Readonly<{ labels: string[] }>) {
-    return <span className="min-w-0 max-h-48 overflow-y-auto [overflow-wrap:anywhere]">{labels.join(', ')}</span>;
-}
+export { isLocalLoginEnabled, type LocalLoginConsoleSettings } from './isLocalLoginEnabled';

--- a/gravitee-gamma/gamma-ui-shared/src/consoleSettings/isLocalLoginEnabled.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/consoleSettings/isLocalLoginEnabled.ts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-export const authenticationKeys = {
-    all: ['org-authentication'] as const,
-    providers: () => [...authenticationKeys.all, 'providers'] as const,
-    activations: () => [...authenticationKeys.all, 'activations'] as const,
-    detail: (id: string) => [...authenticationKeys.all, 'detail', id] as const,
-} as const;
+export interface LocalLoginConsoleSettings {
+    authentication?: {
+        localLogin?: {
+            enabled?: boolean;
+        };
+    };
+}
+
+export function isLocalLoginEnabled(settings: LocalLoginConsoleSettings | undefined): boolean {
+    return settings?.authentication?.localLogin?.enabled ?? true;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.selectors.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.selectors.ts
@@ -21,3 +21,4 @@ export const useIsAuthenticated = () => useAuthStore(s => !!s.user);
 export const useLogin = () => useAuthStore(s => s.login);
 export const useLogout = () => useAuthStore(s => s.logout);
 export const useIdentityProviders = () => useBootstrapStore(s => s.config?.identityProviders ?? []);
+export const useLocalLoginEnabled = () => useBootstrapStore(s => s.config?.localLoginEnabled ?? true);

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.spec.tsx
@@ -15,11 +15,13 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router-dom';
 
 import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
 import { buildBootstrapConfig, buildUser, TEST_MANAGEMENT_BASE } from '../../../testing/factories';
-import { respondWithError, trackHandler } from '../../../testing/helpers';
+import { respondWith, respondWithError, trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
 import { useAuthStore } from '../auth.store';
 import type { SocialIdentityProvider } from '../auth.types';
 import { LoginPage } from './LoginPage';
@@ -60,28 +62,36 @@ const noColorProvider: SocialIdentityProvider = {
     authorizationEndpoint: 'https://sso.example.com/authorize',
 };
 
-function seedWithProviders(providers: SocialIdentityProvider[]) {
+function seedWithProviders(providers: SocialIdentityProvider[], localLoginEnabled = true) {
     useBootstrapStore.setState({
-        config: buildBootstrapConfig({ identityProviders: providers }),
+        config: buildBootstrapConfig({ identityProviders: providers, localLoginEnabled }),
         loading: false,
         error: null,
     });
 }
 
+function stubLoginMethods(providers: SocialIdentityProvider[] = [], localLoginEnabled = true) {
+    respondWith('get', `${TEST_MANAGEMENT_BASE}/social-identities`, providers);
+    respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, {
+        authentication: { localLogin: { enabled: localLoginEnabled } },
+        reCaptcha: { enabled: false },
+    });
+}
+
 describe('LoginPage', () => {
     describe('username/password form', () => {
-        it('should render the sign-in form', () => {
+        it('should render the sign-in form', async () => {
             renderLoginPage();
 
-            expect(screen.getByLabelText('Username')).toBeTruthy();
+            expect(await screen.findByLabelText('Username')).toBeTruthy();
             expect(screen.getByLabelText('Password')).toBeTruthy();
             expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
         });
 
-        it('should disable submit button when fields are empty', () => {
+        it('should disable submit button when fields are empty', async () => {
             renderLoginPage();
 
-            const button = screen.getByRole('button', { name: 'Sign in' }) as HTMLButtonElement;
+            const button = (await screen.findByRole('button', { name: 'Sign in' })) as HTMLButtonElement;
             expect(button.disabled).toBe(true);
         });
 
@@ -89,7 +99,7 @@ describe('LoginPage', () => {
             const user = userEvent.setup();
             renderLoginPage();
 
-            await user.type(screen.getByLabelText('Username'), 'admin');
+            await user.type(await screen.findByLabelText('Username'), 'admin');
             await user.type(screen.getByLabelText('Password'), 'password');
 
             const button = screen.getByRole('button', { name: 'Sign in' }) as HTMLButtonElement;
@@ -101,7 +111,7 @@ describe('LoginPage', () => {
             respondWithError('post', `${TEST_MANAGEMENT_BASE}/user/login`, 401);
             renderLoginPage();
 
-            await user.type(screen.getByLabelText('Username'), 'admin');
+            await user.type(await screen.findByLabelText('Username'), 'admin');
             await user.type(screen.getByLabelText('Password'), 'wrong');
             await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
@@ -115,68 +125,150 @@ describe('LoginPage', () => {
             trackHandler('get', `${TEST_MANAGEMENT_BASE}/user`, buildUser());
             renderLoginPage();
 
-            await user.type(screen.getByLabelText('Username'), 'admin');
+            await user.type(await screen.findByLabelText('Username'), 'admin');
             await user.type(screen.getByLabelText('Password'), 'password');
             await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
             expect(loginTracker.callCount).toBe(1);
             expect(useAuthStore.getState().user?.displayName).toBe('Test User');
         });
+
+        it('should hide username and password when local login is disabled', async () => {
+            stubLoginMethods([], false);
+            renderLoginPage();
+
+            expect(await screen.findByText('No login method available. Please contact your administrator.')).toBeTruthy();
+            expect(screen.queryByLabelText('Username')).toBeNull();
+            expect(screen.queryByLabelText('Password')).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Sign in' })).toBeNull();
+        });
+
+        it('should show cached login methods without waiting for a refresh', async () => {
+            seedWithProviders([], true);
+            let release: () => void = () => {};
+            const gate = new Promise<void>(resolve => {
+                release = resolve;
+            });
+            server.use(
+                http.get(`${TEST_MANAGEMENT_BASE}/social-identities`, async () => {
+                    await gate;
+                    return HttpResponse.json([]);
+                }),
+                http.get(`${TEST_MANAGEMENT_BASE}/console`, async () => {
+                    await gate;
+                    return HttpResponse.json({ authentication: { localLogin: { enabled: false } } });
+                }),
+            );
+
+            renderLoginPage();
+
+            expect(screen.getByLabelText('Username')).toBeTruthy();
+            expect(screen.queryByLabelText('Loading sign-in options')).toBeNull();
+
+            release();
+            expect(await screen.findByText('No login method available. Please contact your administrator.')).toBeTruthy();
+            expect(screen.queryByLabelText('Username')).toBeNull();
+        });
+
+        it('should skip a duplicate login-methods fetch when bootstrap data is still fresh', () => {
+            useBootstrapStore.setState({
+                config: buildBootstrapConfig({ localLoginEnabled: true }),
+                loading: false,
+                error: null,
+                loginMethodsFetchedAt: Date.now(),
+            });
+            const tracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/console`, {
+                authentication: { localLogin: { enabled: false } },
+            });
+
+            renderLoginPage();
+
+            expect(screen.getByLabelText('Username')).toBeTruthy();
+            expect(tracker.callCount).toBe(0);
+        });
     });
 
     describe('identity provider buttons', () => {
-        it('should not render IdP section when no providers configured', () => {
-            seedWithProviders([]);
+        it('should not render IdP section when no providers configured', async () => {
+            stubLoginMethods([]);
             renderLoginPage();
 
+            await screen.findByLabelText('Username');
             expect(screen.queryByText('or')).toBeNull();
         });
 
-        it('should render IdP buttons when providers are configured', () => {
-            seedWithProviders([googleProvider, githubProvider]);
+        it('should render IdP buttons from the current social-identities response', async () => {
+            seedWithProviders([githubProvider]);
+            stubLoginMethods([googleProvider, githubProvider]);
             renderLoginPage();
 
+            expect(await screen.findByText('Sign in with Google')).toBeTruthy();
             expect(screen.getByText('or')).toBeTruthy();
-            expect(screen.getByText('Sign in with Google')).toBeTruthy();
             expect(screen.getByText('Sign in with GitHub')).toBeTruthy();
         });
 
-        it('should apply provider color as background', () => {
+        it('should drop identity providers that are no longer returned for login', async () => {
             seedWithProviders([googleProvider]);
+            stubLoginMethods([]);
             renderLoginPage();
 
-            const button = screen.getByText('Sign in with Google').closest('button')!;
+            await screen.findByLabelText('Username');
+            expect(screen.queryByText('Sign in with Google')).toBeNull();
+        });
+
+        it('should keep previous identity providers when social-identities cannot be loaded', async () => {
+            seedWithProviders([googleProvider]);
+            respondWithError('get', `${TEST_MANAGEMENT_BASE}/social-identities`, 500);
+            renderLoginPage();
+
+            expect(await screen.findByText('Sign in with Google')).toBeTruthy();
+        });
+
+        it('should show identity providers without the password form when local login is disabled', async () => {
+            stubLoginMethods([googleProvider], false);
+            renderLoginPage();
+
+            expect(await screen.findByText('Sign in with Google')).toBeTruthy();
+            expect(screen.queryByLabelText('Username')).toBeNull();
+            expect(screen.queryByText('or')).toBeNull();
+        });
+
+        it('should apply provider color as background', async () => {
+            stubLoginMethods([googleProvider]);
+            renderLoginPage();
+
+            const button = (await screen.findByText('Sign in with Google')).closest('button')!;
             expect(button.style.backgroundColor).toBe('rgb(66, 133, 244)');
             // #4285F4 has luminance ~0.24 (above 0.179 threshold), so text is black
             expect(button.style.color).toBe('black');
         });
 
-        it('should not apply inline color when provider has no color', () => {
-            seedWithProviders([noColorProvider]);
+        it('should not apply inline color when provider has no color', async () => {
+            stubLoginMethods([noColorProvider]);
             renderLoginPage();
 
-            const button = screen.getByText('Sign in with Corporate SSO').closest('button')!;
+            const button = (await screen.findByText('Sign in with Corporate SSO')).closest('button')!;
             // No inline styles — uses Button variant="outline" default styling
             expect(button.style.backgroundColor).toBe('');
             expect(button.style.color).toBe('');
         });
 
-        it('should use white text on dark provider color', () => {
+        it('should use white text on dark provider color', async () => {
             const darkProvider: SocialIdentityProvider = { ...githubProvider, color: '#111111' };
-            seedWithProviders([darkProvider]);
+            stubLoginMethods([darkProvider]);
             renderLoginPage();
 
-            const button = screen.getByText('Sign in with GitHub').closest('button')!;
+            const button = (await screen.findByText('Sign in with GitHub')).closest('button')!;
             expect(button.style.color).toBe('white');
         });
 
         it('should call loginWithProvider on IdP button click', async () => {
             const user = userEvent.setup();
-            seedWithProviders([googleProvider]);
+            stubLoginMethods([googleProvider]);
             const loginWithProviderSpy = jest.spyOn(useAuthStore.getState(), 'loginWithProvider').mockResolvedValue();
             renderLoginPage();
 
-            await user.click(screen.getByText('Sign in with Google'));
+            await user.click(await screen.findByText('Sign in with Google'));
 
             expect(loginWithProviderSpy).toHaveBeenCalledWith('google-idp', '/');
             loginWithProviderSpy.mockRestore();
@@ -184,11 +276,11 @@ describe('LoginPage', () => {
 
         it('should show error when IdP login fails', async () => {
             const user = userEvent.setup();
-            seedWithProviders([googleProvider]);
+            stubLoginMethods([googleProvider]);
             jest.spyOn(useAuthStore.getState(), 'loginWithProvider').mockRejectedValue(new Error('IdP error'));
             renderLoginPage();
 
-            await user.click(screen.getByText('Sign in with Google'));
+            await user.click(await screen.findByText('Sign in with Google'));
 
             expect(await screen.findByRole('alert')).toBeTruthy();
             expect(screen.getByText('Failed to start identity provider authentication.')).toBeTruthy();
@@ -196,7 +288,7 @@ describe('LoginPage', () => {
 
         it('should pass redirect param to loginWithProvider', async () => {
             const user = userEvent.setup();
-            seedWithProviders([googleProvider]);
+            stubLoginMethods([googleProvider]);
             const loginWithProviderSpy = jest.spyOn(useAuthStore.getState(), 'loginWithProvider').mockResolvedValue();
 
             render(
@@ -205,7 +297,7 @@ describe('LoginPage', () => {
                 </MemoryRouter>,
             );
 
-            await user.click(screen.getByText('Sign in with Google'));
+            await user.click(await screen.findByText('Sign in with Google'));
 
             expect(loginWithProviderSpy).toHaveBeenCalledWith('google-idp', '/dashboard');
             loginWithProviderSpy.mockRestore();

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.tsx
@@ -30,24 +30,46 @@ import {
     Spinner,
     cn,
 } from '@gravitee/graphene-core';
-import { useState, type SubmitEvent } from 'react';
+import { useEffect, useState, type SubmitEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { useIdentityProviders, useLogin } from '../auth.selectors';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+import { useIdentityProviders, useLocalLoginEnabled, useLogin } from '../auth.selectors';
 import { useAuthStore } from '../auth.store';
 import type { SocialIdentityProvider } from '../auth.types';
 import { getProviderTextColor } from '../idp.utils';
 import { IdpIcon } from './IdpIcons';
+
+const NO_LOGIN_METHOD_MESSAGE = 'No login method available. Please contact your administrator.';
+const LOCAL_LOGIN_DESCRIPTION = 'Gravitee Gamma — enter your account credentials to continue.';
+const SSO_LOGIN_DESCRIPTION = 'Gravitee Gamma — sign in with an identity provider to continue.';
+const UNAVAILABLE_LOGIN_DESCRIPTION = 'Gravitee Gamma — sign-in is currently unavailable.';
+
+function loginCardDescription(noLoginMethod: boolean, localLoginEnabled: boolean): string {
+    if (localLoginEnabled) {
+        return LOCAL_LOGIN_DESCRIPTION;
+    }
+    if (noLoginMethod) {
+        return UNAVAILABLE_LOGIN_DESCRIPTION;
+    }
+    return SSO_LOGIN_DESCRIPTION;
+}
 
 export function LoginPage() {
     const login = useLogin();
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const identityProviders = useIdentityProviders();
+    const localLoginEnabled = useLocalLoginEnabled();
+    const refreshLoginMethods = useBootstrapStore(s => s.refreshLoginMethods);
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
     const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        void refreshLoginMethods();
+    }, [refreshLoginMethods]);
 
     const handleSubmit = async (e: SubmitEvent) => {
         e.preventDefault();
@@ -73,80 +95,85 @@ export function LoginPage() {
     };
 
     const canSubmit = Boolean(username && password) && !loading;
+    const noLoginMethod = !localLoginEnabled && identityProviders.length === 0;
+    const displayError = error || (noLoginMethod ? NO_LOGIN_METHOD_MESSAGE : '');
+    const description = loginCardDescription(noLoginMethod, localLoginEnabled);
 
     return (
         <div className={cn('flex min-h-screen flex-col items-center justify-center p-4', 'font-sans text-foreground')}>
             <Card className="w-full max-w-md shadow-md">
                 <CardHeader className="space-y-1 text-center">
                     <CardTitle className="text-2xl">Sign in</CardTitle>
-                    <CardDescription>Gravitee Gamma — enter your account credentials to continue.</CardDescription>
+                    <CardDescription>{description}</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <form onSubmit={handleSubmit} className="space-y-4">
-                        {error ? (
-                            <Alert variant="destructive" role="alert">
-                                <AlertTitle>Could not sign in</AlertTitle>
-                                <AlertDescription>{error}</AlertDescription>
-                            </Alert>
-                        ) : null}
+                    {displayError ? (
+                        <Alert variant="destructive" role="alert" className="mb-4">
+                            <AlertTitle>{error ? 'Could not sign in' : 'Sign-in unavailable'}</AlertTitle>
+                            <AlertDescription>{displayError}</AlertDescription>
+                        </Alert>
+                    ) : null}
 
-                        <Field orientation="vertical" className="gap-2">
-                            <FieldLabel htmlFor="login-username">Username</FieldLabel>
-                            <Input
-                                id="login-username"
-                                name="username"
-                                type="text"
-                                value={username}
-                                onChange={e => setUsername(e.target.value)}
-                                required
-                                autoComplete="username"
-                                placeholder="Enter your username"
-                                // eslint-disable-next-line jsx-a11y/no-autofocus
-                                autoFocus
-                            />
-                        </Field>
+                    {localLoginEnabled ? (
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="login-username">Username</FieldLabel>
+                                <Input
+                                    id="login-username"
+                                    name="username"
+                                    type="text"
+                                    value={username}
+                                    onChange={e => setUsername(e.target.value)}
+                                    required
+                                    autoComplete="username"
+                                    placeholder="Enter your username"
+                                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                                    autoFocus
+                                />
+                            </Field>
 
-                        <Field orientation="vertical" className="gap-2">
-                            <FieldLabel htmlFor="login-password">Password</FieldLabel>
-                            <Input
-                                id="login-password"
-                                name="password"
-                                type="password"
-                                value={password}
-                                onChange={e => setPassword(e.target.value)}
-                                required
-                                autoComplete="current-password"
-                                placeholder="Enter your password"
-                            />
-                        </Field>
+                            <Field orientation="vertical" className="gap-2">
+                                <FieldLabel htmlFor="login-password">Password</FieldLabel>
+                                <Input
+                                    id="login-password"
+                                    name="password"
+                                    type="password"
+                                    value={password}
+                                    onChange={e => setPassword(e.target.value)}
+                                    required
+                                    autoComplete="current-password"
+                                    placeholder="Enter your password"
+                                />
+                            </Field>
 
-                        <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
-                            {loading ? (
-                                <span className="inline-flex items-center justify-center gap-2">
-                                    <Spinner className="size-4 shrink-0" aria-hidden />
-                                    Signing in…
-                                </span>
-                            ) : (
-                                'Sign in'
-                            )}
-                        </Button>
-                    </form>
+                            <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
+                                {loading ? (
+                                    <span className="inline-flex items-center justify-center gap-2">
+                                        <Spinner className="size-4 shrink-0" aria-hidden />
+                                        Signing in…
+                                    </span>
+                                ) : (
+                                    'Sign in'
+                                )}
+                            </Button>
+                        </form>
+                    ) : null}
 
-                    {identityProviders.length > 0 && (
-                        <>
-                            <div className="my-4 flex items-center gap-3">
-                                <Separator className="flex-1" />
-                                <span className="text-muted-foreground text-sm">or</span>
-                                <Separator className="flex-1" />
-                            </div>
+                    {localLoginEnabled && identityProviders.length > 0 ? (
+                        <div className="my-4 flex items-center gap-3">
+                            <Separator className="flex-1" />
+                            <span className="text-muted-foreground text-sm">or</span>
+                            <Separator className="flex-1" />
+                        </div>
+                    ) : null}
 
-                            <div className="flex flex-col gap-3">
-                                {identityProviders.map(provider => (
-                                    <IdpButton key={provider.id} provider={provider} onClick={() => handleIdpLogin(provider.id)} />
-                                ))}
-                            </div>
-                        </>
-                    )}
+                    {identityProviders.length > 0 ? (
+                        <div className="flex flex-col gap-3">
+                            {identityProviders.map(provider => (
+                                <IdpButton key={provider.id} provider={provider} onClick={() => handleIdpLogin(provider.id)} />
+                            ))}
+                        </div>
+                    ) : null}
                 </CardContent>
             </Card>
         </div>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders } from './auth.selectors';
+export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders, useLocalLoginEnabled } from './auth.selectors';
 export { useAuthStore } from './auth.store';
 export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
 export { LoginPage } from './components/LoginPage';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.spec.ts
@@ -13,10 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { http, HttpResponse } from 'msw';
+
 import { useBootstrapStore } from './bootstrap.store';
 import type { SocialIdentityProvider } from '../../features/auth';
 import { TEST_CONFIG, TEST_MANAGEMENT_BASE } from '../../testing/factories';
 import { trackHandler, respondWithError, respondWith, resetAllStores } from '../../testing/helpers';
+import { server } from '../../testing/server';
+
+const GOOGLE_PROVIDER: SocialIdentityProvider = {
+    id: 'google-idp',
+    name: 'Google',
+    clientId: 'google-client-id',
+    type: 'GOOGLE',
+    authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+    scopes: ['openid', 'profile', 'email'],
+    color: '#4285F4',
+};
 
 describe('bootstrapStore', () => {
     beforeEach(() => {
@@ -74,5 +87,101 @@ describe('bootstrapStore', () => {
         await useBootstrapStore.getState().initialize();
 
         expect(useBootstrapStore.getState().config?.identityProviders).toEqual([]);
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(true);
+    });
+
+    it('should treat missing localLogin configuration as enabled', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { reCaptcha: { enabled: false } });
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(true);
+    });
+
+    it('should store localLoginEnabled from console settings', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { authentication: { localLogin: { enabled: false } } });
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+    });
+
+    it('should leave localLoginEnabled off when console fetch fails', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/console`, 500);
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+        expect(useBootstrapStore.getState().loginMethodsFetchedAt).toBeNull();
+    });
+
+    it('should skip a refresh when login methods were just fetched', async () => {
+        await useBootstrapStore.getState().initialize();
+        const tracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/social-identities`, [GOOGLE_PROVIDER]);
+
+        await useBootstrapStore.getState().refreshLoginMethods();
+
+        expect(tracker.callCount).toBe(0);
+        expect(useBootstrapStore.getState().config?.identityProviders).toEqual([]);
+    });
+
+    it('should refresh login methods from the APIs without a full reload', async () => {
+        await useBootstrapStore.getState().initialize();
+        useBootstrapStore.setState({ loginMethodsFetchedAt: 0 });
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/social-identities`, [GOOGLE_PROVIDER]);
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { authentication: { localLogin: { enabled: false } } });
+
+        await useBootstrapStore.getState().refreshLoginMethods();
+
+        expect(useBootstrapStore.getState().config?.identityProviders).toEqual([GOOGLE_PROVIDER]);
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+    });
+
+    it('should keep previous login methods when refresh fetches fail', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/social-identities`, [GOOGLE_PROVIDER]);
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { authentication: { localLogin: { enabled: false } } });
+        await useBootstrapStore.getState().initialize();
+        useBootstrapStore.setState({ loginMethodsFetchedAt: 0 });
+
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/social-identities`, 500);
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/console`, 500);
+
+        await useBootstrapStore.getState().refreshLoginMethods();
+
+        expect(useBootstrapStore.getState().config?.identityProviders).toEqual([GOOGLE_PROVIDER]);
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+    });
+
+    it('should ignore an older refresh that finishes after a newer one', async () => {
+        await useBootstrapStore.getState().initialize();
+        useBootstrapStore.setState({ loginMethodsFetchedAt: 0 });
+
+        let releaseFirst: () => void = () => {};
+        const firstGate = new Promise<void>(resolve => {
+            releaseFirst = resolve;
+        });
+        let socialIdentitiesCalls = 0;
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/social-identities`, async () => {
+                const call = ++socialIdentitiesCalls;
+                if (call === 1) {
+                    await firstGate;
+                    return HttpResponse.json([{ ...GOOGLE_PROVIDER, id: 'stale-idp', name: 'Stale' }]);
+                }
+                return HttpResponse.json([GOOGLE_PROVIDER]);
+            }),
+            http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ authentication: { localLogin: { enabled: true } } })),
+        );
+
+        const firstRefresh = useBootstrapStore.getState().refreshLoginMethods();
+        await Promise.resolve();
+        const secondRefresh = useBootstrapStore.getState().refreshLoginMethods();
+        await secondRefresh;
+        expect(useBootstrapStore.getState().config?.identityProviders).toEqual([GOOGLE_PROVIDER]);
+
+        releaseFirst();
+        await firstRefresh;
+        expect(useBootstrapStore.getState().config?.identityProviders).toEqual([GOOGLE_PROVIDER]);
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(true);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.ts
@@ -16,6 +16,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+import { isLocalLoginEnabled, type LocalLoginConsoleSettings } from '../../../../gamma-ui-shared/src/consoleSettings';
 import type { SocialIdentityProvider } from '../../features/auth/auth.types';
 
 export interface BootstrapConfig {
@@ -23,17 +24,75 @@ export interface BootstrapConfig {
     gammaBaseURL: string;
     organizationId: string;
     identityProviders: SocialIdentityProvider[];
+    localLoginEnabled: boolean;
 }
 
 interface BootstrapState {
     config: BootstrapConfig | null;
     loading: boolean;
     error: Error | null;
+    loginMethodsFetchedAt: number | null;
     initialize: () => Promise<void>;
+    refreshLoginMethods: () => Promise<void>;
 }
+
+/** Skip a LoginPage refetch when bootstrap just loaded the same login-method APIs. */
+const LOGIN_METHODS_FRESH_MS = 30_000;
+
+let latestLoginMethodsRefreshId = 0;
 
 function sanitizeBaseURL(url: string): string {
     return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function organizationManagementUrl(managementBaseURL: string, organizationId: string): string {
+    return `${sanitizeBaseURL(managementBaseURL)}/organizations/${organizationId}`;
+}
+
+function localLoginEnabledFrom(consoleJson: unknown): boolean {
+    if (!consoleJson || typeof consoleJson !== 'object') {
+        return true;
+    }
+    return isLocalLoginEnabled(consoleJson as LocalLoginConsoleSettings);
+}
+
+async function fetchIdentityProviders(managementBaseURL: string, organizationId: string): Promise<SocialIdentityProvider[] | undefined> {
+    try {
+        const idpRes = await fetch(`${organizationManagementUrl(managementBaseURL, organizationId)}/social-identities`);
+        if (idpRes.ok) {
+            return (await idpRes.json()) as SocialIdentityProvider[];
+        }
+    } catch {
+        // Non-fatal: keep the previous list, or an empty list on first load.
+    }
+    return undefined;
+}
+
+async function fetchLocalLoginEnabled(managementBaseURL: string, organizationId: string): Promise<boolean | undefined> {
+    try {
+        const consoleRes = await fetch(`${organizationManagementUrl(managementBaseURL, organizationId)}/console`);
+        if (consoleRes.ok) {
+            return localLoginEnabledFrom(await consoleRes.json());
+        }
+    } catch {
+        // Non-fatal: keep the previous value, or leave local login off until a successful read.
+    }
+    return undefined;
+}
+
+async function loadLoginMethods(
+    managementBaseURL: string,
+    organizationId: string,
+): Promise<{ identityProviders: SocialIdentityProvider[] | undefined; localLoginEnabled: boolean | undefined }> {
+    const [identityProviders, localLoginEnabled] = await Promise.all([
+        fetchIdentityProviders(managementBaseURL, organizationId),
+        fetchLocalLoginEnabled(managementBaseURL, organizationId),
+    ]);
+    return { identityProviders, localLoginEnabled };
+}
+
+function isLoginMethodsFresh(fetchedAt: number | null): boolean {
+    return fetchedAt !== null && Date.now() - fetchedAt < LOGIN_METHODS_FRESH_MS;
 }
 
 export const useBootstrapStore = create<BootstrapState>()(
@@ -42,6 +101,7 @@ export const useBootstrapStore = create<BootstrapState>()(
             config: null,
             loading: false,
             error: null,
+            loginMethodsFetchedAt: null,
 
             initialize: async () => {
                 if (get().config || get().loading) return;
@@ -59,30 +119,59 @@ export const useBootstrapStore = create<BootstrapState>()(
 
                     const managementBaseURL = sanitizeBaseURL(bootstrap.managementBaseURL);
                     const organizationId = bootstrap.organizationId as string;
-
-                    let identityProviders: SocialIdentityProvider[] = [];
-                    try {
-                        const idpRes = await fetch(`${managementBaseURL}/organizations/${organizationId}/social-identities`);
-                        if (idpRes.ok) {
-                            identityProviders = await idpRes.json();
-                        }
-                    } catch {
-                        // Non-fatal: login page will still work with username/password
-                    }
+                    const loginMethods = await loadLoginMethods(managementBaseURL, organizationId);
+                    const loginMethodsFetchedAt =
+                        loginMethods.identityProviders !== undefined && loginMethods.localLoginEnabled !== undefined ? Date.now() : null;
 
                     set({
                         config: {
                             managementBaseURL,
                             gammaBaseURL: sanitizeBaseURL(bootstrap.gammaBaseURL),
                             organizationId,
-                            identityProviders,
+                            identityProviders: loginMethods.identityProviders ?? [],
+                            localLoginEnabled: loginMethods.localLoginEnabled ?? false,
                         },
+                        loginMethodsFetchedAt,
                         loading: false,
                     });
                 } catch (error) {
                     set({ error: error instanceof Error ? error : new Error(String(error)), loading: false });
                     throw error;
                 }
+            },
+
+            refreshLoginMethods: async () => {
+                const config = get().config;
+                if (!config) {
+                    return;
+                }
+                if (isLoginMethodsFresh(get().loginMethodsFetchedAt)) {
+                    return;
+                }
+
+                const requestId = ++latestLoginMethodsRefreshId;
+                const [identityProviders, localLoginEnabled] = await Promise.all([
+                    fetchIdentityProviders(config.managementBaseURL, config.organizationId),
+                    fetchLocalLoginEnabled(config.managementBaseURL, config.organizationId),
+                ]);
+                if (requestId !== latestLoginMethodsRefreshId) {
+                    return;
+                }
+
+                const current = get().config;
+                if (!current) {
+                    return;
+                }
+
+                set({
+                    config: {
+                        ...current,
+                        identityProviders: identityProviders ?? current.identityProviders,
+                        localLoginEnabled: localLoginEnabled ?? current.localLoginEnabled,
+                    },
+                    loginMethodsFetchedAt:
+                        identityProviders !== undefined && localLoginEnabled !== undefined ? Date.now() : get().loginMethodsFetchedAt,
+                });
             },
         }),
         { name: 'bootstrap' },

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
@@ -22,6 +22,7 @@ export const TEST_CONFIG: BootstrapConfig = {
     organizationId: 'test-org',
     gammaBaseURL: 'http://api.test/gamma',
     identityProviders: [],
+    localLoginEnabled: true,
 };
 
 export const TEST_MANAGEMENT_BASE = `${TEST_CONFIG.managementBaseURL}/organizations/${TEST_CONFIG.organizationId}`;

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/helpers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/helpers.ts
@@ -84,7 +84,7 @@ export function respondWithError(method: 'get' | 'post' | 'put' | 'delete', url:
 }
 
 export function resetAllStores() {
-    useBootstrapStore.setState({ config: null, loading: false, error: null });
+    useBootstrapStore.setState({ config: null, loading: false, error: null, loginMethodsFetchedAt: null });
     useAuthStore.setState({ user: null, loading: false, initialized: false, oauthRedirectUrl: null });
     useEnvironmentStore.getState().reset();
     useModulesStore.setState({ modules: [] });
@@ -97,6 +97,7 @@ export function seedBootstrap(overrides: Partial<BootstrapConfig> = {}) {
         config: buildBootstrapConfig(overrides),
         loading: false,
         error: null,
+        loginMethodsFetchedAt: null,
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -109,6 +109,10 @@ jest.mock('../pages/CreateIdentityProviderPage', () => ({
     CreateIdentityProviderPage: () => <div data-testid="create-identity-provider-page" />,
 }));
 
+jest.mock('../pages/EditIdentityProviderPage', () => ({
+    EditIdentityProviderPage: () => <div data-testid="edit-identity-provider-page" />,
+}));
+
 jest.mock('../pages/RegisterApplicationPage', () => ({
     RegisterApplicationPage: () => <div data-testid="register-application-page" />,
 }));
@@ -743,6 +747,11 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('create-identity-provider-page')).not.toBeNull();
     });
 
+    it('routes to Edit Identity Provider', () => {
+        renderPlatform('/authentication/google-idp');
+        expect(screen.getByTestId('edit-identity-provider-page')).not.toBeNull();
+    });
+
     it('hides Authentication without organization-identity_provider-r', () => {
         mockUseModuleRouting.mockReturnValue({
             activeNavKey: 'access-management',
@@ -761,5 +770,12 @@ describe('AppRoutes', () => {
         renderPlatform('/authentication/new');
         expect(screen.queryByTestId('create-identity-provider-page')).toBeNull();
         expect(screen.getByTestId('authentication-page')).not.toBeNull();
+    });
+
+    it('redirects Edit Identity Provider to applications without organization-identity_provider-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-identity_provider-r'));
+        renderPlatform('/authentication/google-idp');
+        expect(screen.queryByTestId('edit-identity-provider-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -64,6 +64,7 @@ import { CorsSettingsPage } from '../pages/CorsSettingsPage';
 import { CreateIdentityProviderPage } from '../pages/CreateIdentityProviderPage';
 import { DictionariesPage } from '../pages/DictionariesPage';
 import { DictionaryDetailPage } from '../pages/DictionaryDetailPage';
+import { EditIdentityProviderPage } from '../pages/EditIdentityProviderPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
 import { EnvAuditLogsPage } from '../pages/EnvAuditLogsPage';
 import { GatewayInstanceEnvironmentPage } from '../pages/GatewayInstanceEnvironmentPage';
@@ -424,6 +425,7 @@ export function AppRoutes() {
                                         </PermissionPageGuard>
                                     }
                                 />
+                                <Route path=":identityProviderId" element={<EditIdentityProviderPage />} />
                             </Route>
                             <Route
                                 path="management-and-schedulers"

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/AuthenticationEmptyProviders.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/AuthenticationEmptyProviders.spec.tsx
@@ -62,6 +62,7 @@ describe('AuthenticationEmptyProviders', () => {
     it('renders through DataTableEmptyState instead of a nested bordered panel', () => {
         renderWithGraphene(<AuthenticationEmptyProviders />);
         expect(screen.getByText('No identity providers yet').closest('div.space-y-6')).toBeNull();
-        expect(screen.getByText('No identity providers yet')).not.toBeNull();
+        expect(screen.getByText('Without a provider').closest('[data-slot="card"]')).not.toBeNull();
+        expect(screen.getByText('With a provider').closest('[data-slot="card"]')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/AuthenticationEmptyProviders.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/AuthenticationEmptyProviders.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Button, DataTableEmptyState } from '@gravitee/graphene-core';
+import { Button, Card, CardContent, DataTableEmptyState } from '@gravitee/graphene-core';
 import {
     ArrowRightIcon,
     CircleCheckIcon,
@@ -88,25 +88,29 @@ export function AuthenticationEmptyProviders({ canCreate = false, onAdd }: Reado
             }
         >
             <div className="flex flex-col items-stretch gap-4 md:flex-row">
-                <div className="flex-1 space-y-3 rounded-xl border p-4">
-                    <p className="text-xs font-semibold text-muted-foreground">Without a provider</p>
-                    <ul className="space-y-1">
-                        {WITHOUT.map(label => (
-                            <ComparisonLine key={label} label={label} variant="negative" />
-                        ))}
-                    </ul>
-                </div>
+                <Card className="flex-1">
+                    <CardContent className="space-y-3 pt-6">
+                        <p className="text-xs font-semibold text-muted-foreground">Without a provider</p>
+                        <ul className="space-y-1">
+                            {WITHOUT.map(label => (
+                                <ComparisonLine key={label} label={label} variant="negative" />
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
                 <div className="hidden shrink-0 items-center justify-center md:flex">
                     <ArrowRightIcon className="size-5 text-primary" aria-hidden />
                 </div>
-                <div className="flex-1 space-y-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
-                    <p className="text-xs font-semibold text-primary">With a provider</p>
-                    <ul className="space-y-1">
-                        {WITH.map(label => (
-                            <ComparisonLine key={label} label={label} variant="positive" />
-                        ))}
-                    </ul>
-                </div>
+                <Card className="flex-1 border-primary/20 bg-primary/5">
+                    <CardContent className="space-y-3 pt-6">
+                        <p className="text-xs font-semibold text-primary">With a provider</p>
+                        <ul className="space-y-1">
+                            {WITH.map(label => (
+                                <ComparisonLine key={label} label={label} variant="positive" />
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
             </div>
 
             <div className="flex flex-col gap-4 pt-5 md:flex-row">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCatalogLoadError.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCatalogLoadError.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Alert, AlertDescription, AlertTitle, Button } from '@gravitee/graphene-core';
+
+export function IdentityProviderCatalogLoadError({ onRetry }: Readonly<{ onRetry: () => void }>) {
+    return (
+        <Alert variant="destructive">
+            <AlertTitle>Groups and roles could not be loaded</AlertTitle>
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+                <span>Group and role mappings cannot be configured until this data is available.</span>
+                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                    Retry
+                </Button>
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderConfigurationFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderConfigurationFields.tsx
@@ -25,11 +25,13 @@ export function IdentityProviderConfigurationFields({
     form,
     showErrors,
     errors,
+    disabled = false,
     onPatch,
 }: Readonly<{
     form: IdentityProviderFormState;
     showErrors: boolean;
     errors: Record<string, string>;
+    disabled?: boolean;
     onPatch: (patch: Partial<IdentityProviderFormState['configuration']>) => void;
 }>) {
     return (
@@ -41,6 +43,7 @@ export function IdentityProviderConfigurationFields({
                 <Input
                     id="idp-client-id"
                     value={form.configuration.clientId}
+                    disabled={disabled}
                     aria-required="true"
                     aria-invalid={showErrors && !!errors.clientId}
                     aria-describedby={showErrors && errors.clientId ? 'idp-client-id-error' : undefined}
@@ -56,6 +59,7 @@ export function IdentityProviderConfigurationFields({
                     id="idp-client-secret"
                     autoComplete="off"
                     value={form.configuration.clientSecret}
+                    disabled={disabled}
                     aria-required="true"
                     aria-invalid={showErrors && !!errors.clientSecret}
                     aria-describedby={showErrors && errors.clientSecret ? 'idp-client-secret-error' : undefined}
@@ -74,6 +78,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-server-url"
                             type="url"
                             value={form.configuration.serverURL ?? ''}
+                            disabled={disabled}
                             aria-required="true"
                             aria-invalid={showErrors && !!errors.serverURL}
                             aria-describedby={showErrors && errors.serverURL ? 'idp-server-url-error' : undefined}
@@ -88,6 +93,7 @@ export function IdentityProviderConfigurationFields({
                         <Input
                             id="idp-domain"
                             value={form.configuration.domain ?? ''}
+                            disabled={disabled}
                             aria-required="true"
                             aria-invalid={showErrors && !!errors.domain}
                             aria-describedby={showErrors && errors.domain ? 'idp-domain-error' : undefined}
@@ -101,6 +107,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-scopes"
                             values={form.configuration.scopes ?? []}
                             placeholder="Enter a scope and press Enter"
+                            disabled={disabled}
                             onChange={scopes => onPatch({ scopes })}
                         />
                     </Field>
@@ -109,7 +116,7 @@ export function IdentityProviderConfigurationFields({
                         <ColorField
                             id="idp-color"
                             value={form.configuration.color ?? ''}
-                            disabled={false}
+                            disabled={disabled}
                             onChange={color => onPatch({ color })}
                         />
                     </Field>
@@ -126,6 +133,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-token-endpoint"
                             type="url"
                             value={form.configuration.tokenEndpoint ?? ''}
+                            disabled={disabled}
                             aria-required="true"
                             aria-invalid={showErrors && !!errors.tokenEndpoint}
                             aria-describedby={showErrors && errors.tokenEndpoint ? 'idp-token-endpoint-error' : undefined}
@@ -141,6 +149,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-token-introspection"
                             type="url"
                             value={form.configuration.tokenIntrospectionEndpoint ?? ''}
+                            disabled={disabled}
                             onChange={event => onPatch({ tokenIntrospectionEndpoint: event.target.value })}
                         />
                     </Field>
@@ -152,6 +161,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-authorize-endpoint"
                             type="url"
                             value={form.configuration.authorizeEndpoint ?? ''}
+                            disabled={disabled}
                             aria-required="true"
                             aria-invalid={showErrors && !!errors.authorizeEndpoint}
                             aria-describedby={showErrors && errors.authorizeEndpoint ? 'idp-authorize-endpoint-error' : undefined}
@@ -169,6 +179,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-userinfo-endpoint"
                             type="url"
                             value={form.configuration.userInfoEndpoint ?? ''}
+                            disabled={disabled}
                             aria-required="true"
                             aria-invalid={showErrors && !!errors.userInfoEndpoint}
                             aria-describedby={showErrors && errors.userInfoEndpoint ? 'idp-userinfo-endpoint-error' : undefined}
@@ -184,6 +195,7 @@ export function IdentityProviderConfigurationFields({
                             id="idp-logout-endpoint"
                             type="url"
                             value={form.configuration.userLogoutEndpoint ?? ''}
+                            disabled={disabled}
                             onChange={event => onPatch({ userLogoutEndpoint: event.target.value })}
                         />
                     </Field>
@@ -200,6 +212,7 @@ export function IdentityProviderConfigurationFields({
                             required
                             invalid={showErrors && !!errors.scopes}
                             describedBy={showErrors && errors.scopes ? 'idp-oidc-scopes-error' : undefined}
+                            disabled={disabled}
                             onChange={scopes => onPatch({ scopes })}
                         />
                         {showErrors && errors.scopes ? <FieldError id="idp-oidc-scopes-error">{errors.scopes}</FieldError> : null}
@@ -209,7 +222,7 @@ export function IdentityProviderConfigurationFields({
                         <ColorField
                             id="idp-oidc-color"
                             value={form.configuration.color ?? ''}
-                            disabled={false}
+                            disabled={disabled}
                             onChange={color => onPatch({ color })}
                         />
                     </Field>
@@ -223,11 +236,13 @@ export function IdentityProviderUserProfileFields({
     form,
     showErrors,
     errors,
+    disabled = false,
     onChange,
 }: Readonly<{
     form: IdentityProviderFormState;
     showErrors: boolean;
     errors: Record<string, string>;
+    disabled?: boolean;
     onChange: (mapping: IdentityProviderFormState['userProfileMapping']) => void;
 }>) {
     return (
@@ -240,6 +255,7 @@ export function IdentityProviderUserProfileFields({
                     id="idp-profile-id"
                     value={form.userProfileMapping.id}
                     placeholder="sub"
+                    disabled={disabled}
                     aria-required="true"
                     aria-invalid={showErrors && !!errors.profileId}
                     aria-describedby={showErrors && errors.profileId ? 'idp-profile-id-error' : undefined}
@@ -253,6 +269,7 @@ export function IdentityProviderUserProfileFields({
                     id="idp-profile-firstname"
                     value={form.userProfileMapping.firstname ?? ''}
                     placeholder="given_name"
+                    disabled={disabled}
                     onChange={event => onChange({ ...form.userProfileMapping, firstname: event.target.value })}
                 />
             </Field>
@@ -262,6 +279,7 @@ export function IdentityProviderUserProfileFields({
                     id="idp-profile-lastname"
                     value={form.userProfileMapping.lastname ?? ''}
                     placeholder="family_name"
+                    disabled={disabled}
                     onChange={event => onChange({ ...form.userProfileMapping, lastname: event.target.value })}
                 />
             </Field>
@@ -271,6 +289,7 @@ export function IdentityProviderUserProfileFields({
                     id="idp-profile-email"
                     value={form.userProfileMapping.email ?? ''}
                     placeholder="email"
+                    disabled={disabled}
                     onChange={event => onChange({ ...form.userProfileMapping, email: event.target.value })}
                 />
             </Field>
@@ -280,6 +299,7 @@ export function IdentityProviderUserProfileFields({
                     id="idp-profile-picture"
                     value={form.userProfileMapping.picture ?? ''}
                     placeholder="picture"
+                    disabled={disabled}
                     onChange={event => onChange({ ...form.userProfileMapping, picture: event.target.value })}
                 />
             </Field>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCreateForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCreateForm.spec.tsx
@@ -129,7 +129,7 @@ describe('IdentityProviderCreateForm', () => {
         expect(mutateAsync).not.toHaveBeenCalled();
     });
 
-    it('creates a Google identity provider and returns to the list', async () => {
+    it('creates a Google identity provider and opens the edit page', async () => {
         renderForm();
         fireEvent.click(screen.getByRole('radio', { name: /^Google$/i }));
         await inputHarness({ name: /^Name/ }).type('Google SSO');
@@ -148,7 +148,7 @@ describe('IdentityProviderCreateForm', () => {
                 configuration: { clientId: 'client-id', clientSecret: 'client-secret' },
             });
             expect(notify.success).toHaveBeenCalledWith('Identity provider successfully saved!');
-            expect(mockNavigate).toHaveBeenCalledWith('..');
+            expect(mockNavigate).toHaveBeenCalledWith('../google-sso', { relative: 'path' });
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCreateForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderCreateForm.tsx
@@ -15,25 +15,13 @@
  */
 
 import { useHasFeature } from '@gravitee/gamma-modules-sdk';
-import {
-    Button,
-    Card,
-    CardContent,
-    Field,
-    FieldDescription,
-    FieldError,
-    FieldLabel,
-    Input,
-    RadioGroup,
-    RadioGroupItem,
-} from '@gravitee/graphene-core';
+import { Button, Card, CardContent } from '@gravitee/graphene-core';
 import { useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { IdentityProviderConfigurationFields, IdentityProviderUserProfileFields } from './IdentityProviderConfigurationFields';
+import { IdentityProviderGeneralFields } from './IdentityProviderGeneralFields';
 import { IdentityProviderTypeSelector } from './IdentityProviderTypeSelector';
-import { RequiredMark } from './RequiredMark';
-import { ToggleRow } from './ToggleRow';
 import { notify } from '../../../shared/notify';
 import { useCreateIdentityProvider } from '../hooks/useIdentityProviderMutations';
 import { OPENID_CONNECT_SSO_LICENSE_FEATURE } from '../license/openidConnectSsoLicense';
@@ -42,8 +30,6 @@ import {
     emptyIdentityProviderForm,
     formToCreatePayload,
     formWithType,
-    IDENTITY_PROVIDER_NAME_MAX,
-    IDENTITY_PROVIDER_NAME_MIN,
     validateIdentityProviderForm,
     type IdentityProviderFormState,
 } from '../utils/identityProviderForm';
@@ -69,9 +55,9 @@ export function IdentityProviderCreateForm() {
             return;
         }
         try {
-            await createMutation.mutateAsync(formToCreatePayload(form));
+            const created = await createMutation.mutateAsync(formToCreatePayload(form));
             notify.success('Identity provider successfully saved!');
-            navigate('..');
+            navigate(`../${created.id}`, { relative: 'path' });
         } catch (error: unknown) {
             notify.error(error, 'Failed to create identity provider');
         }
@@ -93,71 +79,13 @@ export function IdentityProviderCreateForm() {
             <Card>
                 <CardContent className="space-y-4 pt-6">
                     <h2 className="text-base font-semibold">General</h2>
-                    <Field>
-                        <FieldLabel htmlFor="idp-name">
-                            Name <RequiredMark />
-                        </FieldLabel>
-                        <Input
-                            id="idp-name"
-                            value={form.name}
-                            minLength={IDENTITY_PROVIDER_NAME_MIN}
-                            maxLength={IDENTITY_PROVIDER_NAME_MAX}
-                            aria-required="true"
-                            aria-invalid={showErrors && !!errors.name}
-                            aria-describedby={showErrors && errors.name ? 'idp-name-error' : 'idp-name-hint'}
-                            onChange={event => setForm(prev => ({ ...prev, name: event.target.value }))}
-                        />
-                        <FieldDescription id="idp-name-hint">
-                            Identity provider name. The name will be used to define the authentication endpoint.
-                        </FieldDescription>
-                        {showErrors && errors.name ? <FieldError id="idp-name-error">{errors.name}</FieldError> : null}
-                    </Field>
-                    <Field>
-                        <FieldLabel htmlFor="idp-description">Description</FieldLabel>
-                        <Input
-                            id="idp-description"
-                            value={form.description}
-                            onChange={event => setForm(prev => ({ ...prev, description: event.target.value }))}
-                        />
-                        <FieldDescription>Provide a description of the identity provider.</FieldDescription>
-                    </Field>
-                    <ToggleRow
-                        id="idp-enabled"
-                        label="Allow portal authentication to use this identity provider"
-                        checked={form.enabled}
-                        disabled={false}
-                        onToggle={enabled => setForm(prev => ({ ...prev, enabled }))}
+                    <IdentityProviderGeneralFields
+                        form={form}
+                        showErrors={showErrors}
+                        errors={errors}
+                        disabled={createMutation.isPending}
+                        onChange={patch => setForm(prev => ({ ...prev, ...patch }))}
                     />
-                    <ToggleRow
-                        id="idp-email-required"
-                        label="A public email is required to be able to authenticate"
-                        checked={form.emailRequired}
-                        disabled={false}
-                        onToggle={emailRequired => setForm(prev => ({ ...prev, emailRequired }))}
-                    />
-                    <Field>
-                        <FieldLabel>Group and role mappings</FieldLabel>
-                        <FieldDescription>Platform administrators still have the ability to override mappings.</FieldDescription>
-                        <RadioGroup
-                            value={form.syncMappings ? 'each' : 'first'}
-                            onValueChange={value => setForm(prev => ({ ...prev, syncMappings: value === 'each' }))}
-                            className="mt-2 space-y-2"
-                            aria-label="Group and role mappings"
-                        >
-                            <div className="flex items-center gap-2 text-sm">
-                                <RadioGroupItem value="first" id="idp-sync-first" />
-                                <FieldLabel htmlFor="idp-sync-first" className="cursor-pointer font-normal">
-                                    Computed only during first user authentication
-                                </FieldLabel>
-                            </div>
-                            <div className="flex items-center gap-2 text-sm">
-                                <RadioGroupItem value="each" id="idp-sync-each" />
-                                <FieldLabel htmlFor="idp-sync-each" className="cursor-pointer font-normal">
-                                    Computed during each user authentication
-                                </FieldLabel>
-                            </div>
-                        </RadioGroup>
-                    </Field>
                 </CardContent>
             </Card>
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderEditForm.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderEditForm.spec.tsx
@@ -1,0 +1,312 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buttonHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { IdentityProviderEditForm } from './IdentityProviderEditForm';
+import { notify } from '../../../shared/notify';
+import { useUpdateIdentityProvider } from '../hooks/useIdentityProviderMutations';
+import type { IdentityProvider } from '../types/identityProvider';
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../hooks/useIdentityProviderMutations');
+
+const mockUseUpdateIdentityProvider = jest.mocked(useUpdateIdentityProvider);
+const mockOnCancel = jest.fn();
+
+const PROVIDER: IdentityProvider = {
+    id: 'google-idp',
+    name: 'Google',
+    description: 'Google SSO',
+    type: 'GOOGLE',
+    enabled: true,
+    emailRequired: true,
+    syncMappings: false,
+    configuration: { clientId: 'id', clientSecret: 'secret' },
+    groupMappings: [],
+    roleMappings: [],
+};
+
+const ROLE_MAPPED_PROVIDER: IdentityProvider = {
+    ...PROVIDER,
+    roleMappings: [
+        {
+            condition: "{#jsonPath(#profile, '$.job')}",
+            organizations: ['ADMIN'],
+            environments: { DEFAULT: ['USER'] },
+        },
+    ],
+};
+
+function renderForm({
+    canUpdate = true,
+    mappingsDisabled = false,
+    provider = PROVIDER,
+    environments = [{ id: 'DEFAULT', name: 'Default', description: 'Default environment' }],
+}: {
+    canUpdate?: boolean;
+    mappingsDisabled?: boolean;
+    provider?: IdentityProvider;
+    environments?: { id: string; name: string; description?: string }[];
+} = {}) {
+    return renderWithGraphene(
+        <MemoryRouter initialEntries={['/authentication/google-idp']}>
+            <IdentityProviderEditForm
+                provider={provider}
+                groups={[{ id: 'group-a', name: 'Group A' }]}
+                environments={environments}
+                organizationRoles={[{ id: 'ADMIN', name: 'ADMIN' }]}
+                environmentRoles={[{ id: 'USER', name: 'USER' }]}
+                canUpdate={canUpdate}
+                mappingsDisabled={mappingsDisabled}
+                onCancel={mockOnCancel}
+            />
+        </MemoryRouter>,
+    );
+}
+
+describe('IdentityProviderEditForm', () => {
+    let mutateAsync: jest.Mock;
+
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    beforeEach(() => {
+        mutateAsync = jest.fn().mockResolvedValue(PROVIDER);
+        mockOnCancel.mockClear();
+        mockUseUpdateIdentityProvider.mockReturnValue({ mutateAsync, isPending: false } as ReturnType<typeof useUpdateIdentityProvider>);
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    it('saves an updated provider', async () => {
+        mutateAsync.mockResolvedValue({ ...PROVIDER, name: 'Google SSO' });
+        renderForm();
+        await inputHarness({ name: /^Name/ }).type(' SSO');
+        await buttonHarness({ name: 'Update' }).click();
+        await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'Google SSO',
+                    configuration: { clientId: 'id', clientSecret: 'secret' },
+                    groupMappings: [],
+                    roleMappings: [],
+                }),
+            );
+            expect(mutateAsync.mock.calls[0]?.[0]).not.toHaveProperty('userProfileMapping');
+            expect(notify.success).toHaveBeenCalledWith('Identity provider successfully saved!');
+        });
+        expect(screen.getByRole('button', { name: 'Update' })).toHaveProperty('disabled', true);
+        expect(screen.getByLabelText(/^Name/)).toHaveProperty('value', 'Google SSO');
+    });
+
+    it('shows configuration, groups mapping, and roles mapping on the same page', () => {
+        renderForm();
+        expect(screen.getByRole('heading', { name: 'General' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Configuration' })).not.toBeNull();
+        expect(screen.getByLabelText(/^Client Id/)).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Groups Mapping' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Add group mapping' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Roles Mapping' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Add role mapping' })).not.toBeNull();
+        expect(screen.queryByRole('heading', { name: 'User profile mapping' })).toBeNull();
+    });
+
+    it('shows user profile mapping on the same page for OpenID Connect', () => {
+        renderForm({
+            provider: {
+                ...PROVIDER,
+                id: 'oidc-idp',
+                name: 'OIDC',
+                type: 'OIDC',
+                configuration: {
+                    clientId: 'id',
+                    clientSecret: 'secret',
+                    tokenEndpoint: 'https://idp.example.com/token',
+                    authorizeEndpoint: 'https://idp.example.com/authorize',
+                    userInfoEndpoint: 'https://idp.example.com/userinfo',
+                    scopes: ['openid'],
+                },
+                userProfileMapping: { id: 'sub' },
+            },
+        });
+        expect(screen.getByRole('heading', { name: 'Configuration' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'User profile mapping' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Groups Mapping' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Roles Mapping' })).not.toBeNull();
+    });
+
+    it('keeps Update disabled until the form is dirty', () => {
+        renderForm();
+        expect(screen.getByRole('button', { name: 'Update' })).toHaveProperty('disabled', true);
+    });
+
+    it('hides save actions without update permission', () => {
+        renderForm({ canUpdate: false });
+        expect(screen.queryByRole('button', { name: 'Update' })).toBeNull();
+        expect(screen.getByLabelText(/^Name/)).toHaveProperty('disabled', true);
+    });
+
+    it('disables configuration fields without update permission', () => {
+        renderForm({ canUpdate: false });
+        expect(screen.getByLabelText(/^Client Id/)).toHaveProperty('disabled', true);
+    });
+
+    it('keeps general and configuration editable when mapping catalogs failed', async () => {
+        mutateAsync.mockResolvedValue({ ...PROVIDER, name: 'Google SSO' });
+        renderForm({ mappingsDisabled: true });
+        expect(screen.getByLabelText(/^Name/)).toHaveProperty('disabled', false);
+        expect(screen.getByLabelText(/^Client Secret/)).toHaveProperty('disabled', false);
+        expect(screen.getByRole('button', { name: 'Add group mapping' })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Add role mapping' })).toHaveProperty('disabled', true);
+        await inputHarness({ name: /^Name/ }).type(' SSO');
+        await buttonHarness({ name: 'Update' }).click();
+        await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ name: 'Google SSO' }));
+        });
+    });
+
+    it('requires a condition after adding a group mapping', async () => {
+        renderForm();
+        await buttonHarness({ name: 'Add group mapping' }).click();
+        await buttonHarness({ name: 'Update' }).click();
+        expect(await screen.findByText('Condition is required.')).not.toBeNull();
+        expect(mutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('keeps in-progress edits when the provider object is replaced with the same data', async () => {
+        const { rerender } = renderForm();
+        await inputHarness({ name: /^Name/ }).type(' SSO');
+        rerender(
+            <MemoryRouter initialEntries={['/authentication/google-idp']}>
+                <IdentityProviderEditForm
+                    provider={{ ...PROVIDER }}
+                    groups={[{ id: 'group-a', name: 'Group A' }]}
+                    environments={[{ id: 'DEFAULT', name: 'Default', description: 'Default environment' }]}
+                    organizationRoles={[{ id: 'ADMIN', name: 'ADMIN' }]}
+                    environmentRoles={[{ id: 'USER', name: 'USER' }]}
+                    canUpdate
+                    mappingsDisabled={false}
+                    onCancel={mockOnCancel}
+                />
+            </MemoryRouter>,
+        );
+        expect(screen.getByLabelText(/^Name/)).toHaveProperty('value', 'Google SSO');
+    });
+
+    it('restores the loaded provider when Discard is clicked', async () => {
+        renderForm();
+        await inputHarness({ name: /^Name/ }).type(' SSO');
+        await buttonHarness({ name: 'Discard' }).click();
+        expect(screen.getByLabelText(/^Name/)).toHaveProperty('value', 'Google');
+        expect(screen.getByRole('button', { name: 'Update' })).toHaveProperty('disabled', true);
+    });
+
+    it('saves existing role mappings on update', async () => {
+        renderForm({ provider: ROLE_MAPPED_PROVIDER });
+        await inputHarness({ name: /^Condition/ }).type('X');
+        await buttonHarness({ name: 'Update' }).click();
+        await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    roleMappings: [
+                        {
+                            condition: "{#jsonPath(#profile, '$.job')}X",
+                            organizations: ['ADMIN'],
+                            environments: { DEFAULT: ['USER'] },
+                        },
+                    ],
+                }),
+            );
+        });
+    });
+
+    it('saves a newly added role mapping with organization and environment roles', async () => {
+        const user = userEvent.setup();
+        renderForm();
+        await buttonHarness({ name: 'Add role mapping' }).click();
+        await inputHarness({ name: /^Condition/ }).type('has-admin-job');
+        await user.click(screen.getByLabelText(/^Organization roles/));
+        await user.click(screen.getByRole('button', { name: 'ADMIN' }));
+        await user.keyboard('{Escape}');
+        await user.click(screen.getByRole('button', { name: 'Roles' }));
+        await user.click(screen.getByRole('button', { name: 'USER' }));
+        await user.keyboard('{Escape}');
+        await buttonHarness({ name: 'Update' }).click();
+        await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    roleMappings: [
+                        {
+                            condition: 'has-admin-job',
+                            organizations: ['ADMIN'],
+                            environments: { DEFAULT: ['USER'] },
+                        },
+                    ],
+                }),
+            );
+        });
+    });
+
+    it('allows adding an organization-only role mapping when there are no environments', async () => {
+        const user = userEvent.setup();
+        renderForm({ environments: [] });
+        expect(screen.getByRole('button', { name: 'Add role mapping' })).toHaveProperty('disabled', false);
+        await buttonHarness({ name: 'Add role mapping' }).click();
+        await inputHarness({ name: /^Condition/ }).type('is-admin');
+        await user.click(screen.getByLabelText(/^Organization roles/));
+        await user.click(screen.getByRole('button', { name: 'ADMIN' }));
+        await user.keyboard('{Escape}');
+        await buttonHarness({ name: 'Update' }).click();
+        await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    roleMappings: [{ condition: 'is-admin', organizations: ['ADMIN'], environments: {} }],
+                }),
+            );
+        });
+    });
+
+    it('asks the page to handle Cancel on a dirty form', async () => {
+        renderForm();
+        await inputHarness({ name: /^Name/ }).type(' SSO');
+        await buttonHarness({ name: 'Cancel' }).click();
+        expect(mockOnCancel).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderEditForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderEditForm.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Card, CardContent } from '@gravitee/graphene-core';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+
+import { IdentityProviderConfigurationFields, IdentityProviderUserProfileFields } from './IdentityProviderConfigurationFields';
+import { IdentityProviderGeneralFields } from './IdentityProviderGeneralFields';
+import { IdentityProviderGroupMappings } from './IdentityProviderGroupMappings';
+import type { IdentityProviderMappingOption } from './IdentityProviderMappingMultiSelect';
+import { IdentityProviderRoleMappings } from './IdentityProviderRoleMappings';
+import { notify } from '../../../shared/notify';
+import { useUpdateIdentityProvider } from '../hooks/useIdentityProviderMutations';
+import type { IdentityProvider } from '../types/identityProvider';
+import { hasUserProfileMapping } from '../utils/identityProviderDisplay';
+import {
+    formToUpdatePayload,
+    identityProviderToForm,
+    isIdentityProviderFormDirty,
+    validateIdentityProviderForm,
+    type IdentityProviderFormState,
+} from '../utils/identityProviderForm';
+
+export function IdentityProviderEditForm({
+    provider,
+    groups,
+    environments,
+    organizationRoles,
+    environmentRoles,
+    canUpdate,
+    mappingsDisabled = false,
+    onDirtyChange,
+    onCancel,
+}: Readonly<{
+    provider: IdentityProvider;
+    groups: readonly IdentityProviderMappingOption[];
+    environments: readonly IdentityProviderMappingOption[];
+    organizationRoles: readonly IdentityProviderMappingOption[];
+    environmentRoles: readonly IdentityProviderMappingOption[];
+    canUpdate: boolean;
+    mappingsDisabled?: boolean;
+    onDirtyChange?: (dirty: boolean) => void;
+    onCancel: () => void;
+}>) {
+    const updateMutation = useUpdateIdentityProvider(provider.id);
+    const environmentIds = useMemo(() => environments.map(environment => environment.id), [environments]);
+    const [baseline, setBaseline] = useState(() => identityProviderToForm(provider, environmentIds));
+    const [form, setForm] = useState<IdentityProviderFormState>(baseline);
+    const [showErrors, setShowErrors] = useState(false);
+
+    const errors = validateIdentityProviderForm(form);
+    const dirty = isIdentityProviderFormDirty(form, baseline);
+    const disabled = !canUpdate || updateMutation.isPending;
+    const mappingFieldsDisabled = disabled || mappingsDisabled;
+    const showProfile = hasUserProfileMapping(form.type);
+
+    useEffect(() => {
+        onDirtyChange?.(dirty);
+    }, [dirty, onDirtyChange]);
+
+    function patchForm(patch: Partial<IdentityProviderFormState>) {
+        setForm(prev => ({ ...prev, ...patch }));
+    }
+
+    function handleDiscard() {
+        setForm(baseline);
+        setShowErrors(false);
+    }
+
+    async function handleSubmit(event: FormEvent) {
+        event.preventDefault();
+        if (!canUpdate) return;
+        if (Object.keys(errors).length > 0) {
+            setShowErrors(true);
+            return;
+        }
+        try {
+            const updated = await updateMutation.mutateAsync(formToUpdatePayload(form));
+            const next = identityProviderToForm(updated, environmentIds);
+            setBaseline(next);
+            setForm(next);
+            setShowErrors(false);
+            notify.success('Identity provider successfully saved!');
+        } catch (error: unknown) {
+            notify.error(error, 'Failed to update identity provider');
+        }
+    }
+
+    return (
+        <form className="space-y-6" onSubmit={handleSubmit}>
+            <Card>
+                <CardContent className="space-y-4 pt-6">
+                    <h2 className="text-base font-semibold">General</h2>
+                    <IdentityProviderGeneralFields
+                        form={form}
+                        showErrors={showErrors}
+                        errors={errors}
+                        disabled={disabled}
+                        onChange={patchForm}
+                    />
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="space-y-4 pt-6">
+                    <h2 className="text-base font-semibold">Configuration</h2>
+                    <IdentityProviderConfigurationFields
+                        form={form}
+                        showErrors={showErrors}
+                        errors={errors}
+                        disabled={disabled}
+                        onPatch={patch => setForm(prev => ({ ...prev, configuration: { ...prev.configuration, ...patch } }))}
+                    />
+                </CardContent>
+            </Card>
+
+            {showProfile ? (
+                <Card>
+                    <CardContent className="space-y-4 pt-6">
+                        <h2 className="text-base font-semibold">User profile mapping</h2>
+                        <IdentityProviderUserProfileFields
+                            form={form}
+                            showErrors={showErrors}
+                            errors={errors}
+                            disabled={disabled}
+                            onChange={userProfileMapping => patchForm({ userProfileMapping })}
+                        />
+                    </CardContent>
+                </Card>
+            ) : null}
+
+            <IdentityProviderGroupMappings
+                mappings={form.groupMappings}
+                groups={groups}
+                showErrors={showErrors}
+                errors={errors}
+                disabled={mappingFieldsDisabled}
+                onChange={groupMappings => patchForm({ groupMappings })}
+            />
+
+            <IdentityProviderRoleMappings
+                mappings={form.roleMappings}
+                environments={environments}
+                organizationRoles={organizationRoles}
+                environmentRoles={environmentRoles}
+                showErrors={showErrors}
+                errors={errors}
+                disabled={mappingFieldsDisabled}
+                onChange={roleMappings => patchForm({ roleMappings })}
+            />
+
+            {canUpdate ? (
+                <div className="sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t bg-background py-4">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={updateMutation.isPending}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="outline" disabled={!dirty || updateMutation.isPending} onClick={handleDiscard}>
+                        Discard
+                    </Button>
+                    <Button type="submit" disabled={!dirty || updateMutation.isPending}>
+                        {updateMutation.isPending ? 'Saving…' : 'Update'}
+                    </Button>
+                </div>
+            ) : null}
+        </form>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderGeneralFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderGeneralFields.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Field, FieldDescription, FieldError, FieldLabel, Input, RadioGroup, RadioGroupItem } from '@gravitee/graphene-core';
+
+import { RequiredMark } from './RequiredMark';
+import { ToggleRow } from './ToggleRow';
+import { IDENTITY_PROVIDER_NAME_MAX, IDENTITY_PROVIDER_NAME_MIN, type IdentityProviderFormState } from '../utils/identityProviderForm';
+
+export function IdentityProviderGeneralFields({
+    form,
+    showErrors,
+    errors,
+    disabled,
+    onChange,
+}: Readonly<{
+    form: IdentityProviderFormState;
+    showErrors: boolean;
+    errors: Record<string, string>;
+    disabled: boolean;
+    onChange: (patch: Partial<IdentityProviderFormState>) => void;
+}>) {
+    return (
+        <>
+            <Field>
+                <FieldLabel htmlFor="idp-name">
+                    Name <RequiredMark />
+                </FieldLabel>
+                <Input
+                    id="idp-name"
+                    value={form.name}
+                    minLength={IDENTITY_PROVIDER_NAME_MIN}
+                    maxLength={IDENTITY_PROVIDER_NAME_MAX}
+                    disabled={disabled}
+                    aria-required="true"
+                    aria-invalid={showErrors && !!errors.name}
+                    aria-describedby={showErrors && errors.name ? 'idp-name-error' : 'idp-name-hint'}
+                    onChange={event => onChange({ name: event.target.value })}
+                />
+                <FieldDescription id="idp-name-hint">
+                    Identity provider name. The name will be used to define the authentication endpoint.
+                </FieldDescription>
+                {showErrors && errors.name ? <FieldError id="idp-name-error">{errors.name}</FieldError> : null}
+            </Field>
+            <Field>
+                <FieldLabel htmlFor="idp-description">Description</FieldLabel>
+                <Input
+                    id="idp-description"
+                    value={form.description}
+                    disabled={disabled}
+                    onChange={event => onChange({ description: event.target.value })}
+                />
+                <FieldDescription>Provide a description of the identity provider.</FieldDescription>
+            </Field>
+            <ToggleRow
+                id="idp-enabled"
+                label="Allow portal authentication to use this identity provider"
+                checked={form.enabled}
+                disabled={disabled}
+                onToggle={enabled => onChange({ enabled })}
+            />
+            <ToggleRow
+                id="idp-email-required"
+                label="A public email is required to be able to authenticate"
+                checked={form.emailRequired}
+                disabled={disabled}
+                onToggle={emailRequired => onChange({ emailRequired })}
+            />
+            <Field>
+                <FieldLabel>Group and role mappings</FieldLabel>
+                <FieldDescription>Platform administrators still have the ability to override mappings.</FieldDescription>
+                <RadioGroup
+                    value={form.syncMappings ? 'each' : 'first'}
+                    onValueChange={value => onChange({ syncMappings: value === 'each' })}
+                    className="mt-2 space-y-2"
+                    aria-label="Group and role mappings"
+                    disabled={disabled}
+                >
+                    <div className="flex items-center gap-2 text-sm">
+                        <RadioGroupItem value="first" id="idp-sync-first" />
+                        <FieldLabel htmlFor="idp-sync-first" className="cursor-pointer font-normal">
+                            Computed only during first user authentication
+                        </FieldLabel>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                        <RadioGroupItem value="each" id="idp-sync-each" />
+                        <FieldLabel htmlFor="idp-sync-each" className="cursor-pointer font-normal">
+                            Computed during each user authentication
+                        </FieldLabel>
+                    </div>
+                </RadioGroup>
+            </Field>
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderGroupMappings.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderGroupMappings.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Card, CardContent, Field, FieldDescription, FieldError, FieldLabel, Input } from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { IdentityProviderMappingMultiSelect, type IdentityProviderMappingOption } from './IdentityProviderMappingMultiSelect';
+import { RequiredMark } from './RequiredMark';
+import { emptyGroupMapping, type IdentityProviderGroupMappingForm } from '../utils/identityProviderForm';
+
+export function IdentityProviderGroupMappings({
+    mappings,
+    groups,
+    showErrors,
+    errors,
+    disabled,
+    onChange,
+}: Readonly<{
+    mappings: IdentityProviderGroupMappingForm[];
+    groups: readonly IdentityProviderMappingOption[];
+    showErrors: boolean;
+    errors: Record<string, string>;
+    disabled: boolean;
+    onChange: (mappings: IdentityProviderGroupMappingForm[]) => void;
+}>) {
+    function patchMapping(index: number, patch: Partial<IdentityProviderGroupMappingForm>) {
+        onChange(mappings.map((mapping, mappingIndex) => (mappingIndex === index ? { ...mapping, ...patch } : mapping)));
+    }
+
+    return (
+        <Card>
+            <CardContent className="space-y-4 pt-6">
+                <h2 className="text-base font-semibold">Groups Mapping</h2>
+                {mappings.map((mapping, index) => {
+                    const conditionError = errors[`groupMappings.${index}.condition`];
+                    const groupsError = errors[`groupMappings.${index}.groups`];
+                    return (
+                        <Card key={`group-mapping-${index}`}>
+                            <CardContent className="space-y-4 pt-6">
+                                <Field>
+                                    <FieldLabel htmlFor={`idp-group-condition-${index}`}>
+                                        Condition <RequiredMark />
+                                    </FieldLabel>
+                                    <Input
+                                        id={`idp-group-condition-${index}`}
+                                        value={mapping.condition}
+                                        disabled={disabled}
+                                        aria-required="true"
+                                        aria-invalid={showErrors && !!conditionError}
+                                        aria-describedby={
+                                            showErrors && conditionError
+                                                ? `idp-group-condition-${index}-error`
+                                                : `idp-group-condition-${index}-hint`
+                                        }
+                                        onChange={event => patchMapping(index, { condition: event.target.value })}
+                                    />
+                                    <FieldDescription id={`idp-group-condition-${index}-hint`}>
+                                        The condition which should be validated to associate below groups at login time.
+                                    </FieldDescription>
+                                    {showErrors && conditionError ? (
+                                        <FieldError id={`idp-group-condition-${index}-error`}>{conditionError}</FieldError>
+                                    ) : null}
+                                </Field>
+                                <IdentityProviderMappingMultiSelect
+                                    id={`idp-group-groups-${index}`}
+                                    label="Group"
+                                    values={mapping.groups}
+                                    options={groups}
+                                    required
+                                    invalid={showErrors && !!groupsError}
+                                    error={groupsError}
+                                    disabled={disabled}
+                                    placeholder="Select groups"
+                                    emptyMessage="No groups available"
+                                    onChange={selected => patchMapping(index, { groups: selected })}
+                                />
+                                <div className="flex justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={disabled}
+                                        onClick={() => onChange(mappings.filter((_, mappingIndex) => mappingIndex !== index))}
+                                    >
+                                        <Trash2Icon className="size-4" aria-hidden />
+                                        Delete
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+                <Button type="button" variant="outline" disabled={disabled} onClick={() => onChange([...mappings, emptyGroupMapping()])}>
+                    <PlusIcon className="size-4" aria-hidden />
+                    Add group mapping
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderMappingMultiSelect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderMappingMultiSelect.spec.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IdentityProviderMappingMultiSelect } from './IdentityProviderMappingMultiSelect';
+
+function renderSelect(
+    values: string[] = ['group-a', 'deleted-group'],
+    onChange: (values: string[]) => void = jest.fn(),
+    hideLabel = false,
+) {
+    return renderWithGraphene(
+        <IdentityProviderMappingMultiSelect
+            id="idp-groups"
+            label="Group"
+            values={values}
+            options={[{ id: 'group-a', name: 'Group A' }]}
+            placeholder="Select groups"
+            emptyMessage="No groups available"
+            hideLabel={hideLabel}
+            onChange={onChange}
+        />,
+    );
+}
+
+describe('IdentityProviderMappingMultiSelect', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('includes selected ids that are missing from the catalog in the summary', () => {
+        renderSelect();
+        expect(screen.getByText('Group A, deleted-group')).not.toBeNull();
+    });
+
+    it('shows three selected names then an ellipsis, with the full list on hover', async () => {
+        const user = userEvent.setup();
+        renderWithGraphene(
+            <IdentityProviderMappingMultiSelect
+                id="idp-roles"
+                label="Organization roles"
+                values={['org-8', 'user', 'org', 'admin', 'org-2']}
+                options={[
+                    { id: 'org-8', name: 'ORGANIZATION_8' },
+                    { id: 'user', name: 'USER' },
+                    { id: 'org', name: 'ORG' },
+                    { id: 'admin', name: 'ADMIN' },
+                    { id: 'org-2', name: 'ORGANIZATION_2' },
+                ]}
+                placeholder="Select organization roles"
+                emptyMessage="No organization roles available"
+                onChange={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('ORGANIZATION_8, USER, ORG...')).not.toBeNull();
+        expect(screen.queryByText('ORGANIZATION_8, USER, ORG, ADMIN, ORGANIZATION_2')).toBeNull();
+
+        await user.hover(screen.getByText('ORGANIZATION_8, USER, ORG...'));
+        expect((await screen.findByRole('tooltip')).textContent).toBe('ORGANIZATION_8, USER, ORG, ADMIN, ORGANIZATION_2');
+        expect(screen.getByRole('button', { name: 'Organization roles: ORGANIZATION_8, USER, ORG, ADMIN, ORGANIZATION_2' })).not.toBeNull();
+    });
+
+    it('shows every selected name when there are three or fewer', () => {
+        renderSelect();
+        expect(screen.getByText('Group A, deleted-group')).not.toBeNull();
+        expect(screen.queryByText('Group A, deleted-group...')).toBeNull();
+    });
+
+    it('lets the user remove a value that is past the truncated summary', async () => {
+        const user = userEvent.setup();
+        const onChange = jest.fn();
+        renderWithGraphene(
+            <IdentityProviderMappingMultiSelect
+                id="idp-roles"
+                label="Organization roles"
+                values={['org-8', 'user', 'org', 'admin', 'org-2']}
+                options={[
+                    { id: 'org-8', name: 'ORGANIZATION_8' },
+                    { id: 'user', name: 'USER' },
+                    { id: 'org', name: 'ORG' },
+                    { id: 'admin', name: 'ADMIN' },
+                    { id: 'org-2', name: 'ORGANIZATION_2' },
+                ]}
+                placeholder="Select organization roles"
+                emptyMessage="No organization roles available"
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Organization roles: ORGANIZATION_8, USER, ORG, ADMIN, ORGANIZATION_2' }));
+        await user.click(screen.getByRole('button', { name: 'ADMIN' }));
+        expect(onChange).toHaveBeenCalledWith(['org-8', 'user', 'org', 'org-2']);
+    });
+
+    it('keeps a visually hidden label for table cells', () => {
+        renderSelect(['group-a'], jest.fn(), true);
+        expect(screen.getByText('Group')).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Group: Group A' })).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderMappingMultiSelect.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderMappingMultiSelect.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    cn,
+    Field,
+    FieldError,
+    FieldLabel,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    TooltipProvider,
+} from '@gravitee/graphene-core';
+import { CheckIcon, ChevronDownIcon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import { RequiredMark } from './RequiredMark';
+import { TruncatedDisplayText } from '../../../shared/components/TruncatedDisplayText';
+import { formatTruncatedNameSummary } from '../../../shared/utils/truncatedList';
+
+export interface IdentityProviderMappingOption {
+    readonly id: string;
+    readonly name: string;
+    readonly description?: string;
+}
+
+export function IdentityProviderMappingMultiSelect({
+    id,
+    label,
+    values,
+    options,
+    required = false,
+    invalid = false,
+    error,
+    disabled = false,
+    hideLabel = false,
+    placeholder,
+    emptyMessage,
+    onChange,
+}: Readonly<{
+    id: string;
+    label: string;
+    values: string[];
+    options: readonly IdentityProviderMappingOption[];
+    required?: boolean;
+    invalid?: boolean;
+    error?: string;
+    disabled?: boolean;
+    hideLabel?: boolean;
+    placeholder: string;
+    emptyMessage: string;
+    onChange: (values: string[]) => void;
+}>) {
+    const [open, setOpen] = useState(false);
+    const errorId = `${id}-error`;
+    const selected = useMemo(() => {
+        const byId = new Map(options.map(option => [option.id, option]));
+        return values.map(value => byId.get(value) ?? { id: value, name: value });
+    }, [options, values]);
+    const listOptions = useMemo(() => {
+        const byId = new Map(options.map(option => [option.id, option]));
+        const extras = values.filter(value => !byId.has(value)).map(value => ({ id: value, name: value }));
+        return [...options, ...extras];
+    }, [options, values]);
+    const selectedLabels = selected.map(option => option.name);
+    const summary = formatTruncatedNameSummary(selectedLabels);
+    const displayText = selectedLabels.length === 0 ? placeholder : summary.display;
+    const triggerName = selectedLabels.length === 0 ? label : `${label}: ${summary.full}`;
+
+    function toggleValue(valueId: string) {
+        onChange(values.includes(valueId) ? values.filter(value => value !== valueId) : [...values, valueId]);
+    }
+
+    return (
+        <Field>
+            <FieldLabel htmlFor={id} className={hideLabel ? 'sr-only' : undefined}>
+                {label}
+                {required ? (
+                    <>
+                        {' '}
+                        <RequiredMark />
+                    </>
+                ) : null}
+            </FieldLabel>
+            <TooltipProvider delayDuration={300}>
+                <Popover open={open} onOpenChange={setOpen}>
+                    <PopoverTrigger asChild>
+                        <Button
+                            id={id}
+                            type="button"
+                            variant="outline"
+                            aria-label={triggerName}
+                            aria-required={required || undefined}
+                            aria-invalid={invalid || undefined}
+                            aria-describedby={invalid && error ? errorId : undefined}
+                            disabled={disabled}
+                            className="h-10 w-full max-w-full justify-between gap-2 px-3 font-normal"
+                        >
+                            <TruncatedDisplayText
+                                displayText={displayText}
+                                isPlaceholder={selectedLabels.length === 0}
+                                showTooltip={summary.truncated && !open}
+                                labels={selectedLabels}
+                            />
+                            <ChevronDownIcon className="size-4 shrink-0 opacity-50" aria-hidden />
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="block w-72 p-0" align="start">
+                        {listOptions.length === 0 ? (
+                            <p className="p-3 text-sm text-muted-foreground">{emptyMessage}</p>
+                        ) : (
+                            <div className="max-h-48 space-y-1 overflow-y-auto p-2">
+                                {listOptions.map(option => {
+                                    const selectedOption = values.includes(option.id);
+                                    return (
+                                        <button
+                                            key={option.id}
+                                            type="button"
+                                            aria-pressed={selectedOption}
+                                            aria-label={option.name}
+                                            disabled={disabled}
+                                            className={cn(
+                                                'flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground',
+                                                selectedOption && 'bg-accent/50',
+                                            )}
+                                            onClick={() => toggleValue(option.id)}
+                                        >
+                                            <CheckIcon className={cn('size-4 shrink-0', !selectedOption && 'invisible')} aria-hidden />
+                                            <span className="truncate" title={option.name}>
+                                                {option.name}
+                                            </span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </PopoverContent>
+                </Popover>
+            </TooltipProvider>
+            {invalid && error ? <FieldError id={errorId}>{error}</FieldError> : null}
+        </Field>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderRoleMappings.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderRoleMappings.spec.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buttonHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+
+import { IdentityProviderRoleMappings } from './IdentityProviderRoleMappings';
+
+describe('IdentityProviderRoleMappings', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('lets the user add an organization-only role mapping when there are no environments', async () => {
+        const onChange = jest.fn();
+        renderWithGraphene(
+            <IdentityProviderRoleMappings
+                mappings={[]}
+                environments={[]}
+                organizationRoles={[{ id: 'ADMIN', name: 'ADMIN' }]}
+                environmentRoles={[]}
+                showErrors={false}
+                errors={{}}
+                disabled={false}
+                onChange={onChange}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Add role mapping' })).toHaveProperty('disabled', false);
+        await buttonHarness({ name: 'Add role mapping' }).click();
+        expect(onChange).toHaveBeenCalledWith([{ condition: '', organizations: [], environments: {} }]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderRoleMappings.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProviderRoleMappings.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Card,
+    CardContent,
+    Field,
+    FieldDescription,
+    FieldError,
+    FieldLabel,
+    Input,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { IdentityProviderMappingMultiSelect, type IdentityProviderMappingOption } from './IdentityProviderMappingMultiSelect';
+import { RequiredMark } from './RequiredMark';
+import { emptyRoleMapping, type IdentityProviderRoleMappingForm } from '../utils/identityProviderForm';
+
+function environmentRows(
+    catalog: readonly IdentityProviderMappingOption[],
+    mapping: IdentityProviderRoleMappingForm,
+): IdentityProviderMappingOption[] {
+    const byId = new Map(catalog.map(environment => [environment.id, environment]));
+    const ids = [...new Set([...catalog.map(environment => environment.id), ...Object.keys(mapping.environments)])];
+    return ids.map(id => byId.get(id) ?? { id, name: id });
+}
+
+export function IdentityProviderRoleMappings({
+    mappings,
+    environments,
+    organizationRoles,
+    environmentRoles,
+    showErrors,
+    errors,
+    disabled,
+    onChange,
+}: Readonly<{
+    mappings: IdentityProviderRoleMappingForm[];
+    environments: readonly IdentityProviderMappingOption[];
+    organizationRoles: readonly IdentityProviderMappingOption[];
+    environmentRoles: readonly IdentityProviderMappingOption[];
+    showErrors: boolean;
+    errors: Record<string, string>;
+    disabled: boolean;
+    onChange: (mappings: IdentityProviderRoleMappingForm[]) => void;
+}>) {
+    const environmentIds = environments.map(environment => environment.id);
+
+    function patchMapping(index: number, patch: Partial<IdentityProviderRoleMappingForm>) {
+        onChange(mappings.map((mapping, mappingIndex) => (mappingIndex === index ? { ...mapping, ...patch } : mapping)));
+    }
+
+    return (
+        <Card>
+            <CardContent className="space-y-4 pt-6">
+                <h2 className="text-base font-semibold">Roles Mapping</h2>
+                {mappings.map((mapping, index) => {
+                    const conditionError = errors[`roleMappings.${index}.condition`];
+                    const organizationsError = errors[`roleMappings.${index}.organizations`];
+                    return (
+                        <Card key={`role-mapping-${index}`}>
+                            <CardContent className="space-y-4 pt-6">
+                                <Field>
+                                    <FieldLabel htmlFor={`idp-role-condition-${index}`}>
+                                        Condition <RequiredMark />
+                                    </FieldLabel>
+                                    <Input
+                                        id={`idp-role-condition-${index}`}
+                                        value={mapping.condition}
+                                        disabled={disabled}
+                                        aria-required="true"
+                                        aria-invalid={showErrors && !!conditionError}
+                                        aria-describedby={
+                                            showErrors && conditionError
+                                                ? `idp-role-condition-${index}-error`
+                                                : `idp-role-condition-${index}-hint`
+                                        }
+                                        onChange={event => patchMapping(index, { condition: event.target.value })}
+                                    />
+                                    <FieldDescription id={`idp-role-condition-${index}-hint`}>
+                                        The condition which should be validated to associate below roles at login time.
+                                    </FieldDescription>
+                                    {showErrors && conditionError ? (
+                                        <FieldError id={`idp-role-condition-${index}-error`}>{conditionError}</FieldError>
+                                    ) : null}
+                                </Field>
+                                <IdentityProviderMappingMultiSelect
+                                    id={`idp-role-org-${index}`}
+                                    label="Organization roles"
+                                    values={mapping.organizations}
+                                    options={organizationRoles}
+                                    required
+                                    invalid={showErrors && !!organizationsError}
+                                    error={organizationsError}
+                                    disabled={disabled}
+                                    placeholder="Select organization roles"
+                                    emptyMessage="No organization roles available"
+                                    onChange={organizations => patchMapping(index, { organizations })}
+                                />
+                                <Table aria-label={`Environment roles for mapping ${index + 1}`}>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Name</TableHead>
+                                            <TableHead>Description</TableHead>
+                                            <TableHead>Roles selected</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {environmentRows(environments, mapping).map(environment => (
+                                            <TableRow key={environment.id}>
+                                                <TableCell>{environment.name}</TableCell>
+                                                <TableCell className="text-muted-foreground">
+                                                    {environment.description?.trim() || '—'}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <IdentityProviderMappingMultiSelect
+                                                        id={`idp-role-env-${index}-${environment.id}`}
+                                                        label="Roles"
+                                                        values={mapping.environments[environment.id] ?? []}
+                                                        options={environmentRoles}
+                                                        disabled={disabled}
+                                                        placeholder="Select roles"
+                                                        emptyMessage="No environment roles available"
+                                                        hideLabel
+                                                        onChange={roles =>
+                                                            patchMapping(index, {
+                                                                environments: {
+                                                                    ...mapping.environments,
+                                                                    [environment.id]: roles,
+                                                                },
+                                                            })
+                                                        }
+                                                    />
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                                <div className="flex justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={disabled}
+                                        onClick={() => onChange(mappings.filter((_, mappingIndex) => mappingIndex !== index))}
+                                    >
+                                        <Trash2Icon className="size-4" aria-hidden />
+                                        Delete
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+                <Button
+                    type="button"
+                    variant="outline"
+                    disabled={disabled}
+                    onClick={() => onChange([...mappings, emptyRoleMapping(environmentIds)])}
+                >
+                    <PlusIcon className="size-4" aria-hidden />
+                    Add role mapping
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProvidersTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProvidersTable.spec.tsx
@@ -16,6 +16,8 @@
 
 import { buttonHarness, dataTableHarness, inputHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
 import { fireEvent, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { IdentityProvidersTable } from './IdentityProvidersTable';
 import type { IdentityProviderRow } from '../types/identityProvider';
@@ -71,15 +73,17 @@ beforeAll(() => {
 });
 
 describe('IdentityProvidersTable', () => {
+    function renderTable(ui: ReactElement) {
+        return renderWithGraphene(<MemoryRouter initialEntries={['/authentication']}>{ui}</MemoryRouter>);
+    }
     it('renders name, callback id, status, and type', () => {
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
         const table = identityProvidersTable();
         expect(table.getHeaders().slice(0, 4)).toEqual(['Name', 'Id', 'Status', 'Type']);
         expect(table.getRow('Gravitee.io AM').getCellText('Name')).toBe('Gravitee.io AM');
         expect(table.getRow('Google SSO').getCellText('Name')).toBe('Google');
-        expect(table.getRow('Google SSO').getCellText('Id')).toBe('google-idp');
         expect(table.getRow('Gravitee.io AM').getCellText('Id')).toBe('gravitee-am');
-        expect(screen.queryByRole('link', { name: 'Google' })).toBeNull();
+        expect(table.getRow('Google SSO').getCellText('Id')).toBe('google-idp');
         expect(table.getRow('Gravitee.io AM').getCellText('Type')).toBe('Gravitee.io AM');
         expect(table.getRow('Google SSO').getCellText('Type')).toBe('Google');
         expect(table.getRow('Google SSO').getCellElement('Type').querySelector('svg')).toBeNull();
@@ -90,7 +94,7 @@ describe('IdentityProvidersTable', () => {
     });
 
     it('filters rows by search query', async () => {
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
         await inputHarness({ name: 'Search identity providers' }).type('google');
         const table = identityProvidersTable();
         expect(table.queryRow('Organization AM')).toBeNull();
@@ -98,7 +102,7 @@ describe('IdentityProvidersTable', () => {
     });
 
     it('filters rows by callback id', async () => {
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
         await inputHarness({ name: 'Search identity providers' }).type('google-idp');
         const table = identityProvidersTable();
         expect(table.queryRow('Organization AM')).toBeNull();
@@ -106,7 +110,7 @@ describe('IdentityProvidersTable', () => {
     });
 
     it('clears the search from the no-results empty state', async () => {
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
         await inputHarness({ name: 'Search identity providers' }).type('nobody');
         expect(identityProvidersTable().isEmpty()).toBe(true);
         expect(screen.getByText('No identity providers found')).not.toBeNull();
@@ -116,7 +120,7 @@ describe('IdentityProvidersTable', () => {
 
     it('calls onToggle when Activate is selected', async () => {
         const onToggle = jest.fn();
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} canActivate onToggle={onToggle} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} canActivate onToggle={onToggle} />);
         await buttonHarness({ name: /Actions for Google/i }).click();
         (await screen.findByRole('menuitem', { name: /^Activate$/ })).click();
         expect(onToggle).toHaveBeenCalledWith(ROWS[1]);
@@ -124,19 +128,19 @@ describe('IdentityProvidersTable', () => {
 
     it('calls onDelete when Delete is selected', async () => {
         const onDelete = jest.fn();
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} canDelete onDelete={onDelete} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} canDelete onDelete={onDelete} />);
         await buttonHarness({ name: /Actions for Gravitee.io AM/i }).click();
         (await screen.findByRole('menuitem', { name: /^Delete$/ })).click();
         expect(onDelete).toHaveBeenCalledWith(ROWS[0]);
     });
 
     it('hides the actions menu when the user cannot activate or delete', () => {
-        renderWithGraphene(<IdentityProvidersTable rows={ROWS} />);
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
         expect(screen.queryByRole('button', { name: /Actions for Google/i })).toBeNull();
     });
 
     it('shows an unknown status instead of deactivated when activation state is missing', () => {
-        renderWithGraphene(
+        renderTable(
             <IdentityProvidersTable
                 rows={ROWS.map(row => {
                     const { activated: _activated, ...rest } = row;
@@ -148,7 +152,7 @@ describe('IdentityProvidersTable', () => {
     });
 
     it('omits Activate when activation state is unknown', async () => {
-        renderWithGraphene(
+        renderTable(
             <IdentityProvidersTable
                 rows={ROWS.map(row => {
                     const { activated: _activated, ...rest } = row;
@@ -178,10 +182,16 @@ describe('IdentityProvidersTable', () => {
             created_at: 1,
             updated_at: 1,
         }));
-        renderWithGraphene(<IdentityProvidersTable rows={many} />);
+        renderTable(<IdentityProvidersTable rows={many} />);
         fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
         const table = identityProvidersTable();
         expect(table.queryRow('Description 0')).toBeNull();
         expect(table.getRow('Description 10').getCellText('Name')).toBe('Provider 10');
+    });
+
+    it('links each provider name to the edit page', () => {
+        renderTable(<IdentityProvidersTable rows={ROWS} />);
+        expect(screen.getByRole('link', { name: 'Gravitee.io AM' }).getAttribute('href')).toBe('/gravitee-am');
+        expect(screen.getByRole('link', { name: 'Google' }).getAttribute('href')).toBe('/google-idp');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProvidersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/components/IdentityProvidersTable.tsx
@@ -34,6 +34,7 @@ import {
 } from '@gravitee/graphene-core';
 import { CheckIcon, MoreVerticalIcon, SearchIcon, ShieldIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import type { ColCell, ColHeader } from '../../applications/utils/dataTableTypes';
 import { TABLE_PAGE_SIZE_OPTIONS } from '../../applications/utils/paginationConstants';
@@ -122,7 +123,11 @@ function buildColumns({
             id: 'name',
             accessorKey: 'name',
             header: ({ column }: ColHeader<IdentityProviderRow>) => <DataTableColumnHeader column={column} title="Name" />,
-            cell: ({ row }: ColCell<IdentityProviderRow>) => <span className="font-medium">{row.original.name}</span>,
+            cell: ({ row }: ColCell<IdentityProviderRow>) => (
+                <Button asChild variant="link" className="h-auto p-0 text-left text-sm font-medium text-foreground hover:underline">
+                    <Link to={row.original.id}>{row.original.name}</Link>
+                </Button>
+            ),
         },
         {
             id: 'id',

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProvider.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProvider.spec.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useIdentityProviderMappingCatalog } from './useIdentityProvider';
+import { listOrgGroups } from '../../entrypoints/services/groups';
+import { listEnvironmentRoles, listOrganizationEnvironments, listOrganizationRoles } from '../../users/services/organizationUsers';
+
+jest.mock('../../entrypoints/services/groups', () => ({
+    listOrgGroups: jest.fn(),
+}));
+
+jest.mock('../../users/services/organizationUsers', () => ({
+    ...jest.requireActual('../../users/services/organizationUsers'),
+    listOrganizationEnvironments: jest.fn(),
+    listOrganizationRoles: jest.fn(),
+    listEnvironmentRoles: jest.fn(),
+}));
+
+const mockListOrgGroups = jest.mocked(listOrgGroups);
+const mockListOrganizationEnvironments = jest.mocked(listOrganizationEnvironments);
+const mockListOrganizationRoles = jest.mocked(listOrganizationRoles);
+const mockListEnvironmentRoles = jest.mocked(listEnvironmentRoles);
+
+describe('useIdentityProviderMappingCatalog', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('refetches groups, environments, and both role catalogs', async () => {
+        mockListOrgGroups.mockResolvedValue([]);
+        mockListOrganizationEnvironments.mockResolvedValue([]);
+        mockListOrganizationRoles.mockResolvedValue([]);
+        mockListEnvironmentRoles.mockResolvedValue([]);
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+        function Wrapper({ children }: { children: ReactNode }) {
+            return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+        }
+
+        const { result } = renderHook(() => useIdentityProviderMappingCatalog(), { wrapper: Wrapper });
+
+        await waitFor(() => {
+            expect(result.current.groupsQuery.isSuccess).toBe(true);
+            expect(result.current.environmentsQuery.isSuccess).toBe(true);
+            expect(result.current.organizationRolesQuery.isSuccess).toBe(true);
+            expect(result.current.environmentRolesQuery.isSuccess).toBe(true);
+        });
+        expect(mockListOrgGroups).toHaveBeenCalledTimes(1);
+        expect(mockListOrganizationEnvironments).toHaveBeenCalledTimes(1);
+        expect(mockListOrganizationRoles).toHaveBeenCalledTimes(1);
+        expect(mockListEnvironmentRoles).toHaveBeenCalledTimes(1);
+
+        result.current.refetchCatalogs();
+
+        await waitFor(() => {
+            expect(mockListOrgGroups).toHaveBeenCalledTimes(2);
+            expect(mockListOrganizationEnvironments).toHaveBeenCalledTimes(2);
+            expect(mockListOrganizationRoles).toHaveBeenCalledTimes(2);
+            expect(mockListEnvironmentRoles).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProvider.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProvider.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { listOrgGroups } from '../../entrypoints/services/groups';
+import { orgGroupKeys } from '../../entrypoints/utils/queryKeys';
+import { useEnvironmentRoleCatalog, useOrganizationEnvironments, useOrganizationRoleCatalog } from '../../users/hooks/useOrganizationUser';
+import { getIdentityProvider } from '../services/identityProviders';
+import { authenticationKeys } from '../utils/queryKeys';
+
+export function useIdentityProvider(id: string | undefined) {
+    return useQuery({
+        queryKey: authenticationKeys.detail(id ?? ''),
+        queryFn: () => getIdentityProvider(id!),
+        enabled: Boolean(id),
+    });
+}
+
+export function useIdentityProviderMappingCatalog() {
+    const groupsQuery = useQuery({
+        queryKey: orgGroupKeys.list(),
+        queryFn: listOrgGroups,
+    });
+    const environmentsQuery = useOrganizationEnvironments();
+    const organizationRolesQuery = useOrganizationRoleCatalog();
+    const environmentRolesQuery = useEnvironmentRoleCatalog();
+
+    function refetchCatalogs() {
+        void Promise.all([
+            groupsQuery.refetch(),
+            environmentsQuery.refetch(),
+            organizationRolesQuery.refetch(),
+            environmentRolesQuery.refetch(),
+        ]);
+    }
+
+    return { groupsQuery, environmentsQuery, organizationRolesQuery, environmentRolesQuery, refetchCatalogs };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProviderMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/hooks/useIdentityProviderMutations.ts
@@ -19,8 +19,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { saveOrgConsoleSettings } from '../../organization-settings/services/consoleSettings';
 import type { ConsoleSettings } from '../../organization-settings/types/consoleSettings';
 import { orgConsoleSettingsKeys } from '../../organization-settings/utils/queryKeys';
-import { createIdentityProvider, deleteIdentityProvider, updateActivatedIdentityProviders } from '../services/identityProviders';
-import type { NewIdentityProviderPayload } from '../types/identityProvider';
+import {
+    createIdentityProvider,
+    deleteIdentityProvider,
+    updateActivatedIdentityProviders,
+    updateIdentityProvider,
+} from '../services/identityProviders';
+import type { NewIdentityProviderPayload, UpdateIdentityProviderPayload } from '../types/identityProvider';
 import { authenticationKeys } from '../utils/queryKeys';
 
 async function invalidateAuthentication(queryClient: ReturnType<typeof useQueryClient>) {
@@ -37,10 +42,20 @@ export function useCreateIdentityProvider() {
     });
 }
 
+export function useUpdateIdentityProvider(id: string) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (payload: UpdateIdentityProviderPayload) => updateIdentityProvider(id, payload),
+        onSuccess: async () => {
+            await invalidateAuthentication(queryClient);
+        },
+    });
+}
+
 export function useDeleteIdentityProvider() {
     const queryClient = useQueryClient();
     return useMutation({
-        mutationFn: (id: string) => deleteIdentityProvider(id),
+        mutationFn: (providerId: string) => deleteIdentityProvider(providerId),
         onSuccess: async () => {
             await invalidateAuthentication(queryClient);
         },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/services/identityProviders.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/services/identityProviders.spec.ts
@@ -17,9 +17,11 @@
 import {
     createIdentityProvider,
     deleteIdentityProvider,
+    getIdentityProvider,
     listActivatedIdentityProviders,
     listIdentityProviders,
     updateActivatedIdentityProviders,
+    updateIdentityProvider,
 } from './identityProviders';
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
 import type { NewIdentityProviderPayload } from '../types/identityProvider';
@@ -73,5 +75,48 @@ describe('identityProviders service', () => {
     it('encodes special characters in the delete path', async () => {
         await deleteIdentityProvider('google/idp');
         expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/identities/google%2Fidp', { method: 'DELETE' });
+    });
+
+    it('GETs an identity provider and defaults missing mappings to empty arrays', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({
+            id: 'google-idp',
+            name: 'Google',
+            type: 'GOOGLE',
+            enabled: true,
+        });
+        await expect(getIdentityProvider('google/idp')).resolves.toEqual({
+            id: 'google-idp',
+            name: 'Google',
+            type: 'GOOGLE',
+            enabled: true,
+            groupMappings: [],
+            roleMappings: [],
+        });
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/identities/google%2Fidp');
+    });
+
+    it('PUTs an identity provider update payload', async () => {
+        mockApimFetchJsonOrg.mockResolvedValue({
+            id: 'google-idp',
+            name: 'Google SSO',
+            type: 'GOOGLE',
+            enabled: false,
+            groupMappings: [],
+            roleMappings: [],
+        });
+        const payload = {
+            name: 'Google SSO',
+            enabled: false,
+            emailRequired: true,
+            syncMappings: false,
+            configuration: { clientId: 'id', clientSecret: 'secret' },
+            groupMappings: [{ condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-1'] }],
+            roleMappings: [],
+        };
+        await updateIdentityProvider('google-idp', payload);
+        expect(mockApimFetchJsonOrg).toHaveBeenCalledWith('/configuration/identities/google-idp', {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/services/identityProviders.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/services/identityProviders.ts
@@ -20,6 +20,7 @@ import type {
     IdentityProviderActivation,
     IdentityProviderListItem,
     NewIdentityProviderPayload,
+    UpdateIdentityProviderPayload,
 } from '../types/identityProvider';
 
 export async function listIdentityProviders(): Promise<IdentityProviderListItem[]> {
@@ -46,4 +47,25 @@ export async function createIdentityProvider(payload: NewIdentityProviderPayload
 
 export async function deleteIdentityProvider(id: string): Promise<void> {
     await apimFetchJsonOrg<void>(`/configuration/identities/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}
+
+function withMappings(provider: IdentityProvider): IdentityProvider {
+    return {
+        ...provider,
+        groupMappings: provider.groupMappings ?? [],
+        roleMappings: provider.roleMappings ?? [],
+    };
+}
+
+export async function getIdentityProvider(id: string): Promise<IdentityProvider> {
+    const provider = await apimFetchJsonOrg<IdentityProvider>(`/configuration/identities/${encodeURIComponent(id)}`);
+    return withMappings(provider);
+}
+
+export async function updateIdentityProvider(id: string, payload: UpdateIdentityProviderPayload): Promise<IdentityProvider> {
+    const provider = await apimFetchJsonOrg<IdentityProvider>(`/configuration/identities/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+    });
+    return withMappings(provider);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/types/identityProvider.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/types/identityProvider.ts
@@ -61,6 +61,17 @@ export interface IdentityProviderConfiguration {
     userLogoutEndpoint?: string;
 }
 
+export interface GroupMapping {
+    condition: string;
+    groups: string[];
+}
+
+export interface RoleMapping {
+    condition: string;
+    organizations: string[];
+    environments: Record<string, string[]>;
+}
+
 export interface NewIdentityProviderPayload {
     name: string;
     description?: string;
@@ -72,6 +83,18 @@ export interface NewIdentityProviderPayload {
     userProfileMapping?: IdentityProviderUserProfileMapping;
 }
 
+export interface UpdateIdentityProviderPayload {
+    name: string;
+    description?: string;
+    enabled: boolean;
+    emailRequired: boolean;
+    syncMappings: boolean;
+    configuration: IdentityProviderConfiguration;
+    groupMappings: GroupMapping[];
+    roleMappings: RoleMapping[];
+    userProfileMapping?: IdentityProviderUserProfileMapping;
+}
+
 export interface IdentityProvider {
     id: string;
     name: string;
@@ -80,6 +103,8 @@ export interface IdentityProvider {
     enabled: boolean;
     configuration?: IdentityProviderConfiguration;
     userProfileMapping?: IdentityProviderUserProfileMapping;
+    groupMappings: GroupMapping[];
+    roleMappings: RoleMapping[];
     emailRequired?: boolean;
     syncMappings?: boolean;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderForm.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderForm.spec.ts
@@ -16,12 +16,17 @@
 
 import {
     emptyIdentityProviderForm,
+    emptyRoleMapping,
     formToCreatePayload,
+    formToUpdatePayload,
     formWithType,
     IDENTITY_PROVIDER_NAME_MAX,
     IDENTITY_PROVIDER_NAME_MIN,
+    identityProviderToForm,
+    isIdentityProviderFormDirty,
     validateIdentityProviderForm,
 } from './identityProviderForm';
+import type { IdentityProvider } from '../types/identityProvider';
 
 describe('identityProviderForm', () => {
     it('requires name, client id, and client secret', () => {
@@ -107,5 +112,254 @@ describe('identityProviderForm', () => {
         expect(formToCreatePayload(form).configuration.color).toBeUndefined();
         form.configuration.color = '#112233';
         expect(formToCreatePayload(form).configuration.color).toBe('#112233');
+    });
+
+    it('requires condition and groups once a group mapping is added', () => {
+        const form = { ...emptyIdentityProviderForm(), name: 'AM', groupMappings: [{ condition: '', groups: [] }] };
+        form.configuration.clientId = 'id';
+        form.configuration.clientSecret = 'secret';
+        form.configuration.serverURL = 'https://am.example';
+        form.configuration.domain = 'auth';
+        expect(validateIdentityProviderForm(form)).toEqual(
+            expect.objectContaining({
+                'groupMappings.0.condition': 'Condition is required.',
+                'groupMappings.0.groups': 'At least one group is required.',
+            }),
+        );
+    });
+
+    it('requires condition and organization roles once a role mapping is added', () => {
+        const form = {
+            ...emptyIdentityProviderForm(),
+            name: 'AM',
+            roleMappings: [emptyRoleMapping(['DEFAULT'])],
+        };
+        form.configuration.clientId = 'id';
+        form.configuration.clientSecret = 'secret';
+        form.configuration.serverURL = 'https://am.example';
+        form.configuration.domain = 'auth';
+        expect(validateIdentityProviderForm(form)).toEqual(
+            expect.objectContaining({
+                'roleMappings.0.condition': 'Condition is required.',
+                'roleMappings.0.organizations': 'At least one organization role is required.',
+            }),
+        );
+    });
+
+    it('maps a loaded provider onto the form and back onto the update payload', () => {
+        const provider: IdentityProvider = {
+            id: 'am-idp',
+            name: 'AM',
+            description: 'Org AM',
+            type: 'GRAVITEEIO_AM',
+            enabled: false,
+            emailRequired: false,
+            syncMappings: true,
+            configuration: {
+                clientId: 'id',
+                clientSecret: 'secret',
+                serverURL: 'https://am.example',
+                domain: 'auth',
+                scopes: ['openid'],
+                color: '#112233',
+            },
+            userProfileMapping: { id: 'sub', firstname: 'given_name' },
+            groupMappings: [{ condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-a'] }],
+            roleMappings: [
+                {
+                    condition: "{#jsonPath(#profile, '$.job')}",
+                    organizations: ['ADMIN'],
+                    environments: { DEFAULT: ['USER'] },
+                },
+            ],
+        };
+        const form = identityProviderToForm(provider, ['DEFAULT', 'prod']);
+        expect(form.roleMappings[0]?.environments).toEqual({ DEFAULT: ['USER'], prod: [] });
+        expect(formToUpdatePayload(form)).toEqual({
+            name: 'AM',
+            description: 'Org AM',
+            enabled: false,
+            emailRequired: false,
+            syncMappings: true,
+            configuration: {
+                clientId: 'id',
+                clientSecret: 'secret',
+                serverURL: 'https://am.example',
+                domain: 'auth',
+                scopes: ['openid'],
+                color: '#112233',
+            },
+            userProfileMapping: { id: 'sub', firstname: 'given_name' },
+            groupMappings: [{ condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-a'] }],
+            roleMappings: [
+                {
+                    condition: "{#jsonPath(#profile, '$.job')}",
+                    organizations: ['ADMIN'],
+                    environments: { DEFAULT: ['USER'], prod: [] },
+                },
+            ],
+        });
+        expect(isIdentityProviderFormDirty(form, form)).toBe(false);
+        expect(isIdentityProviderFormDirty({ ...form, name: 'AM 2' }, form)).toBe(true);
+    });
+
+    it('treats reordered group and role selections as the same payload', () => {
+        const form = identityProviderToForm(
+            {
+                id: 'am-idp',
+                name: 'AM',
+                type: 'GRAVITEEIO_AM',
+                enabled: true,
+                configuration: {
+                    clientId: 'id',
+                    clientSecret: 'secret',
+                    serverURL: 'https://am.example',
+                    domain: 'auth',
+                    scopes: ['openid', 'profile'],
+                },
+                groupMappings: [{ condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-a', 'group-b'] }],
+                roleMappings: [
+                    {
+                        condition: "{#jsonPath(#profile, '$.job')}",
+                        organizations: ['ADMIN', 'USER'],
+                        environments: { DEFAULT: ['USER', 'API_PUBLISHER'], prod: [] },
+                    },
+                ],
+            },
+            ['DEFAULT', 'prod'],
+        );
+        const reordered: typeof form = {
+            ...form,
+            groupMappings: [{ condition: form.groupMappings[0]!.condition, groups: ['group-b', 'group-a'] }],
+            roleMappings: [
+                {
+                    condition: form.roleMappings[0]!.condition,
+                    organizations: ['USER', 'ADMIN'],
+                    environments: { prod: [], DEFAULT: ['API_PUBLISHER', 'USER'] },
+                },
+            ],
+        };
+        expect(isIdentityProviderFormDirty(reordered, form)).toBe(false);
+    });
+
+    it('treats reordered scopes as a dirty payload', () => {
+        const form = identityProviderToForm({
+            id: 'am-idp',
+            name: 'AM',
+            type: 'GRAVITEEIO_AM',
+            enabled: true,
+            configuration: {
+                clientId: 'id',
+                clientSecret: 'secret',
+                serverURL: 'https://am.example',
+                domain: 'auth',
+                scopes: ['openid', 'profile'],
+            },
+            groupMappings: [],
+            roleMappings: [],
+        });
+        expect(
+            isIdentityProviderFormDirty({ ...form, configuration: { ...form.configuration, scopes: ['profile', 'openid'] } }, form),
+        ).toBe(true);
+    });
+
+    it('rejects duplicate mapping conditions', () => {
+        const form = emptyIdentityProviderForm();
+        form.name = 'AM';
+        form.configuration.clientId = 'id';
+        form.configuration.clientSecret = 'secret';
+        form.configuration.serverURL = 'https://am.example';
+        form.configuration.domain = 'auth';
+        form.groupMappings = [
+            { condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-a'] },
+            { condition: "{#jsonPath(#profile, '$.email')}", groups: ['group-b'] },
+        ];
+        form.roleMappings = [
+            { condition: "{#jsonPath(#profile, '$.job')}", organizations: ['ADMIN'], environments: { DEFAULT: [] } },
+            { condition: "{#jsonPath(#profile, '$.job')}", organizations: ['USER'], environments: { DEFAULT: [] } },
+        ];
+        expect(validateIdentityProviderForm(form)).toEqual(
+            expect.objectContaining({
+                'groupMappings.0.condition': 'Condition must be unique.',
+                'groupMappings.1.condition': 'Condition must be unique.',
+                'roleMappings.0.condition': 'Condition must be unique.',
+                'roleMappings.1.condition': 'Condition must be unique.',
+            }),
+        );
+    });
+
+    it('trims client secret on create and update payloads', () => {
+        const form = formWithType(emptyIdentityProviderForm(), 'GOOGLE');
+        form.name = 'Google SSO';
+        form.configuration.clientId = 'id';
+        form.configuration.clientSecret = '  secret  ';
+        expect(formToCreatePayload(form).configuration.clientSecret).toBe('secret');
+        expect(formToUpdatePayload(form).configuration.clientSecret).toBe('secret');
+    });
+
+    it('omits empty user profile mapping on update for Google', () => {
+        const form = identityProviderToForm(
+            {
+                id: 'google-idp',
+                name: 'Google',
+                type: 'GOOGLE',
+                enabled: true,
+                configuration: { clientId: 'id', clientSecret: 'secret' },
+                groupMappings: [],
+                roleMappings: [],
+            },
+            ['DEFAULT'],
+        );
+        expect(formToUpdatePayload(form).userProfileMapping).toBeUndefined();
+    });
+
+    it('includes user profile mapping on update for Google even though create omits it', () => {
+        const form = identityProviderToForm(
+            {
+                id: 'google-idp',
+                name: 'Google',
+                type: 'GOOGLE',
+                enabled: true,
+                configuration: { clientId: 'id', clientSecret: 'secret' },
+                userProfileMapping: { id: 'email', firstname: 'given_name' },
+                groupMappings: [],
+                roleMappings: [],
+            },
+            ['DEFAULT'],
+        );
+        expect(formToCreatePayload(form).userProfileMapping).toBeUndefined();
+        expect(formToUpdatePayload(form).userProfileMapping).toEqual({ id: 'email', firstname: 'given_name' });
+    });
+
+    it('includes OIDC endpoints and user profile mapping on update', () => {
+        const form = identityProviderToForm({
+            id: 'oidc-idp',
+            name: 'Okta',
+            type: 'OIDC',
+            enabled: true,
+            configuration: {
+                clientId: 'id',
+                clientSecret: 'secret',
+                tokenEndpoint: 'https://okta.example/token',
+                authorizeEndpoint: 'https://okta.example/authorize',
+                userInfoEndpoint: 'https://okta.example/userinfo',
+                scopes: ['openid'],
+            },
+            userProfileMapping: { id: 'sub', email: 'email' },
+            groupMappings: [],
+            roleMappings: [],
+        });
+        expect(formToUpdatePayload(form)).toEqual(
+            expect.objectContaining({
+                name: 'Okta',
+                userProfileMapping: { id: 'sub', email: 'email' },
+                configuration: expect.objectContaining({
+                    tokenEndpoint: 'https://okta.example/token',
+                    authorizeEndpoint: 'https://okta.example/authorize',
+                    userInfoEndpoint: 'https://okta.example/userinfo',
+                    scopes: ['openid'],
+                }),
+            }),
+        );
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderForm.ts
@@ -16,14 +16,29 @@
 
 import { DEFAULT_USER_PROFILE, hasUserProfileMapping } from './identityProviderDisplay';
 import type {
+    GroupMapping,
+    IdentityProvider,
     IdentityProviderConfiguration,
     IdentityProviderType,
     IdentityProviderUserProfileMapping,
     NewIdentityProviderPayload,
+    RoleMapping,
+    UpdateIdentityProviderPayload,
 } from '../types/identityProvider';
 
 export const IDENTITY_PROVIDER_NAME_MIN = 2;
 export const IDENTITY_PROVIDER_NAME_MAX = 50;
+
+export interface IdentityProviderGroupMappingForm {
+    condition: string;
+    groups: string[];
+}
+
+export interface IdentityProviderRoleMappingForm {
+    condition: string;
+    organizations: string[];
+    environments: Record<string, string[]>;
+}
 
 export interface IdentityProviderFormState {
     type: IdentityProviderType;
@@ -34,6 +49,8 @@ export interface IdentityProviderFormState {
     syncMappings: boolean;
     configuration: IdentityProviderConfiguration;
     userProfileMapping: IdentityProviderUserProfileMapping;
+    groupMappings: IdentityProviderGroupMappingForm[];
+    roleMappings: IdentityProviderRoleMappingForm[];
 }
 
 export function emptyConfiguration(type: IdentityProviderType): IdentityProviderConfiguration {
@@ -56,6 +73,18 @@ export function emptyConfiguration(type: IdentityProviderType): IdentityProvider
     return { clientId: '', clientSecret: '' };
 }
 
+export function emptyGroupMapping(): IdentityProviderGroupMappingForm {
+    return { condition: '', groups: [] };
+}
+
+export function emptyRoleMapping(environmentIds: readonly string[]): IdentityProviderRoleMappingForm {
+    return {
+        condition: '',
+        organizations: [],
+        environments: Object.fromEntries(environmentIds.map(environmentId => [environmentId, []])),
+    };
+}
+
 export function emptyIdentityProviderForm(): IdentityProviderFormState {
     return {
         type: 'GRAVITEEIO_AM',
@@ -66,6 +95,8 @@ export function emptyIdentityProviderForm(): IdentityProviderFormState {
         syncMappings: false,
         configuration: emptyConfiguration('GRAVITEEIO_AM'),
         userProfileMapping: { ...DEFAULT_USER_PROFILE },
+        groupMappings: [],
+        roleMappings: [],
     };
 }
 
@@ -104,7 +135,45 @@ export function validateIdentityProviderForm(form: IdentityProviderFormState): R
         if (!form.userProfileMapping.id.trim()) errors.profileId = 'ID is required.';
     }
 
+    form.groupMappings.forEach((mapping, index) => {
+        if (!mapping.condition.trim()) errors[`groupMappings.${index}.condition`] = 'Condition is required.';
+        if (mapping.groups.length === 0) errors[`groupMappings.${index}.groups`] = 'At least one group is required.';
+    });
+    addDuplicateConditionErrors(form.groupMappings, 'groupMappings', errors);
+
+    form.roleMappings.forEach((mapping, index) => {
+        if (!mapping.condition.trim()) errors[`roleMappings.${index}.condition`] = 'Condition is required.';
+        if (mapping.organizations.length === 0)
+            errors[`roleMappings.${index}.organizations`] = 'At least one organization role is required.';
+    });
+    addDuplicateConditionErrors(form.roleMappings, 'roleMappings', errors);
+
     return errors;
+}
+
+function addDuplicateConditionErrors(
+    mappings: readonly { condition: string }[],
+    keyPrefix: 'groupMappings' | 'roleMappings',
+    errors: Record<string, string>,
+) {
+    const indexesByCondition = new Map<string, number[]>();
+    mappings.forEach((mapping, index) => {
+        const condition = mapping.condition.trim();
+        if (!condition) {
+            return;
+        }
+        const indexes = indexesByCondition.get(condition) ?? [];
+        indexes.push(index);
+        indexesByCondition.set(condition, indexes);
+    });
+    for (const indexes of indexesByCondition.values()) {
+        if (indexes.length < 2) {
+            continue;
+        }
+        for (const index of indexes) {
+            errors[`${keyPrefix}.${index}.condition`] = 'Condition must be unique.';
+        }
+    }
 }
 
 function optionalTrimmed(value: string | undefined): string | undefined {
@@ -119,7 +188,7 @@ function optionalHexColor(value: string | undefined): string | undefined {
 
 function compactConfiguration(form: IdentityProviderFormState): IdentityProviderConfiguration {
     const clientId = form.configuration.clientId.trim();
-    const clientSecret = form.configuration.clientSecret;
+    const clientSecret = form.configuration.clientSecret.trim();
     const color = optionalHexColor(form.configuration.color);
     if (form.type === 'GOOGLE' || form.type === 'GITHUB') {
         return { clientId, clientSecret };
@@ -158,13 +227,133 @@ export function formToCreatePayload(form: IdentityProviderFormState): NewIdentit
         configuration: compactConfiguration(form),
     };
     if (hasUserProfileMapping(form.type)) {
-        payload.userProfileMapping = {
-            id: form.userProfileMapping.id.trim(),
-            firstname: optionalTrimmed(form.userProfileMapping.firstname),
-            lastname: optionalTrimmed(form.userProfileMapping.lastname),
-            email: optionalTrimmed(form.userProfileMapping.email),
-            picture: optionalTrimmed(form.userProfileMapping.picture),
-        };
+        payload.userProfileMapping = compactUserProfileMapping(form);
     }
     return payload;
+}
+
+function compactUserProfileMapping(form: IdentityProviderFormState): IdentityProviderUserProfileMapping {
+    return {
+        id: form.userProfileMapping.id.trim(),
+        firstname: optionalTrimmed(form.userProfileMapping.firstname),
+        lastname: optionalTrimmed(form.userProfileMapping.lastname),
+        email: optionalTrimmed(form.userProfileMapping.email),
+        picture: optionalTrimmed(form.userProfileMapping.picture),
+    };
+}
+
+function compactGroupMappings(form: IdentityProviderFormState): GroupMapping[] {
+    return form.groupMappings.map(mapping => ({
+        condition: mapping.condition.trim(),
+        groups: [...mapping.groups],
+    }));
+}
+
+function compactRoleMappings(form: IdentityProviderFormState): RoleMapping[] {
+    return form.roleMappings.map(mapping => ({
+        condition: mapping.condition.trim(),
+        organizations: [...mapping.organizations],
+        environments: Object.fromEntries(Object.entries(mapping.environments).map(([environmentId, roles]) => [environmentId, [...roles]])),
+    }));
+}
+
+export function formToUpdatePayload(form: IdentityProviderFormState): UpdateIdentityProviderPayload {
+    const created = formToCreatePayload(form);
+    const payload: UpdateIdentityProviderPayload = {
+        name: created.name,
+        description: created.description,
+        enabled: created.enabled,
+        emailRequired: created.emailRequired,
+        syncMappings: created.syncMappings,
+        configuration: created.configuration,
+        groupMappings: compactGroupMappings(form),
+        roleMappings: compactRoleMappings(form),
+    };
+    const userProfileMapping = userProfileMappingForUpdate(form);
+    if (userProfileMapping) {
+        payload.userProfileMapping = userProfileMapping;
+    }
+    return payload;
+}
+
+function sortedIds(ids: readonly string[]): string[] {
+    return [...ids].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeMappingsForCompare(payload: UpdateIdentityProviderPayload): UpdateIdentityProviderPayload {
+    return {
+        ...payload,
+        groupMappings: payload.groupMappings.map(mapping => ({
+            condition: mapping.condition,
+            groups: sortedIds(mapping.groups),
+        })),
+        roleMappings: payload.roleMappings.map(mapping => ({
+            condition: mapping.condition,
+            organizations: sortedIds(mapping.organizations),
+            environments: Object.fromEntries(
+                Object.entries(mapping.environments)
+                    .sort(([left], [right]) => left.localeCompare(right))
+                    .map(([environmentId, roles]) => [environmentId, sortedIds(roles)]),
+            ),
+        })),
+    };
+}
+
+export function isIdentityProviderFormDirty(current: IdentityProviderFormState, initial: IdentityProviderFormState): boolean {
+    return (
+        JSON.stringify(normalizeMappingsForCompare(formToUpdatePayload(current))) !==
+        JSON.stringify(normalizeMappingsForCompare(formToUpdatePayload(initial)))
+    );
+}
+
+function userProfileMappingForUpdate(form: IdentityProviderFormState): IdentityProviderUserProfileMapping | undefined {
+    if (hasUserProfileMapping(form.type)) {
+        return compactUserProfileMapping(form);
+    }
+    const compacted = compactUserProfileMapping(form);
+    if (!compacted.id && !compacted.firstname && !compacted.lastname && !compacted.email && !compacted.picture) {
+        return undefined;
+    }
+    return compacted;
+}
+
+export function identityProviderToForm(provider: IdentityProvider, environmentIds: readonly string[] = []): IdentityProviderFormState {
+    const defaults = emptyConfiguration(provider.type);
+    const mappingEnvIds = [
+        ...new Set([...environmentIds, ...provider.roleMappings.flatMap(mapping => Object.keys(mapping.environments ?? {}))]),
+    ];
+    return {
+        type: provider.type,
+        name: provider.name,
+        description: provider.description ?? '',
+        enabled: provider.enabled,
+        emailRequired: provider.emailRequired ?? true,
+        syncMappings: provider.syncMappings ?? false,
+        configuration: {
+            ...defaults,
+            ...provider.configuration,
+            clientId: provider.configuration?.clientId ?? '',
+            clientSecret: provider.configuration?.clientSecret ?? '',
+            scopes: provider.configuration?.scopes ?? defaults.scopes,
+            color: provider.configuration?.color ?? '',
+        },
+        userProfileMapping: {
+            id: provider.userProfileMapping?.id ?? (hasUserProfileMapping(provider.type) ? DEFAULT_USER_PROFILE.id : ''),
+            firstname: provider.userProfileMapping?.firstname ?? '',
+            lastname: provider.userProfileMapping?.lastname ?? '',
+            email: provider.userProfileMapping?.email ?? '',
+            picture: provider.userProfileMapping?.picture ?? '',
+        },
+        groupMappings: provider.groupMappings.map(mapping => ({
+            condition: mapping.condition ?? '',
+            groups: [...(mapping.groups ?? [])],
+        })),
+        roleMappings: provider.roleMappings.map(mapping => ({
+            condition: mapping.condition ?? '',
+            organizations: [...(mapping.organizations ?? [])],
+            environments: Object.fromEntries(
+                mappingEnvIds.map(environmentId => [environmentId, [...(mapping.environments?.[environmentId] ?? [])]]),
+            ),
+        })),
+    };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/authentication/utils/identityProviderPermissions.ts
@@ -16,6 +16,7 @@
 
 export const ORGANIZATION_IDENTITY_PROVIDER_READ_PERMISSION = 'organization-identity_provider-r' as const;
 export const ORGANIZATION_IDENTITY_PROVIDER_CREATE_PERMISSION = 'organization-identity_provider-c' as const;
+export const ORGANIZATION_IDENTITY_PROVIDER_UPDATE_PERMISSION = 'organization-identity_provider-u' as const;
 export const ORGANIZATION_IDENTITY_PROVIDER_DELETE_PERMISSION = 'organization-identity_provider-d' as const;
 export const ORGANIZATION_IDENTITY_PROVIDER_ACTIVATION_UPDATE_PERMISSION = 'organization-identity_provider_activation-u' as const;
 export const ORGANIZATION_SETTINGS_UPDATE_PERMISSION = 'organization-settings-u' as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.spec.tsx
@@ -54,6 +54,11 @@ beforeAll(() => {
             dispatchEvent: jest.fn(),
         })),
     });
+    global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    } as typeof ResizeObserver;
 });
 
 describe('UserProfileCard', () => {
@@ -79,5 +84,28 @@ describe('UserProfileCard', () => {
         expect(copyTextToClipboardWithNotifyHandler).toHaveBeenCalledWith('anna.schmidt@company.com', 'Copied to clipboard');
         expect(copyTextToClipboardWithNotifyHandler).toHaveBeenCalledWith('ldap', 'Copied to clipboard');
         expect(copyTextToClipboardWithNotifyHandler).toHaveBeenCalledWith('Operations', 'Copied to clipboard');
+    });
+
+    it('shows three organization roles then an ellipsis, with the full list on hover', async () => {
+        const user = userEvent.setup();
+        renderWithGraphene(
+            <UserProfileCard
+                user={{
+                    ...USER,
+                    roles: [
+                        { id: 'org-2', name: 'ORGANIZATION_2', scope: 'ORGANIZATION' },
+                        { id: 'org', name: 'ORG', scope: 'ORGANIZATION' },
+                        { id: 'org-1', name: 'ORGANIZATION_1', scope: 'ORGANIZATION' },
+                        { id: 'user', name: 'USER', scope: 'ORGANIZATION' },
+                    ],
+                }}
+            />,
+        );
+
+        expect(screen.getByText('ORGANIZATION_2, ORG, ORGANIZATION_1...')).toBeTruthy();
+        expect(screen.queryByText('ORGANIZATION_2, ORG, ORGANIZATION_1, USER')).toBeNull();
+
+        await user.hover(screen.getByText('ORGANIZATION_2, ORG, ORGANIZATION_1...'));
+        expect((await screen.findByRole('tooltip')).textContent).toBe('ORGANIZATION_2, ORG, ORGANIZATION_1, USER');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserProfileCard.tsx
@@ -18,8 +18,8 @@ import { CalendarIcon, ClockIcon } from '@gravitee/graphene-core/icons';
 import type { ReactNode } from 'react';
 
 import { CopyableProfileValue } from './CopyableProfileValue';
-import { ROLE_LIST_TOOLTIP_CONTENT_CLASS, RoleListTooltipContent } from './RoleListTooltip';
 import { UserAvatar } from './UserAvatar';
+import { TRUNCATED_LIST_TOOLTIP_CONTENT_CLASS, TruncatedListTooltipContent } from '../../../shared/components/TruncatedListTooltip';
 import type { OrganizationUser } from '../types/user';
 import {
     formatCustomFieldCopyValue,
@@ -115,8 +115,8 @@ export function UserProfileCard({ user, headerActions }: UserProfileCardProps) {
                                     <TooltipTrigger asChild>
                                         <span className="cursor-default">{roleSummary.display}</span>
                                     </TooltipTrigger>
-                                    <TooltipContent side="bottom" align="start" className={ROLE_LIST_TOOLTIP_CONTENT_CLASS}>
-                                        <RoleListTooltipContent labels={organizationRoleLabels} />
+                                    <TooltipContent side="bottom" align="start" className={TRUNCATED_LIST_TOOLTIP_CONTENT_CLASS}>
+                                        <TruncatedListTooltipContent labels={organizationRoleLabels} />
                                     </TooltipContent>
                                 </Tooltip>
                             </TooltipProvider>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.spec.tsx
@@ -17,8 +17,8 @@ import { renderWithGraphene } from '@gravitee/graphene-core/testing';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { RoleListTooltipContent } from './RoleListTooltip';
 import { UserRoleMultiSelect } from './UserRoleMultiSelect';
+import { TruncatedListTooltipContent } from '../../../shared/components/TruncatedListTooltip';
 
 const OPTIONS = [
     { value: 'admin', label: 'ADMIN' },
@@ -151,10 +151,49 @@ describe('UserRoleMultiSelect', () => {
         expect(screen.getByText('No organization roles')).toBeTruthy();
     });
 
+    it('shows the first three selected roles and the full list on hover', async () => {
+        const user = userEvent.setup();
+        const options = [
+            { value: 'org-2', label: 'ORGANIZATION_2' },
+            { value: 'org', label: 'ORG' },
+            { value: 'org-1', label: 'ORGANIZATION_1' },
+            { value: 'user', label: 'USER' },
+        ];
+
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={options}
+                selectedValues={['org-2', 'org', 'org-1', 'user']}
+                onSelectedValuesChange={jest.fn()}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        expect(screen.getByText('ORGANIZATION_2, ORG, ORGANIZATION_1...')).toBeTruthy();
+        expect(screen.queryByText('ORGANIZATION_2, ORG, ORGANIZATION_1, USER')).toBeNull();
+
+        await user.hover(screen.getByText('ORGANIZATION_2, ORG, ORGANIZATION_1...'));
+        expect((await screen.findByRole('tooltip')).textContent).toBe('ORGANIZATION_2, ORG, ORGANIZATION_1, USER');
+    });
+
+    it('shows every selected role when there are three or fewer', () => {
+        renderWithGraphene(
+            <UserRoleMultiSelect
+                options={OPTIONS}
+                selectedValues={['admin', 'publisher']}
+                onSelectedValuesChange={jest.fn()}
+                ariaLabel="Organization roles"
+            />,
+        );
+
+        expect(screen.getByText('ADMIN, API_PUBLISHER')).toBeTruthy();
+        expect(screen.queryByText('ADMIN, API_PUBLISHER...')).toBeNull();
+    });
+
     it('renders a comma-separated tooltip with every role name intact', () => {
         const labels = ['Admin', 'ORG_TEST1', 'ORG_TEST10', 'AAASKLNG_LSDJGH_OSRGUH_OURGHS_OUGOSUHG_SOUHFOSDUHAOUGI', 'User'];
 
-        renderWithGraphene(<RoleListTooltipContent labels={labels} />);
+        renderWithGraphene(<TruncatedListTooltipContent labels={labels} />);
 
         expect(screen.getByText(labels.join(', '))).toBeTruthy();
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/components/UserRoleMultiSelect.tsx
@@ -13,21 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    Button,
-    cn,
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from '@gravitee/graphene-core';
+import { Button, cn, Popover, PopoverContent, PopoverTrigger, TooltipProvider } from '@gravitee/graphene-core';
 import { CheckIcon, ChevronDownIcon } from '@gravitee/graphene-core/icons';
 import { useEffect, useMemo, useState } from 'react';
 
-import { ROLE_LIST_TOOLTIP_CONTENT_CLASS, RoleListTooltipContent } from './RoleListTooltip';
+import { TruncatedDisplayText } from '../../../shared/components/TruncatedDisplayText';
+import { formatTruncatedRoleSummary } from '../utils/userDisplay';
 
 export interface RoleMultiSelectOption {
     value: string;
@@ -43,35 +34,6 @@ interface UserRoleMultiSelectProps {
     readonly disabled?: boolean;
     readonly emptyMessage?: string;
     readonly className?: string;
-}
-
-function RoleDisplayText({
-    displayText,
-    isPlaceholder,
-    showTooltip,
-    labels,
-}: Readonly<{
-    displayText: string;
-    isPlaceholder: boolean;
-    showTooltip: boolean;
-    labels: string[];
-}>) {
-    const textClassName = cn('min-w-0 flex-1 truncate text-left', isPlaceholder && 'text-muted-foreground');
-
-    if (!showTooltip) {
-        return <span className={textClassName}>{displayText}</span>;
-    }
-
-    return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <span className={textClassName}>{displayText}</span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="start" className={ROLE_LIST_TOOLTIP_CONTENT_CLASS}>
-                <RoleListTooltipContent labels={labels} />
-            </TooltipContent>
-        </Tooltip>
-    );
 }
 
 export function UserRoleMultiSelect({
@@ -95,8 +57,12 @@ export function UserRoleMultiSelect({
         () => options.filter(option => draftValues.includes(option.value)).map(option => option.label),
         [draftValues, options],
     );
-    const displayText = selectedLabels.length === 0 ? placeholder : selectedLabels.join(', ');
-    const showTooltip = selectedLabels.length > 0 && !popoverOpen;
+    const roleSummary = formatTruncatedRoleSummary(
+        selectedLabels.map(name => ({ name })),
+        3,
+    );
+    const displayText = selectedLabels.length === 0 ? placeholder : roleSummary.display;
+    const showTooltip = roleSummary.truncated && !popoverOpen;
 
     function toggleRole(roleId: string) {
         setDraftValues(current => (current.includes(roleId) ? current.filter(value => value !== roleId) : [...current, roleId]));
@@ -127,7 +93,7 @@ export function UserRoleMultiSelect({
                         disabled={disabled}
                         className={cn('h-10 w-72 max-w-full justify-between gap-2 px-3 font-normal', className)}
                     >
-                        <RoleDisplayText
+                        <TruncatedDisplayText
                             displayText={displayText}
                             isPlaceholder={selectedLabels.length === 0}
                             showTooltip={showTooltip}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userDisplay.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { formatTruncatedNameSummary } from '../../../shared/utils/truncatedList';
 import type { OrganizationUser } from '../types/user';
+
 export { isValidEmail } from '../../../shared/utils/email';
 
 /** Strips HTML tags from user-provided name fields before submit. */
@@ -41,19 +43,7 @@ export function formatTruncatedRoleSummary(
     roles: { name?: string; scope?: string }[] | undefined,
     visibleCount = 3,
 ): { display: string; full: string; truncated: boolean } {
-    const names = roleDisplayNames(roles, { fallbackToId: true });
-    if (names.length === 0) {
-        return { display: '—', full: '—', truncated: false };
-    }
-    const full = names.join(', ');
-    if (names.length <= visibleCount) {
-        return { display: full, full, truncated: false };
-    }
-    return {
-        display: `${names.slice(0, visibleCount).join(', ')}...`,
-        full,
-        truncated: true,
-    };
+    return formatTruncatedNameSummary(roleDisplayNames(roles, { fallbackToId: true }), visibleCount);
 }
 
 export function formatUserStatus(status: string | undefined): string {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.spec.tsx
@@ -206,7 +206,18 @@ describe('AuthenticationPage', () => {
         renderPage();
         expect(screen.queryByRole('heading', { name: 'Authentication' })).not.toBeNull();
         expect(switchHarness({ name: 'Show login form on management console' }).getElement()).not.toBeNull();
+        expect(screen.getByRole('switch', { name: 'Show login form on management console' }).getAttribute('aria-checked')).toBe('true');
         expect(screen.queryByRole('heading', { name: 'Identity Providers' })).not.toBeNull();
+    });
+
+    it('treats a missing local-login setting as enabled', () => {
+        mockUseOrgConsoleSettings.mockReturnValue(
+            makeSettingsResult({
+                data: { authentication: { google: { clientId: 'keep-me' } } },
+            }),
+        );
+        renderPage();
+        expect(screen.getByRole('switch', { name: 'Show login form on management console' }).getAttribute('aria-checked')).toBe('true');
     });
 
     it('navigates to the create page from the add button', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.tsx
@@ -41,6 +41,7 @@ import { toIdentityProviderRows } from '../features/authentication/utils/identit
 import { useOrgConsoleSettings } from '../features/organization-settings/hooks/useOrgConsoleSettings';
 import type { ConsoleSettings } from '../features/organization-settings/types/consoleSettings';
 import { ConfirmDialog } from '../shared/components/ConfirmDialog';
+import { isLocalLoginEnabled } from '../shared/console-settings';
 import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
 import { notify } from '../shared/notify';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
@@ -85,7 +86,7 @@ export function AuthenticationPage() {
         [activationsLoaded, activationsQuery.data, providersQuery.data],
     );
     const hasActivatedIdp = activationsLoaded && rows.some(row => row.activated === true);
-    const localLoginEnabled = settings?.authentication?.localLogin?.enabled === true;
+    const localLoginEnabled = isLocalLoginEnabled(settings);
     const localLoginSystemReadonly = isLocalLoginReadonly(settings?.metadata?.readonly);
     const providersFailed = providersQuery.isError && !isForbidden;
     const activationsFailed = activationsQuery.isError;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.spec.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buttonHarness, renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { EditIdentityProviderPage } from './EditIdentityProviderPage';
+import { useIdentityProvider, useIdentityProviderMappingCatalog } from '../features/authentication/hooks/useIdentityProvider';
+import type { IdentityProvider } from '../features/authentication/types/identityProvider';
+import { ApimApiError } from '../shared/api/apimClient';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: () => true,
+}));
+
+jest.mock('../features/authentication/hooks/useIdentityProvider');
+jest.mock('../shared/hooks/useForbiddenResourceRedirect');
+
+let mockFormDirty = false;
+
+jest.mock('../features/authentication/components/IdentityProviderEditForm', () => {
+    const { useEffect } = jest.requireActual('react');
+    return {
+        IdentityProviderEditForm: ({
+            mappingsDisabled,
+            onDirtyChange,
+        }: {
+            mappingsDisabled?: boolean;
+            onDirtyChange?: (dirty: boolean) => void;
+        }) => {
+            useEffect(() => {
+                onDirtyChange?.(mockFormDirty);
+            }, [onDirtyChange]);
+            return <div data-testid="identity-provider-edit-form" data-mappings-disabled={String(Boolean(mappingsDisabled))} />;
+        },
+    };
+});
+
+const mockUseIdentityProvider = jest.mocked(useIdentityProvider);
+const mockUseIdentityProviderMappingCatalog = jest.mocked(useIdentityProviderMappingCatalog);
+
+const PROVIDER: IdentityProvider = {
+    id: 'google-idp',
+    name: 'Google',
+    type: 'GOOGLE',
+    enabled: true,
+    configuration: { clientId: 'id', clientSecret: 'secret' },
+    groupMappings: [],
+    roleMappings: [],
+};
+
+function emptyCatalog() {
+    return {
+        groupsQuery: { data: [], isLoading: false, isError: false },
+        environmentsQuery: { data: [], isLoading: false, isError: false },
+        organizationRolesQuery: { data: [], isLoading: false, isError: false },
+        environmentRolesQuery: { data: [], isLoading: false, isError: false },
+        refetchCatalogs: jest.fn(),
+    } as unknown as ReturnType<typeof useIdentityProviderMappingCatalog>;
+}
+
+function renderPage() {
+    return renderWithGraphene(
+        <MemoryRouter initialEntries={['/authentication/google-idp']}>
+            <Routes>
+                <Route path="/authentication/:identityProviderId" element={<EditIdentityProviderPage />} />
+                <Route path="/authentication" element={<div data-testid="authentication-list" />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('EditIdentityProviderPage', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+    });
+
+    beforeEach(() => {
+        mockFormDirty = false;
+        mockUseIdentityProviderMappingCatalog.mockReturnValue(emptyCatalog());
+        jest.mocked(useForbiddenResourceRedirect).mockImplementation(() => undefined);
+    });
+
+    it('renders the edit form for a loaded provider', () => {
+        mockUseIdentityProvider.mockReturnValue({
+            data: PROVIDER,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useIdentityProvider>);
+        renderPage();
+        expect(screen.getByRole('heading', { name: 'Update Google identity provider' })).not.toBeNull();
+        expect(screen.getByTestId('identity-provider-edit-form')).not.toBeNull();
+        expect(screen.getByTestId('identity-provider-edit-form').getAttribute('data-mappings-disabled')).toBe('false');
+    });
+
+    it('waits for environments before mounting the form', () => {
+        mockUseIdentityProvider.mockReturnValue({
+            data: PROVIDER,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useIdentityProvider>);
+        mockUseIdentityProviderMappingCatalog.mockReturnValue({
+            ...emptyCatalog(),
+            environmentsQuery: { data: undefined, isLoading: true, isError: false },
+        } as ReturnType<typeof useIdentityProviderMappingCatalog>);
+        renderPage();
+        expect(screen.queryByTestId('identity-provider-edit-form')).toBeNull();
+        expect(screen.queryByRole('heading', { name: 'Update Google identity provider' })).toBeNull();
+    });
+
+    it('mounts the form while group and role catalogs are still loading', () => {
+        mockUseIdentityProvider.mockReturnValue({
+            data: PROVIDER,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useIdentityProvider>);
+        mockUseIdentityProviderMappingCatalog.mockReturnValue({
+            ...emptyCatalog(),
+            groupsQuery: { data: undefined, isLoading: true, isError: false },
+            organizationRolesQuery: { data: undefined, isLoading: true, isError: false },
+            environmentRolesQuery: { data: undefined, isLoading: true, isError: false },
+        } as ReturnType<typeof useIdentityProviderMappingCatalog>);
+        renderPage();
+        expect(screen.getByTestId('identity-provider-edit-form')).not.toBeNull();
+        expect(screen.getByTestId('identity-provider-edit-form').getAttribute('data-mappings-disabled')).toBe('true');
+        expect(screen.queryByText('Groups and roles could not be loaded')).toBeNull();
+    });
+
+    it('shows a not-found message when the provider cannot be loaded', () => {
+        mockUseIdentityProvider.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(404, 'Not found'),
+        } as unknown as ReturnType<typeof useIdentityProvider>);
+        renderPage();
+        expect(screen.getByText('Identity provider not found or failed to load.')).not.toBeNull();
+        expect(screen.queryByTestId('identity-provider-edit-form')).toBeNull();
+    });
+
+    it('redirects when the provider request is forbidden', () => {
+        mockUseIdentityProvider.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as unknown as ReturnType<typeof useIdentityProvider>);
+        renderPage();
+        expect(useForbiddenResourceRedirect).toHaveBeenCalledWith(expect.objectContaining({ isForbidden: true, redirectTo: '..' }));
+        expect(screen.queryByTestId('identity-provider-edit-form')).toBeNull();
+    });
+
+    it('keeps the edit form available when mapping catalogs fail', async () => {
+        const refetchCatalogs = jest.fn();
+        mockUseIdentityProvider.mockReturnValue({
+            data: PROVIDER,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useIdentityProvider>);
+        mockUseIdentityProviderMappingCatalog.mockReturnValue({
+            ...emptyCatalog(),
+            groupsQuery: { data: undefined, isLoading: false, isError: true },
+            refetchCatalogs,
+        } as unknown as ReturnType<typeof useIdentityProviderMappingCatalog>);
+        renderPage();
+        expect(screen.getByRole('heading', { name: 'Update Google identity provider' })).not.toBeNull();
+        expect(screen.getByTestId('identity-provider-edit-form')).not.toBeNull();
+        expect(screen.getByTestId('identity-provider-edit-form').getAttribute('data-mappings-disabled')).toBe('true');
+        expect(screen.getByText('Groups and roles could not be loaded')).not.toBeNull();
+        await buttonHarness({ name: 'Retry' }).click();
+        expect(refetchCatalogs).toHaveBeenCalledTimes(1);
+    });
+
+    it('asks to confirm before leaving a dirty form from Back', async () => {
+        mockFormDirty = true;
+        mockUseIdentityProvider.mockReturnValue({
+            data: PROVIDER,
+            isLoading: false,
+            isError: false,
+            error: null,
+        } as ReturnType<typeof useIdentityProvider>);
+        renderPage();
+        await buttonHarness({ name: 'Back to Authentication' }).click();
+        expect(screen.getByText('Unsaved changes')).not.toBeNull();
+        expect(screen.queryByTestId('authentication-list')).toBeNull();
+        await buttonHarness({ name: 'Leave' }).click();
+        expect(screen.getByTestId('authentication-list')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, PageFocused, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { IdentityProviderCatalogLoadError } from '../features/authentication/components/IdentityProviderCatalogLoadError';
+import { IdentityProviderEditForm } from '../features/authentication/components/IdentityProviderEditForm';
+import type { IdentityProviderMappingOption } from '../features/authentication/components/IdentityProviderMappingMultiSelect';
+import { useIdentityProvider, useIdentityProviderMappingCatalog } from '../features/authentication/hooks/useIdentityProvider';
+import { identityProviderTypeLabel } from '../features/authentication/utils/identityProviderDisplay';
+import { ORGANIZATION_IDENTITY_PROVIDER_UPDATE_PERMISSION } from '../features/authentication/utils/identityProviderPermissions';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+function toRoleOptions(roles: readonly { id: string; name?: string }[]): IdentityProviderMappingOption[] {
+    return roles.map(role => {
+        const name = role.name?.trim() || role.id;
+        return { id: name, name };
+    });
+}
+
+export function EditIdentityProviderPage() {
+    const { identityProviderId } = useParams<{ identityProviderId: string }>();
+    const navigate = useNavigate();
+    const canUpdate = useHasPermission({ anyOf: [ORGANIZATION_IDENTITY_PROVIDER_UPDATE_PERMISSION] });
+    const providerQuery = useIdentityProvider(identityProviderId);
+    const { groupsQuery, environmentsQuery, organizationRolesQuery, environmentRolesQuery, refetchCatalogs } =
+        useIdentityProviderMappingCatalog();
+    const [dirty, setDirty] = useState(false);
+    const [leaveOpen, setLeaveOpen] = useState(false);
+
+    const isForbidden = isForbiddenApiError(providerQuery.isError, providerQuery.error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        permissionPrefix: 'organization-identity_provider-',
+        redirectTo: '..',
+    });
+
+    useEffect(() => {
+        if (!dirty) {
+            return;
+        }
+        function onBeforeUnload(event: BeforeUnloadEvent) {
+            event.preventDefault();
+            event.returnValue = '';
+        }
+        window.addEventListener('beforeunload', onBeforeUnload);
+        return () => window.removeEventListener('beforeunload', onBeforeUnload);
+    }, [dirty]);
+
+    const provider = providerQuery.data;
+
+    const groups = useMemo<IdentityProviderMappingOption[]>(
+        () => (groupsQuery.data ?? []).map(group => ({ id: group.id, name: group.name })),
+        [groupsQuery.data],
+    );
+    const environments = useMemo<IdentityProviderMappingOption[]>(
+        () =>
+            (environmentsQuery.data ?? []).map(environment => ({
+                id: environment.id,
+                name: environment.name?.trim() || environment.id,
+                description: environment.description,
+            })),
+        [environmentsQuery.data],
+    );
+    const organizationRoles = useMemo(() => toRoleOptions(organizationRolesQuery.data ?? []), [organizationRolesQuery.data]);
+    const environmentRoles = useMemo(() => toRoleOptions(environmentRolesQuery.data ?? []), [environmentRolesQuery.data]);
+
+    const mappingCatalogsLoading =
+        groupsQuery.isLoading || environmentsQuery.isLoading || organizationRolesQuery.isLoading || environmentRolesQuery.isLoading;
+    const hasCatalogError = [groupsQuery, environmentsQuery, organizationRolesQuery, environmentRolesQuery].some(query => query.isError);
+    const mappingsDisabled = hasCatalogError || mappingCatalogsLoading;
+
+    function requestLeave() {
+        if (dirty) {
+            setLeaveOpen(true);
+            return;
+        }
+        navigate('..', { relative: 'path' });
+    }
+
+    if (providerQuery.isLoading || (!providerQuery.isError && environmentsQuery.isLoading)) {
+        return (
+            <PageFocused>
+                <div className="space-y-6">
+                    <Skeleton className="h-8 w-48" />
+                    <Skeleton className="h-40 w-full rounded-xl" />
+                    <Skeleton className="h-40 w-full rounded-xl" />
+                </div>
+            </PageFocused>
+        );
+    }
+
+    if (isForbidden) {
+        return null;
+    }
+
+    if (providerQuery.isError || !provider) {
+        return (
+            <PageFocused>
+                <div className="space-y-4">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        className="gap-1.5 px-0 text-muted-foreground"
+                        onClick={() => navigate('..', { relative: 'path' })}
+                    >
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to Authentication
+                    </Button>
+                    <p className="text-sm text-muted-foreground">Identity provider not found or failed to load.</p>
+                </div>
+            </PageFocused>
+        );
+    }
+
+    return (
+        <PageFocused>
+            <div className="space-y-6">
+                <div className="space-y-2">
+                    <Button type="button" variant="ghost" className="gap-1.5 px-0 text-muted-foreground" onClick={requestLeave}>
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to Authentication
+                    </Button>
+                    <h1 className="text-2xl font-semibold tracking-tight">
+                        Update {identityProviderTypeLabel(provider.type)} identity provider
+                    </h1>
+                </div>
+                {hasCatalogError ? <IdentityProviderCatalogLoadError onRetry={refetchCatalogs} /> : null}
+                <IdentityProviderEditForm
+                    key={provider.id}
+                    provider={provider}
+                    groups={groups}
+                    environments={environments}
+                    organizationRoles={organizationRoles}
+                    environmentRoles={environmentRoles}
+                    canUpdate={canUpdate}
+                    mappingsDisabled={mappingsDisabled}
+                    onDirtyChange={setDirty}
+                    onCancel={requestLeave}
+                />
+                <ConfirmDialog
+                    open={leaveOpen}
+                    onOpenChange={setLeaveOpen}
+                    title="Unsaved changes"
+                    description="Leave this page? Unsaved changes will be lost."
+                    confirmLabel="Leave"
+                    onConfirm={() => navigate('..', { relative: 'path' })}
+                />
+            </div>
+        </PageFocused>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.spec.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TooltipProvider } from '@gravitee/graphene-core';
+import { renderWithGraphene } from '@gravitee/graphene-core/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+
+import { TruncatedDisplayText } from './TruncatedDisplayText';
+
+function renderTruncatedDisplayText(ui: ReactElement) {
+    return renderWithGraphene(<TooltipProvider delayDuration={300}>{ui}</TooltipProvider>);
+}
+
+describe('TruncatedDisplayText', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('renders the display text without a tooltip when the list is not truncated', () => {
+        renderTruncatedDisplayText(
+            <TruncatedDisplayText displayText="ADMIN, USER" isPlaceholder={false} showTooltip={false} labels={['ADMIN', 'USER']} />,
+        );
+        expect(screen.getByText('ADMIN, USER')).not.toBeNull();
+        expect(screen.queryByRole('tooltip')).toBeNull();
+    });
+
+    it('shows every label in a tooltip when the display text is truncated', async () => {
+        const user = userEvent.setup();
+        renderTruncatedDisplayText(
+            <TruncatedDisplayText
+                displayText="ADMIN, USER, ORG..."
+                isPlaceholder={false}
+                showTooltip
+                labels={['ADMIN', 'USER', 'ORG', 'API_PUBLISHER']}
+            />,
+        );
+        await user.hover(screen.getByText('ADMIN, USER, ORG...'));
+        expect((await screen.findByRole('tooltip')).textContent).toBe('ADMIN, USER, ORG, API_PUBLISHER');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from '@gravitee/graphene-core';
+
+import { TRUNCATED_LIST_TOOLTIP_CONTENT_CLASS, TruncatedListTooltipContent } from './TruncatedListTooltip';
+
+export function TruncatedDisplayText({
+    displayText,
+    isPlaceholder,
+    showTooltip,
+    labels,
+}: Readonly<{
+    displayText: string;
+    isPlaceholder: boolean;
+    showTooltip: boolean;
+    labels: readonly string[];
+}>) {
+    const textClassName = cn('min-w-0 flex-1 truncate text-left', isPlaceholder && 'text-muted-foreground');
+
+    if (!showTooltip) {
+        return <span className={textClassName}>{displayText}</span>;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className={textClassName}>{displayText}</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="start" className={TRUNCATED_LIST_TOOLTIP_CONTENT_CLASS}>
+                <TruncatedListTooltipContent labels={labels} />
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedListTooltip.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedListTooltip.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-export const authenticationKeys = {
-    all: ['org-authentication'] as const,
-    providers: () => [...authenticationKeys.all, 'providers'] as const,
-    activations: () => [...authenticationKeys.all, 'activations'] as const,
-    detail: (id: string) => [...authenticationKeys.all, 'detail', id] as const,
-} as const;
+export const TRUNCATED_LIST_TOOLTIP_CONTENT_CLASS = 'block max-w-xs items-start p-1 text-left text-xs';
+
+export function TruncatedListTooltipContent({ labels }: Readonly<{ labels: readonly string[] }>) {
+    return <span className="min-w-0 max-h-48 overflow-y-auto [overflow-wrap:anywhere]">{labels.join(', ')}</span>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
@@ -16,3 +16,4 @@
 export type { ConsoleSettings } from './types';
 export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady, useSetConsoleSettings } from './ConsoleSettingsProvider';
 export { isUserGroupRequired } from './isUserGroupRequired';
+export { isLocalLoginEnabled } from '../../../../../../gamma-ui-shared/src/consoleSettings';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isLocalLoginEnabled.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isLocalLoginEnabled.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isLocalLoginEnabled } from './index';
+
+describe('isLocalLoginEnabled', () => {
+    it('defaults a missing local-login setting to enabled', () => {
+        expect(isLocalLoginEnabled(undefined)).toBe(true);
+        expect(isLocalLoginEnabled({})).toBe(true);
+        expect(isLocalLoginEnabled({ authentication: {} })).toBe(true);
+        expect(isLocalLoginEnabled({ authentication: { localLogin: {} } })).toBe(true);
+    });
+
+    it('honors an explicit local-login value', () => {
+        expect(isLocalLoginEnabled({ authentication: { localLogin: { enabled: true } } })).toBe(true);
+        expect(isLocalLoginEnabled({ authentication: { localLogin: { enabled: false } } })).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/truncatedList.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/truncatedList.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatTruncatedNameSummary } from './truncatedList';
+
+describe('formatTruncatedNameSummary', () => {
+    it('shows the first three names then an ellipsis when there are more', () => {
+        expect(formatTruncatedNameSummary(['USER', 'ORG_TEST1', 'ORG_TEST2', 'ADMIN'])).toEqual({
+            display: 'USER, ORG_TEST1, ORG_TEST2...',
+            full: 'USER, ORG_TEST1, ORG_TEST2, ADMIN',
+            truncated: true,
+        });
+    });
+
+    it('shows every name when there are three or fewer', () => {
+        expect(formatTruncatedNameSummary(['USER', 'ADMIN'])).toEqual({
+            display: 'USER, ADMIN',
+            full: 'USER, ADMIN',
+            truncated: false,
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/truncatedList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/truncatedList.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DEFAULT_VISIBLE_NAME_COUNT = 3;
+
+/** First N names for compact display; full list is intended for tooltip. */
+export function formatTruncatedNameSummary(
+    names: readonly string[],
+    visibleCount = DEFAULT_VISIBLE_NAME_COUNT,
+): { display: string; full: string; truncated: boolean } {
+    if (names.length === 0) {
+        return { display: '—', full: '—', truncated: false };
+    }
+    const full = names.join(', ');
+    if (names.length <= visibleCount) {
+        return { display: full, full, truncated: false };
+    }
+    return {
+        display: `${names.slice(0, visibleCount).join(', ')}...`,
+        full,
+        truncated: true,
+    };
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-231
https://gravitee.atlassian.net/browse/FOUND-125
https://gravitee.atlassian.net/browse/FOUND-126

## Description
Adds **edit** for organization identity providers on the Gamma Platform Authentication page, and refreshes login methods on the Gamma login page so activation / local-login changes show up without a stale bootstrap snapshot.
### Edit identity provider (platform)
- Provider **name** on the list is a link to `/authentication/:identityProviderId` (static `new` stays a sibling so it is not treated as an id).
- Edit is one scrolling page under the existing Authentication layout: **General**, **Configuration**, **User profile** (AM / OIDC only), **Groups**, and **Roles**.
- Types: **Google**, **GitHub**, **Gravitee AM**, **OIDC** only. Type is not editable (PUT does not send `type`).
- **GET** `/configuration/identities/{id}` and **PUT** `/configuration/identities/{id}`.
- Groups are stored by **id**; organization and environment roles by **name**. Mapping catalogs (groups, environments, org/env roles) load before the form mounts.
- Duplicate mapping **conditions** are rejected in the UI (`Condition must be unique.`) so the backend `Collectors.toMap` by condition does not 500.
- Google / GitHub **omit** empty `userProfileMapping` on PUT (sending `{ id: '' }` would persist a blank mapping). AM / OIDC always send mapping. Client secret is trimmed.
- Dirty Back / Cancel opens **Unsaved changes**; `beforeunload` while dirty. Update requires `organization-identity_provider-u`; the parent route still requires `organization-identity_provider-r`.
### Login methods (control-plane)
- `refreshLoginMethods()` re-reads **GET** `.../social-identities` and **GET** `.../console` when Login mounts.
- Password form follows current `localLogin.enabled`; IdP buttons follow current social identities.
- Failed **refresh** keeps the previous methods. Failed **first-load** `/console` does not assume local login is on (`localLoginEnabled ?? false`).
### Shared truncation
- Mapping pickers and user role chips use a shared truncated name summary + tooltip (`TruncatedListTooltip` / `formatTruncatedNameSummary`) instead of a users-only `RoleListTooltip`.




https://github.com/user-attachments/assets/44c148bf-6ed9-45e7-8ff7-90e3f5a8ae47

