### PR TITLE
fix(test): resolve elasticsearch fixture days from a single frozen clock

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TimeProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/TimeProvider.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.repository.elasticsearch;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -26,15 +28,52 @@ import lombok.Getter;
 @Getter
 public class TimeProvider {
 
+    /**
+     * Zone "today" and "yesterday" are resolved in, by the sample data and by the tests alike (see
+     * {@link #zone()}). UTC because the sample templates spell their timestamps out in UTC.
+     *
+     * <p>Note this only lines up with the day production resolves daily index names in — which comes from
+     * the default zone — when the JVM itself runs on UTC, as CI does.
+     */
+    private static final ZoneId ZONE = ZoneOffset.UTC;
+
     private static final DateTimeFormatter DATE_TIME_FORMATTER_WITH_DASH = DateTimeFormatter.ofPattern(
         "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
-    ).withZone(ZoneId.systemDefault());
-    private static final DateTimeFormatter DATE_FORMATTER_WITH_DASH = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(
-        ZoneId.systemDefault()
-    );
-    private static final DateTimeFormatter DATE_FORMATTER_WITH_DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd").withZone(
-        ZoneId.systemDefault()
-    );
+    ).withZone(ZONE);
+    private static final DateTimeFormatter DATE_FORMATTER_WITH_DASH = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZONE);
+    private static final DateTimeFormatter DATE_FORMATTER_WITH_DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd").withZone(ZONE);
+
+    /**
+     * How far in the past the reference instant sits, so that sample data projecting timestamps forward
+     * still lands in the past.
+     */
+    private static final Duration BACKDATE = Duration.ofMinutes(30);
+
+    /**
+     * How far into the day the reference instant is held when backdating would otherwise take it out of the
+     * current day. Enough to clear the start-of-day boundary the tests query from.
+     */
+    private static final Duration START_OF_DAY_MARGIN = Duration.ofMinutes(30);
+
+    /**
+     * Reference instant shared by the whole Elasticsearch test module, frozen for the lifetime of the JVM.
+     *
+     * <p>Sample data is indexed once against this instant, and every test asserting on it must resolve
+     * "today" and "yesterday" against the very same value — hence {@link #now()} rather than
+     * {@link Instant#now()} on the test side.
+     */
+    private static final Instant REFERENCE = reference();
+
+    private static Instant reference() {
+        Instant systemNow = Instant.now();
+        Instant backdated = systemNow.minus(BACKDATE);
+        // Backdating must never reach the previous day: repositories with no time range of their own read
+        // today's index off the system clock (MonitoringRepository, the v2 analytics commands), so the
+        // sample data has to sit on the day the system clock is on. Left unclamped, any run starting within
+        // BACKDATE of midnight indexes a dataset dated the day before and fails wholesale.
+        Instant floor = systemNow.atZone(ZONE).toLocalDate().atStartOfDay(ZONE).toInstant().plus(START_OF_DAY_MARGIN);
+        return backdated.isBefore(floor) ? floor : backdated;
+    }
 
     private final Instant now;
     private final String dateToday;
