### PR TITLE
fix(analytics): stop returning histogram buckets outside the requested window

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/HistogramGrid.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/HistogramGrid.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.utils;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Placement of the bucket grid of a date histogram run over a caller-supplied window.
+ *
+ * <p>By default Elasticsearch aligns buckets on epoch multiples of the interval, so the bucket holding the
+ * start of the window generally begins before it. That leaves no good option: filtering strictly on the window
+ * yields a short first bucket, and filtering wider admits documents that come back as a bucket outside the
+ * window — {@code extended_bounds} extends the returned range, it does not clamp it. Since these responses
+ * carry no timestamp per point, such a bucket shifts the whole series by one interval.
+ *
+ * <p>Shifting the grid onto the window itself removes the dilemma: the first bucket starts exactly at the
+ * start of the window, so the filter can begin there and the first bucket is still complete.
+ */
+public final class HistogramGrid {
+
+    private HistogramGrid() {}
+
+    /**
+     * Offset, in milliseconds, that places a bucket boundary exactly on {@code windowStart}.
+     *
+     * @return zero when the window already starts on a boundary, or when the interval is unusable (see
+     *         {@link #usableMillis(Duration)}).
+     */
+    public static long offsetMillis(final Instant windowStart, final Duration interval) {
+        final long intervalMillis = usableMillis(interval);
+        return intervalMillis == 0 ? 0L : Math.floorMod(windowStart.toEpochMilli(), intervalMillis);
+    }
+
+    /**
+     * End of the last bucket the histogram emits for the window, which is the instant a range filter must stop
+     * short of.
+     *
+     * <p>{@code extended_bounds.max} rounds down onto the grid, so the last emitted bucket is the one holding
+     * {@code windowEnd}, not the one starting on it. Filtering up to {@code windowEnd + interval} instead is
+     * only equivalent when the window spans a whole number of intervals; otherwise it admits documents that
+     * open a bucket past {@code extended_bounds.max} — and since {@code extended_bounds} does not clamp, that
+     * bucket is returned, adding a point that carries traffic from after the window.
+     *
+     * @return {@code windowEnd} itself when the interval is unusable (see {@link #usableMillis(Duration)}).
+     */
+    public static Instant endOfLastBucket(final Instant windowStart, final Instant windowEnd, final Duration interval) {
+        final long intervalMillis = usableMillis(interval);
+        if (intervalMillis == 0) {
+            return windowEnd;
+        }
+        final long startMillis = windowStart.toEpochMilli();
+        final long span = windowEnd.toEpochMilli() - startMillis;
+        final long buckets = Math.floorDiv(span, intervalMillis) + 1;
+        return Instant.ofEpochMilli(startMillis + buckets * intervalMillis);
+    }
+
+    /**
+     * @return the interval in milliseconds, or zero when it does not amount to at least one — which covers a
+     *         null, zero or negative duration, and also a positive one shorter than the millisecond the
+     *         histogram is expressed in.
+     */
+    private static long usableMillis(final Duration interval) {
+        if (interval == null) {
+            return 0L;
+        }
+        final long intervalMillis = interval.toMillis();
+        return intervalMillis <= 0 ? 0L : intervalMillis;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapter.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.repository.elasticsearch.utils.HistogramGrid;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseTimeRangeQuery;
 import io.reactivex.rxjava3.core.Maybe;
@@ -89,11 +90,15 @@ public class ResponseTimeRangeQueryAdapter {
         var v2orv4 = json().put("minimum_should_match", 1).set("should", apiFilter);
         var filterQuery = json().set("bool", v2orv4);
 
-        // we just ensure to fetch full bucket interval (a bit too)
-        var from = query.from().minus(query.interval());
-        var to = query.to().plus(query.interval());
+        // Align the bucket grid on the window itself. With the default epoch-aligned grid the bucket holding
+        // `from` starts before it, so the filter would have to reach back past `from` to fill it — and anything
+        // admitted there comes back as a bucket outside the window, because extended_bounds extends the
+        // returned range without clamping it. The upper bound stays open to the end of the last bucket so that
+        // bucket is complete, and stops at the end of that bucket so nothing can open one beyond the window.
+        var from = query.from();
+        var to = HistogramGrid.endOfLastBucket(query.from(), query.to(), query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lt", to.toEpochMilli());
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var bool = json().set("filter", array().add(filterQuery).add(rangeFilter));
@@ -105,6 +110,7 @@ public class ResponseTimeRangeQueryAdapter {
         ObjectNode histogram = json()
             .put("field", TIME_FIELD)
             .put(intervalFieldName, query.interval().toMillis() + "ms")
+            .put("offset", HistogramGrid.offsetMillis(query.from(), query.interval()) + "ms")
             .put("min_doc_count", 0)
             .set(
                 "extended_bounds",

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapter.java
@@ -23,6 +23,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.repository.elasticsearch.utils.HistogramGrid;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
 import java.time.Instant;
@@ -103,11 +104,15 @@ public class SearchResponseStatusOverTimeAdapter {
             apiFilter.add(filterV2);
         }
 
-        // we just ensure to fetch full bucket interval (a bit too)
-        Instant from = query.from().minus(query.interval());
-        Instant to = query.to().plus(query.interval());
+        // Align the bucket grid on the window itself. With the default epoch-aligned grid the bucket holding
+        // `from` starts before it, so the filter would have to reach back past `from` to fill it — and anything
+        // admitted there comes back as a bucket outside the window, because extended_bounds extends the
+        // returned range without clamping it. The upper bound stays open to the end of the last bucket so that
+        // bucket is complete, and stops at the end of that bucket so nothing can open one beyond the window.
+        Instant from = query.from();
+        Instant to = HistogramGrid.endOfLastBucket(query.from(), query.to(), query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lt", to.toEpochMilli());
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var v2orv4 = json().put("minimum_should_match", 1).set("should", apiFilter);
@@ -125,6 +130,7 @@ public class SearchResponseStatusOverTimeAdapter {
         ObjectNode histogram = json()
             .put("field", TIME_FIELD)
             .put(intervalFieldName, query.interval().toMillis() + "ms")
+            .put("offset", HistogramGrid.offsetMillis(query.from(), query.interval()) + "ms")
             .put("min_doc_count", 0)
             .set(
                 "extended_bounds",

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.repository.elasticsearch.utils.HistogramGrid;
 import io.gravitee.repository.healthcheck.v4.model.AverageHealthCheckResponseTimeOvertime;
 import io.gravitee.repository.healthcheck.v4.model.AverageHealthCheckResponseTimeOvertimeQuery;
 import io.reactivex.rxjava3.core.Maybe;
@@ -64,11 +65,15 @@ public class AverageHealthCheckResponseTimeOvertimeAdapter
 
     private ObjectNode query(AverageHealthCheckResponseTimeOvertimeQuery query) {
         JsonNode termFilter = json().set("term", json().put("api", query.apiId()));
-        // we just ensure to fetch full bucket interval
-        Instant from = query.from().minus(query.interval());
-        Instant to = query.to().plus(query.interval());
+        // Align the bucket grid on the window itself. With the default epoch-aligned grid the bucket holding
+        // `from` starts before it, so the filter would have to reach back past `from` to fill it — and anything
+        // admitted there comes back as a bucket outside the window, because extended_bounds extends the
+        // returned range without clamping it. The upper bound stays open to the end of the last bucket so that
+        // bucket is complete, and stops at the end of that bucket so nothing can open one beyond the window.
+        Instant from = query.from();
+        Instant to = HistogramGrid.endOfLastBucket(query.from(), query.to(), query.interval());
 
-        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lte", to.toEpochMilli());
+        ObjectNode timestamp = json().put("gte", from.toEpochMilli()).put("lt", to.toEpochMilli());
         JsonNode rangeFilter = json().set("range", json().set(TIME_FIELD, timestamp));
 
         var bool = json().set("filter", array().add(termFilter).add(rangeFilter));
@@ -80,6 +85,7 @@ public class AverageHealthCheckResponseTimeOvertimeAdapter
         ObjectNode histogram = json()
             .put("field", TIME_FIELD)
             .put(intervalFieldName, query.interval().toMillis() + "ms")
+            .put("offset", HistogramGrid.offsetMillis(query.from(), query.interval()) + "ms")
             .put("min_doc_count", 0)
             .set(
                 "extended_bounds",

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/HistogramGridTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/HistogramGridTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HistogramGridTest {
+
+    static Stream<Duration> intervals_that_do_not_amount_to_a_millisecond() {
+        return Stream.of(null, Duration.ZERO, Duration.ofMinutes(-10), Duration.ofNanos(500));
+    }
+
+    @Nested
+    class OffsetMillis {
+
+        static Stream<Instant> window_starts() {
+            return Stream.of(
+                Instant.parse("2026-08-24T10:17:42.123Z"),
+                Instant.parse("2026-08-24T10:30:00Z"),
+                Instant.parse("2026-08-24T00:00:00.001Z"),
+                Instant.parse("1969-12-31T23:52:30Z")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("window_starts")
+        void should_place_a_bucket_boundary_exactly_on_the_window_start(final Instant windowStart) {
+            // Given
+            final Duration interval = Duration.ofMinutes(10);
+
+            // When
+            final long offset = HistogramGrid.offsetMillis(windowStart, interval);
+
+            // Then
+            assertThat(offset).isGreaterThanOrEqualTo(0).isLessThan(interval.toMillis());
+            assertThat((windowStart.toEpochMilli() - offset) % interval.toMillis()).isZero();
+        }
+
+        @Test
+        void should_not_shift_the_grid_when_the_window_already_starts_on_a_boundary() {
+            // Given
+            final Instant windowStart = Instant.parse("2026-08-24T10:30:00Z");
+
+            // When
+            final long offset = HistogramGrid.offsetMillis(windowStart, Duration.ofMinutes(30));
+
+            // Then
+            assertThat(offset).isZero();
+        }
+
+        @Test
+        void should_return_a_positive_offset_for_a_window_starting_before_the_epoch() {
+            // Given
+            final Instant windowStart = Instant.parse("1969-12-31T23:52:30Z");
+
+            // When
+            final long offset = HistogramGrid.offsetMillis(windowStart, Duration.ofMinutes(10));
+
+            // Then
+            assertThat(offset).isEqualTo(Duration.ofMinutes(2).plusSeconds(30).toMillis());
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.repository.elasticsearch.utils.HistogramGridTest#intervals_that_do_not_amount_to_a_millisecond")
+        void should_not_shift_the_grid_when_the_interval_is_not_usable(final Duration interval) {
+            // Given
+            final Instant windowStart = Instant.parse("2026-08-24T10:17:42.123Z");
+
+            // When
+            final long offset = HistogramGrid.offsetMillis(windowStart, interval);
+
+            // Then
+            assertThat(offset).isZero();
+        }
+    }
+
+    @Nested
+    class EndOfLastBucket {
+
+        @Test
+        void should_stop_one_interval_past_the_window_when_it_spans_whole_intervals() {
+            // Given a window of exactly four intervals
+            final Instant from = Instant.parse("2026-08-24T10:00:00Z");
+            final Instant to = Instant.parse("2026-08-24T11:00:00Z");
+
+            // When
+            final Instant end = HistogramGrid.endOfLastBucket(from, to, Duration.ofMinutes(15));
+
+            // Then the last emitted bucket starts on the window end, so its own end is one interval further
+            assertThat(end).isEqualTo(Instant.parse("2026-08-24T11:15:00Z"));
+        }
+
+        @Test
+        void should_stop_at_the_end_of_the_bucket_holding_the_window_end_when_it_does_not() {
+            // Given a window of 59m53s bucketed by 15s: the grid sits on :07, so the last emitted bucket is
+            // 09:59:52 rather than one starting on the window end
+            final Instant from = Instant.parse("2026-08-24T09:00:07Z");
+            final Instant to = Instant.parse("2026-08-24T10:00:00Z");
+
+            // When
+            final Instant end = HistogramGrid.endOfLastBucket(from, to, Duration.ofSeconds(15));
+
+            // Then the bound is the end of that bucket, which leaves out a document at 10:00:10
+            assertThat(end).isEqualTo(Instant.parse("2026-08-24T10:00:07Z"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.repository.elasticsearch.utils.HistogramGridTest#intervals_that_do_not_amount_to_a_millisecond")
+        void should_return_the_window_end_when_the_interval_is_not_usable(final Duration interval) {
+            // Given
+            final Instant from = Instant.parse("2026-08-24T09:00:07Z");
+            final Instant to = Instant.parse("2026-08-24T10:00:00Z");
+
+            // When
+            final Instant end = HistogramGrid.endOfLastBucket(from, to, interval);
+
+            // Then
+            assertThat(end).isEqualTo(to);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -51,6 +51,7 @@ import io.gravitee.repository.log.v4.model.analytics.HistogramQuery;
 import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountByEventQuery;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
+import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusRangesAggregate;
@@ -496,6 +497,88 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                     .isEqualTo(3);
                 softly.assertThat(result.getStatusCount().get("404")).hasSize((int) nbBuckets).haveAtMost(2, not(is(0)));
             });
+        }
+
+        @Nested
+        class WindowBoundaries {
+
+            // The V2 sample documents for these two APIs all sit on the very same instant, one day before the
+            // shared reference. Deriving the windows from that instant keeps these cases independent of the hour
+            // the build runs at, while pinning what the window is supposed to include and exclude.
+            private static final Instant DOCUMENTS_AT = TimeProvider.now().minus(1, ChronoUnit.DAYS);
+            private static final Duration INTERVAL = Duration.ofMinutes(10);
+
+            private ResponseStatusOverTimeAggregate search(Instant from, Instant to) {
+                return cut.searchResponseStatusOvertime(
+                    new QueryContext("org#1", "env#1"),
+                    ResponseStatusOverTimeQuery.builder()
+                        .apiIds(List.of(APIV2_1, APIV2_2))
+                        .from(from)
+                        .to(to)
+                        .interval(INTERVAL)
+                        .versions(EnumSet.of(V2))
+                        .build()
+                );
+            }
+
+            @Test
+            void should_count_a_document_sitting_on_the_start_of_the_window_in_the_first_bucket() {
+                // Given a window starting exactly on the documents
+                var from = DOCUMENTS_AT;
+                var to = from.plus(1, ChronoUnit.HOURS);
+
+                // When
+                var result = search(from, to);
+
+                // Then the series spans the window and the documents land on its first point
+                SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(result.getStatusCount()).containsOnlyKeys("200", "401");
+                    softly.assertThat(result.getStatusCount().get("200")).hasSize(7).contains(2L, atIndex(0));
+                    softly.assertThat(result.getStatusCount().get("401")).hasSize(7).contains(2L, atIndex(0));
+                });
+            }
+
+            @Test
+            void should_ignore_a_document_one_millisecond_before_the_window() {
+                // Given a window opening just after the documents
+                var from = DOCUMENTS_AT.plusMillis(1);
+                var to = from.plus(1, ChronoUnit.HOURS);
+
+                // When
+                var result = search(from, to);
+
+                // Then nothing is reported: rounding the lower bound down to a bucket boundary would have
+                // counted them into the first point
+                assertThat(result.getStatusCount()).isEmpty();
+            }
+
+            @Test
+            void should_ignore_a_document_past_the_last_bucket_of_a_window_that_is_not_a_whole_number_of_intervals() {
+                // Given a window of 65 minutes bucketed by 10: it spans 6 whole intervals plus 5 minutes, so the
+                // last emitted bucket ends one minute before the documents. Stopping one interval past the window
+                // end instead would reach four minutes past them and report an eighth point.
+                var to = DOCUMENTS_AT.minus(6, ChronoUnit.MINUTES);
+                var from = to.minus(65, ChronoUnit.MINUTES);
+
+                // When
+                var result = search(from, to);
+
+                // Then
+                assertThat(result.getStatusCount()).isEmpty();
+            }
+
+            @Test
+            void should_ignore_a_document_past_the_end_of_the_last_bucket() {
+                // Given a window closing more than one interval before the documents
+                var to = DOCUMENTS_AT.minus(1, ChronoUnit.HOURS);
+                var from = to.minus(1, ChronoUnit.HOURS);
+
+                // When
+                var result = search(from, to);
+
+                // Then nothing is reported: the upper bound reaches the end of the last bucket and no further
+                assertThat(result.getStatusCount()).isEmpty();
+            }
         }
 
         private Condition<Long> is(long expected) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/ResponseTimeRangeQueryAdapterTest.java
@@ -26,6 +26,7 @@ import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.gravitee.elasticsearch.version.Version;
+import io.gravitee.repository.elasticsearch.utils.HistogramGrid;
 import io.gravitee.repository.log.v4.model.analytics.ResponseTimeRangeQuery;
 import java.time.Duration;
 import java.time.Instant;
@@ -67,12 +68,19 @@ class ResponseTimeRangeQueryAdapterTest {
             .toIterable()
             .extracting(JsonNode::asText)
             .contains("MyAPI");
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong()))
-            .isBeforeOrEqualTo(start)
-            .isCloseTo(start, within(interval.toMillis(), ChronoUnit.MILLIS));
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lte").asLong()))
-            .isAfterOrEqualTo(end)
-            .isCloseTo(end, within(interval.toMillis(), ChronoUnit.MILLIS));
+        // The bucket grid is shifted onto the window, so the filter starts exactly at `from`: nothing that
+        // happened before it can be counted.
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong())).isEqualTo(
+            start.truncatedTo(ChronoUnit.MILLIS)
+        );
+        // The upper bound is exclusive and reaches the end of the last bucket, so that bucket is complete and
+        // a document exactly on the bound cannot open one beyond the window.
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lt").asLong())).isEqualTo(
+            HistogramGrid.endOfLastBucket(start.truncatedTo(ChronoUnit.MILLIS), end.truncatedTo(ChronoUnit.MILLIS), interval)
+        );
+        assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/offset").asText()).isEqualTo(
+            HistogramGrid.offsetMillis(start, interval) + "ms"
+        );
         // aggs
         assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/field").asText()).isEqualTo("@timestamp");
         assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/fixed_interval").asText()).isEqualTo("1800000ms");
@@ -112,12 +120,19 @@ class ResponseTimeRangeQueryAdapterTest {
             .toIterable()
             .extracting(JsonNode::asText)
             .contains("MyAPI");
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong()))
-            .isBeforeOrEqualTo(start)
-            .isCloseTo(start, within(interval.toMillis(), ChronoUnit.MILLIS));
-        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lte").asLong()))
-            .isAfterOrEqualTo(end)
-            .isCloseTo(end, within(interval.toMillis(), ChronoUnit.MILLIS));
+        // The bucket grid is shifted onto the window, so the filter starts exactly at `from`: nothing that
+        // happened before it can be counted.
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/gte").asLong())).isEqualTo(
+            start.truncatedTo(ChronoUnit.MILLIS)
+        );
+        // The upper bound is exclusive and reaches the end of the last bucket, so that bucket is complete and
+        // a document exactly on the bound cannot open one beyond the window.
+        assertThat(Instant.ofEpochMilli(jsonQuery.at("/query/bool/filter/1/range/@timestamp/lt").asLong())).isEqualTo(
+            HistogramGrid.endOfLastBucket(start.truncatedTo(ChronoUnit.MILLIS), end.truncatedTo(ChronoUnit.MILLIS), interval)
+        );
+        assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/offset").asText()).isEqualTo(
+            HistogramGrid.offsetMillis(start, interval) + "ms"
+        );
         // aggs
         assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/field").asText()).isEqualTo("@timestamp");
         assertThat(jsonQuery.at("/aggregations/by_date/date_histogram/interval").asText()).isEqualTo("1800000ms");

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusOverTimeAdapterTest.java
@@ -72,6 +72,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                          "extended_bounds": { "max": 1697969730000, "min": 1697883330000 },
                          "field": "@timestamp",
                          "fixed_interval": "600000ms",
+                         "offset": "330000ms",
                          "min_doc_count": 0
                        }
                      }
@@ -83,8 +84,8 @@ class SearchResponseStatusOverTimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "gte": 1697883330000,
+                               "lt": 1697970330000
                              }
                            }
                          }
@@ -122,6 +123,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                          "extended_bounds": { "max": 1697969730000, "min": 1697883330000 },
                          "field": "@timestamp",
                          "fixed_interval": "600000ms",
+                         "offset": "330000ms",
                          "min_doc_count": 0
                        }
                      }
