### PR TITLE
feat: integrate API Products into category-filtered catalog

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -75,6 +75,7 @@ describe('CatalogComponent', () => {
         id: apiProduct.navigationItemId,
         rootId: 'product-root-1',
         apiProductId: apiProduct.id,
+        categoryIds: ['cat-1'],
       }),
       fakePortalNavigationApi({ id: 'api-nav-2', rootId: 'api-root-2', apiId: mcpApi.id }),
     ],
@@ -123,6 +124,7 @@ describe('CatalogComponent', () => {
     fixture = TestBed.createComponent(CatalogComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    catalogHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, CatalogHarness);
   };
 
   afterEach(() => {
@@ -289,6 +291,47 @@ describe('CatalogComponent', () => {
 
       const categorySelect = await harnessLoader.getHarness(DropdownSearchComponentHarness);
       expect(await categorySelect.getTriggerText()).toContain('Category One');
+    });
+
+    it('should render the selected category for an API Product in list view', async () => {
+      await initWithQueryParams({ category: 'cat-1' });
+
+      flushCategories(categories);
+      fixture.detectChanges();
+
+      expectCatalogRequest(1, 20, 'cat-1').flush(
+        createCatalogResponse({
+          data: [
+            fakePortalNavigationApiProduct({
+              id: apiProduct.navigationItemId,
+              rootId: 'product-root-1',
+              apiProductId: apiProduct.id,
+              categoryIds: ['cat-1'],
+            }),
+          ],
+          apis: [],
+          apiProducts: [apiProduct],
+          metadata: {
+            pagination: {
+              current_page: 1,
+              size: 20,
+              total: 1,
+              total_pages: 1,
+            },
+          },
+        }),
+      );
+      fixture.detectChanges();
+
+      fixture.componentInstance.toggleViewMode();
+      fixture.detectChanges();
+
+      const rows = await catalogHarness.getAllRowsCellText();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        name: expect.stringContaining('AI Workspace'),
+        category: expect.stringContaining('Category One'),
+      });
     });
 
     it('should show a generic error state for an unknown or hidden category id, without calling search', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -248,6 +248,7 @@ export class CatalogComponent {
             apiNames: item.apis.map(api => api.name),
             rootId: item.rootId,
             navItemId: item.navItemId,
+            categoryIds: item.categoryIds,
           } satisfies CatalogApiProductVM;
         });
 

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-catalog-search.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-catalog-search.ts
@@ -52,6 +52,7 @@ export interface PortalCatalogApiProductSearchItem {
   rootId: string;
   navItemId: string;
   apis: ApiProductApi[];
+  categoryIds?: string[];
 }
 
 export type PortalCatalogSearchItem = PortalCatalogApiSearchItem | PortalCatalogApiProductSearchItem;

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-item.ts
@@ -54,6 +54,7 @@ export interface PortalNavigationApi extends BasePortalNavigationItem {
 export interface PortalNavigationApiProduct extends BasePortalNavigationItem {
   type: 'API_PRODUCT';
   apiProductId: string;
+  categoryIds?: string[];
 }
 
 export type PortalNavigationItem =

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -261,7 +261,13 @@ describe('PortalNavigationItemsService', () => {
     };
     const rawResponse = {
       data: [
-        { type: 'API_PRODUCT' as const, apiProductId: apiProduct.id, id: 'product-nav-1', rootId: 'product-root-1' },
+        {
+          type: 'API_PRODUCT' as const,
+          apiProductId: apiProduct.id,
+          id: 'product-nav-1',
+          rootId: 'product-root-1',
+          categoryIds: ['cat-1'],
+        },
         { type: 'API' as const, apiId: api.id, id: 'api-nav-1', rootId: 'api-root-1', categoryIds: ['cat-1'] },
       ],
       apis: [api],
@@ -288,6 +294,7 @@ describe('PortalNavigationItemsService', () => {
           rootId: 'product-root-1',
           navItemId: 'product-nav-1',
           apis: apiProduct.apis,
+          categoryIds: ['cat-1'],
         },
         {
           type: 'API',

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
@@ -182,6 +182,7 @@ export class PortalNavigationItemsService {
             rootId: item.rootId,
             navItemId: item.id,
             apis: apiProduct.apis,
+            categoryIds: item.categoryIds,
           } satisfies PortalCatalogApiProductSearchItem,
         ];
       }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -8654,6 +8654,12 @@ components:
                   type: string
                   format: uuid
                   description: The API Product ID for the navigation item
+                categoryIds:
+                  type: array
+                  description: The IDs of the Portal Next categories this API Product navigation item is assigned to
+                  items:
+                    type: string
+                    format: uuid
               required: [ apiProductId ]
         PortalNavigationItem:
             oneOf:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -108,6 +108,8 @@ class PortalNavigationItemMapperTest {
     @Test
     void should_map_api_product() {
         var apiProductId = "00000000-0000-0000-0000-000000000019";
+        var category1 = PortalCategoryId.random();
+        var category2 = PortalCategoryId.random();
         var apiProduct = PortalNavigationApiProduct.builder()
             .id(PortalNavigationFixtures.randomNavigationId())
             .organizationId("org")
@@ -117,6 +119,7 @@ class PortalNavigationItemMapperTest {
             .area(PortalArea.TOP_NAVBAR)
             .order(1)
             .apiProductId(apiProductId)
+            .categoryIds(List.of(category1, category2))
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();
@@ -126,6 +129,7 @@ class PortalNavigationItemMapperTest {
         assertThat(mapped.getActualInstance()).isInstanceOf(io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct.class);
         var mappedApiProduct = (io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct) mapped.getActualInstance();
         assertThat(mappedApiProduct.getApiProductId()).isEqualTo(UUID.fromString(apiProductId));
+        assertThat(mappedApiProduct.getCategoryIds()).containsExactly(category1.id(), category2.id());
         assertThat(mappedApiProduct.getTitle()).isEqualTo("API Product");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceNotAuthenticatedTest.java
@@ -21,6 +21,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PortalNavigationItemsResourceNotAuthenticatedTest extends AbstractResourceTest {
 
     private static final String ENV_ID = "DEFAULT";
+    private static final String CATEGORY_ID = "11111111-1111-1111-1111-111111111111";
 
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
@@ -142,5 +144,79 @@ public class PortalNavigationItemsResourceNotAuthenticatedTest extends AbstractR
         @SuppressWarnings("unchecked")
         var data = (List<Object>) result.get("data");
         assertThat(data).isEmpty();
+    }
+
+    @Test
+    void should_not_return_private_api_product_in_category_filtered_catalog_search() {
+        var apiProductId = "00000000-0000-0000-0000-000000000101";
+        var item = PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000102"))
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Private Product")
+            .segment("private-product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(apiProductId)
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID)))
+            .published(true)
+            .visibility(PortalVisibility.PRIVATE)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(item));
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder()
+                    .id(apiProductId)
+                    .environmentId(ENV_ID)
+                    .name("Private Product")
+                    .version("1.0.0")
+                    .apiIds(Set.of())
+                    .build()
+            )
+        );
+
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("categoryId", CATEGORY_ID).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).isEmpty();
+    }
+
+    @Test
+    void should_return_public_api_product_in_category_filtered_catalog_search() {
+        var apiProductId = "00000000-0000-0000-0000-000000000201";
+        var item = PortalNavigationApiProduct.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000202"))
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Public Product")
+            .segment("public-product")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiProductId(apiProductId)
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID)))
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(item));
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder().id(apiProductId).environmentId(ENV_ID).name("Public Product").version("1.0.0").apiIds(Set.of()).build()
+            )
+        );
+
+        Response response = target("/_search").queryParam("type", "catalog").queryParam("categoryId", CATEGORY_ID).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Map<String, Object>>) result.get("data");
+        assertThat(data)
+            .singleElement()
+            .satisfies(product ->
+                assertThat(product).containsEntry("id", item.getId().json()).containsEntry("categoryIds", List.of(CATEGORY_ID))
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -585,7 +585,7 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void should_exclude_api_products_from_catalog_search_when_category_id_is_present() {
+    void should_return_api_and_api_product_assigned_to_catalog_category() {
         var apiItem = PortalNavigationApi.builder()
             .id(PortalNavigationItemId.random())
             .organizationId("org")
@@ -605,7 +605,10 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
             "Payments Product",
             PortalArea.TOP_NAVBAR,
             apiProductId
-        );
+        )
+            .toBuilder()
+            .categoryIds(List.of(PortalCategoryId.of(CATEGORY_ID_1)))
+            .build();
         apiProductItem.setEnvironmentId(ENV_ID);
         portalNavigationItemsQueryService.initWith(List.of(apiItem, apiProductItem));
         var apis = List.of(Api.builder().id("api-uuid-1").name("Auth API").environmentId(ENV_ID).build());
@@ -634,9 +637,16 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
         var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
         @SuppressWarnings("unchecked")
         var data = (List<Map<String, Object>>) result.get("data");
-        assertThat(data).hasSize(1);
-        assertThat(data.getFirst()).containsEntry("id", apiItem.getId().toString());
-        assertThat(result.get("apiProducts")).isNull();
+        assertThat(data).hasSize(2);
+        assertThat(data).anySatisfy(item -> assertThat(item).containsEntry("id", apiItem.getId().toString()));
+        assertThat(data).anySatisfy(item ->
+            assertThat(item).containsEntry("id", apiProductItem.getId().toString()).containsEntry("categoryIds", List.of(CATEGORY_ID_1))
+        );
+        @SuppressWarnings("unchecked")
+        var apiProducts = (List<Map<String, Object>>) result.get("apiProducts");
+        assertThat(apiProducts)
+            .singleElement()
+            .satisfies(product -> assertThat(product).containsEntry("id", apiProductId.toString()));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCase.java
@@ -80,18 +80,13 @@ public class GetVisiblePortalCatalogItemsUseCase {
     private final CheckTypoToleranceDomainService checkTypoToleranceDomainService;
 
     public Output execute(Input input) {
-        String categoryId = input.categoryId().map(PortalCategoryId::toString).orElse(null);
         List<PortalNavigationItem> navigationItems = portalNavigationItemsQueryService.search(
             PortalNavigationItemQueryCriteria.builder().environmentId(input.environmentId()).build()
         );
         Map<PortalNavigationItemId, PortalNavigationItem> navigationItemsById = navigationItems
             .stream()
             .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity(), (first, ignored) -> first));
-        List<PortalNavigationApi> accessibleApis = input
-            .viewerContext()
-            .userId()
-            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId, categoryId))
-            .orElseGet(() -> apiVisibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryId));
+        List<PortalNavigationApi> accessibleApis = resolveAccessibleApis(input, input.categoryId());
         Set<PortalNavigationItemId> accessibleApiNavigationItemIds = accessibleApis
             .stream()
             .map(PortalNavigationItem::getId)
