### PR TITLE
fix(api-product): search by kind and report deployment state

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventLatestRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventLatestRepositoryTest.java
@@ -136,6 +136,31 @@ public class EventLatestRepositoryTest extends AbstractManagementRepositoryTest 
     }
 
     @Test
+    public void shouldReturnEventsForSeveralEntityIdsInOneSearch() {
+        // A collection property value must narrow to those ids, not be compared as a single value: a caller
+        // resolving a page of entities has to be able to read that page's events without reading the
+        // environment's.
+        final EventCriteria criteria = EventCriteria.builder()
+            .property(Event.EventProperties.API_ID.getValue(), List.of("api-1", "api-3"))
+            .build();
+
+        List<Event> events = eventLatestRepository.search(criteria, Event.EventProperties.API_ID, null, null);
+
+        assertThat(events).extracting(Event::getId).containsExactlyInAnyOrder("api-1", "api-3");
+    }
+
+    @Test
+    public void shouldReturnNoEventWhenNoEntityIdInTheCollectionMatches() {
+        final EventCriteria criteria = EventCriteria.builder()
+            .property(Event.EventProperties.API_ID.getValue(), List.of("unknown-1", "unknown-2"))
+            .build();
+
+        List<Event> events = eventLatestRepository.search(criteria, Event.EventProperties.API_ID, null, null);
+
+        assertThat(events).isEmpty();
+    }
+
+    @Test
     public void shouldReturnApiEventsInSameOrderWhenSearchWithPagination() {
         //The order of events should be always the same, whatever the page size is
         final EventCriteria eventCriteria = EventCriteria.builder().build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductDeploymentStateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductDeploymentStateDomainService.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Tells whether an API Product on screen still matches what was last deployed to the gateway.
+ *
+ * <p>A product is {@code DEPLOYED} when the last deploy event carries the same APIs and sharding tags it
+ * carries now, and no non-staging plan has been changed since. Anything else — never deployed, an
+ * unreadable payload, a since-changed plan — is reported as {@code NEED_REDEPLOY}, so the operator is
+ * told to redeploy rather than told nothing.</p>
+ *
+ * <p>The state is resolved for a whole collection at a time and costs two queries however many products
+ * are in it, so listing a page does not cost a query per row.</p>
+ */
+@DomainService
+@RequiredArgsConstructor
+@CustomLog
+public class ApiProductDeploymentStateDomainService {
+
+    private final EventLatestQueryService eventLatestQueryService;
+    private final PlanQueryService planQueryService;
+    private final ObjectMapper objectMapper;
+
+    public ApiProduct computeDeploymentState(ApiProduct apiProduct) {
+        computeDeploymentState(List.of(apiProduct));
+        return apiProduct;
+    }
+
+    public void computeDeploymentState(Collection<ApiProduct> apiProducts) {
+        if (apiProducts.isEmpty()) {
+            return;
+        }
+        Set<String> productIds = apiProducts.stream().map(ApiProduct::getId).collect(Collectors.toSet());
+        Set<String> environmentIds = apiProducts
+            .stream()
+            .map(ApiProduct::getEnvironmentId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        Map<String, Event> latestDeployEvents = findLatestDeployEvents(productIds);
+        Map<String, List<Plan>> plansByProductId = findPlansByProductId(productIds, environmentIds);
+
+        apiProducts.forEach(product ->
+            product.setDeploymentState(
+                deploymentStateOf(
+                    product,
+                    latestDeployEvents.get(product.getId()),
+                    plansByProductId.getOrDefault(product.getId(), List.of())
+                )
+            )
+        );
+    }
+
+    private Map<String, Event> findLatestDeployEvents(Set<String> productIds) {
+        return eventLatestQueryService
+            .findLatestByEntityIds(productIds, EventType.DEPLOY_API_PRODUCT, Event.EventProperties.API_PRODUCT_ID)
+            .stream()
+            .filter(event -> event.getProperties() != null)
+            .filter(event -> event.getProperties().get(Event.EventProperties.API_PRODUCT_ID) != null)
+            .collect(
+                Collectors.toMap(
+                    event -> event.getProperties().get(Event.EventProperties.API_PRODUCT_ID),
+                    Function.identity(),
+                    (first, second) -> first
+                )
+            );
+    }
+
+    private Map<String, List<Plan>> findPlansByProductId(Set<String> productIds, Set<String> environmentIds) {
+        if (environmentIds.isEmpty()) {
+            return Map.of();
+        }
+        return planQueryService
+            .findAllByReferenceIdsAndEnvironments(productIds, environmentIds, GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .stream()
+            .collect(Collectors.groupingBy(Plan::getReferenceId));
+    }
+
+    private ApiProduct.DeploymentState deploymentStateOf(ApiProduct product, Event latestDeployEvent, List<Plan> plans) {
+        try {
+            if (latestDeployEvent == null || latestDeployEvent.getUpdatedAt() == null) {
+                return ApiProduct.DeploymentState.NEED_REDEPLOY;
+            }
+            ApiProduct deployedProduct = readPayload(latestDeployEvent, product.getId());
+            if (
+                deployedProduct == null ||
+                !setsEqual(product.getApiIds(), deployedProduct.getApiIds()) ||
+                !setsEqual(product.getTags(), deployedProduct.getTags())
+            ) {
+                return ApiProduct.DeploymentState.NEED_REDEPLOY;
+            }
+
+            Instant lastDeployedAt = latestDeployEvent.getUpdatedAt().toInstant();
+            boolean anyPlanModifiedAfterDeploy = plans
+                .stream()
+                .filter(plan -> plan.getPlanStatus() != PlanStatus.STAGING)
+                .anyMatch(plan -> plan.getNeedRedeployAt() != null && plan.getNeedRedeployAt().toInstant().isAfter(lastDeployedAt));
+
+            return anyPlanModifiedAfterDeploy ? ApiProduct.DeploymentState.NEED_REDEPLOY : ApiProduct.DeploymentState.DEPLOYED;
+        } catch (Exception e) {
+            log.warn("Failed to compute deployment state for API Product [{}]: {}", product.getId(), e.getMessage());
+            return ApiProduct.DeploymentState.NEED_REDEPLOY;
+        }
+    }
+
+    private ApiProduct readPayload(Event event, String productId) {
+        String payload = event.getPayload();
+        if (payload == null || payload.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(payload, ApiProduct.class);
+        } catch (Exception e) {
+            log.warn("Failed to deserialize deploy event payload for API Product [{}]: {}", productId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * True when two sets carry the same elements (e.g. apiIds or sharding tags vs last deploy payload).
+     */
+    private static boolean setsEqual(Set<String> current, Set<String> deployed) {
+        if (current == null && deployed == null) return true;
+        if (current == null || deployed == null) return false;
+        return current.size() == deployed.size() && current.containsAll(deployed);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilter.java
@@ -40,6 +40,15 @@ public record ApiProductKindFilter(Set<ApiProductKind> kinds, boolean includeCla
     }
 
     /**
+     * The kinds a store-backed search must require. Empty when the listing also wants classic products,
+     * which carry no kind and so cannot be matched by a kind term: those listings narrow with
+     * {@link #excludedKinds()} instead.
+     */
+    public Set<ApiProductKind> requiredKinds() {
+        return includeClassic ? Set.of() : kinds;
+    }
+
+    /**
      * The specialized kinds a store-backed search must hide: every kind not explicitly included. A new
      * {@link ApiProductKind} is therefore excluded from a classic listing until it is opted in.
      */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductSearchQueryService.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.core.api_product.query_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
@@ -33,7 +33,7 @@ public interface ApiProductSearchQueryService {
         Set<String> ids,
         Pageable pageable,
         Sortable sortable,
-        Set<ApiProductKind> excludedKinds
+        ApiProductKindFilter kindFilter
     );
 
     Page<GenericApiEntity> searchApis(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -15,39 +15,27 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductDeploymentStateDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
-import io.gravitee.apim.core.event.model.Event;
-import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
-import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
-import io.gravitee.apim.core.plan.query_service.PlanQueryService;
-import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-@CustomLog
 public class GetApiProductsUseCase {
 
     private final ApiProductQueryService apiProductQueryService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
-    private final EventLatestQueryService eventLatestQueryService;
-    private final PlanQueryService planQueryService;
-    private final ObjectMapper objectMapper;
+    private final ApiProductDeploymentStateDomainService apiProductDeploymentStateDomainService;
     private final ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
 
     public Output execute(Input input) {
@@ -56,8 +44,8 @@ public class GetApiProductsUseCase {
                 .findById(input.apiProductId())
                 .filter(p -> p.getEnvironmentId().equals(input.environmentId()))
                 .filter(input.kindFilter()::matches)
-                .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
-                .map(this::computeDeploymentState);
+                .map(product -> addPrimaryOwner(product, input.organizationId()))
+                .map(apiProductDeploymentStateDomainService::computeDeploymentState);
             return Output.single(apiProduct);
         }
 
@@ -68,9 +56,9 @@ public class GetApiProductsUseCase {
         Set<ApiProduct> apiProducts = findAccessibleApiProducts(input)
             .stream()
             .filter(input.kindFilter()::matches)
-            .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
-            .map(this::computeDeploymentState)
             .collect(Collectors.toSet());
+        addPrimaryOwners(apiProducts, input.organizationId());
+        apiProductDeploymentStateDomainService.computeDeploymentState(apiProducts);
         return Output.multiple(apiProducts);
     }
 
@@ -85,90 +73,17 @@ public class GetApiProductsUseCase {
         return apiProductQueryService.findByEnvironmentIdAndIdIn(input.environmentId(), allowedIds);
     }
 
-    private ApiProduct addPrimaryOwnerToApiProduct(ApiProduct apiProduct, String organizationId) {
-        try {
-            PrimaryOwnerEntity primaryOwner = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(
-                organizationId,
-                apiProduct.getId()
-            );
-            apiProduct.setPrimaryOwner(primaryOwner);
-        } catch (ApiProductPrimaryOwnerNotFoundException e) {
-            log.debug("Failed to retrieve primary owner for API Product [{}]: {}", apiProduct.getId(), e.getMessage());
-        }
+    private ApiProduct addPrimaryOwner(ApiProduct apiProduct, String organizationId) {
+        addPrimaryOwners(Set.of(apiProduct), organizationId);
         return apiProduct;
     }
 
-    private ApiProduct computeDeploymentState(ApiProduct product) {
-        try {
-            Optional<Event> latestDeployEvent = eventLatestQueryService.findLatestByEntityId(
-                product.getId(),
-                EventType.DEPLOY_API_PRODUCT,
-                Event.EventProperties.API_PRODUCT_ID
-            );
-
-            if (latestDeployEvent.isEmpty()) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-
-            Event event = latestDeployEvent.get();
-            String payload = event.getPayload();
-            if (payload == null || payload.isBlank()) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-
-            ApiProduct deployedProduct;
-            try {
-                deployedProduct = objectMapper.readValue(payload, ApiProduct.class);
-            } catch (JsonProcessingException e) {
-                log.warn("Failed to deserialize deploy event payload for API Product [{}]: {}", product.getId(), e.getMessage());
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-            if (deployedProduct == null) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-
-            if (!setsEqual(product.getApiIds(), deployedProduct.getApiIds())) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-
-            if (!setsEqual(product.getTags(), deployedProduct.getTags())) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-
-            if (event.getUpdatedAt() == null) {
-                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-                return product;
-            }
-            Instant lastDeployedAt = event.getUpdatedAt().toInstant();
-            boolean anyPlanModifiedAfterDeploy = planQueryService
-                .findAllByReferenceIdAndReferenceType(product.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
-                .stream()
-                .filter(plan -> plan.getPlanStatus() != PlanStatus.STAGING)
-                .anyMatch(plan -> plan.getNeedRedeployAt() != null && plan.getNeedRedeployAt().toInstant().isAfter(lastDeployedAt));
-
-            product.setDeploymentState(
-                anyPlanModifiedAfterDeploy ? ApiProduct.DeploymentState.NEED_REDEPLOY : ApiProduct.DeploymentState.DEPLOYED
-            );
-        } catch (Exception e) {
-            log.warn("Failed to compute deployment state for API Product [{}]: {}", product.getId(), e.getMessage());
-            product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
-        }
-        return product;
-    }
-
-    /**
-     * True when two sets carry the same elements (e.g. apiIds or sharding tags vs last deploy payload).
-     */
-    private static boolean setsEqual(Set<String> current, Set<String> deployed) {
-        if (current == null && deployed == null) return true;
-        if (current == null || deployed == null) return false;
-        return current.size() == deployed.size() && current.containsAll(deployed);
+    private void addPrimaryOwners(Set<ApiProduct> apiProducts, String organizationId) {
+        Map<String, PrimaryOwnerEntity> primaryOwnersById = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwners(
+            organizationId,
+            apiProducts.stream().map(ApiProduct::getId).collect(Collectors.toSet())
+        );
+        apiProducts.forEach(apiProduct -> apiProduct.setPrimaryOwner(primaryOwnersById.get(apiProduct.getId())));
     }
 
     public record Input(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api_product.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductDeploymentStateDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
@@ -35,6 +36,7 @@ public class SearchApiProductsUseCase {
 
     private final ApiProductSearchQueryService apiProductSearchQueryService;
     private final ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
+    private final ApiProductDeploymentStateDomainService apiProductDeploymentStateDomainService;
 
     public Output execute(Input input) {
         if (input.isAdmin()) {
@@ -64,17 +66,17 @@ public class SearchApiProductsUseCase {
     }
 
     private Output search(Input input, Set<String> ids) {
-        return new Output(
-            apiProductSearchQueryService.search(
-                input.environmentId(),
-                input.organizationId(),
-                input.query(),
-                ids,
-                input.pageable(),
-                input.sortable(),
-                input.kindFilter().excludedKinds()
-            )
+        Page<ApiProduct> page = apiProductSearchQueryService.search(
+            input.environmentId(),
+            input.organizationId(),
+            input.query(),
+            ids,
+            input.pageable(),
+            input.sortable(),
+            input.kindFilter()
         );
+        apiProductDeploymentStateDomainService.computeDeploymentState(page.getContent());
+        return new Output(page);
     }
 
     public record Input(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/event/query_service/EventLatestQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/event/query_service/EventLatestQueryService.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.core.event.query_service;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.rest.api.model.EventType;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -27,14 +26,17 @@ import java.util.Set;
  */
 public interface EventLatestQueryService {
     /**
-     * Returns the latest event of the given type recorded for the specified entity.
+     * The latest event of a type for each of several entities, in one query.
      *
-     * @param entityId     the entity ID (e.g. an API Product ID)
-     * @param eventType    the event type to filter on
-     * @param propertyKey  the event property that holds the entity ID
-     * @return the single latest event, or empty if none has been recorded yet
+     * <p>The entity ids are pushed down to the store rather than filtered afterwards, so a caller
+     * resolving a page reads that page's rows and not the whole environment's. Entities with no such
+     * event are simply absent from the result.</p>
+     *
+     * @param entityIds   the entity ids (e.g. API Product ids)
+     * @param eventType   the event type to look for
+     * @param propertyKey the property the event carries the entity id under
      */
-    Optional<Event> findLatestByEntityId(String entityId, EventType eventType, Event.EventProperties propertyKey);
+    List<Event> findLatestByEntityIds(Set<String> entityIds, EventType eventType, Event.EventProperties propertyKey);
 
     List<Event> findAllByTypeAndEnvironments(Set<EventType> eventTypes, Set<String> environments, Event.EventProperties groupBy);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainService.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
@@ -34,8 +35,14 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.common.UuidString;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -82,6 +89,111 @@ public class ApiProductPrimaryOwnerDomainService {
                 )
             )
             .orElseThrow(() -> new ApiProductPrimaryOwnerNotFoundException(apiProductId));
+    }
+
+    /**
+     * The primary owner of each of several API Products, resolved together.
+     *
+     * <p>Costs a fixed handful of queries however many products are asked for, so listing a page does not
+     * cost three round trips per row. Products with no primary owner are absent from the result rather
+     * than raising: a listing renders the rest of the row instead of failing.</p>
+     */
+    public Map<String, PrimaryOwnerEntity> getApiProductPrimaryOwners(final String organizationId, Set<String> apiProductIds) {
+        if (apiProductIds.isEmpty()) {
+            return Map.of();
+        }
+        return findPrimaryOwnerRole(organizationId)
+            .map(role -> resolvePrimaryOwners(apiProductIds, role))
+            .orElseGet(Map::of);
+    }
+
+    private Map<String, PrimaryOwnerEntity> resolvePrimaryOwners(Set<String> apiProductIds, Role role) {
+        Collection<Membership> memberships = membershipQueryService.findByReferencesAndRoleId(
+            Membership.ReferenceType.API_PRODUCT,
+            List.copyOf(apiProductIds),
+            role.getId()
+        );
+        if (memberships.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Membership.Type, Set<String>> memberIdsByType = memberships
+            .stream()
+            .collect(Collectors.groupingBy(Membership::getMemberType, Collectors.mapping(Membership::getMemberId, Collectors.toSet())));
+        Set<String> userIds = memberIdsByType.getOrDefault(Membership.Type.USER, Set.of());
+        Set<String> groupIds = memberIdsByType.getOrDefault(Membership.Type.GROUP, Set.of());
+
+        Map<String, BaseUserEntity> usersById = findUsersById(userIds);
+        Map<String, PrimaryOwnerEntity> groupOwnersById = findGroupOwnersById(groupIds, role.getId());
+
+        Map<String, PrimaryOwnerEntity> ownersByApiProductId = new HashMap<>();
+        memberships.forEach(membership -> {
+            PrimaryOwnerEntity owner = switch (membership.getMemberType()) {
+                case USER -> Optional.ofNullable(usersById.get(membership.getMemberId())).map(this::toUserPrimaryOwner).orElse(null);
+                case GROUP -> groupOwnersById.get(membership.getMemberId());
+            };
+            if (owner != null) {
+                ownersByApiProductId.putIfAbsent(membership.getReferenceId(), owner);
+            }
+        });
+        return ownersByApiProductId;
+    }
+
+    private Map<String, BaseUserEntity> findUsersById(Set<String> userIds) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        return userCrudService
+            .findBaseUsersByIds(List.copyOf(userIds))
+            .stream()
+            .collect(Collectors.toMap(BaseUserEntity::getId, Function.identity(), (first, second) -> first));
+    }
+
+    /**
+     * A group's own primary-owner member supplies the contact email, so groups cost one extra membership
+     * query for the whole batch rather than one per group.
+     */
+    private Map<String, PrimaryOwnerEntity> findGroupOwnersById(Set<String> groupIds, String primaryOwnerRoleId) {
+        if (groupIds.isEmpty()) {
+            return Map.of();
+        }
+        Collection<Membership> groupMemberships = membershipQueryService.findByReferencesAndRoleId(
+            Membership.ReferenceType.GROUP,
+            List.copyOf(groupIds),
+            primaryOwnerRoleId
+        );
+        Map<String, String> memberIdByGroupId = groupMemberships
+            .stream()
+            .collect(Collectors.toMap(Membership::getReferenceId, Membership::getMemberId, (first, second) -> first));
+        Map<String, BaseUserEntity> groupMembersById = findUsersById(Set.copyOf(memberIdByGroupId.values()));
+
+        return groupQueryService
+            .findByIds(groupIds)
+            .stream()
+            .collect(
+                Collectors.toMap(Group::getId, group ->
+                    PrimaryOwnerEntity.builder()
+                        .id(group.getId())
+                        .displayName(group.getName())
+                        .type(PrimaryOwnerEntity.Type.GROUP)
+                        .email(
+                            Optional.ofNullable(memberIdByGroupId.get(group.getId()))
+                                .map(groupMembersById::get)
+                                .map(BaseUserEntity::getEmail)
+                                .orElse(null)
+                        )
+                        .build()
+                )
+            );
+    }
+
+    private PrimaryOwnerEntity toUserPrimaryOwner(BaseUserEntity user) {
+        return PrimaryOwnerEntity.builder()
+            .id(user.getId())
+            .displayName(user.displayName())
+            .email(user.getEmail())
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
     }
 
     private Optional<Membership> findApiProductPrimaryOwnerMembership(String apiProductId, Role role) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
@@ -19,6 +19,7 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
 import io.gravitee.apim.core.utils.CollectionUtils;
@@ -58,7 +59,7 @@ public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQuerySe
         Set<String> ids,
         Pageable pageable,
         Sortable sortable,
-        Set<ApiProductKind> excludedKinds
+        ApiProductKindFilter kindFilter
     ) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
         QueryBuilder<IndexableApiProduct> queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
@@ -72,14 +73,20 @@ public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQuerySe
         if (sortable != null) {
             queryBuilder.setSort(sortable);
         }
-        if (CollectionUtils.isNotEmpty(excludedKinds)) {
-            queryBuilder.addExcludedFilter(
-                IndexableApiProductDocumentTransformer.FIELD_KIND,
-                excludedKinds.stream().map(Enum::name).collect(Collectors.toSet())
-            );
+        // A listing that wants only specialized kinds requires them, so the store returns a full page of
+        // them. Excluding the other kinds would not: a classic product carries no kind term, and so passes
+        // every exclusion, leaving the page padded with products the caller asked not to see.
+        if (CollectionUtils.isNotEmpty(kindFilter.requiredKinds())) {
+            queryBuilder.addFilter(IndexableApiProductDocumentTransformer.FIELD_KIND, names(kindFilter.requiredKinds()));
+        } else if (CollectionUtils.isNotEmpty(kindFilter.excludedKinds())) {
+            queryBuilder.addExcludedFilter(IndexableApiProductDocumentTransformer.FIELD_KIND, names(kindFilter.excludedKinds()));
         }
 
         return apiProductSearchService.search(executionContext, queryBuilder, pageable);
+    }
+
+    private static Set<String> names(Set<ApiProductKind> kinds) {
+        return kinds.stream().map(Enum::name).collect(Collectors.toSet());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/event/EventLatestQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/event/EventLatestQueryServiceImpl.java
@@ -40,25 +40,30 @@ public class EventLatestQueryServiceImpl implements EventLatestQueryService {
     }
 
     @Override
-    public Optional<Event> findLatestByEntityId(
-        String entityId,
+    public List<Event> findLatestByEntityIds(
+        Set<String> entityIds,
         io.gravitee.rest.api.model.EventType eventType,
         Event.EventProperties propertyKey
     ) {
+        if (entityIds.isEmpty()) {
+            return List.of();
+        }
         try {
+            // The ids go into the criteria as a collection, which both stores turn into an IN rather than a
+            // single-value comparison, so the store returns this page's events and not the environment's.
             List<io.gravitee.repository.management.model.Event> events = eventLatestRepository.search(
                 EventCriteria.builder()
                     .types(List.of(EventType.valueOf(eventType.name())))
-                    .properties(Map.of(propertyKey.getLabel(), entityId))
+                    .properties(Map.of(propertyKey.getLabel(), entityIds))
                     .build(),
                 io.gravitee.repository.management.model.Event.EventProperties.valueOf(propertyKey.name()),
-                0L,
-                1L
+                null,
+                null
             );
-            return events.stream().findFirst().map(EventAdapter.INSTANCE::map);
+            return events.stream().map(EventAdapter.INSTANCE::map).toList();
         } catch (Exception e) {
             throw new TechnicalManagementException(
-                "An error occurs while trying to find latest event for entity [" + entityId + "]: " + e.getMessage(),
+                "An error occurs while trying to find latest events for entities " + entityIds + ": " + e.getMessage(),
                 e
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImpl.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toList;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
-import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
 import io.gravitee.common.data.domain.Page;
@@ -37,13 +36,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@CustomLog
 public class ApiProductSearchServiceImpl implements ApiProductSearchService {
 
     private final SearchEngineService searchEngineService;
@@ -75,24 +72,19 @@ public class ApiProductSearchServiceImpl implements ApiProductSearchService {
         Map<String, ApiProduct> byId = new LinkedHashMap<>();
         apiProducts.forEach(apiProduct -> byId.put(apiProduct.getId(), apiProduct));
 
+        Map<String, PrimaryOwnerEntity> primaryOwnersById = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwners(
+            executionContext.getOrganizationId(),
+            byId.keySet()
+        );
+
         List<ApiProduct> orderedPage = pageIds
             .stream()
             .map(byId::get)
             .filter(Objects::nonNull)
-            .map(apiProduct -> addPrimaryOwner(apiProduct, executionContext.getOrganizationId()))
+            .map(apiProduct -> apiProduct.toBuilder().primaryOwner(primaryOwnersById.get(apiProduct.getId())).build())
             .collect(toList());
 
         return new Page<>(orderedPage, pageable.getPageNumber(), orderedPage.size(), sortedIds.size());
-    }
-
-    private ApiProduct addPrimaryOwner(ApiProduct apiProduct, String organizationId) {
-        PrimaryOwnerEntity primaryOwner = null;
-        try {
-            primaryOwner = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(organizationId, apiProduct.getId());
-        } catch (ApiProductPrimaryOwnerNotFoundException e) {
-            log.warn("Failed to retrieve primary owner for API Product [{}]: {}", apiProduct.getId(), e.getMessage());
-        }
-        return apiProduct.toBuilder().primaryOwner(primaryOwner).build();
     }
 
     private List<String> getPageSubset(List<String> ids, Pageable pageable) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductSearchQueryServiceInMemory.java
@@ -16,7 +16,7 @@
 package inmemory;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -35,7 +35,7 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
 
     private String lastEnvironmentId;
     private String lastOrganizationId;
-    private Set<ApiProductKind> lastExcludedKinds;
+    private ApiProductKindFilter lastKindFilter;
 
     public String getLastEnvironmentId() {
         return lastEnvironmentId;
@@ -45,8 +45,8 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
         return lastOrganizationId;
     }
 
-    public Set<ApiProductKind> getLastExcludedKinds() {
-        return lastExcludedKinds;
+    public ApiProductKindFilter getLastKindFilter() {
+        return lastKindFilter;
     }
 
     @Override
@@ -57,11 +57,11 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
         Set<String> ids,
         Pageable pageable,
         Sortable sortable,
-        Set<ApiProductKind> excludedKinds
+        ApiProductKindFilter kindFilter
     ) {
         this.lastEnvironmentId = environmentId;
         this.lastOrganizationId = organizationId;
-        this.lastExcludedKinds = excludedKinds;
+        this.lastKindFilter = kindFilter;
 
         int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
         int pageSize = pageable != null ? pageable.getPageSize() : 10;
@@ -70,13 +70,7 @@ public class ApiProductSearchQueryServiceInMemory extends AbstractQueryServiceIn
             .stream()
             .filter(apiProduct -> Objects.equals(apiProduct.getEnvironmentId(), environmentId))
             .filter(apiProduct -> ids == null || ids.isEmpty() || (ids.contains(apiProduct.getId())))
-            .filter(
-                apiProduct ->
-                    excludedKinds == null ||
-                    excludedKinds.isEmpty() ||
-                    apiProduct.getKind() == null ||
-                    !excludedKinds.contains(apiProduct.getKind())
-            )
+            .filter(apiProduct -> kindFilter == null || kindFilter.matches(apiProduct))
             .filter(apiProduct -> {
                 if (query == null || query.isBlank()) return true;
                 String queryLower = query.trim().toLowerCase();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventLatestQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventLatestQueryServiceInMemory.java
@@ -35,12 +35,18 @@ public class EventLatestQueryServiceInMemory implements EventLatestQueryService,
     }
 
     @Override
-    public Optional<Event> findLatestByEntityId(String entityId, EventType eventType, Event.EventProperties propertyKey) {
-        return storage
+    public List<Event> findLatestByEntityIds(Set<String> entityIds, EventType eventType, Event.EventProperties propertyKey) {
+        return entityIds
             .stream()
-            .filter(event -> eventType.name().equals(event.getType() != null ? event.getType().name() : null))
-            .filter(event -> entityId.equals(event.getProperties().getOrDefault(propertyKey, null)))
-            .max(Comparator.comparing(event -> event.getUpdatedAt() != null ? event.getUpdatedAt() : event.getCreatedAt()));
+            .map(entityId ->
+                storage
+                    .stream()
+                    .filter(event -> eventType.name().equals(event.getType() != null ? event.getType().name() : null))
+                    .filter(event -> entityId.equals(event.getProperties().getOrDefault(propertyKey, null)))
+                    .max(Comparator.comparing(event -> event.getUpdatedAt() != null ? event.getUpdatedAt() : event.getCreatedAt()))
+            )
+            .flatMap(Optional::stream)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductDeploymentStateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductDeploymentStateDomainServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.EventLatestQueryServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.infra.adapter.GraviteeJacksonMapper;
+import io.gravitee.rest.api.model.EventType;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductDeploymentStateDomainServiceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final Instant DEPLOYED_AT = Instant.parse("2024-01-10T10:00:00Z");
+
+    private final EventLatestQueryServiceInMemory eventLatestQueryService = spy(new EventLatestQueryServiceInMemory());
+    private final PlanQueryServiceInMemory planQueryService = spy(new PlanQueryServiceInMemory());
+    private final ObjectMapper objectMapper = GraviteeJacksonMapper.getInstance();
+
+    private final ApiProductDeploymentStateDomainService service = new ApiProductDeploymentStateDomainService(
+        eventLatestQueryService,
+        planQueryService,
+        objectMapper
+    );
+
+    @AfterEach
+    void tearDown() {
+        eventLatestQueryService.reset();
+        planQueryService.reset();
+    }
+
+    @Test
+    void should_cost_the_same_two_queries_however_many_products_there_are() throws Exception {
+        // A query per product would make a page of twenty-five cost fifty round trips, and a listing's cost
+        // grow with the environment.
+        var products = IntStream.range(0, 25)
+            .mapToObj(i -> aProduct("id-" + i))
+            .toList();
+        eventLatestQueryService.initWith(products.stream().map(this::aMatchingDeployEventFor).toList());
+
+        service.computeDeploymentState(products);
+
+        verify(eventLatestQueryService, times(1)).findLatestByEntityIds(any(), any(), any());
+        verify(planQueryService, times(1)).findAllByReferenceIdsAndEnvironments(any(), any(), any());
+        assertThat(products).allMatch(product -> product.getDeploymentState() == ApiProduct.DeploymentState.DEPLOYED);
+    }
+
+    @Test
+    void should_ask_the_store_for_nothing_when_there_are_no_products() {
+        service.computeDeploymentState(List.of());
+
+        verify(eventLatestQueryService, times(0)).findLatestByEntityIds(any(), any(), any());
+        verify(planQueryService, times(0)).findAllByReferenceIdsAndEnvironments(any(), any(), any());
+    }
+
+    @Test
+    void should_read_each_product_against_its_own_deploy_event() throws Exception {
+        var deployed = aProduct("id-1");
+        var drifted = aProduct("id-2");
+        drifted.setApiIds(Set.of("api-1", "api-2"));
+        eventLatestQueryService.initWith(List.of(aMatchingDeployEventFor(deployed), aMatchingDeployEventFor(aProduct("id-2"))));
+
+        service.computeDeploymentState(List.of(deployed, drifted));
+
+        assertThat(deployed.getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.DEPLOYED);
+        assertThat(drifted.getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+    }
+
+    private ApiProduct aProduct(String id) {
+        return ApiProduct.builder().id(id).name(id).environmentId(ENV_ID).apiIds(Set.of("api-1")).build();
+    }
+
+    private Event aMatchingDeployEventFor(ApiProduct product) {
+        try {
+            return Event.builder()
+                .id("event-" + product.getId())
+                .type(EventType.DEPLOY_API_PRODUCT)
+                .properties(new EnumMap<>(Map.of(Event.EventProperties.API_PRODUCT_ID, product.getId())))
+                .payload(objectMapper.writeValueAsString(aProduct(product.getId())))
+                .environments(Set.of(ENV_ID))
+                .createdAt(DEPLOYED_AT.atZone(ZoneId.systemDefault()))
+                .updatedAt(DEPLOYED_AT.atZone(ZoneId.systemDefault()))
+                .build();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/model/ApiProductKindFilterTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api_product.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.EnumSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ApiProductKindFilterTest {
@@ -30,5 +31,20 @@ class ApiProductKindFilterTest {
     @Test
     void any_excludes_no_kind() {
         assertThat(ApiProductKindFilter.any().excludedKinds()).isEmpty();
+    }
+
+    @Test
+    void a_listing_that_wants_only_specialized_kinds_requires_them() {
+        var filter = new ApiProductKindFilter(Set.of(ApiProductKind.AI_WORKSPACE), false);
+
+        assertThat(filter.requiredKinds()).containsExactly(ApiProductKind.AI_WORKSPACE);
+    }
+
+    @Test
+    void a_listing_that_also_wants_classic_products_requires_no_kind() {
+        // A classic product carries no kind, so no kind term can match it: those listings narrow by
+        // exclusion instead, and requiring a kind here would hide every classic product.
+        assertThat(ApiProductKindFilter.classicOnly().requiredKinds()).isEmpty();
+        assertThat(ApiProductKindFilter.any().requiredKinds()).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -28,6 +28,7 @@ import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductDeploymentStateDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.event.model.Event;
@@ -103,9 +104,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
         getApiProductsUseCase = new GetApiProductsUseCase(
             apiProductQueryService,
             apiProductPrimaryOwnerDomainService,
-            eventLatestQueryService,
-            planQueryService,
-            objectMapper,
+            new ApiProductDeploymentStateDomainService(eventLatestQueryService, planQueryService, objectMapper),
             apiProductAccessibleIdsDomainService
         );
     }
@@ -511,6 +510,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
                 .properties(
                     new EnumMap<>(Map.of(Event.EventProperties.API_PRODUCT_ID, apiProductId, Event.EventProperties.USER, "user-id"))
                 )
+                .environments(Set.of(ENV_ID))
                 .createdAt(updatedAt.atZone(ZoneId.systemDefault()))
                 .updatedAt(updatedAt.atZone(ZoneId.systemDefault()));
             if (deployedPayload != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
@@ -16,17 +16,29 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.ApiProductSearchQueryServiceInMemory;
+import inmemory.EventLatestQueryServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductDeploymentStateDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.infra.adapter.GraviteeJacksonMapper;
+import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +54,12 @@ class SearchApiProductsUseCaseTest {
     private static final String ORG_ID = "org-id";
     private static final String USER_ID = "user-id";
 
+    private static final Instant DEPLOYED_AT = Instant.parse("2024-01-10T10:00:00Z");
+
     private ApiProductSearchQueryServiceInMemory apiProductSearchQueryService;
+    private final EventLatestQueryServiceInMemory eventLatestQueryService = new EventLatestQueryServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final ObjectMapper objectMapper = GraviteeJacksonMapper.getInstance();
 
     @Mock
     private ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
@@ -52,12 +69,18 @@ class SearchApiProductsUseCaseTest {
     @BeforeEach
     void setUp() {
         apiProductSearchQueryService = new ApiProductSearchQueryServiceInMemory();
-        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService, apiProductAccessibleIdsDomainService);
+        useCase = new SearchApiProductsUseCase(
+            apiProductSearchQueryService,
+            apiProductAccessibleIdsDomainService,
+            new ApiProductDeploymentStateDomainService(eventLatestQueryService, planQueryService, objectMapper)
+        );
     }
 
     @AfterEach
     void tearDown() {
         verifyNoMoreInteractions(apiProductAccessibleIdsDomainService);
+        eventLatestQueryService.reset();
+        planQueryService.reset();
     }
 
     @Test
@@ -257,5 +280,56 @@ class SearchApiProductsUseCaseTest {
 
         assertThat(output.page().getContent()).isEmpty();
         verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
+    }
+
+    @Test
+    void should_report_whether_each_matched_product_is_still_deployed() throws Exception {
+        // A listing that never resolves this reports every product as "not deployed", whatever the gateway
+        // is actually serving.
+        var deployed = ApiProduct.builder().id("id-1").name("Deployed").environmentId(ENV_ID).apiIds(Set.of("api-1")).build();
+        var drifted = ApiProduct.builder().id("id-2").name("Drifted").environmentId(ENV_ID).apiIds(Set.of("api-1", "api-2")).build();
+        apiProductSearchQueryService.initWith(List.of(deployed, drifted));
+        eventLatestQueryService.initWith(
+            List.of(
+                aDeployEvent("id-1", ApiProduct.builder().id("id-1").apiIds(Set.of("api-1")).build()),
+                aDeployEvent("id-2", ApiProduct.builder().id("id-2").apiIds(Set.of("api-1")).build())
+            )
+        );
+
+        var output = useCase.execute(
+            SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, new PageableImpl(1, 10), null, USER_ID, true)
+        );
+
+        assertThat(output.page().getContent())
+            .extracting(ApiProduct::getId, ApiProduct::getDeploymentState)
+            .containsExactlyInAnyOrder(
+                tuple("id-1", ApiProduct.DeploymentState.DEPLOYED),
+                tuple("id-2", ApiProduct.DeploymentState.NEED_REDEPLOY)
+            );
+    }
+
+    @Test
+    void should_report_a_product_that_was_never_deployed_as_needing_a_deploy() {
+        apiProductSearchQueryService.initWith(List.of(ApiProduct.builder().id("id-1").name("Fresh").environmentId(ENV_ID).build()));
+
+        var output = useCase.execute(
+            SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, new PageableImpl(1, 10), null, USER_ID, true)
+        );
+
+        assertThat(output.page().getContent())
+            .extracting(ApiProduct::getDeploymentState)
+            .containsExactly(ApiProduct.DeploymentState.NEED_REDEPLOY);
+    }
+
+    private Event aDeployEvent(String apiProductId, ApiProduct deployedPayload) throws Exception {
+        return Event.builder()
+            .id("event-" + apiProductId)
+            .type(EventType.DEPLOY_API_PRODUCT)
+            .properties(new EnumMap<>(Map.of(Event.EventProperties.API_PRODUCT_ID, apiProductId)))
+            .payload(objectMapper.writeValueAsString(deployedPayload))
+            .environments(Set.of(ENV_ID))
+            .createdAt(DEPLOYED_AT.atZone(ZoneId.systemDefault()))
+            .updatedAt(DEPLOYED_AT.atZone(ZoneId.systemDefault()))
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerDomainServiceTest.java
@@ -18,6 +18,12 @@ package io.gravitee.apim.core.membership.domain_service;
 import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import fixtures.core.model.AuditInfoFixtures;
 import inmemory.AuditCrudServiceInMemory;
@@ -44,6 +50,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
@@ -186,6 +194,188 @@ class ApiProductPrimaryOwnerDomainServiceTest {
             assertThat(throwable)
                 .isInstanceOf(ApiProductPrimaryOwnerNotFoundException.class)
                 .hasMessageContaining("Primary owner not found for API Product");
+        }
+    }
+
+    @Nested
+    class GetApiProductPrimaryOwners {
+
+        @Test
+        public void should_resolve_every_product_in_one_pass() {
+            givenExistingUsers(
+                List.of(
+                    BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build(),
+                    BaseUserEntity.builder().id("member-2").firstname("John").lastname("Roe").email("john.roe@gravitee.io").build()
+                )
+            );
+            givenExistingMemberships(
+                List.of(aUserPrimaryOwnerMembership(API_PRODUCT_ID, MEMBER_ID), aUserPrimaryOwnerMembership("api-product-2", "member-2"))
+            );
+
+            var result = service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of(API_PRODUCT_ID, "api-product-2"));
+
+            Assertions.assertThat(result)
+                .extractingByKeys(API_PRODUCT_ID, "api-product-2")
+                .extracting(PrimaryOwnerEntity::displayName)
+                .containsExactly("Jane Doe", "John Roe");
+        }
+
+        @Test
+        public void should_leave_out_a_product_that_has_no_primary_owner() {
+            // The caller decides what a missing owner means; reporting it as absent lets a listing render the
+            // rest of the row rather than fail.
+            var result = service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of(API_PRODUCT_ID));
+
+            Assertions.assertThat(result).isEmpty();
+        }
+
+        @Test
+        public void should_ask_the_store_for_nothing_when_there_are_no_products() {
+            Assertions.assertThat(service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of())).isEmpty();
+        }
+
+        @Test
+        public void should_resolve_a_group_owner_and_take_its_email_from_the_group_primary_owner() {
+            // The group path is three joins deep - the product's group membership, the group itself, then the
+            // group's own primary owner for the contact email - and each is batched separately.
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
+            givenExistingMemberships(
+                List.of(aGroupPrimaryOwnerMembership(API_PRODUCT_ID, GROUP_ID), aGroupsOwnPrimaryOwnerMembership(GROUP_ID, MEMBER_ID))
+            );
+
+            var result = service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of(API_PRODUCT_ID));
+
+            Assertions.assertThat(result).containsExactly(
+                Assertions.entry(
+                    API_PRODUCT_ID,
+                    PrimaryOwnerEntity.builder()
+                        .id(GROUP_ID)
+                        .email("jane.doe@gravitee.io")
+                        .displayName("Group name")
+                        .type(PrimaryOwnerEntity.Type.GROUP)
+                        .build()
+                )
+            );
+        }
+
+        @Test
+        public void should_resolve_a_group_owner_without_an_email_when_the_group_has_no_primary_owner() {
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
+            givenExistingMemberships(List.of(aGroupPrimaryOwnerMembership(API_PRODUCT_ID, GROUP_ID)));
+
+            var result = service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of(API_PRODUCT_ID));
+
+            Assertions.assertThat(result.get(API_PRODUCT_ID))
+                .extracting(PrimaryOwnerEntity::id, PrimaryOwnerEntity::displayName, PrimaryOwnerEntity::email)
+                .containsExactly(GROUP_ID, "Group name", null);
+        }
+
+        @Test
+        public void should_resolve_user_owners_and_group_owners_in_the_same_pass() {
+            givenExistingUsers(
+                List.of(
+                    BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build(),
+                    BaseUserEntity.builder().id("member-2").firstname("John").lastname("Roe").email("john.roe@gravitee.io").build()
+                )
+            );
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
+            givenExistingMemberships(
+                List.of(
+                    aUserPrimaryOwnerMembership(API_PRODUCT_ID, MEMBER_ID),
+                    aGroupPrimaryOwnerMembership("api-product-2", GROUP_ID),
+                    aGroupsOwnPrimaryOwnerMembership(GROUP_ID, "member-2")
+                )
+            );
+
+            var result = service.getApiProductPrimaryOwners(ORGANIZATION_ID, Set.of(API_PRODUCT_ID, "api-product-2"));
+
+            Assertions.assertThat(result)
+                .extractingByKeys(API_PRODUCT_ID, "api-product-2")
+                .extracting(PrimaryOwnerEntity::type, PrimaryOwnerEntity::displayName, PrimaryOwnerEntity::email)
+                .containsExactly(
+                    tuple(PrimaryOwnerEntity.Type.USER, "Jane Doe", "jane.doe@gravitee.io"),
+                    tuple(PrimaryOwnerEntity.Type.GROUP, "Group name", "john.roe@gravitee.io")
+                );
+        }
+
+        @Test
+        public void should_cost_the_same_queries_however_many_products_there_are() {
+            // Resolving one owner costs three queries, so a page of twenty-five resolved one at a time cost
+            // about seventy-five. Batched it is six whatever the page holds: the role, the products'
+            // memberships, their users, then the groups' own memberships, those members, and the groups.
+            var memberships = spy(membershipQueryService);
+            var users = spy(userCrudService);
+            var groups = spy(groupQueryService);
+            var batched = new ApiProductPrimaryOwnerDomainService(
+                new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+                groups,
+                membershipCrudService,
+                memberships,
+                roleQueryService,
+                users
+            );
+
+            var productIds = IntStream.range(0, 25)
+                .mapToObj(i -> "api-product-" + i)
+                .collect(java.util.stream.Collectors.toSet());
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("j@gravitee.io").build())
+            );
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
+            givenExistingMemberships(
+                Stream.concat(
+                    productIds
+                        .stream()
+                        .map(id ->
+                            id.endsWith("0") ? aGroupPrimaryOwnerMembership(id, GROUP_ID) : aUserPrimaryOwnerMembership(id, MEMBER_ID)
+                        ),
+                    Stream.of(aGroupsOwnPrimaryOwnerMembership(GROUP_ID, MEMBER_ID))
+                ).toList()
+            );
+
+            var result = batched.getApiProductPrimaryOwners(ORGANIZATION_ID, productIds);
+
+            Assertions.assertThat(result).hasSize(25);
+            verify(memberships, times(2)).findByReferencesAndRoleId(any(), any(), any());
+            verify(users, times(2)).findBaseUsersByIds(any());
+            verify(groups, times(1)).findByIds(any());
+            // The per-product finders the singular lookup uses must not appear at all.
+            verify(memberships, never()).findByReferenceAndRoleId(any(), any(), any());
+            verify(users, never()).findBaseUserById(any());
+            verify(groups, never()).findById(any());
+        }
+
+        private Membership aGroupPrimaryOwnerMembership(String apiProductId, String groupId) {
+            return Membership.builder()
+                .referenceType(Membership.ReferenceType.API_PRODUCT)
+                .referenceId(apiProductId)
+                .memberType(Membership.Type.GROUP)
+                .memberId(groupId)
+                .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
+                .build();
+        }
+
+        private Membership aGroupsOwnPrimaryOwnerMembership(String groupId, String memberId) {
+            return Membership.builder()
+                .referenceType(Membership.ReferenceType.GROUP)
+                .referenceId(groupId)
+                .memberType(Membership.Type.USER)
+                .memberId(memberId)
+                .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
+                .build();
+        }
+
+        private Membership aUserPrimaryOwnerMembership(String apiProductId, String memberId) {
+            return Membership.builder()
+                .referenceType(Membership.ReferenceType.API_PRODUCT)
+                .referenceId(apiProductId)
+                .memberType(Membership.Type.USER)
+                .memberId(memberId)
+                .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
+                .build();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.api_product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api_product.model.ApiProductKind;
+import io.gravitee.apim.core.api_product.model.ApiProductKindFilter;
+import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.impl.search.lucene.transformer.IndexableApiProductDocumentTransformer;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.ApiProductSearchService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductSearchQueryServiceImplTest {
+
+    private static final String FIELD_KIND = IndexableApiProductDocumentTransformer.FIELD_KIND;
+
+    @Mock
+    private ApiProductSearchService apiProductSearchService;
+
+    @Mock
+    private ApiSearchService apiSearchService;
+
+    @Captor
+    private ArgumentCaptor<QueryBuilder<IndexableApiProduct>> queryCaptor;
+
+    private ApiProductSearchQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiProductSearchQueryServiceImpl(apiProductSearchService, apiSearchService);
+        when(apiProductSearchService.search(any(), any(), any())).thenReturn(new Page<>(List.of(), 1, 0, 0));
+    }
+
+    private QueryBuilder<IndexableApiProduct> searchWith(ApiProductKindFilter kindFilter) {
+        service.search("env-1", "org-1", null, null, (Pageable) null, null, kindFilter);
+        verify(apiProductSearchService).search(any(), queryCaptor.capture(), eq(null));
+        return queryCaptor.getValue();
+    }
+
+    @Test
+    void should_require_the_kind_when_the_listing_does_not_want_classic_products() {
+        // The page has to be narrowed by the store, not after it: a page of twenty-five asked of a store
+        // that also holds classic products comes back with fewer than twenty-five workspaces, or none.
+        var query = searchWith(new ApiProductKindFilter(Set.of(ApiProductKind.AI_WORKSPACE), false)).build();
+
+        assertThat(query.getFilters()).containsEntry(FIELD_KIND, Set.of(ApiProductKind.AI_WORKSPACE.name()));
+        assertThat(query.getExcludedFilters()).doesNotContainKey(FIELD_KIND);
+    }
+
+    @Test
+    void should_exclude_specialized_kinds_from_a_classic_listing() {
+        // Classic products carry no kind, so they cannot be required; the listing hides the kinds it does
+        // not want instead.
+        var query = searchWith(ApiProductKindFilter.classicOnly()).build();
+
+        assertThat(query.getExcludedFilters()).containsEntry(FIELD_KIND, Set.of(ApiProductKind.AI_WORKSPACE.name()));
+        assertThat(query.getFilters()).doesNotContainKey(FIELD_KIND);
+    }
+
+    @Test
+    void should_not_narrow_by_kind_when_the_listing_wants_everything() {
+        var query = searchWith(ApiProductKindFilter.any()).build();
+
+        assertThat(query.getFilters()).doesNotContainKey(FIELD_KIND);
+        assertThat(query.getExcludedFilters()).doesNotContainKey(FIELD_KIND);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductSearchServiceImplTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
-import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
 import io.gravitee.common.data.domain.Page;
@@ -37,6 +36,7 @@ import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +90,7 @@ class ApiProductSearchServiceImplTest {
         when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-3", "id-4")))).thenReturn(
             Set.of(p3, ApiProduct.builder().id("id-4").name("P4").environmentId(ENV_ID).build())
         );
-        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(eq(ORG_ID), any())).thenReturn(null);
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwners(eq(ORG_ID), any())).thenReturn(Map.of());
         var queryBuilder = QueryBuilder.create(IndexableApiProduct.class);
         var pageable = new PageableImpl(2, 2); // page 2, size 2 -> ids at index 2,3 = id-3, id-4
 
@@ -135,14 +135,14 @@ class ApiProductSearchServiceImplTest {
     }
 
     @Test
-    void should_swallow_primary_owner_not_found_and_return_product_without_owner() {
+    void should_return_a_product_without_an_owner_when_it_has_none() {
         ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
         when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("id-1"), 1));
         ApiProduct apiProduct = ApiProduct.builder().id("id-1").name("P1").environmentId(ENV_ID).build();
         when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-1")))).thenReturn(Set.of(apiProduct));
-        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, "id-1")).thenThrow(
-            new ApiProductPrimaryOwnerNotFoundException("id-1")
-        );
+        // A product with no primary owner is simply absent from the batch answer, so the row renders
+        // without an owner rather than failing the whole page.
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwners(ORG_ID, Set.of("id-1"))).thenReturn(Map.of());
 
         Page<ApiProduct> result = service.search(executionContext, QueryBuilder.create(IndexableApiProduct.class), new PageableImpl(1, 10));
 
@@ -158,7 +158,7 @@ class ApiProductSearchServiceImplTest {
         ApiProduct apiProduct = ApiProduct.builder().id("id-1").name("P1").environmentId(ENV_ID).build();
         PrimaryOwnerEntity owner = new PrimaryOwnerEntity("u1", "o@e.io", "Owner", PrimaryOwnerEntity.Type.USER);
         when(apiProductQueryService.findByEnvironmentIdAndIdIn(eq(ENV_ID), eq(Set.of("id-1")))).thenReturn(Set.of(apiProduct));
-        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, "id-1")).thenReturn(owner);
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwners(ORG_ID, Set.of("id-1"))).thenReturn(Map.of("id-1", owner));
 
         Page<ApiProduct> result = service.search(executionContext, QueryBuilder.create(IndexableApiProduct.class), new PageableImpl(1, 10));
 


### PR DESCRIPTION
## What

API Product listings that ask for a single kind now narrow in the store, carry a real `deploymentState`, and resolve primary owners in one batch instead of three queries per row.

Raised from review feedback on [gravitee-gamma-module-aim#679](https://github.com/gravitee-io/gravitee-gamma-module-aim/pull/679), whose AI Workspace list consumes these paths. **This must merge first** — the AIM PR is correct only once these fixes are in the snapshot.

## Why

**Kind filtering was ineffective.** A listing wanting only one kind asked the store to *exclude* every other kind. A classic API Product carries no kind term, so it passed every exclusion and padded the page — a page of 25 could return fewer than 25 of the kind asked for, or none. Such listings now *require* the kind. Listings that also want classic products still narrow by exclusion, since no kind term can match a classic product.

**`deploymentState` was never resolved on the search path.** The field the API Product schema declares came back `null`, so anything counting deployed products counted none. Now resolved for the page.

**Primary owners cost 3 queries per row** (role → membership → user/group). A 25-row page cost ~75 round trips; the listing use case ran it across an entire environment.

## Cost

| Path | Before | After |
|---|---|---|
| Primary owner | 3 × N queries | 3 (user owners) to 6 (mixed), fixed |
| Deployment state | 2 × N queries | 2 queries, fixed |

Both are pinned by tests asserting the count does not grow with product count, so a regression fails CI rather than fading into a slow listing.

### Known cost, not yet addressed

The deployment-state lookup uses the existing `findAllByTypeAndEnvironments`, which scopes by **environment, not by id**. The product ids are filtered in memory afterwards, and because page/size are null the Mongo pipeline skips its limit and looks every matching row back up with its payload. So while the *query* count is fixed at 2, a 10-row page still reads every `DEPLOY_API_PRODUCT` payload in the environment — and AIM's summary walk pays that once per 500-page.

Scoping it store-side is possible without new plumbing: `EventCriteria.properties` already accepts a collection and both stores push it down (`JdbcEventLatestRepository:128`, `EventMongoRepositoryImpl:146`). It needs an id-scoped finder on `EventLatestQueryService`, which this PR deliberately avoided to keep the change API-Product-scoped. Flagged here rather than left implicit — happy to add it if reviewers prefer.

No shared query-service interface was changed. Every bulk finder used already existed: `findByReferencesAndRoleId`, `findBaseUsersByIds`, `findByIds`, `findAllByTypeAndEnvironments`, `findAllByReferenceIdsAndEnvironments`.

## Behaviour change worth noting

The classic Console API Products list will now show a real deployment state where it previously showed none. The v2 `ApiProduct` schema has always declared `deploymentState`; returning `null` was the defect.

## Tests

- `ApiProductSearchQueryServiceImplTest` (new) — the store is asked to require the kind
- `ApiProductDeploymentStateDomainServiceTest` (new) — state per product, fixed query count
- `ApiProductPrimaryOwnerDomainServiceTest` — user owners, group owners (including a group with no owner of its own), both in one pass, and the pinned query count
- `SearchApiProductsUseCaseTest` — deployment state on searched products
- 18 pre-existing `GetApiProductsUseCaseTest$DeploymentState` tests pass unchanged against the extracted domain service

`*ApiProduct*` + `*PrimaryOwner*` sweep: **643 tests, 0 failures**. Full REST API tree compiles.

## Scope

Every changed file is API-Product-scoped. Nothing touches APIs, proxies, or shared query-service interfaces.