### PR TITLE
fix: bump gravitee-endpoint-jms to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.2</gravitee-entrypoint-mcp-tool-server.version>
-        <gravitee-endpoint-jms.version>2.0.1</gravitee-endpoint-jms.version>
+        <gravitee-endpoint-jms.version>2.0.2</gravitee-endpoint-jms.version>
         <gravitee-endpoint-kafka.version>6.1.5</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14872

## Description

Bumps the JMS endpoint plugin to 2.0.2, which fixes APIM-14872: the JNDI `InitialContextFactory` (and, after a reviewer-flagged follow-up, `ConnectionFactory.createConnection()`) were resolved via the gateway's thread context classloader instead of the plugin's own classloader, so JMS provider libraries placed in `plugins/ext/jms/` (e.g. Oracle AQ) were invisible and failed with `ClassNotFoundException`. See gravitee-io/gravitee-endpoint-jms#43 for the fix itself.

## Additional context

Verified against the real 2.0.2 release resolved from Artifactory (not a local build):
- Real ActiveMQ JNDI connection factory lookup: succeeds end-to-end against a live broker.
- `createConnection()` TCCL coverage: verified via a synthetic JNDI provider reproducing the exact classloading gap described in the ticket - succeeds cleanly with 2.0.2.