### PR TITLE
fix(repository): seed token-bucket row outside the locking transaction

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
@@ -49,8 +49,14 @@ import org.springframework.stereotype.Repository;
  * under concurrency. Owning the connection here guarantees the lock is held across the whole
  * read-modify-write regardless of how the surrounding context wires its transaction manager.
  *
- * <p>The first request for a key has no row to lock, so a concurrent insert can lose the race with a
- * duplicate-key error; that is retried, and the retry locks the now-existing row.
+ * <p>The first request for a key has no row to lock, so the row is <em>seeded</em> first — a full,
+ * untouched bucket inserted in auto-commit, outside any locking transaction — and the locking
+ * transaction then consumes from it. A concurrent seeder simply loses with a duplicate-key error,
+ * which is ignored: either way the row exists afterwards. Seeding must never happen inside the
+ * locking transaction: on MySQL/MariaDB (and SQL Server's {@code HOLDLOCK}) an empty locking SELECT
+ * takes a shared range lock on the index gap, so N concurrent first requests would all take it and
+ * then every INSERT would wait on the others' — a guaranteed deadlock storm under a concurrent
+ * first request, which no bounded retry reliably survives.
  *
  * <p><strong>No automatic eviction.</strong> Unlike the other backends — Mongo (TTL index), Redis
  * ({@code PEXPIREAT}) and Hazelcast (entry TTL) all honour {@link TokenBucketCalculator#ttlMillis} — a
@@ -63,7 +69,8 @@ import org.springframework.stereotype.Repository;
 @Repository("tokenBucketRateLimitRepository")
 public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
 
-    private static final int MAX_INSERT_RETRIES = 5;
+    /** Safety net only: the seed/lock handshake converges by design, retries cover external interference (e.g. a purge racing the seed). */
+    private static final int MAX_RETRIES = 5;
 
     /** Upper bound on each statement, preserved from the previous transaction-template timeout so a request cannot block indefinitely on the row lock. */
     private static final int STATEMENT_TIMEOUT_SECONDS = 5;
@@ -116,28 +123,51 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
         long nowMillis,
         Supplier<TokenBucket> supplier
     ) throws SQLException {
+        // Validate before any write so a contract violation cannot seed a row before failing.
+        TokenBucketCalculator.requireValidArgs(tokensRequested, refillPeriodMillis, capacity);
         for (int attempt = 0; ; attempt++) {
             try {
-                return consumeInTransaction(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis, supplier);
-            } catch (SQLException e) {
-                // Concurrent first-insert race; the row now exists, so the retry's locking SELECT serialises on it.
-                // PostgreSQL surfaces it as an integrity violation, MySQL/MariaDB as an InnoDB deadlock.
-                if ((isIntegrityViolation(e) || isTransientRollback(e)) && attempt < MAX_INSERT_RETRIES) {
-                    continue;
+                TokenBucketConsumeResult result = consumeInTransaction(
+                    key,
+                    tokensRequested,
+                    refillRate,
+                    refillPeriodMillis,
+                    capacity,
+                    nowMillis
+                );
+                if (result == null) {
+                    // First request for this key: seed the row (see the class javadoc), then lock and consume it.
+                    seed(key, TokenBucketCalculator.newFullBucket(supplier.get(), capacity, nowMillis));
+                    result = consumeInTransaction(key, tokensRequested, refillRate, refillPeriodMillis, capacity, nowMillis);
                 }
-                throw e;
+                if (result != null) {
+                    return result;
+                }
+                // The row vanished between the seed and the locking pass (external purge racing us): retry.
+            } catch (SQLException e) {
+                // A leftover transient rollback or integrity violation is safe to replay: the transaction rolled back entirely.
+                if ((!isIntegrityViolation(e) && !isTransientRollback(e)) || attempt >= MAX_RETRIES) {
+                    throw e;
+                }
+            }
+            if (attempt >= MAX_RETRIES) {
+                throw new SQLException("Token bucket '" + key + "' could not be consumed after " + (attempt + 1) + " attempts");
             }
         }
     }
 
+    /**
+     * Lock the row for {@code key}, refill/consume and write it back, all in one transaction.
+     * Returns {@code null} — after releasing the (range) lock via rollback — when no row exists yet,
+     * so the caller can seed it lock-free.
+     */
     private TokenBucketConsumeResult consumeInTransaction(
         String key,
         long tokensRequested,
         long refillRate,
         long refillPeriodMillis,
         long capacity,
-        long nowMillis,
-        Supplier<TokenBucket> supplier
+        long nowMillis
     ) throws SQLException {
         final DataSource dataSource = jdbcTemplate.getDataSource();
         try (Connection connection = dataSource.getConnection()) {
@@ -145,9 +175,11 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
             connection.setAutoCommit(false);
             try {
                 TokenBucket bucket = selectForUpdate(connection, key);
-                boolean isNew = bucket == null;
-                if (isNew) {
-                    bucket = TokenBucketCalculator.newFullBucket(supplier.get(), capacity, nowMillis);
+                if (bucket == null) {
+                    // Nothing read, nothing written: roll back to release the range lock the empty
+                    // locking SELECT may hold, so the caller's seed INSERT cannot deadlock on it.
+                    connection.rollback();
+                    return null;
                 }
 
                 TokenBucketConsumeResult result = TokenBucketCalculator.refillAndTryConsume(
@@ -159,16 +191,35 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
                     nowMillis
                 );
 
-                if (isNew) {
-                    insert(connection, key, bucket);
-                } else {
-                    update(connection, key, bucket);
-                }
+                update(connection, key, bucket);
                 connection.commit();
                 return result;
             } catch (SQLException | RuntimeException e) {
                 connection.rollback();
                 throw e;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        }
+    }
+
+    /**
+     * Insert a full, untouched bucket for {@code key} in auto-commit, tolerating the duplicate key a
+     * concurrent seeder loses with — either way the row exists (and is committed) afterwards.
+     */
+    private void seed(String key, TokenBucket bucket) throws SQLException {
+        final DataSource dataSource = jdbcTemplate.getDataSource();
+        try (Connection connection = dataSource.getConnection()) {
+            final boolean previousAutoCommit = connection.getAutoCommit();
+            // The seed must be committed and visible before the locking pass, whatever the pool's default.
+            connection.setAutoCommit(true);
+            try {
+                insert(connection, key, bucket);
+            } catch (SQLException e) {
+                if (!isIntegrityViolation(e)) {
+                    throw e;
+                }
+                // Another request seeded the row first; the locking pass will consume from it.
             } finally {
                 connection.setAutoCommit(previousAutoCommit);
             }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepository.java
@@ -145,8 +145,10 @@ public class JdbcTokenBucketRateLimitRepository implements TokenBucketRateLimitR
                 }
                 // The row vanished between the seed and the locking pass (external purge racing us): retry.
             } catch (SQLException e) {
-                // A leftover transient rollback or integrity violation is safe to replay: the transaction rolled back entirely.
-                if ((!isIntegrityViolation(e) && !isTransientRollback(e)) || attempt >= MAX_RETRIES) {
+                // A transient rollback is safe to replay: the transaction rolled back entirely. Integrity
+                // violations cannot surface here — the transaction only reads and updates, and a duplicate
+                // key on the seed is absorbed by seed() itself.
+                if (!isTransientRollback(e) || attempt >= MAX_RETRIES) {
                     throw e;
                 }
             }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepositoryFailureTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/ratelimit/JdbcTokenBucketRateLimitRepositoryFailureTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Covers how {@link JdbcTokenBucketRateLimitRepository} handles database failures: the seed/lock
+ * handshake on a first request and the bounded retry around it.
+ *
+ * <p>These paths are driven by errors a container-backed test can only produce by racing — a
+ * duplicate key from a concurrent seeder, an InnoDB deadlock — which is precisely the flakiness the
+ * seed-outside-the-lock design removes. Here they are injected deterministically against a stubbed
+ * JDBC layer. Functional behaviour against real databases stays in
+ * {@link JdbcTokenBucketRateLimitRepositoryTest}.
+ */
+class JdbcTokenBucketRateLimitRepositoryFailureTest {
+
+    private static final String KEY = "k";
+    private static final String SUBSCRIPTION = "sub";
+    private static final long CAPACITY = 10L;
+    private static final long NOW = 1_000L;
+
+    /** SQLState of an InnoDB/range-lock deadlock: transient, safe to replay. */
+    private static final String DEADLOCK_SQLSTATE = "40001";
+
+    /** SQLState of a primary-key clash: the concurrent seeder that lost. */
+    private static final String DUPLICATE_KEY_SQLSTATE = "23505";
+
+    /** SQLState of a connection failure: neither transient nor an integrity violation, so never replayed. */
+    private static final String CONNECTION_FAILURE_SQLSTATE = "08006";
+
+    private final DataSource dataSource = mock(DataSource.class);
+    private final FakeDatabase database = new FakeDatabase();
+    private final JdbcTokenBucketRateLimitRepository repository = new JdbcTokenBucketRateLimitRepository("");
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        when(dataSource.getConnection()).thenAnswer(database);
+        ReflectionTestUtils.setField(repository, "jdbcTemplate", new JdbcTemplate(dataSource));
+    }
+
+    @Test
+    void seeds_the_row_outside_the_transaction_then_consumes_it_on_first_request() {
+        TokenBucketConsumeResult result = consume();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(database.insertCount).isEqualTo(1);
+        // One locking SELECT that finds nothing, one that finds the seeded row.
+        assertThat(database.selectCount).isEqualTo(2);
+        assertThat(database.updateCount).isEqualTo(1);
+    }
+
+    @Test
+    void rolls_back_the_empty_locking_select_before_seeding() {
+        consume();
+
+        // The range lock the empty SELECT may hold must be released before the seed INSERT runs,
+        // otherwise concurrent first requests deadlock on each other.
+        assertThat(database.rollbackCount).isEqualTo(1);
+        assertThat(database.rolledBackBeforeFirstInsert).isTrue();
+    }
+
+    @Test
+    void tolerates_a_concurrent_seeder_winning_the_insert() {
+        database.insertFailures.add(sqlException(DUPLICATE_KEY_SQLSTATE));
+
+        TokenBucketConsumeResult result = consume();
+
+        assertThat(result.allowed()).isTrue();
+        // The duplicate key is swallowed: the row exists either way, so the locking pass consumes it.
+        assertThat(database.insertCount).isEqualTo(1);
+        assertThat(database.updateCount).isEqualTo(1);
+    }
+
+    @Test
+    void rethrows_a_seed_failure_that_is_not_a_duplicate_key() {
+        database.insertFailures.add(sqlException(CONNECTION_FAILURE_SQLSTATE));
+
+        assertThat(rootFailureOf(this::consume).getSQLState()).isEqualTo(CONNECTION_FAILURE_SQLSTATE);
+        assertThat(database.insertCount).isEqualTo(1);
+    }
+
+    @Test
+    void retries_a_deadlocked_transaction_and_succeeds() {
+        database.rowPresent = true;
+        database.selectFailures.add(sqlException(DEADLOCK_SQLSTATE));
+
+        TokenBucketConsumeResult result = consume();
+
+        assertThat(result.allowed()).isTrue();
+        assertThat(database.selectCount).isEqualTo(2);
+        assertThat(database.rollbackCount).isEqualTo(1);
+    }
+
+    @Test
+    void does_not_retry_a_failure_that_is_not_transient() {
+        database.rowPresent = true;
+        database.selectFailures.add(sqlException(CONNECTION_FAILURE_SQLSTATE));
+
+        assertThat(rootFailureOf(this::consume).getSQLState()).isEqualTo(CONNECTION_FAILURE_SQLSTATE);
+        assertThat(database.selectCount).isEqualTo(1);
+    }
+
+    @Test
+    void gives_up_after_a_bounded_number_of_deadlocks() {
+        database.rowPresent = true;
+        database.alwaysDeadlock = true;
+
+        assertThat(rootFailureOf(this::consume).getSQLState()).isEqualTo(DEADLOCK_SQLSTATE);
+        // The initial attempt plus MAX_RETRIES, then the deadlock propagates rather than looping forever.
+        assertThat(database.selectCount).isEqualTo(6);
+    }
+
+    @Test
+    void gives_up_when_the_row_keeps_vanishing_between_the_seed_and_the_lock() {
+        // Simulates an external purge deleting the row as fast as it is seeded.
+        database.discardInserts = true;
+
+        assertThat(rootFailureOf(this::consume).getMessage()).contains("could not be consumed after 6 attempts");
+        assertThat(database.insertCount).isEqualTo(6);
+    }
+
+    @Test
+    void rejects_invalid_arguments_before_touching_the_database() {
+        assertThatThrownBy(() -> repository.refillAndTryConsume(KEY, 1, 1, 0, CAPACITY, NOW, seed()).blockingGet()).isInstanceOf(
+            IllegalArgumentException.class
+        );
+
+        // A contract violation must not leave a seeded row behind.
+        verifyNoInteractions(dataSource);
+    }
+
+    private TokenBucketConsumeResult consume() {
+        return repository.refillAndTryConsume(KEY, 1, 0, 1_000L, CAPACITY, NOW, seed()).blockingGet();
+    }
+
+    private Supplier<TokenBucket> seed() {
+        return () -> {
+            TokenBucket bucket = new TokenBucket(KEY);
+            bucket.setSubscription(SUBSCRIPTION);
+            return bucket;
+        };
+    }
+
+    private static SQLException sqlException(String sqlState) {
+        return new SQLException("stubbed " + sqlState, sqlState);
+    }
+
+    /** Unwrap the RxJava wrapper {@code blockingGet} adds around a checked exception. */
+    private static SQLException rootFailureOf(ThrowingCallable callable) {
+        Throwable thrown = catchThrowable(callable);
+        assertThat(thrown).isNotNull();
+        Throwable root = thrown;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertThat(root).isInstanceOf(SQLException.class);
+        return (SQLException) root;
+    }
+
+    /**
+     * Minimal stand-in for the token-bucket table: one optional row, plus hooks to make the next
+     * statement fail the way a real database would.
+     */
+    private static final class FakeDatabase implements Answer<Connection> {
+
+        private final Deque<SQLException> selectFailures = new ArrayDeque<>();
+        private final Deque<SQLException> insertFailures = new ArrayDeque<>();
+
+        private boolean rowPresent;
+        private boolean alwaysDeadlock;
+        private boolean discardInserts;
+        private boolean rolledBackBeforeFirstInsert;
+
+        private int selectCount;
+        private int insertCount;
+        private int updateCount;
+        private int rollbackCount;
+
+        @Override
+        public Connection answer(InvocationOnMock invocation) throws SQLException {
+            Connection connection = mock(Connection.class);
+            doAnswer(ignored -> {
+                rollbackCount++;
+                rolledBackBeforeFirstInsert = insertCount == 0;
+                return null;
+            })
+                .when(connection)
+                .rollback();
+            when(connection.prepareStatement(anyString())).thenAnswer(statement -> prepare(statement.getArgument(0)));
+            return connection;
+        }
+
+        private PreparedStatement prepare(String sql) throws SQLException {
+            PreparedStatement statement = mock(PreparedStatement.class);
+            if (sql.startsWith("select")) {
+                when(statement.executeQuery()).thenAnswer(ignored -> executeSelect());
+            } else if (sql.startsWith("insert")) {
+                when(statement.executeUpdate()).thenAnswer(ignored -> executeInsert());
+            } else {
+                when(statement.executeUpdate()).thenAnswer(ignored -> {
+                    updateCount++;
+                    return 1;
+                });
+            }
+            return statement;
+        }
+
+        private ResultSet executeSelect() throws SQLException {
+            selectCount++;
+            if (alwaysDeadlock) {
+                throw sqlException(DEADLOCK_SQLSTATE);
+            }
+            if (!selectFailures.isEmpty()) {
+                throw selectFailures.poll();
+            }
+            ResultSet resultSet = mock(ResultSet.class);
+            when(resultSet.next()).thenReturn(rowPresent);
+            when(resultSet.getString(1)).thenReturn(KEY);
+            when(resultSet.getLong(2)).thenReturn(CAPACITY);
+            when(resultSet.getLong(3)).thenReturn(NOW);
+            when(resultSet.getString(4)).thenReturn(SUBSCRIPTION);
+            return resultSet;
+        }
+
+        private int executeInsert() throws SQLException {
+            insertCount++;
+            if (!insertFailures.isEmpty()) {
+                SQLException failure = insertFailures.poll();
+                // A duplicate key means another seeder committed the row first.
+                rowPresent = DUPLICATE_KEY_SQLSTATE.equals(failure.getSQLState());
+                throw failure;
+            }
+            rowPresent = !discardInserts;
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-234

## Description

`JdbcTokenBucketRateLimitRepositoryTest.concurrent_consumes_never_exceed_available_tokens` fails intermittently on MariaDB with `SQLTransactionRollbackException: Deadlock found when trying to get lock` (e.g. build 2015447: 51 deadlocks in 22 ms, one task exhausting all 5 retries).

Root cause: the first request for a key inserts the row **inside** the locking transaction. On MySQL/MariaDB (and SQL Server with `HOLDLOCK`), an empty `SELECT ... FOR UPDATE` takes a **shared range lock** on the index gap. N concurrent first requests all take it, then every `INSERT` waits on the others' range lock — a guaranteed deadlock storm that a bounded retry without backoff cannot reliably survive.

This PR removes the deadlock class instead of tuning the retry:

- When the locking `SELECT` finds no row, the transaction **rolls back immediately** (releasing the range lock), then the row is **seeded in auto-commit** — a full, untouched bucket, no token consumed — and a second locking pass consumes from it. The inserter never holds a prior lock, so no deadlock cycle can form.
- A concurrent seeder losing with a duplicate-key error is ignored: either way the row exists afterwards.
- `requireValidArgs` is now called before any write so a contract violation cannot seed a row before failing.
- The retry loop remains as a bounded safety net (external purge racing the seed, leftover transient rollbacks), and now also bounds the previously unbounded null-result path.

Semantics are unchanged: no token is consumed during seeding, consumption still happens entirely under the row lock, and a crash between seed and consume leaves a full bucket — indistinguishable from a bucket never touched. The contract test (200 concurrent consumes on a fresh key) is deliberately untouched and still exercises the first-request stampede.

## Additional context

Verified locally by running `JdbcTokenBucketRateLimitRepositoryTest` (13 tests) against MariaDB (×3 runs), PostgreSQL and MySQL: all green, zero deadlock warnings in the driver logs (the original CI run emitted 51). SQL Server is covered by the CI matrix; the same reasoning applies (`HOLDLOCK` range lock released by the rollback before seeding).

The file is identical on `master`; forward-port will be a clean cherry-pick.

