### PR TITLE
fix(portal): align login div in centre on firefox

### DIFF
--- a/gravitee-apim-portal-webui-next/src/scss/layout.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/layout.scss
@@ -53,6 +53,8 @@ $container-content-padding-vertical: 32px;
     display: flex;
     width: 100%;
     max-width: $max-width;
+    // Firefox ignores justify-self on a block-level parent.
+    margin-inline: auto;
     justify-content: center; // when flex-flow is column
     justify-self: center; // when flex-flow is row
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14978

## Description

The Portal Next login card was flush left in Firefox because it was centered with justify-self on a block-level parent, which Firefox ignores outside grid. Added margin-inline: auto on the shared .content container so the card stays horizontally centered in Firefox and Chromium.

## Additional context

- Before :

<img width="1718" height="1098" alt="image" src="https://github.com/user-attachments/assets/8b2d5a13-bf42-4991-9a5a-fac6d21567f9" />

<img width="1727" height="1109" alt="image" src="https://github.com/user-attachments/assets/530f7303-e955-4d8f-9f7b-8b2d8a6d2b7d" />


- After :

<img width="1723" height="1105" alt="image" src="https://github.com/user-attachments/assets/eacd0114-ab12-4429-896d-feb0c874b263" />
