### PR TITLE
fix(gamma): change save cta placement to bottom and added spec file

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.spec.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+
+import { OrgSettingsFormShell } from './OrgSettingsFormShell';
+
+type ShellProps = ComponentProps<typeof OrgSettingsFormShell>;
+
+function renderShell(overrides: Partial<ShellProps> = {}) {
+    const onSave = jest.fn();
+    const onDiscard = jest.fn();
+    render(
+        <OrgSettingsFormShell
+            title="CORS"
+            description="Configure CORS for the Management Console."
+            canEdit
+            isDirty
+            isValid
+            isSaving={false}
+            isLoading={false}
+            isError={false}
+            onSave={onSave}
+            onDiscard={onDiscard}
+            {...overrides}
+        >
+            {overrides.children ?? <div data-testid="form-content">Form fields</div>}
+        </OrgSettingsFormShell>,
+    );
+    return { onSave, onDiscard };
+}
+
+describe('OrgSettingsFormShell', () => {
+    it('places Discard and Save after the form content in a sticky bottom bar when dirty', () => {
+        renderShell();
+
+        const content = screen.getByTestId('form-content');
+        const discard = screen.getByRole('button', { name: 'Discard' });
+        const save = screen.getByRole('button', { name: /Save changes/i });
+
+        expect(content.compareDocumentPosition(discard) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        expect(content.compareDocumentPosition(save) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        expect(save.closest('.sticky.bottom-0')).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'CORS' }).closest('.flex.items-start.justify-between')).toBeNull();
+    });
+
+    it('does not show Discard or Save when there are no unsaved changes', () => {
+        renderShell({ isDirty: false });
+
+        expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+    });
+
+    it('does not show Discard or Save when the user cannot edit', () => {
+        renderShell({ canEdit: false });
+
+        expect(screen.queryByRole('button', { name: 'Discard' })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+    });
+
+    it('invokes discard and save handlers', () => {
+        const { onSave, onDiscard } = renderShell();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+        fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        expect(onDiscard).toHaveBeenCalledTimes(1);
+        expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Save when the form is invalid', () => {
+        renderShell({ isValid: false });
+
+        expect(screen.getByRole('button', { name: /Save changes/i })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('button', { name: 'Discard' })).toHaveProperty('disabled', false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.tsx
@@ -69,22 +69,9 @@ export function OrgSettingsFormShell({
     return (
         <TooltipProvider delayDuration={200}>
             <div className="space-y-6">
-                <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-1">
-                        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
-                        <p className="text-sm text-muted-foreground">{description}</p>
-                    </div>
-                    {isDirty && canEdit ? (
-                        <div className="flex shrink-0 items-center gap-2">
-                            <Button variant="outline" size="sm" onClick={onDiscard} disabled={isSaving}>
-                                Discard
-                            </Button>
-                            <Button size="sm" onClick={onSave} disabled={isSaving || !isValid}>
-                                <CheckIcon className="size-4" aria-hidden />
-                                {isSaving ? 'Saving…' : 'Save changes'}
-                            </Button>
-                        </div>
-                    ) : null}
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+                    <p className="text-sm text-muted-foreground">{description}</p>
                 </div>
 
                 <Alert>
@@ -105,6 +92,18 @@ export function OrgSettingsFormShell({
                 ) : null}
 
                 {children}
+
+                {isDirty && canEdit ? (
+                    <div className="sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t bg-background py-4">
+                        <Button variant="outline" size="sm" onClick={onDiscard} disabled={isSaving}>
+                            Discard
+                        </Button>
+                        <Button size="sm" onClick={onSave} disabled={isSaving || !isValid}>
+                            <CheckIcon className="size-4" aria-hidden />
+                            {isSaving ? 'Saving…' : 'Save changes'}
+                        </Button>
+                    </div>
+                ) : null}
             </div>
         </TooltipProvider>
     );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-52

## Summary
- Moves **Discard** and **Save changes** off the Organization Settings page header onto a sticky bottom action bar, matching identity-provider and other Gamma forms.
- One change in `OrgSettingsFormShell` covers CORS, SMTP, and Management & Schedulers ([FOUND-45](https://gravitee.atlassian.net/browse/FOUND-45) / review on [FOUND-52](https://gravitee.atlassian.net/browse/FOUND-52)).
- Dirty-state behavior is unchanged: CTAs still appear only when the form is dirty and the user can edit; Save stays disabled while invalid or saving.

## Test plan
- [x] CORS: edit a field, confirm Discard / Save sit in a sticky bar at the bottom (not beside the title), then discard and save.
- [x] SMTP: same after a dirty edit.
- [x] Management & Schedulers: same after a dirty edit.
- [x] Read-only user: no Discard / Save.
- [x] Clean form: no Discard / Save until something changes.
## Additional context

<img width="1728" height="853" alt="image" src="https://github.com/user-attachments/assets/93b1ba8a-2752-4c48-a5eb-9e9338630c45" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



[FOUND-45]: https://gravitee.atlassian.net/browse/FOUND-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-52]: https://gravitee.atlassian.net/browse/FOUND-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