### PR TITLE
chore: bump up resource-oauth2-provider-api to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
     <gravitee-resource-cache-provider-api.version>2.2.0</gravitee-resource-cache-provider-api.version>
     <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
-    <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
+    <gravitee-resource-oauth2-provider-api.version>1.6.0</gravitee-resource-oauth2-provider-api.version>
     <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>
     <gravitee-scoring-api.version>0.7.0</gravitee-scoring-api.version>
     <gravitee-secret-api.version>3.0.0</gravitee-secret-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-113

## Description

bump up resource-oauth2-provider-api to 1.6.0


