### PR TITLE
feat(portal-next): expose theme automation REST endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -30,6 +30,8 @@ import io.gravitee.apim.rest.api.automation.resource.GroupsResource;
 import io.gravitee.apim.rest.api.automation.resource.OpenAPIResource;
 import io.gravitee.apim.rest.api.automation.resource.OrganizationResource;
 import io.gravitee.apim.rest.api.automation.resource.PortalResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalThemeResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalThemesResource;
 import io.gravitee.apim.rest.api.automation.resource.PortalsResource;
 import io.gravitee.apim.rest.api.automation.resource.SharedPolicyGroupsResource;
 import io.gravitee.apim.rest.api.automation.spring.PermissionsFilter;
@@ -67,6 +69,8 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(DictionaryResource.class);
         register(PortalsResource.class);
         register(PortalResource.class);
+        register(PortalThemesResource.class);
+        register(PortalThemeResource.class);
         register(GammaModuleAutomationResource.class);
 
         register(ValidationDomainMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -46,6 +46,7 @@ public interface PortalMapper {
         Portal portal,
         String hrid,
         io.gravitee.apim.core.portal.model.PortalNavigationStructure structure,
+        String activeThemeHrid,
         List<Validator.Error> errors
     ) {
         var state = new PortalState(
@@ -60,6 +61,7 @@ public interface PortalMapper {
         structure.areas().forEach((area, paths) -> writeWireArea(wireStructure, area, toApiNavigation(paths)));
         state.setStructure(wireStructure);
         state.setNavigation(wireStructure.getTopNavbar());
+        state.setActiveThemeHrid(activeThemeHrid);
         return state;
     }
 
@@ -91,6 +93,7 @@ public interface PortalMapper {
     @Mapping(target = "hrid", ignore = true)
     @Mapping(target = "navigation", ignore = true)
     @Mapping(target = "structure", ignore = true)
+    @Mapping(target = "activeThemeHrid", ignore = true)
     void mapPortalToState(Portal portal, @MappingTarget PortalState state);
 
     default io.gravitee.apim.core.portal.model.PortalNavigationStructure toCoreStructure(PortalSpec spec) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalThemeMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalThemeMapper.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.Errors;
+import io.gravitee.apim.rest.api.automation.model.PortalNextThemeBackground;
+import io.gravitee.apim.rest.api.automation.model.PortalNextThemeColor;
+import io.gravitee.apim.rest.api.automation.model.PortalNextThemeDefinition;
+import io.gravitee.apim.rest.api.automation.model.PortalNextThemeFont;
+import io.gravitee.apim.rest.api.automation.model.PortalThemeState;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalThemeMapper {
+    PortalThemeMapper INSTANCE = Mappers.getMapper(PortalThemeMapper.class);
+
+    default PortalThemeState toPortalThemeState(Theme theme, String hrid, AuditInfo audit, List<Validator.Error> errors) {
+        var state = new PortalThemeState(theme.getId(), audit.environmentId(), audit.organizationId(), toErrors(errors));
+        state.setHrid(hrid);
+        state.setName(theme.getName());
+        state.setDefinition(toWireDefinition(theme.getDefinitionPortalNext()));
+        state.setLogo(theme.getLogo());
+        state.setOptionalLogo(theme.getOptionalLogo());
+        state.setFavicon(theme.getFavicon());
+        state.setBackgroundImage(theme.getBackgroundImage());
+        return state;
+    }
+
+    default ThemeDefinition toCoreDefinition(PortalNextThemeDefinition wire) {
+        if (wire == null) {
+            return null;
+        }
+        return ThemeDefinition.builder()
+            .customCss(wire.getCustomCss())
+            .font(toCoreFont(wire.getFont()))
+            .color(toCoreColor(wire.getColor()))
+            .build();
+    }
+
+    default PortalNextThemeDefinition toWireDefinition(ThemeDefinition core) {
+        if (core == null) {
+            return null;
+        }
+        return new PortalNextThemeDefinition()
+            .customCss(core.getCustomCss())
+            .font(toWireFont(core.getFont()))
+            .color(toWireColor(core.getColor()));
+    }
+
+    default Errors toErrors(List<Validator.Error> validationErrors) {
+        if (validationErrors == null || validationErrors.isEmpty()) {
+            return null;
+        }
+        var wire = new Errors();
+        wire.setSevere(validationErrors.stream().filter(Validator.Error::isSevere).map(Validator.Error::getMessage).toList());
+        wire.setWarning(validationErrors.stream().filter(Validator.Error::isWarning).map(Validator.Error::getMessage).toList());
+        return wire;
+    }
+
+    private static ThemeDefinition.Font toCoreFont(PortalNextThemeFont wire) {
+        if (wire == null) {
+            return null;
+        }
+        return ThemeDefinition.Font.builder().fontFamily(wire.getFontFamily()).build();
+    }
+
+    private static PortalNextThemeFont toWireFont(ThemeDefinition.Font core) {
+        if (core == null) {
+            return null;
+        }
+        return new PortalNextThemeFont().fontFamily(core.getFontFamily());
+    }
+
+    private static ThemeDefinition.Color toCoreColor(PortalNextThemeColor wire) {
+        if (wire == null) {
+            return null;
+        }
+        return ThemeDefinition.Color.builder()
+            .primary(wire.getPrimary())
+            .secondary(wire.getSecondary())
+            .tertiary(wire.getTertiary())
+            .error(wire.getError())
+            .background(toCoreBackground(wire.getBackground()))
+            .build();
+    }
+
+    private static PortalNextThemeColor toWireColor(ThemeDefinition.Color core) {
+        if (core == null) {
+            return null;
+        }
+        return new PortalNextThemeColor()
+            .primary(core.getPrimary())
+            .secondary(core.getSecondary())
+            .tertiary(core.getTertiary())
+            .error(core.getError())
+            .background(toWireBackground(core.getBackground()));
+    }
+
+    private static ThemeDefinition.Background toCoreBackground(PortalNextThemeBackground wire) {
+        if (wire == null) {
+            return null;
+        }
+        return ThemeDefinition.Background.builder().page(wire.getPage()).card(wire.getCard()).build();
+    }
+
+    private static PortalNextThemeBackground toWireBackground(ThemeDefinition.Background core) {
+        if (core == null) {
+            return null;
+        }
+        return new PortalNextThemeBackground().page(core.getPage()).card(core.getCard());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
@@ -58,6 +58,11 @@ public class EnvironmentResource {
         return resourceContext.getResource(PortalsResource.class);
     }
 
+    @Path("/portal-themes")
+    public PortalThemesResource getPortalThemesResource() {
+        return resourceContext.getResource(PortalThemesResource.class);
+    }
+
     /**
      * Gamma modules, addressed by their plugin id (e.g. {@code /aim}). Literal siblings above always win the
      * match; an unknown segment answers 404 with the module named.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -74,7 +74,9 @@ public class PortalResource extends AbstractResource {
         PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
         try {
             var output = getPortalUseCase.execute(new GetPortalUseCase.Input(auditInfo, id));
-            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid, output.structure(), null)).build();
+            return Response.ok(
+                PortalMapper.INSTANCE.toPortalState(output.portal(), hrid, output.structure(), output.activeThemeHrid(), null)
+            ).build();
         } catch (PortalNotFoundException e) {
             throw new HRIDNotFoundException(hrid);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalThemeResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.use_case.DeletePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.GetPortalThemeUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.PortalThemeMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class PortalThemeResource extends AbstractResource {
+
+    @Inject
+    private GetPortalThemeUseCase getPortalThemeUseCase;
+
+    @Inject
+    private DeletePortalThemeUseCase deletePortalThemeUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.READ) })
+    public Response getThemeByHrid(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        var themeId = HRIDToUUID.portalTheme().context(auditInfo).hrid(hrid).id();
+        try {
+            var output = getPortalThemeUseCase.execute(new GetPortalThemeUseCase.Input(auditInfo, themeId));
+            return Response.ok(PortalThemeMapper.INSTANCE.toPortalThemeState(output.theme(), hrid, auditInfo, null)).build();
+        } catch (ThemeNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.DELETE) })
+    public Response deleteThemeByHrid(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        var themeId = HRIDToUUID.portalTheme().context(auditInfo).hrid(hrid).id();
+        try {
+            deletePortalThemeUseCase.execute(new DeletePortalThemeUseCase.Input(auditInfo, themeId));
+        } catch (ThemeNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalThemesResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.theme.domain_service.ValidateThemeDomainService;
+import io.gravitee.apim.core.theme.use_case.CreateOrUpdatePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.ValidatePortalThemeUseCase;
+import io.gravitee.apim.rest.api.automation.mapper.PortalThemeMapper;
+import io.gravitee.apim.rest.api.automation.model.PortalThemeSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+public class PortalThemesResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreateOrUpdatePortalThemeUseCase createOrUpdatePortalThemeUseCase;
+
+    @Inject
+    private ValidatePortalThemeUseCase validatePortalThemeUseCase;
+
+    @Path("/{hrid}")
+    public PortalThemeResource getPortalThemeResource() {
+        return resourceContext.getResource(PortalThemeResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(@Valid @NotNull PortalThemeSpec spec, @QueryParam("dryRun") boolean dryRun) {
+        var auditInfo = getAuditInfo();
+        var input = new ValidateThemeDomainService.Input(
+            auditInfo,
+            spec.getHrid(),
+            spec.getName(),
+            PortalThemeMapper.INSTANCE.toCoreDefinition(spec.getDefinition()),
+            spec.getLogo(),
+            spec.getOptionalLogo(),
+            spec.getFavicon(),
+            spec.getBackgroundImage()
+        );
+        var output = dryRun ? validatePortalThemeUseCase.execute(input) : createOrUpdatePortalThemeUseCase.execute(input);
+        return Response.ok(
+            PortalThemeMapper.INSTANCE.toPortalThemeState(output.theme(), spec.getHrid(), auditInfo, output.errors())
+        ).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
@@ -78,11 +78,17 @@ public class PortalsResource extends AbstractResource {
         );
         var structure = PortalMapper.INSTANCE.toCoreStructure(spec);
 
-        var input = new CreateOrUpdatePortalUseCase.Input(auditInfo, portal, structure);
+        var input = new CreateOrUpdatePortalUseCase.Input(auditInfo, portal, structure, spec.getActiveThemeHrid());
         var output = dryRun ? validatePortalUseCase.execute(input) : createOrUpdatePortalUseCase.execute(input);
 
         return Response.ok(
-            PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid(), output.structure(), output.errors())
+            PortalMapper.INSTANCE.toPortalState(
+                output.portal(),
+                spec.getHrid(),
+                output.structure(),
+                output.activeThemeHrid(),
+                output.errors()
+            )
         ).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -894,6 +894,86 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  # Themes
+  /organizations/{orgId}/environments/{envId}/portal-themes:
+    put:
+      operationId: createOrUpdatePortalTheme
+      tags:
+        - Themes
+      summary: Create or update a Theme
+      description: Create or update a next-gen portal Theme from PortalThemeSpec
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/dryRunQueryParam"
+      requestBody:
+        description: Theme specification
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/PortalThemeSpec"
+        required: true
+      responses:
+        "200":
+          description: State of the successfully created/updated Theme
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalThemeState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/Error"
+  /organizations/{orgId}/environments/{envId}/portal-themes/{hrid}:
+    parameters:
+      - $ref: "#/components/parameters/orgIdParam"
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/hridParam"
+    get:
+      operationId: getPortalTheme
+      tags:
+        - Themes
+      summary: Get one Theme
+      description: Get a Theme using HRID
+      responses:
+        "200":
+          description: Theme successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortalThemeState"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      operationId: deletePortalTheme
+      tags:
+        - Themes
+      summary: Delete one Theme
+      description: Delete a Theme using HRID
+      responses:
+        "204":
+          description: Theme successfully deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+
   # API Documentations
   /organizations/{orgId}/environments/{envId}/apis/{apiHrid}/documentations:
     put:
@@ -3306,6 +3386,15 @@ components:
             when only `navigation` is provided, it is mapped to `structure.topNavbar` for backward compatibility.
           items:
             $ref: "#/components/schemas/PortalNavigationPath"
+        activeThemeHrid:
+          type: string
+          description: |
+            HRID of the Theme this portal should use as its active theme. When set, applying the portal
+            marks the referenced theme as active (enabled) and disables every other PORTAL_NEXT theme
+            in the environment. Leaving this field unset clears the reference and disables the
+            previously-active theme; the portal-next UI will then lazily fall back to a fresh default theme.
+          examples:
+            - brand-theme
       required:
         - hrid
         - name
@@ -3495,6 +3584,93 @@ components:
       allOf:
         - $ref: "#/components/schemas/PortalLinkSpec"
         - $ref: "#/components/schemas/PortalLinkStatus"
+
+    # Theme schemas
+    PortalThemeSpec:
+      description: |
+        Specification of a next-gen portal Theme. Applying a Theme through the Automation API
+        makes it the active Theme for the environment; every other Theme in the same environment
+        is disabled.
+      type: object
+      properties:
+        hrid:
+          $ref: "#/components/schemas/Hrid"
+        name:
+          type: string
+          description: Display name of the theme
+          examples:
+            - Default Theme
+        definition:
+          $ref: "#/components/schemas/PortalNextThemeDefinition"
+        logo:
+          type: string
+          description: |
+            Primary logo. Inline data URI (for example `data:image/png;base64,...`), the same shape the
+            console produces on upload.
+        optionalLogo:
+          type: string
+          description: Alternate logo for contexts where the primary one does not render well (dark background, small badge, etc.).
+        favicon:
+          type: string
+          description: Browser tab icon. Same inline data URI convention as `logo`.
+        backgroundImage:
+          type: string
+          description: Hero / landing page background image. Same inline data URI convention as `logo`.
+      required:
+        - hrid
+        - name
+        - definition
+    PortalThemeState:
+      description: State of a Theme that has been created/updated.
+      allOf:
+        - $ref: "#/components/schemas/PortalThemeSpec"
+        - $ref: "#/components/schemas/BaseStatus"
+    PortalNextThemeDefinition:
+      description: Visual definition of a next-gen portal Theme.
+      type: object
+      properties:
+        customCss:
+          type: string
+          description: Custom CSS applied on top of the palette.
+        font:
+          $ref: "#/components/schemas/PortalNextThemeFont"
+        color:
+          $ref: "#/components/schemas/PortalNextThemeColor"
+    PortalNextThemeFont:
+      description: Typography settings for a next-gen portal Theme.
+      type: object
+      properties:
+        fontFamily:
+          type: string
+          description: CSS `font-family` value.
+    PortalNextThemeColor:
+      description: Palette for a next-gen portal Theme.
+      type: object
+      properties:
+        primary:
+          type: string
+          description: Primary color (CSS color value).
+        secondary:
+          type: string
+          description: Secondary color (CSS color value).
+        tertiary:
+          type: string
+          description: Tertiary color (CSS color value).
+        error:
+          type: string
+          description: Error color (CSS color value).
+        background:
+          $ref: "#/components/schemas/PortalNextThemeBackground"
+    PortalNextThemeBackground:
+      description: Background palette for a next-gen portal Theme.
+      type: object
+      properties:
+        page:
+          type: string
+          description: Page background color (CSS color value).
+        card:
+          type: string
+          description: Card background color (CSS color value).
 
   responses:
     NotFound:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -66,7 +66,9 @@ class PortalResourceTest extends AbstractResourceTest {
         @Test
         void should_return_portal_by_hrid() {
             var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
-            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted, PortalNavigationStructure.empty()));
+            when(getPortalUseCase.execute(any())).thenReturn(
+                new GetPortalUseCase.Output(persisted, PortalNavigationStructure.empty(), null)
+            );
 
             try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
                 assertThat(response.getStatus()).isEqualTo(200);
@@ -88,7 +90,7 @@ class PortalResourceTest extends AbstractResourceTest {
             // order is inverted in the list to show that API returns it in the correct order
             var navigation = List.of(new NavigationPath("/projects/alpha", "Alpha", 1), new NavigationPath("/projects", null));
             when(getPortalUseCase.execute(any())).thenReturn(
-                new GetPortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(navigation))
+                new GetPortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(navigation), null)
             );
 
             try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalThemeResourceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.exception.ThemeNotFoundException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.apim.core.theme.use_case.DeletePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.GetPortalThemeUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalThemeState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalThemeResourceTest extends AbstractResourceTest {
+
+    private static final String THEME_HRID = "default-theme";
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder().organizationId(ORGANIZATION).environmentId(ENVIRONMENT).build();
+    private static final String THEME_ID = HRIDToUUID.portalTheme().context(AUDIT_INFO).hrid(THEME_HRID).id();
+
+    @Inject
+    private GetPortalThemeUseCase getPortalThemeUseCase;
+
+    @Inject
+    private DeletePortalThemeUseCase deletePortalThemeUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(getPortalThemeUseCase, deletePortalThemeUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portal-themes";
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_the_theme() {
+            when(getPortalThemeUseCase.execute(any())).thenReturn(new GetPortalThemeUseCase.Output(aTheme()));
+
+            try (var response = rootTarget(THEME_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getPortalThemeUseCase).execute(any());
+
+                var state = response.readEntity(PortalThemeState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(THEME_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("Default Theme");
+                    soft.assertThat(state.getId()).isEqualTo(THEME_ID);
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_theme_is_missing() {
+            when(getPortalThemeUseCase.execute(any())).thenThrow(new ThemeNotFoundException(THEME_ID));
+
+            try (var response = rootTarget(THEME_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_the_theme() {
+            try (var response = rootTarget(THEME_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deletePortalThemeUseCase).execute(any());
+            }
+        }
+
+        @Test
+        void should_return_404_when_theme_is_missing() {
+            doThrow(new ThemeNotFoundException(THEME_ID)).when(deletePortalThemeUseCase).execute(any());
+
+            try (var response = rootTarget(THEME_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    private static Theme aTheme() {
+        return Theme.builder()
+            .id(THEME_ID)
+            .name("Default Theme")
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(ENVIRONMENT)
+            .enabled(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalThemesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalThemesResourceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.apim.core.theme.use_case.CreateOrUpdatePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.ValidatePortalThemeUseCase;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.PortalThemeState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalThemesResourceTest extends AbstractResourceTest {
+
+    private static final String THEME_HRID = "default-theme";
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder().organizationId(ORGANIZATION).environmentId(ENVIRONMENT).build();
+    private static final String THEME_ID = HRIDToUUID.portalTheme().context(AUDIT_INFO).hrid(THEME_HRID).id();
+
+    @Inject
+    private CreateOrUpdatePortalThemeUseCase createOrUpdatePortalThemeUseCase;
+
+    @Inject
+    private ValidatePortalThemeUseCase validatePortalThemeUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdatePortalThemeUseCase, validatePortalThemeUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portal-themes";
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_when_validation_passes() {
+            when(validatePortalThemeUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalThemeUseCase.Output(aTheme(), List.of()));
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("theme.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalThemeUseCase);
+                verify(validatePortalThemeUseCase).execute(any());
+
+                var state = response.readEntity(PortalThemeState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(THEME_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("Default Theme");
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getId()).isEqualTo(THEME_ID);
+                    soft.assertThat(state.getErrors()).isNull();
+                    soft.assertThat(state.getDefinition().getCustomCss()).isEqualTo(".portal { padding: 0; }");
+                    soft.assertThat(state.getDefinition().getColor().getPrimary()).isEqualTo("#123456");
+                });
+            }
+        }
+
+        @Test
+        void should_return_state_with_errors_when_validation_fails() {
+            when(validatePortalThemeUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalThemeUseCase.Output(aTheme(), List.of(Validator.Error.severe("spec.name must not be blank")))
+            );
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("theme.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalThemeUseCase);
+
+                var state = response.readEntity(PortalThemeState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("spec.name");
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("theme-missing-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(validatePortalThemeUseCase);
+                verifyNoInteractions(createOrUpdatePortalThemeUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_create_or_update_theme() {
+            when(createOrUpdatePortalThemeUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalThemeUseCase.Output(aTheme(), List.of())
+            );
+
+            try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("theme.json")))) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalThemeUseCase).execute(any());
+
+                var state = response.readEntity(PortalThemeState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo(THEME_ID);
+                    soft.assertThat(state.getHrid()).isEqualTo(THEME_HRID);
+                });
+            }
+        }
+    }
+
+    private static Theme aTheme() {
+        return Theme.builder()
+            .id(THEME_ID)
+            .name("Default Theme")
+            .type(ThemeType.PORTAL_NEXT)
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .referenceId(ENVIRONMENT)
+            .enabled(true)
+            .definitionPortalNext(
+                ThemeDefinition.builder()
+                    .customCss(".portal { padding: 0; }")
+                    .color(ThemeDefinition.Color.builder().primary("#123456").build())
+                    .build()
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -67,7 +67,7 @@ class PortalsResourceTest extends AbstractResourceTest {
         void should_return_populated_state_without_calling_use_case() {
             when(validatePortalUseCase.execute(any())).thenAnswer(inv -> {
                 var input = (CreateOrUpdatePortalUseCase.Input) inv.getArgument(0);
-                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.structure(), List.of());
+                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.structure(), null, List.of());
             });
 
             try (
@@ -95,7 +95,7 @@ class PortalsResourceTest extends AbstractResourceTest {
         void should_echo_navigation_in_dry_run() {
             when(validatePortalUseCase.execute(any())).thenAnswer(inv -> {
                 var input = (CreateOrUpdatePortalUseCase.Input) inv.getArgument(0);
-                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.structure(), List.of());
+                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.structure(), null, List.of());
             });
 
             try (
@@ -139,7 +139,7 @@ class PortalsResourceTest extends AbstractResourceTest {
         void should_create_or_update_portal() {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
             when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
-                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.empty(), List.of())
+                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.empty(), null, List.of())
             );
 
             try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal.json")))) {
@@ -167,7 +167,7 @@ class PortalsResourceTest extends AbstractResourceTest {
                 new NavigationPath("/projects/alpha/docs", null)
             );
             when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
-                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(echoed), List.of())
+                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(echoed), null, List.of())
             );
 
             try (
@@ -202,7 +202,7 @@ class PortalsResourceTest extends AbstractResourceTest {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
             when(createOrUpdatePortalUseCase.execute(any())).thenAnswer(inv -> {
                 var input = (CreateOrUpdatePortalUseCase.Input) inv.getArgument(0);
-                return new CreateOrUpdatePortalUseCase.Output(persisted, input.structure(), List.of());
+                return new CreateOrUpdatePortalUseCase.Output(persisted, input.structure(), null, List.of());
             });
 
             try (
@@ -240,7 +240,7 @@ class PortalsResourceTest extends AbstractResourceTest {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
             var echoed = List.of(new NavigationPath("/x", null));
             when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
-                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(echoed), List.of())
+                new CreateOrUpdatePortalUseCase.Output(persisted, PortalNavigationStructure.ofTopNavbar(echoed), null, List.of())
             );
 
             try (

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -211,6 +211,10 @@ import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionCRDUseCase;
 import io.gravitee.apim.core.subscription.use_case.RejectSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.theme.use_case.CreateOrUpdatePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.DeletePortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.GetPortalThemeUseCase;
+import io.gravitee.apim.core.theme.use_case.ValidatePortalThemeUseCase;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.core.user.service_provider.UserPasswordService;
@@ -1438,6 +1442,26 @@ public class ResourceContextConfiguration {
     @Bean
     public DeletePortalLinkUseCase deletePortalLinkUseCase() {
         return mock(DeletePortalLinkUseCase.class);
+    }
+
+    @Bean
+    public CreateOrUpdatePortalThemeUseCase createOrUpdatePortalThemeUseCase() {
+        return mock(CreateOrUpdatePortalThemeUseCase.class);
+    }
+
+    @Bean
+    public ValidatePortalThemeUseCase validatePortalThemeUseCase() {
+        return mock(ValidatePortalThemeUseCase.class);
+    }
+
+    @Bean
+    public GetPortalThemeUseCase getPortalThemeUseCase() {
+        return mock(GetPortalThemeUseCase.class);
+    }
+
+    @Bean
+    public DeletePortalThemeUseCase deletePortalThemeUseCase() {
+        return mock(DeletePortalThemeUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/theme-missing-hrid.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/theme-missing-hrid.json
@@ -1,0 +1,4 @@
+{
+  "name": "No HRID Theme",
+  "definition": {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/theme.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/theme.json
@@ -1,0 +1,22 @@
+{
+  "hrid": "default-theme",
+  "name": "Default Theme",
+  "definition": {
+    "customCss": ".portal { padding: 0; }",
+    "font": {
+      "fontFamily": "Inter"
+    },
+    "color": {
+      "primary": "#123456",
+      "secondary": "#654321",
+      "tertiary": "#abcdef",
+      "error": "#ff0000",
+      "background": {
+        "page": "#ffffff",
+        "card": "#f4f4f4"
+      }
+    }
+  },
+  "logo": "data:image/png;base64,LOGO",
+  "favicon": "data:image/png;base64,FAV"
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-175

## Description

Wires the REST layer for the automation **portal theme** use cases created in the base PR, and extends the Portal resource with a theme reference.

- Theme automation endpoints - themes become GitOps-managed via the Automation API: create, update, delete, and validate (dry-run).
- `activeThemeHrid` on PortalSpec - a portal now declares which theme it uses. On apply, the referenced theme is marked active for the environment and the previously-active PORTAL_NEXT theme is disabled.
- Symmetric clear semantics - leaving `activeThemeHrid` unset clears the reference and disables the previously-active theme. On the next portal-next visit the UI lazily falls back to a fresh default theme; the previous customized theme is preserved (disabled, not deleted) and can be re-attached later.
- Portal deletion mirrors the same rule - deleting an automation-managed portal disables whichever theme it was pointing at.
- GET reverse-resolves the HRID - retrieving a portal returns the current `activeThemeHrid` so the CRD round-trips cleanly.

## To be confirmed

- [ ] New API resource is named: portal-theme. Other type of themes (e.g. gamma) will have dedicated resources.