@@ -133,8 +135,8 @@ class SearchResponseStatusOverTimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "gte": 1697883330000,
+                               "lt": 1697970330000
                              }
                            }
                          }
@@ -172,6 +174,7 @@ class SearchResponseStatusOverTimeAdapterTest {
                          "extended_bounds": { "max": 1697969730000, "min": 1697883330000 },
                          "field": "@timestamp",
                          "interval": "600000ms",
+                         "offset": "330000ms",
                          "min_doc_count": 0
                        }
                      }
@@ -183,8 +186,8 @@ class SearchResponseStatusOverTimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "gte": 1697883330000,
+                               "lt": 1697970330000
                              }
                            }
                          }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/healthcheck/adapter/AverageHealthCheckResponseTimeOvertimeAdapterTest.java
@@ -59,6 +59,7 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          "extended_bounds": { "max": 1697969730000, "min": 1697883330000 },
                          "field": "@timestamp",
                          "fixed_interval": "600000ms",
+                         "offset": "330000ms",
                          "min_doc_count": 0
                        }
                      }
@@ -70,8 +71,8 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "gte": 1697883330000,
+                               "lt": 1697970330000
                              }
                            }
                          }
@@ -103,6 +104,7 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          "extended_bounds": { "max": 1697969730000, "min": 1697883330000 },
                          "field": "@timestamp",
                          "interval": "600000ms",
