### PR TITLE
chore(distribution): bump authz pdp to 2.1.1 and authz module to 1.16.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -274,12 +274,12 @@
 
     <!-- Gamma plugins -->
     <gravitee-gamma-module-aim.version>3.20.2</gravitee-gamma-module-aim.version>
-    <gravitee-gamma-module-authz.version>1.13.0</gravitee-gamma-module-authz.version>
+    <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.3.0</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.4.0</gravitee-gamma-module-esm.version>
 
     <!-- Authz plugins -->
-    <gravitee-service-authz-pdp.version>2.1.0</gravitee-service-authz-pdp.version>
+    <gravitee-service-authz-pdp.version>2.1.1</gravitee-service-authz-pdp.version>
     <gravitee-policy-authz-pep.version>1.4.0</gravitee-policy-authz-pep.version>
     <gravitee-policy-authz-pdp-authzen.version>1.2.0</gravitee-policy-authz-pdp-authzen.version>
     </properties>


### PR DESCRIPTION
Bumps the two authz plugins bundled by the distribution to their latest releases.

### `gravitee-service-authz-pdp` 2.1.0 → 2.1.1

- fix: match policies that target a namespaced action (AUTHZ-93)

A policy targeting an action declared inside a schema namespace (`ds::Action::"drive"`) never matched, because the PDP hardcoded the `Action` entity type when building the request UID. A request can now name a namespaced action either as a canonical entity UID in `action.name`, or with a bare name plus `action.properties.type`. No previously accepted action string changes identity.

### `gravitee-gamma-module-authz` 1.13.0 → 1.16.0

- feat(observability): add the authz decisions view
- feat(observability): add the authorization overview dashboard
- feat(persistence): jdbc foundation, schema and test harness
- feat(persistence): pdp, schema, policy and entity repositories on jdbc

The JDBC support requires the 4.13 module classloader anchoring, which this branch already carries.

### Verification

Both artifacts resolve from the releases repository:

- `com.graviteesource.gamma:gravitee-service-authz-pdp:2.1.1:zip`
- `com.graviteesource.gamma.module:gravitee-gamma-module-authz:1.16.0:zip`