### PR TITLE
feat(portal): add API Product subscription lifecycle actions

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
@@ -15,7 +15,73 @@
     limitations under the License.
 
 -->
-<h1 class="next-gen-h3" i18n="@@apiProductSubscriptionDetailsTitle">Subscription Details</h1>
+<div class="subscription-header">
+  <h1 class="next-gen-h3" i18n="@@apiProductSubscriptionDetailsTitle">Subscription Details</h1>
+  <div class="subscription-actions" [attr.aria-busy]="isActionPending()">
+    @if (canPause()) {
+      <button
+        mat-stroked-button
+        type="button"
+        data-testid="pause-subscription"
+        [disabled]="isActionPending()"
+        (click)="pauseSubscription()"
+        i18n="@@apiProductSubscriptionPause"
+      >
+        Pause
+      </button>
+    }
+    @if (canResume()) {
+      <button
+        mat-stroked-button
+        type="button"
+        data-testid="resume-subscription"
+        [disabled]="isActionPending()"
+        (click)="resumeSubscription()"
+        i18n="@@apiProductSubscriptionResume"
+      >
+        Resume
+      </button>
+    }
+    @if (canRetry()) {
+      <button
+        mat-stroked-button
+        type="button"
+        data-testid="retry-subscription"
+        [disabled]="isActionPending()"
+        (click)="retrySubscription()"
+        i18n="@@apiProductSubscriptionRetry"
+      >
+        Retry subscription
+      </button>
+    }
+    @if (canClose()) {
+      <button
+        mat-stroked-button
+        color="warn"
+        type="button"
+        data-testid="close-subscription"
+        [disabled]="isActionPending()"
+        (click)="closeSubscription()"
+        i18n="@@apiProductSubscriptionClose"
+      >
+        Close
+      </button>
+    }
+  </div>
+</div>
+
+@if (actionFeedback(); as feedback) {
+  <p
+    class="action-feedback"
+    data-testid="subscription-action-feedback"
+    [class.action-feedback--error]="feedback.type === 'error'"
+    [class.action-feedback--success]="feedback.type === 'success'"
+    [attr.role]="feedback.type === 'error' ? 'alert' : 'status'"
+    [attr.aria-live]="feedback.type === 'success' ? 'polite' : null"
+  >
+    {{ feedback.message }}
+  </p>
+}
 
 @if (product(); as productDetails) {
   <mat-card appearance="outlined">
@@ -24,7 +90,10 @@
     </mat-card-header>
     <mat-card-content class="details-grid" data-testid="product-subscription-summary">
       <span class="details-grid__label" i18n="@@apiProductSubscriptionStatus">Status</span>
-      <span>{{ subscription().status | capitalizeFirst }}</span>
+      <span>{{ displayedSubscription().status | capitalizeFirst }}</span>
+
+      <span class="details-grid__label" i18n="@@apiProductSubscriptionAccessStatus">Access status</span>
+      <span>{{ accessStatusLabel() }}</span>
 
       <span class="details-grid__label" i18n="@@apiProductSubscriptionProduct">API Product</span>
       <span
@@ -40,29 +109,29 @@
       } @else if (applicationResource.isLoading()) {
         <span i18n="@@apiProductSubscriptionApplicationLoading">Loading application...</span>
       } @else {
-        <span>{{ subscription().application }}</span>
+        <span>{{ displayedSubscription().application }}</span>
       }
 
       <span class="details-grid__label" i18n="@@apiProductSubscriptionId">Subscription ID</span>
-      <span>{{ subscription().id }}</span>
+      <span>{{ displayedSubscription().id }}</span>
 
       <span class="details-grid__label" i18n="@@apiProductSubscriptionPlan">Plan</span>
-      <span>{{ productDetails.plan?.name || productDetails.plan?.id || subscription().plan }}</span>
+      <span>{{ productDetails.plan?.name || productDetails.plan?.id || displayedSubscription().plan }}</span>
 
       @if (planSecurityLabel()) {
         <span class="details-grid__label" i18n="@@apiProductSubscriptionAuthentication">Authentication</span>
         <span>{{ planSecurityLabel() }}</span>
       }
 