@@ -45,7 +84,7 @@ public class TimeProvider {
     private final String yesterdayWithDot;
 
     public TimeProvider() {
-        now = Instant.now().minus(30, ChronoUnit.MINUTES);
+        now = REFERENCE;
         final Instant yesterday = now.minus(1, ChronoUnit.DAYS);
 
         dateToday = DATE_FORMATTER_WITH_DASH.format(now);
@@ -56,6 +95,21 @@ public class TimeProvider {
 
         todayWithDot = DATE_FORMATTER_WITH_DOT.format(now);
         yesterdayWithDot = DATE_FORMATTER_WITH_DOT.format(yesterday);
+    }
+
+    /**
+     * @return the reference instant every Elasticsearch test must use instead of {@link Instant#now()}.
+     */
+    public static Instant now() {
+        return REFERENCE;
+    }
+
+    /**
+     * @return the zone every Elasticsearch test must resolve days in, so that the window they query and the
+     *         daily index the data sits in refer to the same day.
+     */
+    public static ZoneId zone() {
+        return ZONE;
     }
 
     public void setTimestamps(Map<String, Object> data) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/ElasticsearchLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/ElasticsearchLogRepositoryTest.java
@@ -24,7 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
+import io.gravitee.repository.elasticsearch.TimeProvider;
 import io.gravitee.repository.log.model.ExtendedLog;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -47,7 +49,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
         ExtendedLog log = logRepository.findById(
             queryContext,
             "29381bce-df59-47b2-b81b-cedf59c7b23e",
-            System.currentTimeMillis() - 24 * 60 * 60 * 1000
+            TimeProvider.now().minus(1, ChronoUnit.DAYS).toEpochMilli()
         );
 
         assertThat(log).isNotNull();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -66,8 +66,6 @@ import io.gravitee.repository.log.v4.model.analytics.TopHitsAggregate;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsQueryCriteria;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -208,7 +206,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_average_connection_duration_by_entrypoint_for_a_time_period() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.truncatedTo(ChronoUnit.DAYS).minus(Duration.ofDays(1));
             var to = now.truncatedTo(ChronoUnit.DAYS);
 
@@ -270,8 +268,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_response_status_by_entrypoint_for_a_given_api_and_date_range() {
-            var yesterdayAtStartOfTheDayEpochMilli = LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-            var yesterdayAtEndOfTheDayEpochMilli = LocalDate.now().minusDays(1).atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            var yesterday = TimeProvider.now().atZone(TimeProvider.zone()).toLocalDate().minusDays(1);
+            var yesterdayAtStartOfTheDayEpochMilli = yesterday.atStartOfDay(TimeProvider.zone()).toInstant().toEpochMilli();
+            var yesterdayAtEndOfTheDayEpochMilli = yesterday.atTime(23, 59, 59).atZone(TimeProvider.zone()).toInstant().toEpochMilli();
 
             var result = cut.searchResponseStatusRanges(
                 new QueryContext("org#1", "env#1"),
@@ -350,7 +349,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         @Test
         void should_return_response_status_by_entrypoint_for_a_given_api() {
             // Given
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = from.plus(Duration.ofDays(1));
             Duration interval = Duration.ofMinutes(10);
@@ -374,7 +373,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         @Test
         void should_return_response_status_for_api_v2_and_v4() {
             // Given
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = from.plus(Duration.ofDays(1));
             Duration interval = Duration.ofMinutes(10);
@@ -429,7 +428,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_response_status_over_time_for_a_given_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -450,7 +449,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_response_status_over_time_for_api_v2_and_v4() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -512,8 +511,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_count_for_a_given_api_and_date_range() {
-            var yesterdayAtStartOfTheDayEpochMilli = LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-            var yesterdayAtEndOfTheDayEpochMilli = LocalDate.now().minusDays(1).atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            var yesterday = TimeProvider.now().atZone(TimeProvider.zone()).toLocalDate().minusDays(1);
+            var yesterdayAtStartOfTheDayEpochMilli = yesterday.atStartOfDay(TimeProvider.zone()).toInstant().toEpochMilli();
+            var yesterdayAtEndOfTheDayEpochMilli = yesterday.atTime(23, 59, 59).atZone(TimeProvider.zone()).toInstant().toEpochMilli();
 
             var result = cut.searchTopHitsApi(
                 new QueryContext("org#1", "env#1"),
@@ -530,8 +530,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_count_for_api_v2_and_v4() {
-            var yesterdayAtStartOfTheDayEpochMilli = LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-            var yesterdayAtEndOfTheDayEpochMilli = LocalDate.now().minusDays(1).atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            var yesterday = TimeProvider.now().atZone(TimeProvider.zone()).toLocalDate().minusDays(1);
+            var yesterdayAtStartOfTheDayEpochMilli = yesterday.atStartOfDay(TimeProvider.zone()).toInstant().toEpochMilli();
+            var yesterdayAtEndOfTheDayEpochMilli = yesterday.atTime(23, 59, 59).atZone(TimeProvider.zone()).toInstant().toEpochMilli();
 
             var result = cut.searchTopHitsApi(
                 new QueryContext("org#1", "env#1"),
@@ -575,7 +576,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_count_for_a_given_api_and_date_range() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS).toEpochMilli();
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS).toEpochMilli();
 
@@ -595,7 +596,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_count_for_a_apiv2_and_v4() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS).toEpochMilli();
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS).toEpochMilli();
 
@@ -641,8 +642,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_count_for_a_given_api_and_date_range() {
-            var yesterdayAtStartOfTheDayEpochMilli = LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-            var yesterdayAtEndOfTheDayEpochMilli = LocalDate.now().minusDays(1).atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            var yesterday = TimeProvider.now().atZone(TimeProvider.zone()).toLocalDate().minusDays(1);
+            var yesterdayAtStartOfTheDayEpochMilli = yesterday.atStartOfDay(TimeProvider.zone()).toInstant().toEpochMilli();
+            var yesterdayAtEndOfTheDayEpochMilli = yesterday.atTime(23, 59, 59).atZone(TimeProvider.zone()).toInstant().toEpochMilli();
 
             var result = cut.searchTopApps(
                 new QueryContext("org#1", "env#1"),
@@ -663,8 +665,9 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_top_hits_fom_V4_and_V2() {
-            var yesterdayAtStartOfTheDayEpochMilli = LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-            var yesterdayAtEndOfTheDayEpochMilli = LocalDate.now().minusDays(1).atTime(23, 59, 59).toInstant(ZoneOffset.UTC).toEpochMilli();
+            var yesterday = TimeProvider.now().atZone(TimeProvider.zone()).toLocalDate().minusDays(1);
+            var yesterdayAtStartOfTheDayEpochMilli = yesterday.atStartOfDay(TimeProvider.zone()).toInstant().toEpochMilli();
+            var yesterdayAtEndOfTheDayEpochMilli = yesterday.atTime(23, 59, 59).atZone(TimeProvider.zone()).toInstant().toEpochMilli();
 
             var result = cut.searchTopApps(
                 new QueryContext("org#1", "env#1"),
@@ -711,7 +714,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
     class TopFailedApis {
 
         private static final String V4_API_ID = "4a6895d5-a1bc-4041-a895-d5a1bce041ae";
-        private static final Instant NOW = Instant.now();
+        private static final Instant NOW = TimeProvider.now();
         private static final long FROM = NOW.truncatedTo(ChronoUnit.DAYS).minus(Duration.ofDays(1)).toEpochMilli();
         private static final long TO = NOW.truncatedTo(ChronoUnit.DAYS).toEpochMilli();
 
@@ -768,7 +771,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_histogram_aggregates_for_a_given_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -809,7 +812,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_histogram_aggregates_for_a_v2_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -835,7 +838,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_histogram_aggregates_for_avg_gateway_response_time_ms() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -869,7 +872,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_histogram_aggregates_for_a_given_api_with_query_string() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var interval = Duration.ofMinutes(30);
@@ -905,7 +908,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_terms() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -930,7 +933,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_a_v2_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -954,7 +957,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_range() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -979,7 +982,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_terms_with_query_parameter() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -1007,7 +1010,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_terms_with_order_avg() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -1034,7 +1037,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_group_by_aggregate_for_terms_with_order_value() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -1065,7 +1068,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_stats_for_a_given_api_and_field() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -1092,7 +1095,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_stats_for_a_v2_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 
@@ -1115,7 +1118,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_empty_if_no_stats_found() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(10)).truncatedTo(ChronoUnit.DAYS);
             var to = from.plus(Duration.ofDays(1));
 
@@ -1133,7 +1136,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_stats_for_a_given_api_and_field_with_query_string() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var queryString = "status:404 AND http-method:8";
@@ -1168,7 +1171,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_all_the_requests_count_by_entrypoint_for_a_given_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var result = cut.searchRequestsCountByEvent(
@@ -1186,7 +1189,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_count_for_a_v2_api() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var result = cut.searchRequestsCountByEvent(
@@ -1204,7 +1207,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_count_for_a_given_api_and_field_with_query_string() {
-            var now = Instant.now();
+            var now = TimeProvider.now();
             var from = now.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var to = now.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
             var queryString = "status:404 AND http-method:8";
@@ -1277,8 +1280,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         private static final String NATIVE_API_ID = "273f4728-1e30-4c78-bf47-281e304c78a5";
         private static final QueryContext QUERY_CONTEXT = new QueryContext("DEFAULT", "DEFAULT");
-        private final TimeProvider timeProvider = new TimeProvider();
-        private final Instant now = timeProvider.getNow();
+        private final Instant now = TimeProvider.now();
 
         @Test
         void should_return_latest_value_summed_per_key() {
@@ -1428,7 +1430,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         private static final QueryContext QUERY_CONTEXT = new QueryContext("DEFAULT", "DEFAULT");
 
-        private static final Instant NOW = Instant.now().truncatedTo(ChronoUnit.DAYS);
+        private static final Instant NOW = TimeProvider.now().truncatedTo(ChronoUnit.DAYS);
         private static final Instant TOMORROW = NOW.plus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
         private static final Instant YESTERDAY = NOW.minus(Duration.ofDays(1)).truncatedTo(ChronoUnit.DAYS);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest.java
@@ -31,7 +31,6 @@ import io.gravitee.repository.log.v4.model.message.MessageMetricsQuery;
 import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -181,7 +180,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_yesterday() {
             var from =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(0)
                     .withMinute(1)
@@ -191,7 +190,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
                 1000;
 
             var to =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(23)
                     .withMinute(59)
@@ -219,7 +218,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_whenever_to_yesterday() {
             var to =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(23)
                     .withMinute(59)
@@ -247,7 +246,12 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_today_to_whenever() {
             var from =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(0).withMinute(1).withSecond(0).withNano(0).toEpochSecond() *
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+                    .withHour(0)
+                    .withMinute(1)
+                    .withSecond(0)
+                    .withNano(0)
+                    .toEpochSecond() *
                 1000;
 
             var result = metricsV4Repository.searchMetrics(
@@ -489,7 +493,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_yesterday_from_multi_indexes() {
             var from =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(0)
                     .withMinute(1)
@@ -499,7 +503,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
                 1000;
 
             var to =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(23)
                     .withMinute(59)
@@ -532,7 +536,7 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_whenever_to_yesterday_from_multi_indexes() {
             var to =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
                     .minusDays(1)
                     .withHour(23)
                     .withMinute(59)
@@ -565,7 +569,12 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
         @Test
         void should_return_a_page_of_connection_logs_from_today_to_whenever_from_multi_indexes() {
             var from =
-                ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(0).withMinute(1).withSecond(0).withNano(0).toEpochSecond() *
+                ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+                    .withHour(0)
+                    .withMinute(1)
+                    .withSecond(0)
+                    .withNano(0)
+                    .toEpochSecond() *
                 1000;
 
             var result = metricsV4Repository.searchMetrics(

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_FindNativeApiMetrics.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_FindNativeApiMetrics.java
@@ -24,8 +24,6 @@ import io.gravitee.repository.elasticsearch.TimeProvider;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetricKeys;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetrics;
 import jakarta.annotation.PostConstruct;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -48,9 +46,21 @@ public class MetricsElasticsearchRepositoryTest_FindNativeApiMetrics extends Abs
 
     /** Window [today 09:00 UTC, today 11:00 UTC) covering all native fixture events. */
     private static final long FROM_MILLIS =
-        ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(9).withMinute(0).withSecond(0).withNano(0).toEpochSecond() * 1000;
+        ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+            .withHour(9)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toEpochSecond() *
+        1000;
     private static final long TO_MILLIS =
-        ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(11).withMinute(0).withSecond(0).withNano(0).toEpochSecond() * 1000;
+        ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+            .withHour(11)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toEpochSecond() *
+        1000;
 
     private static final String API_ID = "kafka-api-001";
     private static final String GATEWAY_ID = "2c99d50d-d318-42d3-99d5-0dd31862d3d2";

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_SearchNativeApiMetrics.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest_SearchNativeApiMetrics.java
@@ -25,8 +25,6 @@ import io.gravitee.repository.elasticsearch.TimeProvider;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetrics;
 import io.gravitee.repository.log.v4.model.connection.NativeApiMetricsQuery;
 import jakarta.annotation.PostConstruct;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -40,9 +38,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class MetricsElasticsearchRepositoryTest_SearchNativeApiMetrics extends AbstractElasticsearchRepositoryTest {
 
     private static final long FROM_MILLIS =
-        ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(9).withMinute(0).withSecond(0).withNano(0).toEpochSecond() * 1000;
+        ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+            .withHour(9)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toEpochSecond() *
+        1000;
     private static final long TO_MILLIS =
-        ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).withHour(11).withMinute(0).withSecond(0).withNano(0).toEpochSecond() * 1000;
+        ZonedDateTime.ofInstant(TimeProvider.now(), TimeProvider.zone())
+            .withHour(11)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toEpochSecond() *
+        1000;
 
     private static final String API_ID = "kafka-api-001";
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-236

## Description

The Elasticsearch repository test module holds two clocks, and they disagree by a full calendar day whenever a build starts within 30 minutes of midnight UTC.

`TimeProvider` backdates the sample data by 30 minutes — `Instant.now().minus(30, ChronoUnit.MINUTES)` — and derives `dateToday`, `dateYesterday` and the daily index names from it. The tests, meanwhile, compute their windows from a raw `Instant.now()`, `LocalDate.now()` or `System.currentTimeMillis()`: 38 call sites across five classes. Started at 00:17 UTC, the dataset is dated the previous day while the tests query the current one, and every date-bound assertion fails at once. That is exactly what happened on the 2026-08-24 nightly: 798 tests, 23 failures, 2 errors, on this module alone. The nightly is scheduled inside that window, so this is systematic rather than flaky.

This makes `TimeProvider` the single clock of the module:

- the reference instant is frozen for the lifetime of the JVM instead of being recomputed on every `new TimeProvider()` — a second one was already being minted inside a `@Nested` class;
- `TimeProvider.now()` and `TimeProvider.zone()` replace every direct read of the system clock in the integration tests. The pattern already existed in `HealthCheckElasticsearchRepositoryTest`, which is precisely why that class never failed;
- backdating can no longer take the reference out of the current day. This part is not cosmetic: `AbstractIndexNameGenerator.getTodayIndexName()` resolves today's index from `LocalDate.now()`, so `MonitoringRepository` and the v2 analytics commands — which carry no time range of their own — read whichever day the system clock is on, no matter what the tests agree among themselves. Sharing a clock is necessary but not sufficient; the data has to sit on the system's day.

Test-only change. No production code is touched.

## Additional context

**Reproducing it without waiting for midnight.** Putting the JVM in a zone whose local clock has just passed midnight (`TZ=Etc/GMT+$N`, with `N` the current UTC hour) reproduces it faithfully, because the production clock then follows the same day. Inflating the backdate instead also reproduces the day shift, but it stretches the gap between the reference instant and the real clock, which reddens healthcheck tests for unrelated reasons.

| Run | Result |
| --- | --- |
| `master`, JVM just past midnight | 798 tests, 23 failures, 2 errors — the 27 failure lines identical to the nightly |
| This branch, reference forced into the midnight window | 801 tests, 0 failures |
| This branch, ordinary daytime, licence and prettier checks on | 801 tests, 0 failures |

**Backports.** The defect is on `4.9.x` through `4.12.x` as well — same backdate, same double use of the clock. The cherry-pick will not land cleanly everywhere: `4.12.x` should apply, `4.11.x` and `4.10.x` are missing `MetricsElasticsearchRepositoryTest_*NativeApiMetrics`, and `4.9.x` is missing `MetricsElasticsearchRepositoryTest` entirely and still carries a different `TimeProvider`. Expect to write the older ones by hand.

**Two neighbouring defects found on the way, deliberately left alone.**

- [FOUND-235](https://gravitee.atlassian.net/browse/FOUND-235) — the sample templates spell their timestamps out in UTC (`"@timestamp": "${dateToday}T06:54:30.047Z"`) while production resolves the day in the default zone. Four tests fail for a developer whose local date differs from the UTC date; on CEST that is 00:00 to 02:00 local. CI runs on UTC and never sees it.
- Not yet ticketed: `SearchResponseStatusOverTimeAdapter`, `AverageHealthCheckResponseTimeOvertimeAdapter` and `ResponseTimeRangeQueryAdapter` widen their range filter by one interval on each side while leaving `extended_bounds` on `[from, to]`. `extended_bounds` extends, it does not clamp — that is `hard_bounds` — so a document falling in the margin produces a bucket outside the requested window. Since the response carries no per-point timestamp, only `timeRange` plus ordered lists, an extra leading bucket shifts the whole series by one interval. Production code, unlike everything else here.


[FOUND-235]: https://gravitee.atlassian.net/browse/FOUND-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