### PR TITLE
feat(portal-next): portal-scoped current theme resolution

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.theme.use_case.GetCurrentThemeUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.InlinePictureEntity;
@@ -52,7 +53,7 @@ public class ThemeResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getPortalTheme(@QueryParam("type") ThemeType themeType) {
+    public Response getPortalTheme(@QueryParam("type") ThemeType themeType, @QueryParam("portalId") String portalId) {
         if (Objects.isNull(themeType)) {
             throw new ThemeTypeNotSupportedException();
         }
@@ -61,6 +62,7 @@ public class ThemeResource extends AbstractResource {
                 GetCurrentThemeUseCase.Input.builder()
                     .type(io.gravitee.apim.core.theme.model.ThemeType.valueOf(themeType.name()))
                     .executionContext(GraviteeContext.getExecutionContext())
+                    .portalId(portalId != null ? PortalId.of(portalId) : null)
                     .build()
             )
             .result();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCase.java
@@ -16,12 +16,17 @@
 package io.gravitee.apim.core.theme.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.theme.crud_service.ThemeCrudService;
 import io.gravitee.apim.core.theme.domain_service.DefaultThemeDomainService;
 import io.gravitee.apim.core.theme.model.Theme;
 import io.gravitee.apim.core.theme.model.ThemeType;
 import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -32,19 +37,42 @@ public class GetCurrentThemeUseCase {
 
     private final ThemeQueryService themeQueryService;
     private final DefaultThemeDomainService defaultThemeDomainService;
+    private final PortalCrudService portalCrudService;
+    private final ThemeCrudService themeCrudService;
 
     public Output execute(Input input) {
-        var currentTheme = this.themeQueryService.findByThemeTypeAndEnvironmentId(input.type(), input.executionContext().getEnvironmentId())
+        var envId = input.executionContext().getEnvironmentId();
+        var theme = resolveByPortal(input.portalId(), envId).orElseGet(() ->
+            resolveEnabledOrCreate(input.type(), envId, input.executionContext())
+        );
+        return new Output(theme);
+    }
+
+    private Optional<Theme> resolveByPortal(PortalId portalId, String envId) {
+        if (portalId == null) {
+            return Optional.empty();
+        }
+        return portalCrudService
+            .findByIdAndEnvironmentId(portalId, envId)
+            .map(Portal::getActiveThemeId)
+            .flatMap(themeId -> themeCrudService.findByIdAndEnvironmentId(themeId, envId));
+    }
+
+    private Theme resolveEnabledOrCreate(ThemeType type, String envId, ExecutionContext ctx) {
+        return themeQueryService
+            .findByThemeTypeAndEnvironmentId(type, envId)
             .stream()
             .filter(theme -> Objects.equals(true, theme.isEnabled()))
             .findFirst()
-            .orElseGet(() -> this.defaultThemeDomainService.createAndEnableDefaultTheme(input.type(), input.executionContext()));
-
-        return new Output(currentTheme);
+            .orElseGet(() -> defaultThemeDomainService.createAndEnableDefaultTheme(type, ctx));
     }
 
     @Builder
-    public record Input(ThemeType type, ExecutionContext executionContext) {}
+    public record Input(ThemeType type, ExecutionContext executionContext, PortalId portalId) {
+        public Input(ThemeType type, ExecutionContext executionContext) {
+            this(type, executionContext, null);
+        }
+    }
 
     public record Output(Theme result) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCase.java
@@ -41,30 +41,30 @@ public class GetCurrentThemeUseCase {
     private final ThemeCrudService themeCrudService;
 
     public Output execute(Input input) {
-        var envId = input.executionContext().getEnvironmentId();
-        var theme = resolveByPortal(input.portalId(), envId).orElseGet(() ->
-            resolveEnabledOrCreate(input.type(), envId, input.executionContext())
+        var environmentId = input.executionContext().getEnvironmentId();
+        var theme = resolveByPortal(input.portalId(), environmentId).orElseGet(() ->
+            resolveEnabledOrCreate(input.type(), environmentId, input.executionContext())
         );
         return new Output(theme);
     }
 
-    private Optional<Theme> resolveByPortal(PortalId portalId, String envId) {
+    private Optional<Theme> resolveByPortal(PortalId portalId, String environmentId) {
         if (portalId == null) {
             return Optional.empty();
         }
         return portalCrudService
-            .findByIdAndEnvironmentId(portalId, envId)
+            .findByIdAndEnvironmentId(portalId, environmentId)
             .map(Portal::getActiveThemeId)
-            .flatMap(themeId -> themeCrudService.findByIdAndEnvironmentId(themeId, envId));
+            .flatMap(themeId -> themeCrudService.findByIdAndEnvironmentId(themeId, environmentId));
     }
 
-    private Theme resolveEnabledOrCreate(ThemeType type, String envId, ExecutionContext ctx) {
+    private Theme resolveEnabledOrCreate(ThemeType type, String environmentId, ExecutionContext executionContext) {
         return themeQueryService
-            .findByThemeTypeAndEnvironmentId(type, envId)
+            .findByThemeTypeAndEnvironmentId(type, environmentId)
             .stream()
             .filter(theme -> Objects.equals(true, theme.isEnabled()))
             .findFirst()
-            .orElseGet(() -> defaultThemeDomainService.createAndEnableDefaultTheme(type, ctx));
+            .orElseGet(() -> defaultThemeDomainService.createAndEnableDefaultTheme(type, executionContext));
     }
 
     @Builder

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetCurrentThemeUseCaseTest.java
@@ -20,10 +20,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.InMemoryAlternative;
 import inmemory.ParametersDomainServiceInMemory;
+import inmemory.PortalCrudServiceInMemory;
 import inmemory.ThemeCrudServiceInMemory;
 import inmemory.ThemePortalNextAssetsDomainServiceInMemory;
 import inmemory.ThemeQueryServiceInMemory;
 import inmemory.ThemeServiceLegacyWrapperInMemory;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.theme.domain_service.DefaultThemeDomainService;
 import io.gravitee.apim.core.theme.domain_service.ThemeDomainService;
 import io.gravitee.apim.core.theme.domain_service.ThemePortalNextAssetsDomainService;
@@ -67,6 +70,7 @@ public class GetCurrentThemeUseCaseTest {
     ThemeServiceLegacyWrapperInMemory themeServiceLegacyWrapper = new ThemeServiceLegacyWrapperInMemory();
     ThemeQueryServiceInMemory themeQueryServiceInMemory = new ThemeQueryServiceInMemory(themeCrudService);
     ThemePortalNextAssetsDomainServiceInMemory themePortalNextAssetsDomainService = new ThemePortalNextAssetsDomainServiceInMemory();
+    PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
 
     DefaultThemeDomainService defaultThemeDomainService;
     GetCurrentThemeUseCase cut;
@@ -132,14 +136,18 @@ public class GetCurrentThemeUseCaseTest {
             themeServiceLegacyWrapper,
             themePortalNextAssetsDomainService
         );
-        cut = new GetCurrentThemeUseCase(themeQueryServiceInMemory, defaultThemeDomainService);
+        cut = new GetCurrentThemeUseCase(themeQueryServiceInMemory, defaultThemeDomainService, portalCrudService, themeCrudService);
     }
 
     @AfterEach
     void tearDown() {
-        Stream.of(parametersDomainService, themeCrudService, themeServiceLegacyWrapper, themeQueryServiceInMemory).forEach(
-            InMemoryAlternative::reset
-        );
+        Stream.of(
+            parametersDomainService,
+            themeCrudService,
+            themeServiceLegacyWrapper,
+            themeQueryServiceInMemory,
+            portalCrudService
+        ).forEach(InMemoryAlternative::reset);
     }
 
     @Test
@@ -189,6 +197,63 @@ public class GetCurrentThemeUseCaseTest {
             .satisfies(res -> {
                 assertThat(res.getId()).isEqualTo("portal-default-theme");
             });
+    }
+
+    @Test
+    void should_return_portal_referenced_theme_when_portal_id_provided() {
+        var portalTheme = aPortalNextTheme(false).toBuilder().id("portal-attached-theme").build();
+        var envWideTheme = aPortalNextTheme(true).toBuilder().id("env-enabled-theme").build();
+        themeCrudService.initWith(List.of(portalTheme, envWideTheme));
+        var portal = aPortalIn(EXECUTION_CONTEXT.getEnvironmentId()).withActiveThemeId("portal-attached-theme");
+        portalCrudService.initWith(List.of(portal));
+
+        var result = cut.execute(
+            GetCurrentThemeUseCase.Input.builder()
+                .type(ThemeType.PORTAL_NEXT)
+                .executionContext(EXECUTION_CONTEXT)
+                .portalId(portal.getId())
+                .build()
+        );
+
+        assertThat(result.result().getId()).isEqualTo("portal-attached-theme");
+    }
+
+    @Test
+    void should_fall_back_to_enabled_theme_when_portal_has_no_active_theme() {
+        var envWideTheme = aPortalNextTheme(true);
+        themeCrudService.initWith(List.of(envWideTheme));
+        var portal = aPortalIn(EXECUTION_CONTEXT.getEnvironmentId());
+        portalCrudService.initWith(List.of(portal));
+
+        var result = cut.execute(
+            GetCurrentThemeUseCase.Input.builder()
+                .type(ThemeType.PORTAL_NEXT)
+                .executionContext(EXECUTION_CONTEXT)
+                .portalId(portal.getId())
+                .build()
+        );
+
+        assertThat(result.result()).isEqualTo(envWideTheme);
+    }
+
+    @Test
+    void should_fall_back_to_enabled_theme_when_portal_id_unknown() {
+        var envWideTheme = aPortalNextTheme(true);
+        themeCrudService.initWith(List.of(envWideTheme));
+
+        var result = cut.execute(
+            GetCurrentThemeUseCase.Input.builder()
+                .type(ThemeType.PORTAL_NEXT)
+                .executionContext(EXECUTION_CONTEXT)
+                .portalId(PortalId.of("00000000-0000-0000-0000-0000000000ff"))
+                .build()
+        );
+
+        assertThat(result.result()).isEqualTo(envWideTheme);
+    }
+
+    private Portal aPortalIn(String environmentId) {
+        return Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), environmentId, "organization-id", "Default Portal");
     }
 
     private Theme aPortalTheme(boolean enabled) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-175

## Description

Follow-up to the theme automation work: flips theme resolution from env-first to portal-first, matching where ownership already lives (`Portal.activeThemeId`). 

Unblocks multi-portal-per-env without further code - the current "one enabled per env" invariant stops being coherent the moment `allowMultiplePortalPerEnv` flips, and removes a source of dual-truth between `Portal.activeThemeId` and `Theme.enabled`.

Portal-webui-next `GET /theme` gains an optional `portalId` query param; when supplied, resolution follows the portal's reference, otherwise it falls back to today's env-wide `enabled` lookup with lazy default-create. Console v2 untouched, nullable param, no OpenAPI/DB changes. 

Stacked on #19301.