-      @if (subscription().created_at; as createdAt) {
+      @if (displayedSubscription().created_at; as createdAt) {
         <span class="details-grid__label" i18n="@@apiProductSubscriptionCreatedAt">Created at</span>
         <span>{{ createdAt | date: 'medium' }}</span>
       }
-      @if (subscription().start_at; as startAt) {
+      @if (displayedSubscription().start_at; as startAt) {
         <span class="details-grid__label" i18n="@@apiProductSubscriptionStartsAt">Starts at</span>
         <span>{{ startAt | date: 'medium' }}</span>
       }
-      @if (subscription().end_at; as endAt) {
+      @if (displayedSubscription().end_at; as endAt) {
         <span class="details-grid__label" i18n="@@apiProductSubscriptionEndsAt">Ends at</span>
         <span>{{ endAt | date: 'medium' }}</span>
       }
@@ -97,8 +166,8 @@
       <mat-card-title class="next-gen-h4" i18n="@@apiProductSubscriptionCredentialsTitle">API access</mat-card-title>
     </mat-card-header>
     <mat-card-content class="credentials">
-      @if (subscription().status !== 'ACCEPTED') {
-        @switch (subscription().status) {
+      @if (displayedSubscription().status !== 'ACCEPTED') {
+        @switch (displayedSubscription().status) {
           @case ('PENDING') {
             <p i18n="@@apiProductSubscriptionPending">Your subscription request is being reviewed.</p>
           }
@@ -106,12 +175,27 @@
             <p i18n="@@apiProductSubscriptionRejected">This subscription request was rejected.</p>
           }
           @case ('PAUSED') {
-            <p i18n="@@apiProductSubscriptionPaused">This subscription is paused.</p>
+            <p i18n="@@apiProductSubscriptionPaused">This subscription was paused by the API publisher.</p>
           }
           @case ('CLOSED') {
             <p i18n="@@apiProductSubscriptionClosed">This subscription is closed.</p>
           }
         }
+      } @else if (displayedSubscription().consumerStatus === 'FAILURE') {
+        <app-banner type="error">
+          <div>
+            <p class="next-gen-h5" i18n="@@apiProductSubscriptionConsumerFailed">Subscription consumer failed</p>
+            <p i18n="@@apiProductSubscriptionConsumerFailedDescription">There is a problem with the subscription consumer.</p>
+            @if (displayedSubscription().failureCause; as failureCause) {
+              <p>
+                <span class="next-gen-h6" i18n="@@apiProductSubscriptionConsumerFailureCause">Failure cause:</span>
+                {{ failureCause }}
+              </p>
+            }
+          </div>
+        </app-banner>
+      } @else if (displayedSubscription().consumerStatus === 'STOPPED') {
+        <p i18n="@@apiProductSubscriptionConsumerPaused">API access for this subscription is paused.</p>
       } @else {
         @if (productDetails.plan?.security === 'OAUTH2' || productDetails.plan?.security === 'JWT') {
           @if (applicationResource.isLoading()) {
@@ -132,7 +216,7 @@
         } @else {
           @switch (productDetails.plan?.security) {
             @case ('API_KEY') {
-              <app-api-keys-list [apiKeys]="subscription().keys ?? []" [canManageApiKey]="false" />
+              <app-api-keys-list [apiKeys]="displayedSubscription().keys ?? []" [canManageApiKey]="false" />
             }
             @case ('KEY_LESS') {
               <p i18n="@@apiProductSubscriptionKeyless">No credentials are required for this plan.</p>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
@@ -29,6 +29,28 @@ p {
   margin: 0;
 }
 
+.subscription-header,
+.subscription-actions {
+  display: flex;
+  align-items: center;
+  gap: layout.$container-padding-horizontal;
+}
+
+.subscription-header {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.action-feedback {
+  &--success {
+    color: app-theme.$primary-main-color;
+  }
+
+  &--error {
+    color: app-theme.$error-main-color;
+  }
+}
+
 .details-grid {
   display: grid;
   grid-template-columns: minmax(140px, auto) 1fr;
@@ -58,6 +80,11 @@ p {
 }
 
 @media (max-width: 600px) {
+  .subscription-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .details-grid {
     grid-template-columns: 1fr;
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
@@ -13,41 +13,96 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { of } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { ApiProductSubscriptionDetailsComponent } from './api-product-subscription-details.component';
 import { ApiProductSubscriptionDetailsHarness } from './api-product-subscription-details.harness';
+import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/confirm-dialog.harness';
 import { fakeApplication } from '../../../../entities/application/application.fixture';
-import { fakeApiProductSubscriptionDetails, fakeSubscription } from '../../../../entities/subscription';
+import { UserApplicationPermissions } from '../../../../entities/permission/permission';
+import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import {
+  fakeApiProductSubscriptionDetails,
+  fakeSubscription,
+  Subscription,
+  SubscriptionConsumerStatusEnum,
+} from '../../../../entities/subscription';
 import { ApplicationService } from '../../../../services/application.service';
+import { PermissionsService } from '../../../../services/permissions.service';
+import { SubscriptionService } from '../../../../services/subscription.service';
 import { AppTestingModule } from '../../../../testing/app-testing.module';
 
 describe('ApiProductSubscriptionDetailsComponent', () => {
   let fixture: ComponentFixture<ApiProductSubscriptionDetailsComponent>;
+  let rootLoader: HarnessLoader;
   let applicationService: jest.Mocked<Pick<ApplicationService, 'get'>>;
+  let permissionsService: jest.Mocked<Pick<PermissionsService, 'getApplicationPermissions'>>;
+  let subscriptionService: jest.Mocked<Pick<SubscriptionService, 'changeConsumerStatus' | 'close' | 'get' | 'resumeConsumerStatus'>>;
+
+  const acceptedSubscription = (modifier: Partial<Subscription> = {}): Subscription =>
+    fakeSubscription({
+      status: 'ACCEPTED',
+      consumerStatus: SubscriptionConsumerStatusEnum.STARTED,
+      reference_type: 'API_PRODUCT',
+      reference_id: 'api-product-id',
+      api: undefined,
+      apiProduct: fakeApiProductSubscriptionDetails(),
+      ...modifier,
+    });
 
   beforeEach(async () => {
     applicationService = {
       get: jest.fn().mockReturnValue(of(fakeApplication({ name: 'My application' }))),
     };
+    permissionsService = {
+      getApplicationPermissions: jest.fn(),
+    };
+    subscriptionService = {
+      changeConsumerStatus: jest.fn(),
+      close: jest.fn(),
+      get: jest.fn(),
+      resumeConsumerStatus: jest.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [ApiProductSubscriptionDetailsComponent, AppTestingModule],
-      providers: [provideNoopAnimations(), provideRouter([]), { provide: ApplicationService, useValue: applicationService }],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ApplicationService, useValue: applicationService },
+        { provide: PermissionsService, useValue: permissionsService },
+        { provide: SubscriptionService, useValue: subscriptionService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiProductSubscriptionDetailsComponent);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
   });
 
+  async function init(
+    subscription: Subscription = acceptedSubscription(),
+    permissions: UserApplicationPermissions = fakeUserApplicationPermissions({ SUBSCRIPTION: ['U', 'D'] }),
+  ): Promise<ApiProductSubscriptionDetailsHarness> {
+    permissionsService.getApplicationPermissions.mockReturnValue(of(permissions));
+    subscriptionService.get.mockReturnValue(of(subscription));
+    subscriptionService.changeConsumerStatus.mockReturnValue(of(subscription));
+    subscriptionService.close.mockReturnValue(of(undefined));
+    subscriptionService.resumeConsumerStatus.mockReturnValue(of(subscription));
+    fixture.componentRef.setInput('subscription', subscription);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+  }
+
   it('should show API Product subscription summary and included APIs', async () => {
-    fixture.componentRef.setInput(
-      'subscription',
-      fakeSubscription({
-        status: 'ACCEPTED',
+    const harness = await init(
+      acceptedSubscription({
         start_at: '2026-08-01T10:00:00Z',
         end_at: '2027-08-01T10:00:00Z',
         apiProduct: fakeApiProductSubscriptionDetails({
@@ -56,10 +111,9 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
       }),
     );
 
-    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
-
     expect(await harness.getSummaryText()).toContain('Commerce Product');
     expect(await harness.getSummaryText()).toContain('Accepted');
+    expect(await harness.getSummaryText()).toContain('Active');
     expect(await harness.getSummaryText()).toContain('My application');
     expect(await harness.getCredentialsText()).toContain('No credentials are required');
     expect(await harness.getApiCount()).toBe(1);
@@ -67,24 +121,15 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
   });
 
   it('should show the subscription lifecycle state instead of credentials', async () => {
-    fixture.componentRef.setInput(
-      'subscription',
-      fakeSubscription({
-        status: 'PENDING',
-        apiProduct: fakeApiProductSubscriptionDetails(),
-      }),
-    );
-
-    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
+    const harness = await init(acceptedSubscription({ status: 'PENDING' }));
 
     expect(await harness.getCredentialsText()).toContain('subscription request is being reviewed');
     expect(fixture.nativeElement.querySelectorAll('app-api-product-subscription-api-access app-copy-code')).toHaveLength(0);
   });
 
   it.each(['CLOSED', 'REJECTED'] as const)('should not show KEY_LESS access for a %s subscription', async status => {
-    fixture.componentRef.setInput(
-      'subscription',
-      fakeSubscription({
+    const harness = await init(
+      acceptedSubscription({
         status,
         apiProduct: fakeApiProductSubscriptionDetails({
           plan: { id: 'plan-id', name: 'Keyless', security: 'KEY_LESS', mode: 'STANDARD' },
@@ -92,30 +137,262 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
       }),
     );
 
-    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
-
     expect(await harness.getCredentialsText()).toContain(
       status === 'CLOSED' ? 'subscription is closed' : 'subscription request was rejected',
     );
     expect(fixture.nativeElement.textContent).toContain('API access is not available for the current subscription status');
     expect(fixture.nativeElement.querySelectorAll('app-api-product-subscription-api-access app-copy-code')).toHaveLength(0);
+    expect(await harness.getPauseButton()).toBeNull();
+    expect(await harness.getResumeButton()).toBeNull();
+    expect(await harness.getCloseButton()).toBeNull();
   });
 
   it('should show OAuth2 application credentials once', async () => {
-    fixture.componentRef.setInput(
-      'subscription',
-      fakeSubscription({
-        status: 'ACCEPTED',
+    const harness = await init(
+      acceptedSubscription({
         apiProduct: fakeApiProductSubscriptionDetails({
           plan: { id: 'plan-id', name: 'OAuth', security: 'OAUTH2', mode: 'STANDARD' },
         }),
       }),
     );
 
-    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductSubscriptionDetailsHarness);
-
     expect(await harness.getCredentialsText()).toContain('Client ID');
     expect(await harness.getCredentialsText()).toContain('Client Secret');
     expect(fixture.nativeElement.querySelectorAll('[data-testid="product-subscription-credentials"] app-copy-code')).toHaveLength(2);
+  });
+
+  it('should distinguish a publisher-paused subscription from a consumer pause', async () => {
+    const harness = await init(acceptedSubscription({ status: 'PAUSED', consumerStatus: SubscriptionConsumerStatusEnum.STOPPED }));
+
+    expect(await harness.getSummaryText()).toContain('Unavailable');
+    expect(await harness.getCredentialsText()).toContain('paused by the API publisher');
+    expect(await harness.getCredentialsText()).not.toContain('API access for this subscription is paused');
+  });
+
+  it('should show a failed consumer without exposing credentials', async () => {
+    const harness = await init(
+      acceptedSubscription({
+        consumerStatus: SubscriptionConsumerStatusEnum.FAILURE,
+        failureCause: 'Connection refused',
+      }),
+    );
+
+    expect(await harness.getSummaryText()).toContain('Unavailable');
+    expect(await harness.getCredentialsText()).toContain('Subscription consumer failed');
+    expect(await harness.getCredentialsText()).toContain('Connection refused');
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="product-subscription-credentials"] app-api-keys-list')).toHaveLength(0);
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="product-subscription-credentials"] app-copy-code')).toHaveLength(0);
+    expect(await harness.getPauseButton()).toBeNull();
+    expect(await harness.getResumeButton()).toBeNull();
+    expect(await harness.getRetryButton()).not.toBeNull();
+    expect(await harness.getCloseButton()).not.toBeNull();
+  });
+
+  it('should show Pause and Close actions for an active accepted subscription', async () => {
+    const harness = await init();
+
+    expect(await harness.getPauseButton()).not.toBeNull();
+    expect(await harness.getResumeButton()).toBeNull();
+    expect(await harness.getCloseButton()).not.toBeNull();
+  });
+
+  it('should hide lifecycle actions without application permissions', async () => {
+    const harness = await init(acceptedSubscription(), fakeUserApplicationPermissions());
+
+    expect(await harness.getPauseButton()).toBeNull();
+    expect(await harness.getResumeButton()).toBeNull();
+    expect(await harness.getCloseButton()).toBeNull();
+  });
+
+  it('should hide Retry without the application update permission', async () => {
+    const failedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.FAILURE });
+    const harness = await init(failedSubscription, fakeUserApplicationPermissions({ SUBSCRIPTION: ['D'] }));
+
+    expect(await harness.getRetryButton()).toBeNull();
+    expect(await harness.getCloseButton()).not.toBeNull();
+  });
+
+  it('should pause the subscription, reload details and disable API access', async () => {
+    const initialSubscription = acceptedSubscription();
+    const pausedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.STOPPED });
+    const harness = await init(initialSubscription);
+    subscriptionService.changeConsumerStatus.mockReturnValue(of(pausedSubscription));
+    subscriptionService.get.mockReturnValue(of(pausedSubscription));
+
+    await (await harness.getPauseButton())!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(subscriptionService.changeConsumerStatus).toHaveBeenCalledWith(initialSubscription.id, SubscriptionConsumerStatusEnum.STOPPED);
+    expect(subscriptionService.get).toHaveBeenCalledWith(initialSubscription.id);
+    expect(await harness.getFeedbackText()).toContain('paused');
+    expect(await harness.getFeedbackAttribute('role')).toEqual('status');
+    expect(await harness.getFeedbackAttribute('aria-live')).toEqual('polite');
+    expect(await harness.getResumeButton()).not.toBeNull();
+    expect(await harness.getCredentialsText()).toContain('subscription is paused');
+    expect(fixture.nativeElement.textContent).toContain('API access is not available for the current subscription status');
+  });
+
+  it('should disable Pause and Close while pausing is in progress', async () => {
+    const action$ = new Subject<Subscription>();
+    const harness = await init();
+    subscriptionService.changeConsumerStatus.mockReturnValue(action$);
+
+    await (await harness.getPauseButton())!.click();
+    fixture.detectChanges();
+
+    expect(await (await harness.getPauseButton())!.isDisabled()).toBe(true);
+    expect(await (await harness.getCloseButton())!.isDisabled()).toBe(true);
+
+    action$.error(new Error('Request failed'));
+  });
+
+  it('should resume a consumer-paused subscription', async () => {
+    const pausedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.STOPPED });
+    const resumedSubscription = acceptedSubscription();
+    const harness = await init(pausedSubscription);
+    subscriptionService.changeConsumerStatus.mockReturnValue(of(resumedSubscription));
+    subscriptionService.get.mockReturnValue(of(resumedSubscription));
+
+    await (await harness.getResumeButton())!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(subscriptionService.changeConsumerStatus).toHaveBeenCalledWith(pausedSubscription.id, SubscriptionConsumerStatusEnum.STARTED);
+    expect(await harness.getFeedbackText()).toContain('resumed');
+    expect(await harness.getPauseButton()).not.toBeNull();
+  });
+
+  it('should disable Resume and Close while resuming is in progress', async () => {
+    const action$ = new Subject<Subscription>();
+    const pausedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.STOPPED });
+    const harness = await init(pausedSubscription);
+    subscriptionService.changeConsumerStatus.mockReturnValue(action$);
+
+    await (await harness.getResumeButton())!.click();
+    fixture.detectChanges();
+
+    expect(await (await harness.getResumeButton())!.isDisabled()).toBe(true);
+    expect(await (await harness.getCloseButton())!.isDisabled()).toBe(true);
+
+    action$.error(new Error('Request failed'));
+  });
+
+  it('should retry a failed consumer and reload subscription details', async () => {
+    const failedSubscription = acceptedSubscription({
+      consumerStatus: SubscriptionConsumerStatusEnum.FAILURE,
+      failureCause: 'Connection refused',
+    });
+    const resumedSubscription = acceptedSubscription();
+    const harness = await init(failedSubscription);
+    subscriptionService.resumeConsumerStatus.mockReturnValue(of(resumedSubscription));
+    subscriptionService.get.mockReturnValue(of(resumedSubscription));
+
+    await (await harness.getRetryButton())!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(subscriptionService.resumeConsumerStatus).toHaveBeenCalledWith(failedSubscription.id);
+    expect(subscriptionService.get).toHaveBeenCalledWith(failedSubscription.id);
+    expect(await harness.getFeedbackText()).toContain('retried');
+    expect(await harness.getRetryButton()).toBeNull();
+    expect(await harness.getPauseButton()).not.toBeNull();
+  });
+
+  it('should disable Retry and Close while retrying is in progress', async () => {
+    const action$ = new Subject<Subscription>();
+    const failedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.FAILURE });
+    const harness = await init(failedSubscription);
+    subscriptionService.resumeConsumerStatus.mockReturnValue(action$);
+
+    await (await harness.getRetryButton())!.click();
+    fixture.detectChanges();
+
+    expect(await (await harness.getRetryButton())!.isDisabled()).toBe(true);
+    expect(await (await harness.getCloseButton())!.isDisabled()).toBe(true);
+
+    action$.error(new Error('Request failed'));
+    fixture.detectChanges();
+
+    expect(await harness.getFeedbackText()).toContain('could not be retried');
+    expect(await (await harness.getRetryButton())!.isDisabled()).toBe(false);
+  });
+
+  it('should close the subscription after confirmation', async () => {
+    const initialSubscription = acceptedSubscription();
+    const closedSubscription = acceptedSubscription({ status: 'CLOSED' });
+    const harness = await init(initialSubscription);
+    subscriptionService.get.mockReturnValue(of(closedSubscription));
+
+    await (await harness.getCloseButton())!.click();
+    const dialog = await rootLoader.getHarness(ConfirmDialogHarness);
+    await dialog.confirm();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(subscriptionService.close).toHaveBeenCalledWith(initialSubscription.id);
+    expect(await harness.getFeedbackText()).toContain('closed');
+    expect(await harness.getPauseButton()).toBeNull();
+    expect(await harness.getResumeButton()).toBeNull();
+    expect(await harness.getCloseButton()).toBeNull();
+  });
+
+  it('should display Closed after closing a consumer-paused subscription', async () => {
+    const initialSubscription = acceptedSubscription();
+    const pausedSubscription = acceptedSubscription({ consumerStatus: SubscriptionConsumerStatusEnum.STOPPED });
+    const closedSubscription = acceptedSubscription({
+      status: 'CLOSED',
+      consumerStatus: SubscriptionConsumerStatusEnum.STOPPED,
+    });
+    const harness = await init(initialSubscription);
+    subscriptionService.get.mockReturnValueOnce(of(pausedSubscription)).mockReturnValueOnce(of(closedSubscription));
+
+    await (await harness.getPauseButton())!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await (await harness.getCloseButton())!.click();
+    const dialog = await rootLoader.getHarness(ConfirmDialogHarness);
+    await dialog.confirm();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.getSummaryText()).toContain('Closed');
+    expect(await harness.getSummaryText()).toContain('Unavailable');
+    expect(await harness.getCredentialsText()).toContain('subscription is closed');
+    expect(await harness.getCredentialsText()).not.toContain('subscription is paused');
+  });
+
+  it('should keep the subscription open when close is cancelled', async () => {
+    const harness = await init();
+
+    await (await harness.getCloseButton())!.click();
+    const dialog = await rootLoader.getHarness(ConfirmDialogHarness);
+    await dialog.cancel();
+
+    expect(subscriptionService.close).not.toHaveBeenCalled();
+  });
+
+  it('should display an inline error when an action fails', async () => {
+    const harness = await init();
+    subscriptionService.changeConsumerStatus.mockReturnValue(throwError(() => new Error('Request failed')));
+
+    await (await harness.getPauseButton())!.click();
+    fixture.detectChanges();
+
+    expect(await harness.getFeedbackText()).toContain('could not be paused');
+    expect(await harness.getFeedbackAttribute('role')).toEqual('alert');
+    expect(await harness.getFeedbackAttribute('aria-live')).toBeNull();
+    expect(await (await harness.getPauseButton())!.isDisabled()).toBe(false);
+  });
+
+  it('should distinguish a successful action followed by a refresh failure', async () => {
+    const harness = await init();
+    subscriptionService.get.mockReturnValue(throwError(() => new Error('Refresh failed')));
+
+    await (await harness.getPauseButton())!.click();
+    fixture.detectChanges();
+
+    expect(subscriptionService.changeConsumerStatus).toHaveBeenCalled();
+    expect(await harness.getFeedbackText()).toContain('updated, but its latest details could not be loaded');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
@@ -14,30 +14,46 @@
  * limitations under the License.
  */
 import { DatePipe } from '@angular/common';
-import { Component, computed, inject, input } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, linkedSignal, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
 import { RouterLink } from '@angular/router';
+import { catchError, map, Observable, of, switchMap } from 'rxjs';
 
 import { ApiProductSubscriptionApiAccessComponent } from './api-product-subscription-api-access/api-product-subscription-api-access.component';
 import { ApiKeysListComponent } from '../../../../components/api-access/api-keys-list/api-keys-list.component';
+import { BannerComponent } from '../../../../components/banner/banner.component';
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { CopyCodeComponent } from '../../../../components/copy-code/copy-code.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { getPlanSecurityTypeLabel } from '../../../../entities/plan/plan';
-import { isActiveApiKey, Subscription } from '../../../../entities/subscription/subscription';
+import { isActiveApiKey, Subscription, SubscriptionConsumerStatusEnum } from '../../../../entities/subscription/subscription';
 import { CapitalizeFirstPipe } from '../../../../pipe/capitalize-first.pipe';
 import { ToPeriodTimeUnitLabelPipe } from '../../../../pipe/time-unit.pipe';
 import { ApplicationService } from '../../../../services/application.service';
+import { PermissionsService } from '../../../../services/permissions.service';
+import { SubscriptionService } from '../../../../services/subscription.service';
+
+type LifecycleAction = 'pause' | 'resume' | 'retry' | 'close';
+
+interface ActionFeedback {
+  type: 'success' | 'error';
+  message: string;
+}
 
 @Component({
   selector: 'app-api-product-subscription-details',
   imports: [
     ApiKeysListComponent,
     ApiProductSubscriptionApiAccessComponent,
+    BannerComponent,
     CapitalizeFirstPipe,
     CopyCodeComponent,
     DatePipe,
     LoaderComponent,
+    MatButtonModule,
     MatCardModule,
     RouterLink,
     ToPeriodTimeUnitLabelPipe,
@@ -47,23 +63,180 @@ import { ApplicationService } from '../../../../services/application.service';
 })
 export class ApiProductSubscriptionDetailsComponent {
   private readonly applicationService = inject(ApplicationService);
+  private readonly permissionsService = inject(PermissionsService);
+  private readonly subscriptionService = inject(SubscriptionService);
+  private readonly dialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly subscription = input.required<Subscription>();
 
-  protected readonly product = computed(() => this.subscription().apiProduct);
+  protected readonly displayedSubscription = linkedSignal(() => this.subscription());
+  protected readonly pendingAction = signal<LifecycleAction | null>(null);
+  protected readonly actionFeedback = signal<ActionFeedback | null>(null);
+  protected readonly product = computed(() => this.displayedSubscription().apiProduct);
   protected readonly plan = computed(() => this.product()?.plan);
   protected readonly planSecurityLabel = computed(() => getPlanSecurityTypeLabel(this.plan()?.security));
-  protected readonly apiAccessEnabled = computed(() => {
-    const status = this.subscription().status;
-    return status === 'ACCEPTED' || (this.plan()?.security === 'KEY_LESS' && status !== 'CLOSED' && status !== 'REJECTED');
+  protected readonly accessStatusLabel = computed(() => {
+    const subscription = this.displayedSubscription();
+    if (subscription.status !== 'ACCEPTED') {
+      return $localize`:@@apiProductSubscriptionAccessStatusUnavailable:Unavailable`;
+    }
+    if (subscription.consumerStatus === SubscriptionConsumerStatusEnum.STOPPED) {
+      return $localize`:@@apiProductSubscriptionAccessStatusPaused:Paused`;
+    }
+    return subscription.consumerStatus === SubscriptionConsumerStatusEnum.STARTED
+      ? $localize`:@@apiProductSubscriptionAccessStatusActive:Active`
+      : $localize`:@@apiProductSubscriptionAccessStatusUnavailable:Unavailable`;
   });
-  protected readonly activeApiKey = computed(() => this.subscription().keys?.find(apiKey => isActiveApiKey(apiKey))?.key);
+  protected readonly apiAccessEnabled = computed(() => {
+    const subscription = this.displayedSubscription();
+    const statusAllowsAccess =
+      subscription.status === 'ACCEPTED' ||
+      (this.plan()?.security === 'KEY_LESS' && subscription.status !== 'CLOSED' && subscription.status !== 'REJECTED');
+    return subscription.consumerStatus === SubscriptionConsumerStatusEnum.STARTED && statusAllowsAccess;
+  });
+  protected readonly activeApiKey = computed(() => this.displayedSubscription().keys?.find(isActiveApiKey)?.key);
   protected readonly applicationResource = rxResource({
-    params: () => this.subscription().application,
+    params: () => this.displayedSubscription().application,
     stream: ({ params }) => this.applicationService.get(params),
+  });
+  protected readonly permissionsResource = rxResource({
+    params: () => this.displayedSubscription().application,
+    stream: ({ params }) => this.permissionsService.getApplicationPermissions(params),
   });
   protected readonly clientId = computed(
     () => this.applicationResource.value()?.settings.oauth?.client_id ?? this.applicationResource.value()?.settings.app?.client_id,
   );
   protected readonly clientSecret = computed(() => this.applicationResource.value()?.settings.oauth?.client_secret);
+  protected readonly isActionPending = computed(() => this.pendingAction() !== null);
+  protected readonly canPause = computed(() => {
+    const subscription = this.displayedSubscription();
+    return (
+      subscription.status === 'ACCEPTED' &&
+      subscription.consumerStatus === SubscriptionConsumerStatusEnum.STARTED &&
+      (this.permissionsResource.value()?.SUBSCRIPTION?.includes('U') ?? false)
+    );
+  });
+  protected readonly canResume = computed(() => {
+    const subscription = this.displayedSubscription();
+    return (
+      subscription.status === 'ACCEPTED' &&
+      subscription.consumerStatus === SubscriptionConsumerStatusEnum.STOPPED &&
+      (this.permissionsResource.value()?.SUBSCRIPTION?.includes('U') ?? false)
+    );
+  });
+  protected readonly canRetry = computed(() => {
+    const subscription = this.displayedSubscription();
+    return (
+      subscription.status === 'ACCEPTED' &&
+      subscription.consumerStatus === SubscriptionConsumerStatusEnum.FAILURE &&
+      (this.permissionsResource.value()?.SUBSCRIPTION?.includes('U') ?? false)
+    );
+  });
+  protected readonly canClose = computed(() => {
+    const subscription = this.displayedSubscription();
+    return (
+      (subscription.status === 'ACCEPTED' || subscription.status === 'PAUSED') &&
+      (this.permissionsResource.value()?.SUBSCRIPTION?.includes('D') ?? false)
+    );
+  });
+
+  protected pauseSubscription(): void {
+    const subscriptionId = this.displayedSubscription().id;
+    this.executeAction('pause', this.subscriptionService.changeConsumerStatus(subscriptionId, SubscriptionConsumerStatusEnum.STOPPED));
+  }
+
+  protected resumeSubscription(): void {
+    const subscriptionId = this.displayedSubscription().id;
+    this.executeAction('resume', this.subscriptionService.changeConsumerStatus(subscriptionId, SubscriptionConsumerStatusEnum.STARTED));
+  }
+
+  protected retrySubscription(): void {
+    const subscriptionId = this.displayedSubscription().id;
+    this.executeAction('retry', this.subscriptionService.resumeConsumerStatus(subscriptionId));
+  }
+
+  protected closeSubscription(): void {
+    const dialogData: ConfirmDialogData = {
+      title: $localize`:@@apiProductSubscriptionCloseDialogTitle:Close this subscription?`,
+      content: $localize`:@@apiProductSubscriptionCloseDialogContent:You will lose access to all APIs in this API Product.`,
+      confirmLabel: $localize`:@@apiProductSubscriptionCloseDialogConfirm:Yes, close`,
+      cancelLabel: $localize`:@@apiProductSubscriptionCloseDialogCancel:Cancel`,
+    };
+
+    this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        id: 'confirmApiProductSubscriptionCloseDialog',
+        data: dialogData,
+      })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(confirmed => {
+        if (confirmed) {
+          this.executeAction('close', this.subscriptionService.close(this.displayedSubscription().id));
+        }
+      });
+  }
+
+  private executeAction(action: LifecycleAction, request: Observable<unknown>): void {
+    const subscriptionId = this.displayedSubscription().id;
+    this.pendingAction.set(action);
+    this.actionFeedback.set(null);
+
+    request
+      .pipe(
+        switchMap(() =>
+          this.subscriptionService.get(subscriptionId).pipe(
+            map(subscription => ({ subscription })),
+            catchError(() => of({ subscription: undefined })),
+          ),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: ({ subscription }) => {
+          this.pendingAction.set(null);
+          if (subscription) {
+            this.displayedSubscription.set(subscription);
+            this.actionFeedback.set({ type: 'success', message: this.getSuccessMessage(action) });
+          } else {
+            this.actionFeedback.set({
+              type: 'error',
+              message: $localize`:@@apiProductSubscriptionRefreshError:The subscription was updated, but its latest details could not be loaded. Refresh the page.`,
+            });
+          }
+        },
+        error: () => {
+          this.pendingAction.set(null);
+          this.actionFeedback.set({ type: 'error', message: this.getErrorMessage(action) });
+        },
+      });
+  }
+
+  private getSuccessMessage(action: LifecycleAction): string {
+    switch (action) {
+      case 'pause':
+        return $localize`:@@apiProductSubscriptionPauseSuccess:Subscription paused.`;
+      case 'resume':
+        return $localize`:@@apiProductSubscriptionResumeSuccess:Subscription resumed.`;
+      case 'retry':
+        return $localize`:@@apiProductSubscriptionRetrySuccess:Subscription retried.`;
+      case 'close':
+        return $localize`:@@apiProductSubscriptionCloseSuccess:Subscription closed.`;
+    }
+  }
+
+  private getErrorMessage(action: LifecycleAction): string {
+    switch (action) {
+      case 'pause':
+        return $localize`:@@apiProductSubscriptionPauseError:The subscription could not be paused. Try again.`;
+      case 'resume':
+        return $localize`:@@apiProductSubscriptionResumeError:The subscription could not be resumed. Try again.`;
+      case 'retry':
+        return $localize`:@@apiProductSubscriptionRetryError:The subscription could not be retried. Try again.`;
+      case 'close':
+        return $localize`:@@apiProductSubscriptionCloseError:The subscription could not be closed. Try again.`;
+    }
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
   static hostSelector = 'app-api-product-subscription-details';
@@ -22,6 +23,11 @@ export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
   private readonly credentials = this.locatorFor('[data-testid="product-subscription-credentials"]');
   private readonly apiCards = this.locatorForAll('app-api-product-subscription-api-access');
   private readonly applicationLink = this.locatorForOptional('a[href*="/dashboard/applications/"]');
+  private readonly pauseButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="pause-subscription"]' }));
+  private readonly resumeButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="resume-subscription"]' }));
+  private readonly retryButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="retry-subscription"]' }));
+  private readonly closeButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="close-subscription"]' }));
+  private readonly feedback = this.locatorForOptional('[data-testid="subscription-action-feedback"]');
 
   async getSummaryText(): Promise<string> {
     return (await this.summary()).text();
@@ -37,5 +43,29 @@ export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
 
   async getApplicationLink(): Promise<string | null> {
     return (await this.applicationLink())?.getAttribute('href') ?? null;
+  }
+
+  async getPauseButton(): Promise<MatButtonHarness | null> {
+    return this.pauseButton();
+  }
+
+  async getResumeButton(): Promise<MatButtonHarness | null> {
+    return this.resumeButton();
+  }
+
+  async getRetryButton(): Promise<MatButtonHarness | null> {
+    return this.retryButton();
+  }
+
+  async getCloseButton(): Promise<MatButtonHarness | null> {
+    return this.closeButton();
+  }
+
+  async getFeedbackText(): Promise<string | null> {
+    return (await this.feedback())?.text() ?? null;
+  }
+
+  async getFeedbackAttribute(attribute: string): Promise<string | null> {
+    return (await this.feedback())?.getAttribute(attribute) ?? null;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.spec.ts
@@ -21,6 +21,7 @@ import {
   fakeApiProductSubscriptionDetails,
   fakeSubscription,
   fakeSubscriptionResponse,
+  SubscriptionConsumerStatusEnum,
   SubscriptionsResponse,
   SubscriptionStatusEnum,
 } from '../entities/subscription';
@@ -138,4 +139,22 @@ describe('SubscriptionService', () => {
 
     req.flush(null);
   });
+
+  it.each([SubscriptionConsumerStatusEnum.STARTED, SubscriptionConsumerStatusEnum.STOPPED])(
+    'should change subscription consumer status to %s',
+    consumerStatus => {
+      const subscription = fakeSubscription({ consumerStatus });
+
+      service.changeConsumerStatus(subscription.id, consumerStatus).subscribe(response => {
+        expect(response).toEqual(subscription);
+      });
+
+      const req = httpTestingController.expectOne(
+        `${TESTING_BASE_URL}/subscriptions/${subscription.id}/_changeConsumerStatus?status=${consumerStatus}`,
+      );
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toBeNull();
+      req.flush(subscription);
+    },
+  );
 });

--- a/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription.service.ts
@@ -21,6 +21,7 @@ import { ConfigService } from './config.service';
 import {
   CreateSubscription,
   Subscription,
+  SubscriptionConsumerStatusEnum,
   SubscriptionReferenceType,
   SubscriptionsResponse,
   SubscriptionStatusEnum,
@@ -77,6 +78,12 @@ export class SubscriptionService {
 
   close(subscriptionId: string) {
     return this.http.post<void>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/_close`, null);
+  }
+
+  changeConsumerStatus(subscriptionId: string, status: SubscriptionConsumerStatusEnum): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/_changeConsumerStatus`, null, {
+      params: { status },
+    });
   }
 
   resumeConsumerStatus(subscriptionId: string): Observable<Subscription> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
@@ -51,6 +51,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -82,6 +83,11 @@ public class SubscriptionResource extends AbstractResource {
     private static final String INCLUDE_KEYS = "keys";
     private static final String INCLUDE_CONSUMER_CONFIGURATION = "consumerConfiguration";
     private static final String INCLUDE_API_PRODUCT = "apiProduct";
+    private static final Set<SubscriptionStatus> API_PRODUCT_CLOSABLE_STATUSES = Set.of(
+        SubscriptionStatus.PENDING,
+        SubscriptionStatus.ACCEPTED,
+        SubscriptionStatus.PAUSED
+    );
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -91,14 +97,12 @@ public class SubscriptionResource extends AbstractResource {
     ) {
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        boolean apiProductSubscription = SubscriptionReferenceType.API_PRODUCT.name().equals(subscriptionEntity.getReferenceType());
+        boolean apiProductSubscription = isApiProductSubscription(subscriptionEntity);
 
         if (!hasReadPermission(executionContext, subscriptionEntity, apiProductSubscription)) {
             throw new ForbiddenAccessException();
         }
-        if (apiProductSubscription && !Objects.equals(executionContext.getEnvironmentId(), subscriptionEntity.getEnvironmentId())) {
-            throw new SubscriptionNotFoundException(subscriptionId);
-        }
+        validateApiProductEnvironment(executionContext, subscriptionEntity, apiProductSubscription);
         Subscription subscription = SubscriptionMapper.INSTANCE.map(subscriptionEntity);
         if (apiProductSubscription && include.contains(INCLUDE_API_PRODUCT)) {
             var output = getPortalApiProductSubscriptionDetailsUseCase.execute(
@@ -151,11 +155,16 @@ public class SubscriptionResource extends AbstractResource {
     public Response closeSubscription(@PathParam("subscriptionId") String subscriptionId) {
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        if (hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), RolePermissionAction.DELETE)) {
-            closeSubscriptionUsecase.execute(new CloseSubscriptionUseCase.Input(subscriptionId, getAuditInfo()));
-            return Response.noContent().build();
+        boolean apiProductSubscription = isApiProductSubscription(subscriptionEntity);
+        validateApiProductEnvironment(executionContext, subscriptionEntity, apiProductSubscription);
+        if (!hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), RolePermissionAction.DELETE)) {
+            throw new ForbiddenAccessException();
         }
-        throw new ForbiddenAccessException();
+        if (apiProductSubscription && !API_PRODUCT_CLOSABLE_STATUSES.contains(subscriptionEntity.getStatus())) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        closeSubscriptionUsecase.execute(new CloseSubscriptionUseCase.Input(subscriptionId, getAuditInfo()));
+        return Response.noContent().build();
     }
 
     @PUT
@@ -168,6 +177,7 @@ public class SubscriptionResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+        validateApiProductEnvironment(executionContext, subscriptionEntity, isApiProductSubscription(subscriptionEntity));
 
         if (!hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), UPDATE)) {
             throw new ForbiddenAccessException();
@@ -205,12 +215,18 @@ public class SubscriptionResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+        boolean apiProductSubscription = isApiProductSubscription(subscriptionEntity);
+        validateApiProductEnvironment(executionContext, subscriptionEntity, apiProductSubscription);
 
         if (!hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), UPDATE)) {
             throw new ForbiddenAccessException();
         }
 
         if (subscriptionConsumerStatus == null) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        if (apiProductSubscription && subscriptionEntity.getStatus() != SubscriptionStatus.ACCEPTED) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 
@@ -234,6 +250,7 @@ public class SubscriptionResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+        validateApiProductEnvironment(executionContext, subscriptionEntity, isApiProductSubscription(subscriptionEntity));
 
         if (!hasPermission(executionContext, APPLICATION_SUBSCRIPTION, subscriptionEntity.getApplication(), UPDATE)) {
             throw new ForbiddenAccessException();
@@ -250,5 +267,19 @@ public class SubscriptionResource extends AbstractResource {
     @Path("keys")
     public SubscriptionKeysResource getSubscriptionKeysResource() {
         return resourceContext.getResource(SubscriptionKeysResource.class);
+    }
+
+    private static boolean isApiProductSubscription(SubscriptionEntity subscription) {
+        return SubscriptionReferenceType.API_PRODUCT.name().equals(subscription.getReferenceType());
+    }
+
+    private static void validateApiProductEnvironment(
+        ExecutionContext executionContext,
+        SubscriptionEntity subscription,
+        boolean apiProductSubscription
+    ) {
+        if (apiProductSubscription && !Objects.equals(executionContext.getEnvironmentId(), subscription.getEnvironmentId())) {
+            throw new SubscriptionNotFoundException(subscription.getId());
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -2653,6 +2653,8 @@ paths:
             responses:
                 204:
                     description: No-Content
+                400:
+                    description: API Product subscription cannot be closed in its current status
                 403:
                     $ref: "#/components/responses/PermissionError"
                 404:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.subscription.model.PortalApiProductSubscriptionDetails;
+import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.GetPortalApiProductSubscriptionDetailsUseCase;
 import io.gravitee.apim.core.subscription.use_case.SearchPortalSubscriptionsUseCase;
 import io.gravitee.common.data.domain.Page;
@@ -90,12 +91,15 @@ class SubscriptionResourceTest extends AbstractResourceTest {
     @Autowired
     private GetPortalApiProductSubscriptionDetailsUseCase getPortalApiProductSubscriptionDetailsUseCase;
 
+    @Autowired
+    private CloseSubscriptionUseCase closeSubscriptionUseCase;
+
     private SubscriptionEntity subscriptionEntity;
 
     @BeforeEach
     void init() {
         resetAllMocks();
-        reset(getPortalApiProductSubscriptionDetailsUseCase);
+        reset(getPortalApiProductSubscriptionDetailsUseCase, closeSubscriptionUseCase);
 
         subscriptionEntity = new SubscriptionEntity();
         subscriptionEntity.setId(SUBSCRIPTION);
@@ -396,6 +400,48 @@ class SubscriptionResourceTest extends AbstractResourceTest {
     class CloseSubscription {
 
         @Test
+        void should_close_api_product_subscription() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+
+            var response = target(SUBSCRIPTION).path("_close").request().post(null);
+
+            assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+            verify(closeSubscriptionUseCase).execute(any(CloseSubscriptionUseCase.Input.class));
+        }
+
+        @Test
+        void should_withdraw_pending_api_product_subscription() {
+            givenApiProductSubscription(SubscriptionStatus.PENDING);
+
+            var response = target(SUBSCRIPTION).path("_close").request().post(null);
+
+            assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+            verify(closeSubscriptionUseCase).execute(any(CloseSubscriptionUseCase.Input.class));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SubscriptionStatus.class, names = { "CLOSED", "REJECTED" })
+        void should_reject_closing_api_product_subscription_with_invalid_status(SubscriptionStatus status) {
+            givenApiProductSubscription(status);
+
+            var response = target(SUBSCRIPTION).path("_close").request().post(null);
+
+            assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+            verifyNoInteractions(closeSubscriptionUseCase);
+        }
+
+        @Test
+        void should_not_close_api_product_subscription_from_another_environment() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setEnvironmentId("other-environment");
+
+            var response = target(SUBSCRIPTION).path("_close").request().post(null);
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+            verifyNoInteractions(closeSubscriptionUseCase);
+        }
+
+        @Test
         void testPermissionsForClosingASubscription() {
             reset(permissionService);
 
@@ -437,6 +483,18 @@ class SubscriptionResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_not_update_api_product_subscription_from_another_environment() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setEnvironmentId("other-environment");
+
+            Response response = target(SUBSCRIPTION).request().put(json(new UpdateSubscriptionInput()));
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+            verify(subscriptionService).findById(SUBSCRIPTION);
+            verifyNoMoreInteractions(subscriptionService);
+        }
+
+        @Test
         void shouldUpdateSubscriptionConfiguration() {
             UpdateSubscriptionInput updateSubscriptionInput = new UpdateSubscriptionInput();
             SubscriptionConfigurationInput subscriptionConfigurationInput = new SubscriptionConfigurationInput();
@@ -469,6 +527,52 @@ class SubscriptionResourceTest extends AbstractResourceTest {
 
     @Nested
     class ChangeSubscriptionConsumerStatus {
+
+        @Test
+        void should_pause_api_product_subscription_by_consumer() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setConsumerStatus(SubscriptionConsumerStatus.STARTED);
+
+            var response = target(SUBSCRIPTION).path("_changeConsumerStatus").queryParam("status", "STOPPED").request().post(null);
+
+            assertEquals(HttpStatusCode.OK_200, response.getStatus());
+            verify(subscriptionService).pauseConsumer(GraviteeContext.getExecutionContext(), SUBSCRIPTION);
+        }
+
+        @Test
+        void should_resume_api_product_subscription_by_consumer() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setConsumerStatus(SubscriptionConsumerStatus.STOPPED);
+
+            var response = target(SUBSCRIPTION).path("_changeConsumerStatus").queryParam("status", "STARTED").request().post(null);
+
+            assertEquals(HttpStatusCode.OK_200, response.getStatus());
+            verify(subscriptionService).resumeConsumer(GraviteeContext.getExecutionContext(), SUBSCRIPTION);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SubscriptionStatus.class, names = { "PENDING", "PAUSED", "CLOSED", "REJECTED" })
+        void should_reject_consumer_status_change_for_api_product_subscription_with_invalid_status(SubscriptionStatus status) {
+            givenApiProductSubscription(status);
+
+            var response = target(SUBSCRIPTION).path("_changeConsumerStatus").queryParam("status", "STOPPED").request().post(null);
+
+            assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+            verify(subscriptionService, times(0)).pauseConsumer(any(), any());
+            verify(subscriptionService, times(0)).resumeConsumer(any(), any());
+        }
+
+        @Test
+        void should_not_change_consumer_status_for_api_product_subscription_from_another_environment() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setEnvironmentId("other-environment");
+
+            var response = target(SUBSCRIPTION).path("_changeConsumerStatus").queryParam("status", "STOPPED").request().post(null);
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+            verify(subscriptionService, times(0)).pauseConsumer(any(), any());
+            verify(subscriptionService, times(0)).resumeConsumer(any(), any());
+        }
 
         @Test
         void shouldPauseSubscriptionByConsumer() {
@@ -547,6 +651,18 @@ class SubscriptionResourceTest extends AbstractResourceTest {
 
             verify(subscriptionService, times(1)).resumeFailed(GraviteeContext.getExecutionContext(), subscriptionEntity.getId());
             assertEquals(200, response.getStatus());
+        }
+
+        @Test
+        void should_not_resume_failed_api_product_subscription_from_another_environment() {
+            givenApiProductSubscription(SubscriptionStatus.ACCEPTED);
+            subscriptionEntity.setConsumerStatus(SubscriptionConsumerStatus.FAILURE);
+            subscriptionEntity.setEnvironmentId("other-environment");
+
+            Response response = target(SUBSCRIPTION).path("_resumeFailure").request().post(null);
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+            verify(subscriptionService, times(0)).resumeFailed(any(), any());
         }
 
         @Test
@@ -688,5 +804,12 @@ class SubscriptionResourceTest extends AbstractResourceTest {
 
             private String url;
         }
+    }
+
+    private void givenApiProductSubscription(SubscriptionStatus status) {
+        subscriptionEntity.setApi(null);
+        subscriptionEntity.setReferenceId(API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        subscriptionEntity.setStatus(status);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
@@ -49,6 +49,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApplicationHookContext;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
@@ -296,6 +297,59 @@ class CloseSubscriptionUseCaseTest {
         assertThat(result.subscription())
             .extracting(SubscriptionEntity::getId, SubscriptionEntity::getStatus)
             .containsExactly(SUBSCRIPTION_ID, SubscriptionEntity.Status.CLOSED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SubscriptionEntity.Status.class, names = { "ACCEPTED", "PAUSED" })
+    void should_close_api_product_subscription_with_product_side_effects(SubscriptionEntity.Status status) {
+        // Given
+        var apiProductId = "api-product-id";
+        var application = givenExistingApplication(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).apiKeyMode(ApiKeyMode.EXCLUSIVE).build()
+        );
+        var subscription = givenExistingSubscription(
+            SubscriptionFixtures.aSubscription()
+                .toBuilder()
+                .id(SUBSCRIPTION_ID)
+                .referenceId(apiProductId)
+                .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                .applicationId(application.getId())
+                .planId("plan-id")
+                .status(status)
+                .build()
+        );
+        givenExistingApiKeysForSubscription(
+            List.of(
+                ApiKeyFixtures.anApiKey()
+                    .toBuilder()
+                    .id("api-key-id")
+                    .key("api-key")
+                    .applicationId(application.getId())
+                    .subscriptions(List.of(subscription.getId()))
+                    .revoked(false)
+                    .expireAt(Instant.now().plus(1, ChronoUnit.DAYS).atZone(ZoneId.systemDefault()))
+                    .build()
+            )
+        );
+
+        // When
+        var result = usecase.execute(new Input(SUBSCRIPTION_ID, AUDIT_INFO));
+
+        // Then
+        assertThat(result.subscription().getStatus()).isEqualTo(SubscriptionEntity.Status.CLOSED);
+        assertThat(apiKeyCrudService.storage()).allMatch(ApiKeyEntity::isRevoked);
+        assertThat(triggerNotificationService.getHookNotifications()).containsExactly(
+            new SubscriptionClosedApiProductHookContext(apiProductId, APPLICATION_ID, "plan-id")
+        );
+        assertThat(triggerNotificationService.getApplicationNotifications()).containsExactly(
+            new ApplicationNotification(
+                new SubscriptionClosedApplicationHookContext(APPLICATION_ID, SubscriptionReferenceType.API_PRODUCT, apiProductId, "plan-id")
+            )
+        );
+        assertThat(auditCrudServiceInMemory.storage())
+            .extracting(AuditEntity::getReferenceType)
+            .contains(AuditEntity.AuditReferenceType.API_PRODUCT, AuditEntity.AuditReferenceType.APPLICATION);
+        assertThat(apiCrudService.storage()).isEmpty();
     }
 
     @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -2852,6 +2852,47 @@ public class SubscriptionServiceTest {
     }
 
     @Test
+    public void shouldPauseApiProductSubscriptionByConsumer() throws Exception {
+        String apiProductId = "api-product-id";
+        Subscription subscription = buildTestSubscription(
+            SUBSCRIPTION_ID,
+            apiProductId,
+            ACCEPTED,
+            PLAN_ID,
+            APPLICATION_ID,
+            SUBSCRIBER_ID,
+            SubscriptionReferenceType.API_PRODUCT
+        );
+        subscription.setConsumerStatus(Subscription.ConsumerStatus.STARTED);
+        planEntityV4.setReferenceId(apiProductId);
+        planEntityV4.setReferenceType(GenericPlanEntity.ReferenceType.API_PRODUCT);
+
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(subscription)).thenReturn(subscription);
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
+        when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
+        final ApiKeyEntity apiKey = buildTestApiKey(subscription.getId(), false, false);
+        when(apiKeyService.findBySubscription(any(), any())).thenReturn(List.of(apiKey));
+
+        subscriptionService.pauseConsumer(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
+
+        assertThat(subscription.getConsumerStatus()).isEqualTo(Subscription.ConsumerStatus.STOPPED);
+        assertThat(subscription.getConsumerPausedAt()).isNotNull();
+        verify(apiKeyService).update(GraviteeContext.getExecutionContext(), apiKey);
+        verify(auditService).createApiProductAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> auditLogData.getEvent().equals(SUBSCRIPTION_PAUSED_BY_CONSUMER)),
+            eq(apiProductId)
+        );
+        verify(auditService).createApplicationAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> auditLogData.getEvent().equals(SUBSCRIPTION_PAUSED_BY_CONSUMER)),
+            eq(APPLICATION_ID)
+        );
+        verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
+    }
+
+    @Test
     public void shouldNotResumeByConsumerBecauseDoesNoExist() throws Exception {
         assertThrows(SubscriptionNotFoundException.class, () -> {
             // Stub
@@ -2938,6 +2979,47 @@ public class SubscriptionServiceTest {
             argThat(auditLogData -> auditLogData.getEvent().equals(SUBSCRIPTION_RESUMED_BY_CONSUMER)),
             eq(APPLICATION_ID)
         );
+    }
+
+    @Test
+    public void shouldResumeApiProductSubscriptionByConsumer() throws Exception {
+        String apiProductId = "api-product-id";
+        Subscription subscription = buildTestSubscription(
+            SUBSCRIPTION_ID,
+            apiProductId,
+            ACCEPTED,
+            PLAN_ID,
+            APPLICATION_ID,
+            SUBSCRIBER_ID,
+            SubscriptionReferenceType.API_PRODUCT
+        );
+        subscription.setConsumerStatus(Subscription.ConsumerStatus.STOPPED);
+        subscription.setConsumerPausedAt(new Date());
+        planEntityV4.setReferenceId(apiProductId);
+        planEntityV4.setReferenceType(GenericPlanEntity.ReferenceType.API_PRODUCT);
+
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(subscription)).thenReturn(subscription);
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
+        final ApiKeyEntity apiKey = buildTestApiKey(subscription.getId(), false, false);
+        when(apiKeyService.findBySubscription(any(), any())).thenReturn(List.of(apiKey));
+
+        subscriptionService.resumeConsumer(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
+
+        assertThat(subscription.getConsumerStatus()).isEqualTo(Subscription.ConsumerStatus.STARTED);
+        assertThat(subscription.getConsumerPausedAt()).isNull();
+        verify(apiKeyService).update(GraviteeContext.getExecutionContext(), apiKey);
+        verify(auditService).createApiProductAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> auditLogData.getEvent().equals(SUBSCRIPTION_RESUMED_BY_CONSUMER)),
+            eq(apiProductId)
+        );
+        verify(auditService).createApplicationAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(auditLogData -> auditLogData.getEvent().equals(SUBSCRIPTION_RESUMED_BY_CONSUMER)),
+            eq(APPLICATION_ID)
+        );
+        verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-135

## Summary

Add Pause, Resume, and Close lifecycle actions for API Product subscriptions in Portal Next.



## Changes

- Add Pause and Resume actions using the existing consumer status endpoint.
- Add Close action with an explicit confirmation dialog.
- Display actions according to the subscription status and application permissions.
- Disable lifecycle actions while a request is pending.
- Refresh subscription details and display inline success or error feedback.
- Disable API access and hide credentials while the consumer status is stopped.
- Validate the API Product subscription environment and allowed states in Portal API.
- Preserve the existing audit and API key revocation behavior.
- Keep the existing behavior of direct API subscriptions unchanged.
- Document the invalid API Product subscription state response in the existing OpenAPI contract.

Uploading Nagranie z ekranu 2026-08-25 o 09.21.40.mov…


