### PR TITLE
feat(ci): release a hotfix from a branch cut off a released tag

### DIFF
--- a/.circleci/ci/src/jobs/job-publish-rpm-packages.ts
+++ b/.circleci/ci/src/jobs/job-publish-rpm-packages.ts
@@ -23,11 +23,17 @@ import { parse } from '../utils';
 export class PublishRpmPackagesJob {
   private static jobName = 'job-publish-rpm-packages';
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
-    const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
+    const { qualifier } = parse(environment.graviteeioVersion);
+
+    // These RPMs go to the production repository, and rpm has no notion of a pre-release: an alpha
+    // of the next version outranks the current release, so a plain `dnf update` would install it.
+    // A hotfix is the exception. It packages the released version with a higher release number, so
+    // it sits above the release it fixes and below the next patch — where it belongs.
+    const isPrerelease = qualifier.full.length > 0 && qualifier.name !== 'hotfix';
 
     let steps: Command[];
 
-    if (parsedGraviteeioVersion.qualifier.full && parsedGraviteeioVersion.qualifier.full.length > 0) {
+    if (isPrerelease) {
       steps = [
         new commands.Run({
           name: 'Publishing RPMs is not supported for prerelease version',

--- a/.circleci/ci/src/pipelines/pipeline-release.ts
+++ b/.circleci/ci/src/pipelines/pipeline-release.ts
@@ -16,13 +16,35 @@
 import { Config } from '../circleci-config';
 import { ReleaseWorkflow } from '../workflows';
 import { CircleCIEnvironment } from './circleci-environment';
-import { isSupportBranch } from '../utils';
+import { isHotfixBranch, isSupportBranch } from '../utils';
 import { initDynamicConfig } from './config-factory';
 
-export function generateReleaseConfig(environment: CircleCIEnvironment): Config {
-  if (!isSupportBranch(environment.branch)) {
-    throw new Error('Release is only supported on support branches');
+const HOTFIX_QUALIFIER = /-hotfix\.\d+$/;
+
+/**
+ * The version and the branch reach this pipeline as two independent inputs, and nothing downstream
+ * brings them together: the published version comes from the poms of whichever branch runs, while
+ * the tag comes from the version. A mismatch therefore tags one version and publishes another,
+ * without failing. A hotfix is where the two diverge most easily, since `hotfix/4.12.17` and
+ * `4.12.17-hotfix.1` name the same release twice.
+ */
+function assertVersionMatchesBranch(version: string, branch: string): void {
+  if (isHotfixBranch(branch)) {
+    const releasedVersion = branch.substring('hotfix/'.length);
+    if (!version.startsWith(`${releasedVersion}-`)) {
+      throw new Error(`${branch} releases ${releasedVersion} with a qualifier, not ${version}`);
+    }
+  } else if (HOTFIX_QUALIFIER.test(version)) {
+    throw new Error(`${version} is only released from hotfix/${version.replace(HOTFIX_QUALIFIER, '')}, not from ${branch}`);
   }
+}
+
+export function generateReleaseConfig(environment: CircleCIEnvironment): Config {
+  if (!isSupportBranch(environment.branch) && !isHotfixBranch(environment.branch)) {
+    throw new Error('Release is only supported on a support branch (X.Y.x) or a hotfix branch (hotfix/X.Y.Z)');
+  }
+
+  assertVersionMatchesBranch(environment.graviteeioVersion, environment.branch);
 
   const dynamicConfig = initDynamicConfig();
   const workflow = ReleaseWorkflow.create(dynamicConfig, environment);

--- a/.circleci/ci/src/pipelines/tests/pipeline-build-rpm.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-build-rpm.spec.ts
@@ -18,11 +18,12 @@ import { generateBuildRpmConfig } from '../pipeline-build-rpm';
 
 describe('Build RPM workflow tests', () => {
   it.each`
-    graviteeioVersion  | isDryRun | dockerTagAsLatest | apimVersionPath                                           | expectedFileName
-    ${'4.2.0-alpha.1'} | ${true}  | ${false}          | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'build-rpm-prerelease-dry-run.yml'}
-    ${'4.2.0-alpha.1'} | ${false} | ${false}          | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'build-rpm-prerelease-no-dry-run.yml'}
-    ${'4.2.0'}         | ${true}  | ${false}          | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'build-rpm-release-dry-run.yml'}
-    ${'4.2.0'}         | ${false} | ${false}          | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'build-rpm-release-no-dry-run.yml'}
+    graviteeioVersion   | isDryRun | dockerTagAsLatest | apimVersionPath                                            | expectedFileName
+    ${'4.2.0-alpha.1'}  | ${true}  | ${false}          | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}  | ${'build-rpm-prerelease-dry-run.yml'}
+    ${'4.2.0-alpha.1'}  | ${false} | ${false}          | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}  | ${'build-rpm-prerelease-no-dry-run.yml'}
+    ${'4.2.0'}          | ${true}  | ${false}          | ${'./src/pipelines/tests/resources/common/pom.xml'}        | ${'build-rpm-release-dry-run.yml'}
+    ${'4.2.0'}          | ${false} | ${false}          | ${'./src/pipelines/tests/resources/common/pom.xml'}        | ${'build-rpm-release-no-dry-run.yml'}
+    ${'4.2.0-hotfix.1'} | ${false} | ${false}          | ${'./src/pipelines/tests/resources/common/pom-hotfix.xml'} | ${'build-rpm-hotfix-no-dry-run.yml'}
   `(
     'should build RPM with $graviteeioVersion and dry run as $isDryRun',
     ({ graviteeioVersion, isDryRun, dockerTagAsLatest, apimVersionPath, expectedFileName }) => {

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -18,11 +18,12 @@ import { generateFullReleaseConfig } from '../pipeline-full-release';
 
 describe('Full release tests', () => {
   it.each`
-    baseBranch | branch     | isDryRun | dockerTagAsLatest | graviteeioVersion  | apimVersionPath                                              | expectedResult
-    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-dry-run.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-no-dry-run.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-latest.yml'}
-    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'release-4-2-0-alpha.yml'}
+    baseBranch | branch            | isDryRun | dockerTagAsLatest | graviteeioVersion   | apimVersionPath                                              | expectedResult
+    ${'4.2.x'} | ${'4.2.x'}        | ${true}  | ${false}          | ${'4.2.0'}          | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'}        | ${false} | ${false}          | ${'4.2.0'}          | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-no-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'}        | ${false} | ${true}           | ${'4.2.0'}          | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-latest.yml'}
+    ${'4.2.x'} | ${'4.2.x'}        | ${false} | ${false}          | ${'4.2.0-alpha.1'}  | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'release-4-2-0-alpha.yml'}
+    ${'4.2.x'} | ${'hotfix/4.2.0'} | ${false} | ${false}          | ${'4.2.0-hotfix.1'} | ${'./src/pipelines/tests/resources/common/pom-hotfix.xml'}   | ${'release-4-2-0-hotfix.yml'}
   `(
     'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version $graviteeioVersion',
     ({ baseBranch, branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {

--- a/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
@@ -43,7 +43,7 @@ describe('Release tests', () => {
     },
   );
 
-  it('should throw error when branch is not a support branch', () => {
+  it('should throw error when branch is neither a support nor a hotfix branch', () => {
     expect.assertions(1);
 
     try {
@@ -60,7 +60,47 @@ describe('Release tests', () => {
         isDryRun: false,
       });
     } catch (e) {
-      expect(e).toStrictEqual(new Error('Release is only supported on support branches'));
+      expect(e).toStrictEqual(new Error('Release is only supported on a support branch (X.Y.x) or a hotfix branch (hotfix/X.Y.Z)'));
     }
+  });
+
+  it('should build release config on a hotfix branch cut from a released tag', () => {
+    const result = generateReleaseConfig({
+      action: 'release',
+      sha1: '784ff35ca',
+      changedFiles: [],
+      buildNum: '1234',
+      buildId: '1234',
+      graviteeioVersion: '4.2.0-hotfix.1',
+      baseBranch: '4.2.x',
+      branch: 'hotfix/4.2.0',
+      apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+      isDryRun: false,
+    });
+
+    const expected = fs.readFileSync('./src/pipelines/tests/resources/release/release-4-2-0-hotfix.yml', 'utf-8');
+    expect(result.stringify()).toStrictEqual(expected);
+  });
+
+  it.each`
+    graviteeioVersion   | branch            | expectedError
+    ${'4.2.0'}          | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0 with a qualifier, not 4.2.0'}
+    ${'4.2.1-hotfix.1'} | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0 with a qualifier, not 4.2.1-hotfix.1'}
+    ${'4.2.0-hotfix.1'} | ${'4.2.x'}        | ${'4.2.0-hotfix.1 is only released from hotfix/4.2.0, not from 4.2.x'}
+  `('should throw for version $graviteeioVersion on branch $branch', ({ graviteeioVersion, branch, expectedError }) => {
+    expect(() =>
+      generateReleaseConfig({
+        action: 'release',
+        sha1: '784ff35ca',
+        changedFiles: [],
+        buildNum: '1234',
+        buildId: '1234',
+        graviteeioVersion,
+        baseBranch: '4.2.x',
+        branch,
+        apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+        isDryRun: false,
+      }),
+    ).toThrow(expectedError);
   });
 });

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-hotfix-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm/build-rpm-hotfix-no-dry-run.yml
@@ -1,0 +1,89 @@
+# This file is generated from the TypeScript sources in .circleci/ci.
+# Do not edit it by hand — run `npm run generate` instead.
+
+version: 2.1
+setup: false
+parameters:
+  gio_action:
+    type: string
+    default: pull_requests
+    description: ""
+  dry_run:
+    type: boolean
+    default: true
+    description: Run in dry run mode?
+  docker_tag_as_latest:
+    type: boolean
+    default: false
+    description: Is this version the latest version available?
+  graviteeio_version:
+    type: string
+    default: ""
+    description: Version of APIM to be used in docker images
+  apim_version_path:
+    type: string
+    default: /home/circleci/project/pom.xml
+    description: Path to pom.xml with APIM version
+jobs:
+  job-publish-rpm-packages:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://8CG6HxY5gYsl-85eJKuIoA/field/password
+          var-name: GIO_PACKAGECLOUD_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key
+          var-name: GPG_KEY_PUBLIC
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key
+          var-name: GPG_KEY_PRIVATE
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/field/login
+          var-name: GPG_KEY_NAME
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/passphrase
+          var-name: GPG_KEY_PASSPHRASE
+      - run:
+          name: Building and publishing RPMs
+          command: |
+            export GIT_GRAVITEE_PACKAGES_REPO=$(mktemp -d)
+            git clone --depth 1 --branch master --single-branch --no-tag git@github.com:gravitee-io/packages.git ${GIT_GRAVITEE_PACKAGES_REPO}
+
+            cd ${GIT_GRAVITEE_PACKAGES_REPO}/apim/4.x
+            ./build.sh -v 4.2.0-hotfix.1
+
+            echo "change RPM file owner from root to graviteeio"
+            docker run --rm \
+                -v "${PWD}:/rpms" \
+                --workdir /rpms \
+                --entrypoint /bin/sh \
+                graviteeio/fpm:rpm \
+                -c 'chown 1001:1001 *.rpm'
+
+            docker run --rm \
+                -v "${PWD}:/rpms" \
+                -e "GPG_KEY_NAME" \
+                -e "GPG_KEY_PUBLIC" \
+                -e "GPG_KEY_PRIVATE" \
+                -e "GPG_KEY_PASSPHRASE" \
+                graviteeio/rpmsign
+
+            echo "RPMs will be published in https://packagecloud.io/graviteeio/rpms"
+
+            docker run --rm \
+                -v "${GIT_GRAVITEE_PACKAGES_REPO}/apim/4.x:/packages" \
+                -e PACKAGECLOUD_TOKEN=${GIO_PACKAGECLOUD_TOKEN} \
+                digitalocean/packagecloud \
+                push --yes --skip-errors --verbose graviteeio/rpms/el/7 /packages/*.rpm
+workflows:
+  build-rpm:
+    jobs:
+      - job-publish-rpm-packages:
+          context:
+            - cicd-orchestrator
+          name: Build and push RPM packages for APIM 4.2.0-hotfix.1
+orbs:
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/common/pom-hotfix.xml
+++ b/.circleci/ci/src/pipelines/tests/resources/common/pom-hotfix.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>22.0.2</version>
+    </parent>
+
+    <groupId>io.gravitee.apim</groupId>
+    <artifactId>gravitee-api-management</artifactId>
+    <version>${revision}${sha1}${changelist}</version>
+    <packaging>pom</packaging>
+
+    <name>Gravitee.io APIM</name>
+
+    <scm>
+        <url>https://github.com/gravitee-io/gravitee-api-management</url>
+        <connection>scm:git:git://github.com/gravitee-io/gravitee-api-management.git</connection>
+        <developerConnection>scm:git:git@github.com:gravitee-io/gravitee-api-management.git</developerConnection>
+    </scm>
+
+    <issueManagement>
+        <url>https://github.com/gravitee-io/issues/issues</url>
+        <system>GitHub Issues</system>
+    </issueManagement>
+    <properties>
+        <!-- Version properties -->
+        <revision>4.2.0</revision>
+        <sha1>-hotfix.1</sha1>
+        <changelist>-SNAPSHOT</changelist>
+    </properties>
+</project>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -1,0 +1,1318 @@
+# This file is generated from the TypeScript sources in .circleci/ci.
+# Do not edit it by hand — run `npm run generate` instead.
+
+version: 2.1
+setup: false
+parameters:
+  gio_action:
+    type: string
+    default: pull_requests
+    description: ""
+  dry_run:
+    type: boolean
+    default: true
+    description: Run in dry run mode?
+  docker_tag_as_latest:
+    type: boolean
+    default: false
+    description: Is this version the latest version available?
+  graviteeio_version:
+    type: string
+    default: ""
+    description: Version of APIM to be used in docker images
+  apim_version_path:
+    type: string
+    default: /home/circleci/project/pom.xml
+    description: Path to pom.xml with APIM version
+commands:
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
+  cmd-workspace-install:
+    steps:
+      - restore_cache:
+          name: Restore Yarn workspace cache
+          keys:
+            - gravitee-api-management-v14-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - gravitee-api-management-v14-workspace-{{ .Branch }}
+      - run:
+          name: Install workspace dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn workspace cache
+          key: gravitee-api-management-v14-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ./node_modules
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-webui-install:
+    parameters:
+      apim-ui-project:
+        type: string
+        default: ""
+        description: the name of the UI project to build
+      apim-ui-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the UI project to build
+    steps:
+      - restore_cache:
+          name: Restore Yarn cache
+          keys:
+            - << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
+            - << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}
+      - run:
+          name: Install dependencies
+          command: yarn
+          working_directory: << parameters.apim-ui-project-workdir >>
+      - save_cache:
+          name: Save Yarn cache
+          key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
+          paths:
+            - ./<< parameters.apim-ui-project-workdir >>/node_modules
+  cmd-create-docker-context:
+    steps:
+      - run:
+          name: Create docker context for buildx
+          command: |-
+            docker context create tls-env
+            docker buildx create tls-env --use
+  cmd-docker-login:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Docker Hub
+          command: "echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin "
+    description: Login to Docker Hub
+  cmd-docker-logout:
+    steps:
+      - run:
+          name: Logout from Docker Hub
+          command: docker logout
+    description: Logout from Docker Hub
+  cmd-docker-login-azurecr:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          var-name: DOCKER_REGISTRY_USERNAME
+      - keeper/env-export:
+          secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+          var-name: DOCKER_REGISTRY_PASSWORD
+      - run:
+          name: Login to Azure Container Registry
+          command: echo $DOCKER_REGISTRY_PASSWORD | docker login --username $DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
+    description: Login to Azure Container Registry
+  cmd-docker-logout-azurecr:
+    steps:
+      - run:
+          name: Logout from Azure Container Registry
+          command: docker logout graviteeio.azurecr.io
+    description: Logout from Azure Container Registry
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v14-<< parameters.jobName >>-4.2.x
+    description: Restore Maven cache for a dedicated job
+  cmd-prepare-gpg:
+    steps:
+      - keeper/install
+      - run:
+          command: |-
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key > pub.key
+            gpg --import pub.key
+
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key > private.key
+            # Need --batch to be able to import private key
+            gpg --import --batch private.key
+    description: Prepare GPG command
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - save_cache:
+          key: gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-sync-folder-to-s3:
+    parameters:
+      folder-to-sync:
+        type: string
+        default: ""
+        description: the path of the folder to sync to S3
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Mqmplmfu17bDR5XRLmO1mQ/field/password
+          var-name: AWS_ACCESS_KEY_ID
+      - keeper/env-export:
+          secret-url: keeper://3-pU56sIqcyWWw7HxhxjaQ/field/password
+          var-name: AWS_SECRET_ACCESS_KEY
+      - aws-cli/setup:
+          region: cloudfront
+          version: 2.22.35
+      - aws-s3/sync:
+          arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
+          from: << parameters.folder-to-sync>>
+          to: s3://gravitee-releases-downloads/pre-releases
+    description: Sync folder content to Gravitee download website
+jobs:
+  job-setup:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          var-name: MAVEN_SETTINGS
+      - run:
+          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .gravitee.settings.xml
+  job-slack-announcement:
+    parameters:
+      message:
+        type: string
+        default: ""
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02NGT20S4W
+          event: always
+          custom: |-
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<< parameters.message >>"
+                  }
+                }
+              ]
+            }
+  job-console-webui-build:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-console-webui/build.json"
+      - run:
+          name: Build Console
+          command: NODE_OPTIONS=--max_old_space_size=4086 yarn console:build:prod
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-console-webui/dist
+  job-portal-webui-build:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui
+          apim-ui-project-workdir: gravitee-apim-portal-webui
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-portal-webui/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui
+      - cmd-workspace-install
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build Portal Next
+          command: NODE_OPTIONS=--max_old_space_size=4086 yarn portal-next:build:prod
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist
+  job-gamma-webui-build:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json"
+      - run:
+          name: Build Gamma UI
+          command: NODE_OPTIONS=--max_old_space_size=4086 yarn gamma-console:build:prod
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-gamma/gravitee-gamma-control-plane-webui/dist
+  job-build-docker-webui-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+  job-build-docker-backend-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login
+      - run:
+          name: Build docker image for << parameters.apim-project >>-alpine
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - run:
+          name: Build docker image for << parameters.apim-project >>-debian
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix-debian \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+  job-build-docker-chainguard-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - cmd-docker-login
+      - run:
+          name: Build Chainguard docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix-chainguard \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
+  job-build-docker-chainguard-fips-image:
+    parameters:
+      apim-project:
+        type: string
+        default: ""
+        description: the name of the project to build
+      apim-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the project to build
+      docker-context:
+        type: string
+        default: ""
+        description: the name of context folder for docker build
+      docker-image-name:
+        type: string
+        default: ""
+        description: the name of the image
+      docker-fips-base-image:
+        type: string
+        default: ""
+        description: the FIPS base image passed as BASE_IMAGE build-arg (java or nginx chainguard-fips)
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-create-docker-context
+      - cmd-docker-login-azurecr
+      - run:
+          name: Build Chainguard FIPS docker image for << parameters.apim-project >>
+          command: |-
+            docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-hotfix.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-hotfix-chainguard-fips \
+            << parameters.docker-context >>
+          working_directory: << parameters.apim-project-workdir >>
+      - cmd-docker-logout-azurecr
+  job-backend-build-and-publish-on-download-website:
+    docker:
+      - image: cimg/openjdk:25.0.3-node
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-backend-build-and-publish-on-download-website
+      - run:
+          name: Remove `-SNAPSHOT` from versions
+          command: |-
+            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
+            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
+      - cmd-prepare-gpg
+      - run:
+          name: Maven build APIM engine
+          command: mvn --settings .gravitee.settings.xml -B -U -P all-modules,gio-release clean install -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          environment:
+            BUILD_ID: "1234"
+            BUILD_NUMBER: "1234"
+            GIT_COMMIT: 784ff35ca
+      - run:
+          name: Maven build APIM distribution
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          environment:
+            BUILD_ID: "1234"
+            BUILD_NUMBER: "1234"
+            GIT_COMMIT: 784ff35ca
+      - cmd-save-maven-job-cache:
+          jobName: job-backend-build-and-publish-on-download-website
+      - run:
+          name: Prepare plugin zip to upload
+          command: |-
+            workingDir=$(pwd)
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
+              # Extract folder of the artefact to publish
+              # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
+              artefactFolder=${pathToArtefactFile%/target*}
+
+              # extract publish folder from pom.xml properties, return '/' if no property found
+              publishFolderPath=/$(grep -Po '(?<=<publish-folder-path>).*(?=</publish-folder-path>)' $artefactFolder/pom.xml || echo '')
+
+              if [[ "$publishFolderPath" != "/" ]]; then
+                # extract artefact file of the artefact to publish
+                # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
+                artefactFile=${pathToArtefactFile##*/}
+
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
+                [[ $artefactFile =~ $regex ]]
+                artefactName=${BASH_REMATCH[1]}
+
+                # compute the destination folder on S3 to publish the artefact
+                # e.g. gravitee-apim-repository-mongodb-4.4.21.zip => folder_to_sync/graviteeio-apim/plugins/repositories/gravitee-apim-repository-mongodb
+                artefactFolderToSync=folder_to_sync${publishFolderPath}/${artefactName}
+
+                mkdir -p $artefactFolderToSync
+                cp $pathToArtefactFile $artefactFolderToSync/
+
+                cd $artefactFolderToSync
+
+                md5sum $artefactFile > $artefactFile.md5
+                sha512sum $artefactFile > $artefactFile.sha512sum
+                sha1sum $artefactFile > $artefactFile.sha1
+
+                cd $workingDir
+              fi
+            done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
+            - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-release-commit-and-prepare-next-version:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+          var-name: GIT_USER_NAME
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+          var-name: GIT_USER_EMAIL
+      - run:
+          name: Git config
+          command: |-
+            git config --global user.name "${GIT_USER_NAME}"
+             git config --global user.email "${GIT_USER_EMAIL}"
+      - run:
+          name: "Git release "
+          command: |
+            # Remove `-SNAPSHOT` from source
+            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
+            # and engine-snapshot resolves apim.server.version from its properties, not the root's. Leaving
+            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
+            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            POMS="pom.xml gravitee-apim-distribution/pom.xml"
+            for POM in ${POMS}; do
+              sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"
+            done
+
+            # UI
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-console-webui/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-portal-webui/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
+
+            git add --update
+            git commit -m "4.2.0-hotfix.1"
+            git tag 4.2.0-hotfix.1
+
+            # Set the version to the next version (bump patch version + '-SNAPSHOT')
+            for POM in ${POMS}; do
+              sed -i "s#<revision>.*</revision>#<revision>4.2.0</revision>#" "${POM}"
+              sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" "${POM}"
+              # <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
+              # never matches — the qualifier was silently kept on any pom already holding the empty form.
+              sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1>-hotfix.2</sha1>#" "${POM}"
+            done
+
+            sed -i 's#version: ".*"#version: "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-console-webui/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
+
+            # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
+            sed -e "0,/^version:/{s/version:.*/version: 4.2.0-hotfix.2/}" \
+                -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.0-hotfix.2/ }" \
+                -i helm/Chart.yaml
+
+            git add --update
+            git commit -m 'chore: prepare next version [skip ci]'
+
+            git push -u  origin hotfix/4.2.0
+            git push --tags  origin hotfix/4.2.0
+  job-package-bundle:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Building full-distribution bundle
+          command: |
+            mkdir -p ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1
+            # Console
+            cp -r gravitee-apim-console-webui/dist ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1/graviteeio-apim-console-ui-4.2.0-hotfix.1
+
+            # Gamma Console
+            cp -r gravitee-gamma/gravitee-gamma-control-plane-webui/dist ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1/graviteeio-gamma-ui-4.2.0-hotfix.1
+
+            # Portal
+            cp -r gravitee-apim-portal-webui/dist ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1/graviteeio-apim-portal-ui-4.2.0-hotfix.1
+
+            # Rest API
+            cp -r gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1/graviteeio-apim-rest-api-4.2.0-hotfix.1
+
+            # Gateway
+            cp -r gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution ./folder_to_sync/graviteeio-apim/distributions/graviteeio-full-4.2.0-hotfix.1/graviteeio-apim-gateway-4.2.0-hotfix.1
+
+            cd ./folder_to_sync/graviteeio-apim/distributions
+            zip -q -r graviteeio-full-4.2.0-hotfix.1.zip graviteeio-full-4.2.0-hotfix.1
+
+            md5sum graviteeio-full-4.2.0-hotfix.1.zip > graviteeio-full-4.2.0-hotfix.1.zip.md5
+            sha512sum graviteeio-full-4.2.0-hotfix.1.zip > graviteeio-full-4.2.0-hotfix.1.zip.sha512sum
+            sha1sum graviteeio-full-4.2.0-hotfix.1.zip > graviteeio-full-4.2.0-hotfix.1.zip.sha1
+
+            rm -rf graviteeio-full-4.2.0-hotfix.1
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
+  job-release-helm:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: medium
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+          var-name: GIT_USER_NAME
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+          var-name: GIT_USER_EMAIL
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
+      - run:
+          name: Git config
+          command: |-
+            git config --global user.name "${GIT_USER_NAME}"
+            git config --global user.email "${GIT_USER_EMAIL}"
+      - gh/setup
+      - helm/install_helm_client:
+          version: v3.12.3
+      - run:
+          name: Checkout tag 4.2.0-hotfix.1
+          command: git checkout 4.2.0-hotfix.1
+      - run:
+          name: build the Charts
+          working_directory: ./helm
+          command: |-
+            helm dependency update
+            cp -f "Chart.yaml" "../Chart.yaml.bak"
+            cp -f "values.yaml" "../values.yaml.bak"
+
+            mkdir -p charts/docker/io
+
+            helm package -d charts .
+            mv charts/apim-*.tgz charts/docker/io/
+
+            sed "s/^name:.*/name: apim3/" -i Chart.yaml
+            helm package -d charts .
+            mv charts/apim3-*.tgz charts/docker/io/
+
+            mkdir -p charts/aws/io
+            cp -f "../Chart.yaml.bak" "Chart.yaml"
+            cp -f "../values.yaml.bak" "values.yaml"
+            sed -i -E "s|(repository: )graviteeio/apim-management-api|\1430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteeio/saas-apim-management-api|g" values.yaml
+            sed -i -E "s|(repository: )graviteeio/apim-gateway|\1430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteeio/saas-apim-gateway|g" values.yaml
+            sed -i -E "s|(repository: )graviteeio/apim-portal-ui|\1430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteeio/saas-apim-portal-ui|g" values.yaml
+            sed -i -E "s|(repository: )graviteeio/apim-management-ui|\1430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteeio/saas-apim-management-ui|g" values.yaml
+            helm package -d charts .
+            mv charts/apim-*.tgz charts/aws/io/
+      - cmd-install-yarn
+      - run:
+          name: Install dependencies
+          command: yarn
+          working_directory: ./release
+      - run:
+          name: Install AWS CLI
+          command: |-
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+                        unzip awscliv2.zip
+                        sudo ./aws/install
+                        aws --version
+      - run:
+          name: Open a PR to publish helm chart release into helm-charts repository
+          working_directory: ./release
+          command: yarn zx ci-steps/release-helm.mjs --version=4.2.0-hotfix.1
+      - keeper/env-export:
+          secret-url: keeper://AEmKkeWZ4Zq758pvaPIE1A/custom_field/aws_access_key_id
+          var-name: AWS_ACCESS_KEY_ID
+      - keeper/env-export:
+          secret-url: keeper://AEmKkeWZ4Zq758pvaPIE1A/custom_field/aws_secret_access_key
+          var-name: AWS_SECRET_ACCESS_KEY
+      - keeper/env-export:
+          secret-url: keeper://AEmKkeWZ4Zq758pvaPIE1A/custom_field/aws_region
+          var-name: AWS_REGION
+      - run:
+          name: Login to AWS ECR for Helm OCI
+          command: aws ecr get-login-password --region $AWS_REGION | helm registry login --username AWS --password-stdin 430630701098.dkr.ecr.eu-west-2.amazonaws.com
+      - run:
+          name: Publish helm chart release in AWS ECR
+          working_directory: ./helm
+          command: helm push charts/aws/io/apim-*.tgz oci://430630701098.dkr.ecr.eu-west-2.amazonaws.com/graviteeio/helm/
+  job-publish-rpm-packages:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://8CG6HxY5gYsl-85eJKuIoA/field/password
+          var-name: GIO_PACKAGECLOUD_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key
+          var-name: GPG_KEY_PUBLIC
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key
+          var-name: GPG_KEY_PRIVATE
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/field/login
+          var-name: GPG_KEY_NAME
+      - keeper/env-export:
+          secret-url: keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/passphrase
+          var-name: GPG_KEY_PASSPHRASE
+      - run:
+          name: Building and publishing RPMs
+          command: |
+            export GIT_GRAVITEE_PACKAGES_REPO=$(mktemp -d)
+            git clone --depth 1 --branch master --single-branch --no-tag git@github.com:gravitee-io/packages.git ${GIT_GRAVITEE_PACKAGES_REPO}
+
+            cd ${GIT_GRAVITEE_PACKAGES_REPO}/apim/4.x
+            ./build.sh -v 4.2.0-hotfix.1
+
+            echo "change RPM file owner from root to graviteeio"
+            docker run --rm \
+                -v "${PWD}:/rpms" \
+                --workdir /rpms \
+                --entrypoint /bin/sh \
+                graviteeio/fpm:rpm \
+                -c 'chown 1001:1001 *.rpm'
+
+            docker run --rm \
+                -v "${PWD}:/rpms" \
+                -e "GPG_KEY_NAME" \
+                -e "GPG_KEY_PUBLIC" \
+                -e "GPG_KEY_PRIVATE" \
+                -e "GPG_KEY_PASSPHRASE" \
+                graviteeio/rpmsign
+
+            echo "RPMs will be published in https://packagecloud.io/graviteeio/rpms"
+
+            docker run --rm \
+                -v "${GIT_GRAVITEE_PACKAGES_REPO}/apim/4.x:/packages" \
+                -e PACKAGECLOUD_TOKEN=${GIO_PACKAGECLOUD_TOKEN} \
+                digitalocean/packagecloud \
+                push --yes --skip-errors --verbose graviteeio/rpms/el/7 /packages/*.rpm
+  job-release-notes-apim:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: medium
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+          var-name: GIT_USER_NAME
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+          var-name: GIT_USER_EMAIL
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - keeper/env-export:
+          secret-url: keeper://hfnQD5TEfxzwRXUKhJhM-A/field/password
+          var-name: JIRA_TOKEN
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
+      - run:
+          name: Git config
+          command: |-
+            git config --global user.name "${GIT_USER_NAME}"
+            git config --global user.email "${GIT_USER_EMAIL}"
+      - gh/setup
+      - cmd-install-yarn
+      - run:
+          name: Install dependencies
+          command: yarn
+          working_directory: ./release
+      - run:
+          name: Open a PR to create release notes into docs repository
+          command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0-hotfix.1
+          working_directory: ./release
+      - run:
+          name: Get RELEASE_NOTES_PR_URL
+          command: echo "export RELEASE_NOTES_PR_URL=$(cat /tmp/releaseNotesPrUrl.txt)" >> $BASH_ENV
+      - slack/notify:
+          channel: C02NGT20S4W
+          event: pass
+          custom: |-
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":memo: APIM Changelog 4.2.0-hotfix.1 can be completed <${RELEASE_NOTES_PR_URL}|here> @tech_writers_team :pray:"
+                  }
+                }
+              ]
+            }
+  job-nexus-staging:
+    docker:
+      - image: cimg/openjdk:25.0.3-node
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Checkout tag 4.2.0-hotfix.1
+          command: git checkout 4.2.0-hotfix.1
+      - cmd-restore-maven-job-cache:
+          jobName: job-nexus-staging
+      - attach_workspace:
+          at: .
+      - cmd-prepare-gpg
+      - run:
+          name: Release on Nexus
+          command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots
+      - cmd-save-maven-job-cache:
+          jobName: job-nexus-staging
+  job-trigger-saas-docker-images:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"hotfix/4.2.0", "sha1":"784ff35", "release-version":"4.2.0-hotfix.1", "dry-run":false, "os-distribution":"debian"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"hotfix/4.2.0", "sha1":"784ff35", "release-version":"4.2.0-hotfix.1", "dry-run":false, "os-distribution":"chainguard"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
+  job-trigger-saas-docker-images-chainguard-fips:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger SaaS Docker images pipeline
+          command: |-
+            PIPELINE_ID=$(curl --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/cloud-distributions/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"project":"apim", "distribution":"prod", "branch-version":"hotfix/4.2.0", "sha1":"784ff35", "release-version":"4.2.0-hotfix.1", "dry-run":false, "os-distribution":"chainguard-fips"}}' | jq -r '.id')
+            echo "Pipeline triggered with ID: $PIPELINE_ID"
+            waitForPipelineCompletion() {
+                while true; do
+                    STATUS=$(curl --request GET --url "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" --header "Circle-Token: ${CIRCLE_TOKEN}" | jq -r '.items[].status')
+                    echo "Current status: $STATUS"
+                    if [[ "$STATUS" == "success" ]]; then
+                        echo "Pipeline completed successfully."
+                        break
+                    elif [[ "$STATUS" == "failed" ]]; then
+                        echo "Pipeline failed."
+                        exit 1
+                    fi
+                    sleep 30
+                done
+            }  
+            waitForPipelineCompletion
+  job-trigger-apim-api-docs-pipeline:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger gravitee-apim-api-docs ingestion pipeline
+          command: |-
+            curl --fail --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"version":"4.2.0-hotfix.1", "dry_run":false}}'
+            echo "Docs ingestion pipeline triggered for APIM 4.2.0-hotfix.1."
+  job-aikido-scan-docker-images:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://_XrkO71xa9HZBwxYoUHX0w/field/password
+          var-name: AIKIDO_API_KEY
+      - cmd-docker-login
+      - cmd-docker-login-azurecr
+      - run:
+          name: Pull docker images to scan
+          command: |-
+            IMAGES="
+            graviteeio/apim-portal-ui:4.2.0-hotfix.1
+            graviteeio/apim-portal-ui:4.2.0-hotfix.1-chainguard
+            graviteeio.azurecr.io/apim-portal-ui:4.2.0-hotfix.1-chainguard-fips
+            graviteeio/apim-management-ui:4.2.0-hotfix.1
+            graviteeio/apim-management-ui:4.2.0-hotfix.1-chainguard
+            graviteeio.azurecr.io/apim-management-ui:4.2.0-hotfix.1-chainguard-fips
+            graviteeio/gamma-ui:4.2.0-hotfix.1
+            graviteeio/gamma-ui:4.2.0-hotfix.1-chainguard
+            graviteeio.azurecr.io/gamma-ui:4.2.0-hotfix.1-chainguard-fips
+            graviteeio/apim-management-api:4.2.0-hotfix.1
+            graviteeio/apim-management-api:4.2.0-hotfix.1-debian
+            graviteeio/apim-management-api:4.2.0-hotfix.1-chainguard
+            graviteeio.azurecr.io/apim-management-api:4.2.0-hotfix.1-chainguard-fips
+            graviteeio/apim-gateway:4.2.0-hotfix.1
+            graviteeio/apim-gateway:4.2.0-hotfix.1-debian
+            graviteeio/apim-gateway:4.2.0-hotfix.1-chainguard
+            graviteeio.azurecr.io/apim-gateway:4.2.0-hotfix.1-chainguard-fips
+            "
+            : > /tmp/aikido-images.txt
+            for image in $IMAGES; do
+              if docker pull "$image"; then
+                echo "$image" >> /tmp/aikido-images.txt
+              else
+                echo "WARN: could not pull $image, it will not be scanned"
+              fi
+            done
+            if [ ! -s /tmp/aikido-images.txt ]; then
+              echo "ERROR: none of the images could be pulled"
+              exit 1
+            fi
+      - aikido/scan_docker_image:
+          built_docker_image_file: /tmp/aikido-images.txt
+          fail_on: ""
+      - cmd-docker-logout
+      - cmd-docker-logout-azurecr
+workflows:
+  full_release:
+    jobs:
+      - job-setup:
+          context:
+            - cicd-orchestrator
+          name: Setup
+      - job-slack-announcement:
+          context:
+            - cicd-orchestrator
+          name: Announce release is starting
+          message: 🚀 Starting APIM 4.2.0-hotfix.1 release!
+      - job-portal-webui-build:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal
+          requires:
+            - Setup
+      - job-build-docker-webui-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-console-webui-build:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console
+          requires:
+            - Setup
+      - job-build-docker-webui-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-gamma-webui-build:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console
+          requires:
+            - Setup
+      - job-build-docker-webui-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-backend-build-and-publish-on-download-website:
+          context:
+            - cicd-orchestrator
+          name: Backend build and publish on download website
+          requires:
+            - Setup
+      - job-build-docker-backend-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
+          docker-context: target
+          docker-image-name: apim-management-api
+      - job-build-docker-backend-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
+          docker-context: target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
+          docker-context: target
+          docker-image-name: apim-management-api
+      - job-build-docker-chainguard-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
+          docker-context: target
+          docker-image-name: apim-gateway
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Management API chainguard-fips docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-rest-api
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api
+          docker-context: target
+          docker-image-name: apim-management-api
+          docker-fips-base-image: graviteeio.azurecr.io/java:25-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Backend build and publish on download website
+          apim-project: gravitee-apim-gateway
+          apim-project-workdir: gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway
+          docker-context: target
+          docker-image-name: apim-gateway
+          docker-fips-base-image: graviteeio.azurecr.io/java:25-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal chainguard-fips docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Portal
+          apim-project: gravitee-apim-portal-webui
+          apim-project-workdir: gravitee-apim-portal-webui
+          docker-context: .
+          docker-image-name: apim-portal-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Console
+          apim-project: gravitee-apim-console-webui
+          apim-project-workdir: gravitee-apim-console-webui
+          docker-context: .
+          docker-image-name: apim-management-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-build-docker-chainguard-fips-image:
+          context:
+            - cicd-orchestrator
+          name: Build Gamma Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+          requires:
+            - Build Gamma Console
+          apim-project: gravitee-gamma-control-plane-webui
+          apim-project-workdir: gravitee-gamma/gravitee-gamma-control-plane-webui
+          docker-context: .
+          docker-image-name: gamma-ui
+          docker-fips-base-image: graviteeio.azurecr.io/nginx:1.30-chainguard-fips
+      - job-release-commit-and-prepare-next-version:
+          context:
+            - cicd-orchestrator
+          name: Commit and prepare next version
+          requires:
+            - Backend build and publish on download website
+            - Build APIM Console
+            - Build APIM Portal
+            - Build Gamma Console
+      - job-package-bundle:
+          context:
+            - cicd-orchestrator
+          name: Package bundle
+          requires:
+            - Commit and prepare next version
+      - job-publish-rpm-packages:
+          context:
+            - cicd-orchestrator
+          name: Build and push RPM packages for APIM 4.2.0-hotfix.1
+          requires:
+            - Package bundle
+      - job-trigger-saas-docker-images:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Docker images creation
+          requires:
+            - Build APIM Portal docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Management API docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway docker image for APIM 4.2.0-hotfix.1
+      - job-trigger-saas-docker-images-chainguard:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard Docker images creation
+          requires:
+            - Build APIM Portal chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build Gamma Console chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Management API chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0-hotfix.1
+      - job-trigger-saas-docker-images-chainguard-fips:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger SaaS Chainguard FIPS Docker images creation
+          requires:
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+      - job-nexus-staging:
+          context:
+            - cicd-orchestrator
+          name: Nexus staging
+          requires:
+            - Trigger SaaS Docker images creation
+      - job-trigger-apim-api-docs-pipeline:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger APIM API docs ingestion
+          requires:
+            - Nexus staging
+      - job-release-helm:
+          context:
+            - cicd-orchestrator
+          name: Release Helm Chart
+          requires:
+            - Trigger SaaS Docker images creation
+      - job-release-notes-apim:
+          context:
+            - cicd-orchestrator
+          name: Create release note pull request
+          requires:
+            - Release Helm Chart
+            - Build and push RPM packages for APIM 4.2.0-hotfix.1
+      - job-slack-announcement:
+          context:
+            - cicd-orchestrator
+          name: Announce release is completed
+          message: 🎆 APIM - 4.2.0-hotfix.1 released!
+          requires:
+            - Nexus staging
+            - Release Helm Chart
+            - Trigger APIM API docs ingestion
+            - Build and push RPM packages for APIM 4.2.0-hotfix.1
+      - job-aikido-scan-docker-images:
+          context:
+            - cicd-orchestrator
+          name: Scan docker images with Aikido for APIM 4.2.0-hotfix.1
+          requires:
+            - Build APIM Portal docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Portal chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Portal chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build Gamma Console docker image for APIM 4.2.0-hotfix.1
+            - Build Gamma Console chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build Gamma Console chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Management API docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Management API chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Management API chainguard-fips docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway chainguard docker image for APIM 4.2.0-hotfix.1
+            - Build APIM Gateway chainguard-fips docker image for APIM 4.2.0-hotfix.1
+orbs:
+  keeper: gravitee-io/keeper@0.7.1
+  slack: circleci/slack@4.12.5
+  aws-cli: circleci/aws-cli@5.1.2
+  aws-s3: circleci/aws-s3@4.1.0
+  helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5
+  aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-hotfix.yml
@@ -1,0 +1,438 @@
+# This file is generated from the TypeScript sources in .circleci/ci.
+# Do not edit it by hand — run `npm run generate` instead.
+
+version: 2.1
+setup: false
+parameters:
+  gio_action:
+    type: string
+    default: pull_requests
+    description: ""
+  dry_run:
+    type: boolean
+    default: true
+    description: Run in dry run mode?
+  docker_tag_as_latest:
+    type: boolean
+    default: false
+    description: Is this version the latest version available?
+  graviteeio_version:
+    type: string
+    default: ""
+    description: Version of APIM to be used in docker images
+  apim_version_path:
+    type: string
+    default: /home/circleci/project/pom.xml
+    description: Path to pom.xml with APIM version
+commands:
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
+  cmd-workspace-install:
+    steps:
+      - restore_cache:
+          name: Restore Yarn workspace cache
+          keys:
+            - gravitee-api-management-v14-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - gravitee-api-management-v14-workspace-{{ .Branch }}
+      - run:
+          name: Install workspace dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn workspace cache
+          key: gravitee-api-management-v14-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ./node_modules
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-webui-install:
+    parameters:
+      apim-ui-project:
+        type: string
+        default: ""
+        description: the name of the UI project to build
+      apim-ui-project-workdir:
+        type: string
+        default: ""
+        description: the directory of the UI project to build
+    steps:
+      - restore_cache:
+          name: Restore Yarn cache
+          keys:
+            - << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
+            - << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}
+      - run:
+          name: Install dependencies
+          command: yarn
+          working_directory: << parameters.apim-ui-project-workdir >>
+      - save_cache:
+          name: Save Yarn cache
+          key: << parameters.apim-ui-project >>-cache-v1-{{ .Branch }}-{{ checksum "<< parameters.apim-ui-project-workdir >>/yarn.lock" }}
+          paths:
+            - ./<< parameters.apim-ui-project-workdir >>/node_modules
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v14-<< parameters.jobName >>-4.2.x
+    description: Restore Maven cache for a dedicated job
+  cmd-prepare-gpg:
+    steps:
+      - keeper/install
+      - run:
+          command: |-
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key > pub.key
+            gpg --import pub.key
+
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key > private.key
+            # Need --batch to be able to import private key
+            gpg --import --batch private.key
+    description: Prepare GPG command
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - save_cache:
+          key: gravitee-api-management-v14-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-sync-folder-to-s3:
+    parameters:
+      folder-to-sync:
+        type: string
+        default: ""
+        description: the path of the folder to sync to S3
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://Mqmplmfu17bDR5XRLmO1mQ/field/password
+          var-name: AWS_ACCESS_KEY_ID
+      - keeper/env-export:
+          secret-url: keeper://3-pU56sIqcyWWw7HxhxjaQ/field/password
+          var-name: AWS_SECRET_ACCESS_KEY
+      - aws-cli/setup:
+          region: cloudfront
+          version: 2.22.35
+      - aws-s3/sync:
+          arguments: --endpoint-url https://cellar-c2.services.clever-cloud.com --acl public-read
+          from: << parameters.folder-to-sync>>
+          to: s3://gravitee-releases-downloads/pre-releases
+    description: Sync folder content to Gravitee download website
+jobs:
+  job-setup:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          var-name: MAVEN_SETTINGS
+      - run:
+          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .gravitee.settings.xml
+  job-slack-announcement:
+    parameters:
+      message:
+        type: string
+        default: ""
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02NGT20S4W
+          event: always
+          custom: |-
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<< parameters.message >>"
+                  }
+                }
+              ]
+            }
+  job-console-webui-build:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-install-yarn
+      - cmd-workspace-install
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-console-webui/build.json"
+      - run:
+          name: Build Console
+          command: NODE_OPTIONS=--max_old_space_size=4086 yarn console:build:prod
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-console-webui/dist
+  job-portal-webui-build:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          version: default
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui
+          apim-ui-project-workdir: gravitee-apim-portal-webui
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-portal-webui/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui
+      - cmd-workspace-install
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-hotfix.1\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build Portal Next
+          command: NODE_OPTIONS=--max_old_space_size=4086 yarn portal-next:build:prod
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist
+  job-backend-build-and-publish-on-download-website:
+    docker:
+      - image: cimg/openjdk:25.0.3-node
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-restore-maven-job-cache:
+          jobName: job-backend-build-and-publish-on-download-website
+      - run:
+          name: Remove `-SNAPSHOT` from versions
+          command: |-
+            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
+            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
+      - cmd-prepare-gpg
+      - run:
+          name: Maven build APIM engine
+          command: mvn --settings .gravitee.settings.xml -B -U -P all-modules,gio-release clean install -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          environment:
+            BUILD_ID: "1234"
+            BUILD_NUMBER: "1234"
+            GIT_COMMIT: 784ff35ca
+      - run:
+          name: Maven build APIM distribution
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          environment:
+            BUILD_ID: "1234"
+            BUILD_NUMBER: "1234"
+            GIT_COMMIT: 784ff35ca
+      - cmd-save-maven-job-cache:
+          jobName: job-backend-build-and-publish-on-download-website
+      - run:
+          name: Prepare plugin zip to upload
+          command: |-
+            workingDir=$(pwd)
+            for pathToArtefactFile in $(find ./gravitee-apim-distribution -path '*target/gravitee-apim*.zip'); do
+              # Extract folder of the artefact to publish
+              # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => ./gravitee-apim-repository/gravitee-apim-repository-mongodb
+              artefactFolder=${pathToArtefactFile%/target*}
+
+              # extract publish folder from pom.xml properties, return '/' if no property found
+              publishFolderPath=/$(grep -Po '(?<=<publish-folder-path>).*(?=</publish-folder-path>)' $artefactFolder/pom.xml || echo '')
+
+              if [[ "$publishFolderPath" != "/" ]]; then
+                # extract artefact file of the artefact to publish
+                # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
+                artefactFile=${pathToArtefactFile##*/}
+
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
+                [[ $artefactFile =~ $regex ]]
+                artefactName=${BASH_REMATCH[1]}
+
+                # compute the destination folder on S3 to publish the artefact
+                # e.g. gravitee-apim-repository-mongodb-4.4.21.zip => folder_to_sync/graviteeio-apim/plugins/repositories/gravitee-apim-repository-mongodb
+                artefactFolderToSync=folder_to_sync${publishFolderPath}/${artefactName}
+
+                mkdir -p $artefactFolderToSync
+                cp $pathToArtefactFile $artefactFolderToSync/
+
+                cd $artefactFolderToSync
+
+                md5sum $artefactFile > $artefactFile.md5
+                sha512sum $artefactFile > $artefactFile.sha512sum
+                sha1sum $artefactFile > $artefactFile.sha1
+
+                cd $workingDir
+              fi
+            done
+      - cmd-sync-folder-to-s3:
+          folder-to-sync: folder_to_sync
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
+            - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-release-commit-and-prepare-next-version:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+          var-name: GIT_USER_NAME
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+          var-name: GIT_USER_EMAIL
+      - run:
+          name: Git config
+          command: |-
+            git config --global user.name "${GIT_USER_NAME}"
+             git config --global user.email "${GIT_USER_EMAIL}"
+      - run:
+          name: "Git release "
+          command: |
+            # Remove `-SNAPSHOT` from source
+            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
+            # and engine-snapshot resolves apim.server.version from its properties, not the root's. Leaving
+            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
+            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            POMS="pom.xml gravitee-apim-distribution/pom.xml"
+            for POM in ${POMS}; do
+              sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"
+            done
+
+            # UI
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-console-webui/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-portal-webui/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-hotfix.1"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
+
+            git add --update
+            git commit -m "4.2.0-hotfix.1"
+            git tag 4.2.0-hotfix.1
+
+            # Set the version to the next version (bump patch version + '-SNAPSHOT')
+            for POM in ${POMS}; do
+              sed -i "s#<revision>.*</revision>#<revision>4.2.0</revision>#" "${POM}"
+              sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" "${POM}"
+              # <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
+              # never matches — the qualifier was silently kept on any pom already holding the empty form.
+              sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1>-hotfix.2</sha1>#" "${POM}"
+            done
+
+            sed -i 's#version: ".*"#version: "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-console-webui/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-hotfix.2-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
+
+            # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
+            sed -e "0,/^version:/{s/version:.*/version: 4.2.0-hotfix.2/}" \
+                -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.0-hotfix.2/ }" \
+                -i helm/Chart.yaml
+
+            git add --update
+            git commit -m 'chore: prepare next version [skip ci]'
+
+            git push -u  origin hotfix/4.2.0
+            git push --tags  origin hotfix/4.2.0
+workflows:
+  release:
+    jobs:
+      - job-setup:
+          context:
+            - cicd-orchestrator
+          name: Setup
+      - job-slack-announcement:
+          context:
+            - cicd-orchestrator
+          name: Announce release is starting
+          message: 🚀 Starting APIM 4.2.0-hotfix.1 release!
+      - job-portal-webui-build:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Portal
+          requires:
+            - Setup
+      - job-console-webui-build:
+          context:
+            - cicd-orchestrator
+          name: Build APIM Console
+          requires:
+            - Setup
+      - job-backend-build-and-publish-on-download-website:
+          context:
+            - cicd-orchestrator
+          name: Backend build and publish on download website
+          requires:
+            - Setup
+      - job-release-commit-and-prepare-next-version:
+          context:
+            - cicd-orchestrator
+          name: Commit and prepare next version
+          requires:
+            - Backend build and publish on download website
+            - Build APIM Console
+            - Build APIM Portal
+orbs:
+  keeper: gravitee-io/keeper@0.7.1
+  slack: circleci/slack@4.12.5
+  aws-cli: circleci/aws-cli@5.1.2
+  aws-s3: circleci/aws-s3@4.1.0

--- a/.circleci/ci/src/utils/branch.ts
+++ b/.circleci/ci/src/utils/branch.ts
@@ -36,6 +36,16 @@ export function isSupportBranch(branch: string): boolean {
   return regex.test(branch);
 }
 
+/**
+ * A branch cut from a released tag to carry an urgent fix, without disturbing the support branch.
+ * Named after the tag it starts from, so the release version it produces is readable from it:
+ * `hotfix/4.12.17` releases `4.12.17-hotfix.N`.
+ */
+export function isHotfixBranch(branch: string): boolean {
+  const regex = /^hotfix\/\d+\.\d+\.\d+$/;
+  return regex.test(branch);
+}
+
 export function isSupportBranchOrMaster(branch: string): boolean {
   return isMasterBranch(branch) || isSupportBranch(branch);
 }

--- a/.circleci/ci/src/utils/tests/branch.spec.ts
+++ b/.circleci/ci/src/utils/tests/branch.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { isMasterBranch, isSupportBranch, isSupportBranchOrMaster, sanitizeBranch } from '../branch';
+import { isHotfixBranch, isMasterBranch, isSupportBranch, isSupportBranchOrMaster, sanitizeBranch } from '../branch';
 
 describe('branch', () => {
   describe('sanitize', () => {
@@ -54,6 +54,26 @@ describe('branch', () => {
       ${'x'}                         | ${false}
     `('returns `$expected` for `$branch`', ({ branch, expected }) => {
       expect(isSupportBranch(branch)).toEqual(expected);
+    });
+  });
+
+  describe('isHotfix', () => {
+    it.each`
+      branch                   | expected
+      ${'hotfix/4.12.17'}      | ${true}
+      ${'hotfix/4.12.x'}       | ${false}
+      ${'hotfix/4.12'}         | ${false}
+      ${'hotfix/4.12.17.1'}    | ${false}
+      ${'hotfix/4.12.17-rc'}   | ${false}
+      ${'hotfix'}              | ${false}
+      ${'hotfix/'}             | ${false}
+      ${'4.12.17'}             | ${false}
+      ${'feat/hotfix/4.12.17'} | ${false}
+      ${'hotfix/4.12.17/fix'}  | ${false}
+      ${'4.12.x'}              | ${false}
+      ${'master'}              | ${false}
+    `('returns `$expected` for `$branch`', ({ branch, expected }) => {
+      expect(isHotfixBranch(branch)).toEqual(expected);
     });
   });
 

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -1,129 +1,97 @@
-= Release process
+= Releasing APIM
 
-== 📝 Description
+The scripts in this folder do not build anything. Each one is a *trigger*: it posts to the CircleCI API and hands over. Understanding that explains most of what follows — in particular why the branch you are standing on has no effect on what gets released.
 
-This repo contains some https://github.com/google/zx[zx] scripts to execute the different release steps for APIM.
+== What decides what
 
-== 🛠 Requirement
+Three things, and they are not the same thing.
 
-To run the scripts, you need to have:
+[cols="1,3"]
+|===
+| Where the release runs
+| Derived from `--version`: `4.12.18` releases from `4.12.x`. Never from your current branch — no script reads your local git state. `--branch` overrides it, and you are asked to confirm when it differs from the derived one.
 
-* Node.js >= 16.0.0 (configured in link:.nvmrc[.nvmrc] with v18.4.0)
-* https://github.com/google/zx[zx], to install it you just have to run:
+| Which version is published
+| The poms, through `<revision><sha1><changelist>`. The release clears `<changelist>` to drop `-SNAPSHOT`, and publishes what is left. `--version` does *not* set it — it feeds the commit message, the git tag and the UI `build.json` files.
+
+| What happens next
+| After releasing, the branch is bumped to the next version. `4.12.18` leaves it at `4.12.19-SNAPSHOT`; a qualified version like `4.13.0-alpha.1` leaves it at `4.13.0-alpha.2-SNAPSHOT`.
+|===
+
+The second row is the one that surprises people. If a branch's poms and the `--version` you pass disagree, the tag will say one thing and the artefacts another, without failing.
+
+== Setup
+
+* Node — the version in link:../.nvmrc[.nvmrc]. `nvm use` in this folder picks it up.
+* https://github.com/google/zx[zx], globally: `npm i -g zx`.
+* Dependencies: `yarn install`, here in `release/`.
+* A CircleCI personal token, in a `.env` file next to this README:
++
+[source,shell]
+----
+echo "CIRCLECI_TOKEN=<your token>" > .env
+----
++
+Create the token at https://app.circleci.com/settings/user/tokens. Every command reads it from there and stops immediately if it is missing.
+
+== Releasing
+
+=== The whole thing at once
 
 [source,shell]
 ----
-npm i -g zx
-# Check everything is ok:
-zx -v
+yarn full_release --version=4.12.18
 ----
-* A https://github.com/motdotla/dotenv#readme[dotenv] file containing the variable `CIRCLECI_TOKEN`, which is your personal token on CircleCI:
- - Go to https://app.circleci.com/settings/user/tokens, create a token and copy it
- - Run the following command in the `release` folder to create a `.env` file with the token:
+
+It asks for confirmation on the JIRA release and on leftover alpha qualifiers, then runs every step. Add `--latest` to tag the Docker images as `latest`, or it will ask.
+
+=== Step by step
+
+The older path, still there for when a single step has to be replayed. Each command prints the next one to run.
 
 [source,shell]
 ----
-touch .env && echo "CIRCLECI_TOKEN=[YOUR_TOKEN]" > .env
+yarn release       --version=4.12.18
+yarn package_zip   --version=4.12.18
+yarn docker        --version=4.12.18   # --latest to also tag as latest
+yarn rpms          --version=4.12.18
+yarn helm_chart    --version=4.12.18
+yarn release_notes --version=4.12.18
+yarn nexus_sync    --version=4.12.18
 ----
 
-* Some dependencies to run the scripts, you can install them with:
-[source, shell]
-----
-# In the `release` folder
-yarn install
-----
+`yarn maven_release --version=4.12.18` publishes to Maven Central on its own, outside both paths.
 
+=== Flags
 
-== 🛠 Pre-Release
+[cols="1,3"]
+|===
+| `--version` | Required, everywhere.
+| `--dry-run` | Runs the pipeline without publishing. Not supported by `nexus_sync`.
+| `--latest` | Docker images also get the `latest` tag.
+| `--branch` | Release from a branch other than the derived one. The version commit and the tag are pushed there.
+|===
 
-=== Helm changelog steps
+== Pre-release versions
 
-Before apply the release, and mainly during each fix/feat/... on helm chart, you have to ensure some prerequisites:
-
-. Add changelog entry on `helm/Chart.yaml` file in section `artifacthub.io/changes`. Notice that it is cleanup during release process.
-.. This is used in https://artifacthub.io/packages/helm/graviteeio/apim3/?modal=changelog[artifacthub.io changelog]
-. At least on master branch: update the changelog in right version. This make the master branch the reference for each change on all version.
-
-
-== 🏁 Usage[[Usage]]
-
-=== ⚡️ Full release for the win!
-
-Thanks to link:package.json[package.json], you can run those scripts as simple `yarn` commands (do not forget to use `yarn install` before starting).
-
-Each of the commands needs:
-
-* A `CIRCLECI_TOKEN` in `.env` file
-* the `--version` parameter
-
-Optional flag:
-
-* `--dry-run`: allow to run the pipeline in dry run mode (except for `nexus_sync` which does not have this mode)
-* `--latest`: to tag the docker image as the `latest`
-* `--branch=<name>`: target branch on which the pipeline is triggered. When omitted, the branch is derived from the version (e.g. `4.5.x` for `4.5.11`). Use it to release from any branch (the version bump commit and tag are pushed to that branch). You will be asked to confirm when it differs from the derived branch.
-
-Here is the command to fully release APIM (Releasing 3.15.11, in the following example):
-
-`yarn full_release --version=3.15.11`: You can also provide the `--latest` parameter to flag the image as `latest`.
-
-IMPORTANT::
-If alpha released have been created and you want to release a minor version, don't forget to update:
-- pom.xml: replace `<sha1>alpha.x</sha1>` by `<sha1/>`
-- helm/Chart.yml: remove the `alpha` qualifier from the version
-
-
-=== 🐌 Step by step release
-
-It will allow you to manually trigger these workflows on CircleCI:
-
-1. Release
-2. Package Zip
-3. Docker and RPMs
-4. Helm Chart
-5. Generate changelog
-6. Nexus Sync
-
-This is the legacy process making you execute each step manually
-
-Thanks to link:package.json[package.json], you can run those scripts as simple `yarn` commands (do not forget to use `yarn install` before starting).
-
-Each of the commands needs:
-
-* A `CIRCLECI_TOKEN` in `.env` file
-* the `--version` parameter
-
-Optional flag:
-
-* `--dry-run`: allow to run the pipeline in dry run mode (except for `nexus_sync` which does not have this mode)
-
-Each command, when successful, will guide you to the next command to run, for example:
-
-[source]
-----
-When it's done, run 'yarn nexus_sync --version=3.19.8'
-----
-
-Here are the steps to run to fully release APIM (Releasing 3.19.8, in the following example):
-
-1. `yarn release --version=3.19.8`
-2. `yarn package_zip --version=3.19.8`:
-3. `yarn docker_rpms --version=3.19.8`: You can also provide the `--latest` parameter to flag the image as `latest`.
-4. `yarn helm_chart --version=3.19.8`
-5. `yarn release_notes --version=3.19.8`
-6. `yarn nexus_sync --version=3.19.8`
-
-== 🧪 Handle pre-version releases
-
-To create a pre-version release (like `alpha`, `beta`, RC`, `GA`, ...), you just have to change the `<sha1/>` tag in `pom.xml` file. +
-This tag MUST be of the form: `-NAME.VERSION` (e.g. `-alpha.1`, `-RC.3`, ...)
+Alpha, beta, RC and milestone versions come from the poms, not from a flag. Set `<sha1>` on the branch, in the form `-NAME.NUMBER`:
 
 [source,xml]
 ----
-    <!-- Version properties -->
-    <revision>3.20.0</revision>
-    <sha1>-alpha.1</sha1>
-    <changelist>-SNAPSHOT</changelist>
+<revision>4.13.0</revision>
+<sha1>-alpha.1</sha1>
+<changelist>-SNAPSHOT</changelist>
 ----
 
-Then, follow instructions of <<Usage>> with `--version=3.20.0-alpha.1`. +
-The version of the modifier will be automatically increased. (`3.20.0-alpha.2` in the example above).
+Then release with `--version=4.13.0-alpha.1`. The bump that follows moves to `-alpha.2`, so the next one needs no manual edit.
+
+Going back to a final release means undoing that by hand, before releasing:
+
+* `pom.xml` — `<sha1>-alpha.4</sha1>` back to `<sha1/>`. Since the reactor cut, on `master`, `gravitee-apim-distribution/pom.xml` carries its own triplet and needs the same treatment.
+* `helm/Chart.yaml` — drop the qualifier from `version` and `appVersion`.
+
+`full_release` asks whether this was done. It cannot check.
+
+== Helm changelog
+
+Entries under `artifacthub.io/changes` in `helm/Chart.yaml` feed the https://artifacthub.io/packages/helm/graviteeio/apim3/?modal=changelog[published changelog], and the release wipes the section afterwards. So the entry has to be added with the change itself, not at release time — and on `master` first, which is where the changelog for every version is kept.

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -72,6 +72,61 @@ yarn nexus_sync    --version=4.12.18
 | `--branch` | Release from a branch other than the derived one. The version commit and the tag are pushed there.
 |===
 
+== Hotfixes
+
+When an urgent fix has to ship and the support branch already carries work that is not ready to go out with it, releasing from that branch would drag the lot along. Take the released tag instead:
+
+[source,shell]
+----
+yarn prepare_hotfix --version=4.12.17
+----
+
+It cuts `hotfix/4.12.17` from the tag of the same name and commits the version that branch will release — `4.12.17-hotfix.1`. That step is not optional. A branch cut from a tag sits at the released version with an empty `<changelist>`, so releasing it untouched would republish `4.12.17` under a tag claiming otherwise. The command puts `-hotfix.1` in `<sha1>` and brings `-SNAPSHOT` back, the same shape a pre-release uses.
+
+Then add the fix as one commit, and release from there:
+
+[source,shell]
+----
+yarn full_release --version=4.12.17-hotfix.1
+----
+
+The support branch is untouched throughout, and the Docker `4.12` and `latest` tags are left where they were — a qualified version never claims them.
+
+No `--branch` to pass: a hotfix version names the branch it comes from. `4.12.17-hotfix.1` is released from `hotfix/4.12.17`, the way `4.12.18` is released from `4.12.x`. A branch that contradicts the version is refused — by the command, and again by the pipeline.
+
+One thing is on you afterwards: cherry-pick the fix into the support branch, so the next patch carries it too. What belongs in that patch is a judgement call, not a step that can be automated.
+
+=== The Helm chart
+
+The chart is published with the hotfix version, qualifier and all. Helm reads that as semver, where anything after a `-` is a pre-release. So the chart sorts *below* the release it fixes.
+
+Three things follow, and none of them warn you:
+
+* `helm search repo` hides it. `--devel` shows it.
+* No range matches it — not `^4.12.0`, not `~4.12.0`, not even `>=4.11.0`, with or without `--devel`.
+* `helm upgrade` without `--version` picks the plain release. The fix is gone, and the command reports success.
+
+So name the version, and keep it named:
+
+[source,shell]
+----
+helm upgrade apim graviteeio/apim3 --version 4.12.17-hotfix.1
+----
+
+Unpin when the next patch ships. It carries the same fix and sorts above everything here. Nothing reminds you, so write it down somewhere.
+
+ArgoCD behaves the same way. An `Application` tracking a range never sees the hotfix. `targetRevision` has to name the version, then be changed back later. If the next patch is close, waiting for it is the better answer — it arrives on its own.
+
+No version string avoids this. Semver has nothing between a release and the next patch. And build metadata is ignored in comparisons, so a `+hotfix.1` suffix would rank *equal* to the release.
+
+=== A second hotfix
+
+Nothing to prepare. The release bumps the branch it ran on, and on a qualified version it bumps the qualifier — so `hotfix/4.12.17` comes out of the first release already at `4.12.17-hotfix.2-SNAPSHOT`, and the branch is kept for that reason. Commit the next fix and release it.
+
+Running `prepare_hotfix` again is harmless: it checks the branch out as it stands — origin's copy if you do not have it locally — and prints the version to release. What it will not do is prepare it twice, which would set the qualifier back to `.1`.
+
+The command also refuses to start on a dirty working tree. `git switch` carries uncommitted changes onto the branch it moves to, and they would be committed with the version.
+
 == Pre-release versions
 
 Alpha, beta, RC and milestone versions come from the poms, not from a flag. Set `<sha1>` on the branch, in the form `-NAME.NUMBER`:

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -2,11 +2,24 @@ export function isDryRun() {
   return !!argv['dry-run'];
 }
 
+const HOTFIX_QUALIFIER = /-hotfix\.\d+$/;
+
 /**
- * Target branch of the pipeline: --branch if provided, otherwise the branch derived from the version.
- * @param {{branch: string}} versions result of computeVersion()
+ * Branch the release runs on: the one --branch names, otherwise the one the version implies.
+ *
+ * That is not always versions.branch. A hotfix runs on the branch cut from the tag it fixes, while
+ * versions.branch stays the support line the version belongs to — which is what the documentation
+ * changelog is filed under, hotfix or not.
+ * @param {{version: string, branch: string}} versions result of computeVersion()
  * @returns {string}
  */
 export function getTargetBranch(versions) {
-  return argv.branch ?? versions.branch;
+  const hotfixBranch = HOTFIX_QUALIFIER.test(versions.version) ? `hotfix/${versions.version.replace(HOTFIX_QUALIFIER, '')}` : undefined;
+
+  if (hotfixBranch && argv.branch && argv.branch !== hotfixBranch) {
+    console.log(chalk.red(`${versions.version} is released from ${hotfixBranch}, not from ${argv.branch}.`));
+    process.exit(1);
+  }
+
+  return argv.branch ?? hotfixBranch ?? versions.branch;
 }

--- a/release/helpers/version-helper.mjs
+++ b/release/helpers/version-helper.mjs
@@ -26,9 +26,10 @@ export function computeVersion(releasingVersion) {
 }
 
 /**
- * Returns the support branch a version is released from — always, X.Y.0 included: the release tags
- * and bumps the branch it runs on, and the version after 4.13.0 is 4.13.1, not what master should
- * become.
+ * Returns the support line a version belongs to — always, X.Y.0 included: the release tags and
+ * bumps the branch it runs on, and the version after 4.13.0 is 4.13.1, not what master should
+ * become. Which branch a release runs on is getTargetBranch's answer, and for a hotfix the two
+ * differ.
  * @param releasingVersion
  * @returns {string}
  */

--- a/release/helpers/version-helper.mjs
+++ b/release/helpers/version-helper.mjs
@@ -26,13 +26,15 @@ export function computeVersion(releasingVersion) {
 }
 
 /**
- * Returns the branch related to the version to release. If patch version is 0, then the branch is master, else it's Major.Minor.x
+ * Returns the support branch a version is released from — always, X.Y.0 included: the release tags
+ * and bumps the branch it runs on, and the version after 4.13.0 is 4.13.1, not what master should
+ * become.
  * @param releasingVersion
- * @returns {string|string}
+ * @returns {string}
  */
 function branch(releasingVersion) {
   const split = releasingVersion.split('.');
-  return split[2] === 0 ? 'master' : `${split[0]}.${split[1]}.x`;
+  return `${split[0]}.${split[1]}.x`;
 }
 
 function trimmed(releasingVersion) {
@@ -41,6 +43,5 @@ function trimmed(releasingVersion) {
 }
 
 function pattern(releasingVersion) {
-  const releaseBranch = branch(releasingVersion);
-  return releaseBranch === 'master' ? '' : releaseBranch.replace('x', '*');
+  return branch(releasingVersion).replace('x', '*');
 }

--- a/release/package.json
+++ b/release/package.json
@@ -14,6 +14,7 @@
     "prettier": "prettier --check \"**/*.{js,mjs,json}\"",
     "prettier:fix": "prettier --write \"**/*.{js,mjs,json}\"",
     "full_release": "zx steps/full_release.mjs",
+    "prepare_hotfix": "zx steps/prepare_hotfix.mjs",
     "maven_release": "zx steps/maven_release.mjs",
     "release": "zx steps/1-release.mjs",
     "package_zip": "zx steps/2-package_zip.mjs",

--- a/release/steps/prepare_hotfix.mjs
+++ b/release/steps/prepare_hotfix.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env zx
+
+// Cuts a hotfix branch from a released tag and sets the version that branch will release.
+//
+// The released version comes from the poms — <revision><sha1><changelist> — not from the
+// --version passed to the release, which only feeds the commit message, the tag and the UI
+// build.json files. A branch cut from a tag therefore sits at the released version itself, with
+// an empty changelist: releasing from it untouched would republish that exact version. The
+// qualifier goes into <sha1>, the slot alpha and milestone releases already use, and -SNAPSHOT
+// comes back until the release clears it.
+//
+// Only the first hotfix is prepared here. The release bumps the branch it runs on, and on a
+// qualified version it bumps the qualifier: once 4.12.17-hotfix.1 has shipped, the branch is
+// already at 4.12.17-hotfix.2-SNAPSHOT. So a branch that exists is checked out as it stands —
+// re-running the preparation on it would set the qualifier back to .1 and release backwards.
+
+import { extractVersion } from '../helpers/version-helper.mjs';
+
+const releasedVersion = await extractVersion();
+
+if (!/^\d+\.\d+\.\d+$/.test(releasedVersion)) {
+  console.log(chalk.red(`'${releasedVersion}' is not a released version. Expected X.Y.Z — the tag to branch from.`));
+  process.exit(1);
+}
+
+const branch = `hotfix/${releasedVersion}`;
+const supportBranch = `${releasedVersion.split('.').slice(0, 2).join('.')}.x`;
+
+// Every path below is relative to the repository root, and this script runs from release/.
+cd((await $`git rev-parse --show-toplevel`).stdout.trim());
+
+// git switch carries uncommitted changes onto the branch it moves to, and the commit below takes
+// everything tracked and modified. Work in progress would ship inside the hotfix without a word.
+const dirty = (await $`git status --porcelain`).stdout.trim();
+if (dirty) {
+  console.log(chalk.red('The working tree is not clean. Commit or stash before preparing a hotfix:\n'));
+  console.log(dirty);
+  process.exit(1);
+}
+
+async function exists(ref) {
+  try {
+    await $`git rev-parse --verify --quiet ${ref}`;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The version the branch will release, read where the release itself reads it: the poms.
+function versionFromPom() {
+  const pom = fs.readFileSync('pom.xml', 'utf8');
+  const revision = /<revision>([^<]*)<\/revision>/.exec(pom)?.[1] ?? '';
+  const qualifier = /<sha1>([^<]*)<\/sha1>/.exec(pom)?.[1] ?? '';
+  return `${revision}${qualifier}`;
+}
+
+function printNextSteps() {
+  const version = versionFromPom();
+  console.log(chalk.green(`\n${branch} is ready, at ${version}.\n`));
+  console.log(`  1. Add the fix, as one commit.`);
+  console.log(`  2. yarn full_release --version=${version}`);
+  console.log(`  3. Cherry-pick the fix into ${supportBranch}, so the next patch carries it too.`);
+}
+
+const alreadyPrepared = `${branch} already exists — the release that shipped the previous hotfix left it prepared.`;
+
+if (await exists(`refs/heads/${branch}`)) {
+  console.log(chalk.blue(alreadyPrepared));
+  await $`git switch ${branch}`;
+  printNextSteps();
+  process.exit(0);
+}
+
+if (await exists(`refs/remotes/origin/${branch}`)) {
+  console.log(chalk.blue(`${alreadyPrepared} Checking out origin's.`));
+  await $`git switch -c ${branch} --no-track origin/${branch}`;
+  printNextSteps();
+  process.exit(0);
+}
+
+if (!(await exists(`refs/tags/${releasedVersion}`))) {
+  console.log(chalk.red(`Tag ${releasedVersion} not found. Fetch the tags first: git fetch --tags`));
+  process.exit(1);
+}
+
+const qualifier = '-hotfix.1';
+const version = `${releasedVersion}${qualifier}`;
+
+console.log(chalk.blue(`Cutting ${branch} from tag ${releasedVersion}, to release ${version}\n`));
+
+await $`git switch -c ${branch} --no-track ${releasedVersion}`;
+
+// Edited in Node rather than with sed: the release jobs run on Linux and can use GNU sed, this
+// runs on whatever the developer has, and BSD sed takes different arguments.
+//
+// A file absent from an old tag is skipped — the tree has changed since — unless the version
+// depends on it, and then absence means this is not a tag of this repository. A file that is
+// present but does not match is always an error: the shape moved, and a half-prepared branch would
+// release the wrong version without saying so.
+function edit(path, replacements, { required = false } = {}) {
+  if (!fs.existsSync(path)) {
+    if (required) {
+      console.log(chalk.red(`${path} is missing. This is not a tag of this repository.`));
+      process.exit(1);
+    }
+    console.log(chalk.yellow(`  skipped ${path}, not in this tag`));
+    return;
+  }
+  let content = fs.readFileSync(path, 'utf8');
+  for (const [pattern, replacement] of replacements) {
+    if (!pattern.test(content)) {
+      console.log(chalk.red(`Nothing to replace in ${path} for ${pattern}. Aborting rather than half-preparing the branch.`));
+      process.exit(1);
+    }
+    content = content.replace(pattern, replacement);
+  }
+  fs.writeFileSync(path, content);
+  console.log(`  ${path}`);
+}
+
+const versionTriplet = [
+  // <sha1 /> is self-closing when the qualifier is empty, which a plain <sha1>.*</sha1> pattern
+  // never matches — and a released tag always holds that empty form.
+  [/<sha1( *\/>|>[^<]*<\/sha1>)/, `<sha1>${qualifier}</sha1>`],
+  [/<changelist>.*<\/changelist>/, `<changelist>-SNAPSHOT</changelist>`],
+];
+
+edit('pom.xml', versionTriplet, { required: true });
+
+// The distribution only carries a triplet of its own since it left the product reactor, on master.
+// On a support branch it is still a module and inherits the root's version, so there is nothing
+// to set there.
+const distributionPom = 'gravitee-apim-distribution/pom.xml';
+if (fs.existsSync(distributionPom) && /<revision>/.test(fs.readFileSync(distributionPom, 'utf8'))) {
+  edit(distributionPom, versionTriplet);
+} else {
+  console.log(chalk.yellow(`  skipped ${distributionPom}, it inherits the root version on this branch`));
+}
+
+for (const buildJson of [
+  'gravitee-apim-console-webui/build.json',
+  'gravitee-apim-portal-webui/build.json',
+  'gravitee-apim-portal-webui-next/build.json',
+  'gravitee-gamma/gravitee-gamma-control-plane-webui/build.json',
+]) {
+  edit(buildJson, [[/"version": ".*"/, `"version": "${version}-SNAPSHOT"`]]);
+}
+
+edit(
+  'helm/Chart.yaml',
+  [
+    [/^version:.*$/m, `version: ${version}`],
+    [/^appVersion:.*$/m, `appVersion: ${version}`],
+  ],
+  { required: true },
+);
+
+await $`git add --update`;
+await $`git commit -m ${`chore: prepare ${version}`}`;
+
+printNextSteps();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-347

## Description

Nothing needs this today. It is a capability we do not have, for a situation that will eventually come up: an urgent fix has to ship, and the support branch already carries work that is not ready to go out with it. The only answer available right now is to move commits around on the branch that serves customers — back it up, rewrite the history, put it back — while someone waits. That is the worst possible moment to be inventing a procedure.

The way out is to leave the support branch alone: cut a branch from the released tag, add the one commit that matters, release from there, and cherry-pick the fix back afterwards.

**Most of the machinery already handled it.** The release job commits and tags on the branch the pipeline runs on; the version parser reads `4.12.17-hotfix.1` correctly; a qualified version leaves the `4.12` and `latest` Docker tags untouched, so a hotfix cannot overwrite the minor; and the bump that follows a release moves the branch to `-hotfix.2`, the same way it does for alpha and milestone. Maven orders the versions the way the scheme needs — verified against `ComparableVersion`: `4.12.17 < 4.12.17-hotfix.1 < 4.12.17-hotfix.2 < 4.12.18`, since an unknown qualifier sorts after the release.

Three things were missing.

**The pipeline refused the branch.** `generateReleaseConfig` threw for anything that did not match `^\d+\.\d+\.x$`.

**And the branch had to be prepared, which is the part that is easy to get wrong.** The published version comes from the poms — `<revision><sha1><changelist>` — not from the `--version` passed to the release, which only feeds the commit message, the tag and the UI `build.json` files. A branch cut from a tag therefore sits at the released version with an empty `<changelist>`: releasing it untouched would **republish `4.12.17` under a tag claiming `4.12.17-hotfix.1`**, without failing. `yarn prepare_hotfix --version=4.12.17` cuts the branch and sets the qualifier in `<sha1>`, the slot pre-releases already use.

**And a hotfix shipped no RPM.** The publish job replaces its steps with an `echo` for any qualified version — a guard added in March 2025, after an alpha published into the production repository outranked the release everyone was running. A hotfix is the one qualified version that belongs there: its RPM version is the released one and only the release number moves, so it sits above the release it fixes and below the next patch. The job now makes that exception. The encoding it relies on landed in [gravitee-io/packages#29](https://github.com/gravitee-io/packages/pull/29).

### How to review this

Five commits, each standing on its own.

The first two are unrelated to the feature and can be read first: a dead branch removed from the version resolver, and a rewrite of the release README, which had drifted from the scripts — it documented a `yarn docker_rpms` that does not exist, a Node version three majors behind `.nvmrc`, and no `maven_release` at all.

Then the CI side, then the tooling. That order is deliberate: the command prints the release line to run next, and that line relies on the branch being derived from the version, which the CI commit introduces. Reversed, the command would advertise something that does not work yet. The README section documenting the whole flow rides with the command, so no commit documents what it does not contain.

The RPM comes last and stands alone. It touches one job and nothing else reads it.

## Additional context

**Verified by running it**, not by reading: the script was exercised on a throwaway clone against the real `4.12.17` tag. It leaves the branch at `4.12.17-hotfix.1-SNAPSHOT`, which the release turns into `4.12.17-hotfix.1` — no collision with the published `4.12.17`.

That run found two defects worth mentioning, both fixed here. The script runs from `release/`, so relative paths resolved against the wrong directory and every edit was silently skipped — a run that edits nothing now fails rather than committing a branch that would republish. And the distribution pom only carries a version triplet of its own since the reactor cut, which is master-only: on a support branch it is still a module and inherits the root's, so it is left alone there. Since hotfixes are cut from support-branch tags, that is the common case rather than the exception.

**Two things stay manual, deliberately.** Cherry-picking the fix into the support branch is a judgement call about what belongs in the next patch. And deleting the hotfix branch once the tag exists — the tag is what is kept.

**Noticed, not addressed:** only one of the nine release pipelines checks the branch it runs on, and it is not the one that matters most. `generateFullReleaseConfig` — the `full_release` action, the path the README recommends — has no branch check at all, so the guard added here covers `release` only. Nothing prevents triggering `nexus_staging` or `build_docker_images` from anywhere either. Worth its own ticket.

**Security-sensitive**: this changes CI/CD configuration and adds a script that writes version metadata and commits. It publishes nothing on its own and reads no secret beyond the `CIRCLECI_TOKEN` the other release scripts already use.