@@ -112,10 +107,10 @@ public class GetVisiblePortalCatalogItemsUseCase {
             visibleApis,
             navigationItemsById
         );
-        // Category assignment and catalog filtering are delivered separately; exclude products until catalog filtering is implemented.
-        List<PortalNavigationApiProduct> visibleApiProducts = input.categoryId().isPresent()
-            ? List.of()
-            : findVisibleApiProducts(navigationItems, input, navigationItemsById, accessibleApiNavigationItemIds, accessibleApiProductIds);
+        List<PortalNavigationApiProduct> visibleApiProducts = filterApiProductsByCategory(
+            findVisibleApiProducts(navigationItems, input, navigationItemsById, accessibleApiNavigationItemIds, accessibleApiProductIds),
+            input.categoryId()
+        );
 
         Optional<String> query = input
             .query()
@@ -146,14 +141,61 @@ public class GetVisiblePortalCatalogItemsUseCase {
         Page<PortalNavigationItem> page = new Page<>(pageItems, input.pageable().getPageNumber(), pageItems.size(), entries.size());
 
         List<Api> includedApis = resolveIncludedApis(input, pageEntries, matchingApisById);
+        List<PortalNavigationApi> visibleApisForProductSummaries = resolveVisibleApisForProductSummaries(
+            input,
+            pageEntries,
+            navigationItemsById,
+            accessibleApiProductIds,
+            visibleApis
+        );
         List<PortalCatalogApiProductSummary> includedApiProducts = resolveIncludedApiProducts(
             input,
             pageEntries,
             visibleApiProductsById,
-            visibleApis
+            visibleApisForProductSummaries
         );
 
         return new Output(page, includedApis, includedApiProducts);
+    }
+
+    private List<PortalNavigationApi> resolveAccessibleApis(Input input, Optional<PortalCategoryId> categoryId) {
+        String categoryIdValue = categoryId.map(PortalCategoryId::toString).orElse(null);
+        return input
+            .viewerContext()
+            .userId()
+            .map(userId -> apiVisibilityDomainService.resolveVisibleItems(input.environmentId(), userId, categoryIdValue))
+            .orElseGet(() -> apiVisibilityDomainService.resolveVisiblePublicItems(input.environmentId(), categoryIdValue));
+    }
+
+    private List<PortalNavigationApi> resolveVisibleApisForProductSummaries(
+        Input input,
+        List<CatalogEntry> pageEntries,
+        Map<PortalNavigationItemId, PortalNavigationItem> navigationItemsById,
+        Set<String> accessibleApiProductIds,
+        List<PortalNavigationApi> categoryVisibleApis
+    ) {
+        boolean pageContainsApiProduct = pageEntries
+            .stream()
+            .map(CatalogEntry::item)
+            .anyMatch(PortalNavigationApiProduct.class::isInstance);
+        if (
+            input.categoryId().isEmpty() || !input.includes().contains(PortalNavigationSearchInclude.API_PRODUCT) || !pageContainsApiProduct
+        ) {
+            return categoryVisibleApis;
+        }
+
+        List<PortalNavigationApi> accessibleApis = resolveAccessibleApis(input, Optional.empty());
+        Set<PortalNavigationItemId> accessibleApiNavigationItemIds = accessibleApis
+            .stream()
+            .map(PortalNavigationItem::getId)
+            .collect(Collectors.toSet());
+        return catalogNavigationVisibilityDomainService.filterVisibleItems(
+            accessibleApis,
+            navigationItemsById,
+            input.viewerContext(),
+            accessibleApiNavigationItemIds,
+            accessibleApiProductIds
+        );
     }
 
     private List<PortalNavigationApiProduct> findVisibleApiProducts(
@@ -176,6 +218,20 @@ public class GetVisiblePortalCatalogItemsUseCase {
             accessibleApiNavigationItemIds,
             accessibleApiProductIds
         );
+    }
+
+    private List<PortalNavigationApiProduct> filterApiProductsByCategory(
+        List<PortalNavigationApiProduct> apiProducts,
+        Optional<PortalCategoryId> categoryId
+    ) {
+        return categoryId
+            .map(selectedCategoryId ->
+                apiProducts
+                    .stream()
+                    .filter(item -> item.getCategoryIds().contains(selectedCategoryId))
+                    .toList()
+            )
+            .orElse(apiProducts);
     }
 
     private List<Api> findMatchingApis(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalCatalogItemsUseCaseTest.java
@@ -65,6 +65,7 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
     private static final String ENV_ID = "env-id";
     private static final String ORG_ID = "org-id";
     private static final String CATEGORY_ID_1 = "11111111-1111-1111-1111-111111111111";
+    private static final String CATEGORY_ID_2 = "22222222-2222-2222-2222-222222222222";
     private static final String UNKNOWN_CATEGORY_ID = "99999999-9999-9999-9999-999999999999";
 
     private GetVisiblePortalCatalogItemsUseCase useCase;
@@ -402,7 +403,7 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
     }
 
     @Test
