### PR TITLE
chore(deps): bump gravitee-gamma-module-aim to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
     <gravitee-resource-ai-model-token-classification.version>2.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>1.11.0</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>1.13.0</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.2.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.3.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-238

## Description

1.13.0 - Connection car: The LLM proxy overview now shows the connection card with the entrypoint URL consumers call

## Additional context

<img width="1918" height="751" alt="image" src="https://github.com/user-attachments/assets/79d1abc5-fc45-4a96-a78e-69fd9f681272" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