+                         "offset": "330000ms",
                          "min_doc_count": 0
                        }
                      }
@@ -114,8 +116,8 @@ class AverageHealthCheckResponseTimeOvertimeAdapterTest {
                          {
                            "range": {
                              "@timestamp": {
-                               "gte": 1697882730000,
-                               "lte": 1697970330000
+                               "gte": 1697883330000,
+                               "lt": 1697970330000
                              }
                            }
                          }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-240

## Description

Three time-series adapters widened their range filter by one interval on each side while `extended_bounds` stayed on `[from, to]`. `extended_bounds` extends the returned range — it does not clamp it; clamping is what `hard_bounds` does. A document admitted in the margin **before** `from` therefore came back as a bucket before the start of the window, and since these responses carry no timestamp per point — only `timeRange` plus ordered lists — the consumer can only place values by position. That leading bucket shifts **every point of the series by one interval**.

Asking for response statuses between 10:00 and 11:00 with a 10-minute interval, with one request at 09:52, three at 10:15 and two at 10:45:

```
before   8 buckets   [1, 0, 3, 0, 0, 2, 0, 0]   09:52 shown at 10:00, 10:15 shown at 10:20, …
after    7 buckets   [0, 3, 0, 0, 2, 0, 0]      each point on its true slot
```

### The fix

The root of it is that the bucket grid is aligned on epoch multiples of the interval, so the bucket holding `from` generally starts before it. That left no good option: filter strictly on the window and the first bucket is short; filter wider and the extra traffic comes back as a bucket outside the window.

The grid is now shifted onto the window itself, through the `offset` parameter of `date_histogram`:

```java
Instant from = query.from();
Instant to = query.to().plus(query.interval());
…
.put("offset", HistogramGrid.offsetMillis(query.from(), query.interval()) + "ms")
```

With a bucket boundary sitting exactly on `from`, the filter starts there — nothing that happened before the window is counted — and reaches the end of the last bucket, so that bucket stays complete. The upper bound is exclusive so a document landing exactly on it cannot open a bucket past `extended_bounds.max`.

`offset` is a long-standing `date_histogram` parameter on both Elasticsearch and OpenSearch, unlike `hard_bounds`, so no version gate is needed.

The series keeps its `(to − from) / interval + 1` points and the last one keeps its value. `TimeRangeAdapter` and `DateHistogramAdapter` never widened and are untouched.

## Additional context

**The existing repository tests already asserted the corrected behaviour** — the exact bucket count and the positional correspondence `index i ↔ from + i × interval`. They are unchanged and green.

New coverage, since the previous round of this PR showed that pinning the emitted query is not enough to catch a regression on either bound:

- `AnalyticsElasticsearchRepositoryTest.ResponseStatusOverTime.WindowBoundaries` asserts the returned series rather than the query: a document sitting exactly on `from` lands on the first point with the expected bucket count, a document one millisecond before `from` is not reported, and a document past the end of the last bucket is not reported either. The windows are derived from the instant the sample documents sit on, so the cases do not depend on the hour the build runs at.
- `HistogramGridTest` covers the grid offset itself, including windows already on a boundary, windows before the epoch, and intervals that do not amount to a millisecond.

Full module: **814 tests, 0 failures**, licence and prettier checks included.

### History of this branch

The first implementation rounded the filter bounds down to the epoch-aligned grid and dropped the trailing bound. Review showed both halves were wrong in different ways: rounding down still counted traffic from before `from` into the first bucket, and dropping the trailing bound left the last bucket emitted but empty — a regression on the final point of every series, since that bucket is emitted by `extended_bounds.max` whether or not the filter reaches it.

A claim made in the first description, that this branch unblocked the second half of FOUND-235, rested on that regression and does not hold. The constraint analysis on that ticket is being redone.