-    void should_exclude_api_products_from_catalog_when_category_id_is_present() {
+    void should_filter_catalog_apis_and_api_products_by_category_id() {
         var folder = folder("folder-id", "Catalog", null);
         var apiInCategory = apiItem(
             "api-item-in-category-id",
@@ -411,15 +412,79 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
             PortalVisibility.PUBLIC,
             List.of(PortalCategoryId.of(CATEGORY_ID_1))
         );
-        var apiProductItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
-        navigationItemsQueryService.initWith(List.of(folder, apiInCategory, apiProductItem));
+        var productInCategory = apiProductItem(
+            "product-item-in-category-id",
+            "product-in-category-id",
+            null,
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        var productOutsideCategory = apiProductItem(
+            "product-item-outside-category-id",
+            "product-outside-category-id",
+            null,
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_2))
+        );
+        navigationItemsQueryService.initWith(List.of(folder, apiInCategory, productInCategory, productOutsideCategory));
         initApis(List.of(api("api-in-category-id", "In Category API", "1.0.0")));
-        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of())));
+        apiProductQueryService.initWith(
+            List.of(
+                apiProduct("product-in-category-id", "Matching Product", Set.of()),
+                apiProduct("product-outside-category-id", "Outside Product", Set.of())
+            )
+        );
 
         var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10, Optional.of(CATEGORY_ID_1)));
 
-        assertThat(output.items().getContent()).containsExactly(apiInCategory);
+        assertThat(output.items().getContent()).containsExactly(apiInCategory, productInCategory);
         assertThat(output.includedApiProducts()).isEmpty();
+    }
+
+    @Test
+    void should_preserve_visible_product_api_summaries_when_filtering_catalog_by_product_category() {
+        var productItem = apiProductItem(
+            "product-item-id",
+            "product-id",
+            null,
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        var publicApiItem = apiItem("public-api-item-id", "public-api-id", productItem.getId(), PortalVisibility.PUBLIC);
+        var privateApiItem = apiItem("private-api-item-id", "private-api-id", productItem.getId(), PortalVisibility.PRIVATE);
+        navigationItemsQueryService.initWith(List.of(productItem, publicApiItem, privateApiItem));
+        initApis(List.of(api("public-api-id", "Public API", "1.0.0"), api("private-api-id", "Private API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of("public-api-id", "private-api-id"))));
+
+        var output = useCase.execute(
+            input(Optional.empty(), Set.of(PortalNavigationSearchInclude.API_PRODUCT), 1, 10, Optional.of(CATEGORY_ID_1))
+        );
+
+        assertThat(output.items().getContent()).containsExactly(productItem);
+        assertThat(output.includedApiProducts())
+            .singleElement()
+            .satisfies(summary ->
+                assertThat(summary.apis()).extracting(PortalCatalogApiProductSummary.ApiSummary::id).containsExactly("public-api-id")
+            );
+    }
+
+    @Test
+    void should_not_inherit_api_product_category_from_an_included_api() {
+        var productItem = apiProductItem("product-item-id", "product-id", null, PortalVisibility.PUBLIC);
+        var includedApi = apiItem(
+            "included-api-item-id",
+            "included-api-id",
+            productItem.getId(),
+            PortalVisibility.PUBLIC,
+            List.of(PortalCategoryId.of(CATEGORY_ID_1))
+        );
+        navigationItemsQueryService.initWith(List.of(productItem, includedApi));
+        initApis(List.of(api("included-api-id", "Included API", "1.0.0")));
+        apiProductQueryService.initWith(List.of(apiProduct("product-id", "Product", Set.of("included-api-id"))));
+
+        var output = useCase.execute(input(Optional.empty(), Set.of(), 1, 10, Optional.of(CATEGORY_ID_1)));
+
+        assertThat(output.items().getContent()).isEmpty();
     }
 
     @Test
@@ -541,6 +606,16 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
         PortalNavigationItemId parentId,
         PortalVisibility visibility
     ) {
+        return apiProductItem(id, apiProductId, parentId, visibility, List.of());
+    }
+
+    private PortalNavigationApiProduct apiProductItem(
+        String id,
+        String apiProductId,
+        PortalNavigationItemId parentId,
+        PortalVisibility visibility,
+        List<PortalCategoryId> categoryIds
+    ) {
         return PortalNavigationApiProduct.builder()
             .id(navigationItemId(id))
             .organizationId(ORG_ID)
@@ -553,6 +628,7 @@ class GetVisiblePortalCatalogItemsUseCaseTest {
             .apiProductId(apiProductId)
             .published(true)
             .visibility(visibility)
+            .categoryIds(categoryIds)
             .build();
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-136

## Summary

Integrates API Products into the category-filtered Portal Next catalog.

API Products assigned directly to the selected category are now returned and displayed alongside matching standalone APIs.

## Changes

- expose API Product `categoryIds` through the Portal API
- filter visible API Products by their direct category assignments
- preserve visibility, search, sorting, and pagination behavior
- propagate API Product categories to the Portal Next catalog view
- display assigned categories in the existing catalog list
- prevent API Products from inheriting categories from their nested APIs
- cover authenticated and anonymous catalog access

https://github.com/user-attachments/assets/64696e28-2415-48ea-9d72-2f3914cc6d8a


