### PR TITLE
fix(analytics): unbreak message analytics and add facets and time series

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -79,6 +79,18 @@ public interface AnalyticsRepository {
     MeasuresResult searchMessageMeasures(QueryContext queryContext, MeasuresQuery query);
 
     /**
+     * Message measures broken down by a dimension — operation, connector, API, application.
+     *
+     * <p>Like {@link #searchMessageMeasures}, resolves the matching connection documents first: the
+     * message index carries none of the connection dimensions, so a query filtered on plan or
+     * application can only be answered by joining on request id.
+     */
+    FacetsResult searchMessageFacets(QueryContext queryContext, FacetsQuery query);
+
+    /** Message measures over time, optionally split by a dimension. Same two-phase join. */
+    TimeSeriesResult searchMessageTimeSeries(QueryContext queryContext, TimeSeriesQuery query);
+
+    /**
      * Native Kafka event metrics, read from the {@code event-metrics} data stream (throughput per
      * topic, active connections, authentications, per-operation counters and durations) — as opposed
      * to {@code searchNativeApi*}, which reads connection documents from {@code v4-metrics}.

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
 import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
 import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
@@ -59,6 +60,8 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     private final FacetsResponseAdapter facetsResponseAdapter = new FacetsResponseAdapter();
     private final TimeSeriesResponseAdapter timeSeriesResponseAdapter = new TimeSeriesResponseAdapter();
     private final MessageMeasuresQueryAdapter messageMeasuresQueryAdapter = new MessageMeasuresQueryAdapter();
+    private final MessageFacetsQueryAdapter messageFacetsQueryAdapter = new MessageFacetsQueryAdapter();
+    private final MessageTimeSeriesQueryAdapter messageTimeSeriesQueryAdapter = new MessageTimeSeriesQueryAdapter();
     private final EventMetricsMeasuresQueryAdapter eventMetricsMeasuresQueryAdapter = new EventMetricsMeasuresQueryAdapter();
     private final EventMetricsFacetsQueryAdapter eventMetricsFacetsQueryAdapter = new EventMetricsFacetsQueryAdapter();
     private final EventMetricsTimeSeriesQueryAdapter eventMetricsTimeSeriesQueryAdapter = new EventMetricsTimeSeriesQueryAdapter();
@@ -442,12 +445,54 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
             .blockingGet();
     }
 
-    private Set<String> searchMessageConnectionRequestIDs(MeasuresQuery query, String httpIndex) {
+    @Override
+    public FacetsResult searchMessageFacets(QueryContext queryContext, FacetsQuery query) {
+        var httpIndex = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+
+        var httpConnectionRequestIDs = searchMessageConnectionRequestIDs(query, httpIndex);
+
+        if (httpConnectionRequestIDs.isEmpty()) {
+            return facetsResponseAdapter.empty(query);
+        }
+
+        var messageIndex = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_MESSAGE_METRICS, clusters);
+        var messageQuery = messageFacetsQueryAdapter.adapt(query, httpConnectionRequestIDs);
+
+        log.debug("Message - Facets query: {}", messageQuery);
+
+        return client
+            .search(messageIndex, null, messageQuery)
+            .map(response -> facetsResponseAdapter.adapt(response, query))
+            .blockingGet();
+    }
+
+    @Override
+    public TimeSeriesResult searchMessageTimeSeries(QueryContext queryContext, TimeSeriesQuery query) {
+        var httpIndex = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+
+        var httpConnectionRequestIDs = searchMessageConnectionRequestIDs(query, httpIndex);
+
+        if (httpConnectionRequestIDs.isEmpty()) {
+            return timeSeriesResponseAdapter.empty(query);
+        }
+
+        var messageIndex = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_MESSAGE_METRICS, clusters);
+        var messageQuery = messageTimeSeriesQueryAdapter.adapt(query, httpConnectionRequestIDs);
+
+        log.debug("Message - Time series query: {}", messageQuery);
+
+        return client
+            .search(messageIndex, null, messageQuery)
+            .map(response -> timeSeriesResponseAdapter.adapt(response, query))
+            .blockingGet();
+    }
+
+    private Set<String> searchMessageConnectionRequestIDs(Query query, String httpIndex) {
         return searchMessageConnectionRequestIDs(query, httpIndex, null, new HashSet<>(), 0);
     }
 
     private Set<String> searchMessageConnectionRequestIDs(
-        MeasuresQuery query,
+        Query query,
         String httpIndex,
         JsonObject afterKey,
         Set<String> accumulatedRequestIDs,

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FacetsResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FacetsResponseAdapter.java
@@ -40,7 +40,7 @@ public class FacetsResponseAdapter extends AbstractResponseAdapter {
         return new FacetsResult(AggregationAdapter.toMetricsAndBuckets(aggregations, query));
     }
 
-    FacetsResult empty(FacetsQuery query) {
+    public FacetsResult empty(FacetsQuery query) {
         return new FacetsResult(emptyMetrics(query));
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -167,6 +167,21 @@ public class FilterAdapter {
         return jsonFilters;
     }
 
+    /**
+     * Selects the connection documents whose messages a message query aggregates over.
+     *
+     * <p>Deliberately carries no entrypoint predicate. Which API a connection belongs to is already
+     * expressed by the {@code API} filter every query carries — {@code ApiTypeFilterTransformer}
+     * appends one unconditionally — and the second phase keeps only the request ids that have
+     * message documents, an index no other api type writes to. An entrypoint predicate would
+     * restate that guess in terms the entrypoint ids cannot support: they name plugins, and
+     * {@code http-get} / {@code http-post} serve Message APIs and LLM/MCP proxies alike.
+     *
+     * <p>This used to be {@code must_not(httpFilter())}, which read as "not a plain HTTP proxy" when
+     * {@code httpFilter()} held a single id. Every later widening of that list silently narrowed
+     * this one, and GMA-513 — adding http-get and http-post to fix LLM/MCP dashboards — made every
+     * Message API exposed over them invisible to message analytics.
+     */
     public JsonArray adaptForMessageConnexion(Query query) {
         var jsonFilters = JsonArray.of(TimeRangeAdapter.adapt(query));
         for (var filter : query.filters()) {
@@ -174,7 +189,7 @@ public class FilterAdapter {
                 jsonFilters.add(filter(filter));
             }
         }
-        return jsonFilters.add(messageFilter());
+        return jsonFilters;
     }
 
     public JsonArray adaptForNative(Query query) {
@@ -284,10 +299,6 @@ public class FilterAdapter {
 
     public JsonObject edgeFilter() {
         return JsonObject.of("term", JsonObject.of(ENTRYPOINT_FIELD, EDGE_ENTRYPOINT_ID));
-    }
-
-    public JsonObject messageFilter() {
-        return JsonObject.of("bool", JsonObject.of("must_not", JsonArray.of(httpFilter())));
     }
 
     private JsonObject filter(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFacetsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFacetsQueryAdapter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import io.gravitee.repository.analytics.engine.api.query.Facet;
+import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Breaks message measures down by a dimension — operation, connector, API, application.
+ *
+ * <p>Runs on the second phase of the message join: the caller resolves the connection documents
+ * first and passes their request ids in, because the message index carries none of the connection
+ * dimensions (no plan-id, no app-id, no entrypoint-id) and could not be filtered by them directly.
+ */
+public class MessageFacetsQueryAdapter {
+
+    private final MessageMeasuresQueryAdapter measuresAdapter = new MessageMeasuresQueryAdapter();
+    private final FilterAdapter filterAdapter = new FilterAdapter(new MessageFieldResolver());
+    private final BoolQueryAdapter boolAdapter = new BoolQueryAdapter(filterAdapter);
+
+    public String adapt(FacetsQuery query, Set<String> requestIDs) {
+        return json(query, requestIDs).toString();
+    }
+
+    private JsonObject json(FacetsQuery query, Set<String> requestIDs) {
+        var boolQuery = boolAdapter.messageFilter(query);
+        MessageRequestIdFilter.restrictTo(boolQuery, requestIDs);
+
+        return new JsonObject()
+            .put("size", 0)
+            .put("query", JsonObject.of("bool", boolQuery))
+            .put("aggs", adaptFacets(query.metrics(), query.facets(), query.limit()));
+    }
+
+    JsonObject adaptFacets(List<MetricMeasuresQuery> metrics, List<Facet> facets, Integer limit) {
+        var aggs = new JsonObject();
+        for (var metric : metrics) {
+            aggs.mergeIn(adaptFacets(metric, facets, limit));
+        }
+        return aggs;
+    }
+
+    /**
+     * Nests the requested dimensions, outermost first, and hangs the metric's measures off the
+     * innermost bucket — the shape {@code AggregationAdapter} unwraps on the way back.
+     *
+     * <p>Built top-down, one level per recursion, so every level is keyed by its own facet. Building
+     * it bottom-up is what let a child be keyed by its parent's name, which the response side —
+     * resolving the child strictly by name — cannot survive.
+     */
+    JsonObject adaptFacets(MetricMeasuresQuery metric, List<Facet> facets, Integer limit) {
+        var aggs = new JsonObject();
+        if (facets == null || facets.isEmpty()) {
+            return aggs;
+        }
+
+        var facet = facets.getFirst();
+        var isLast = facets.size() == 1;
+        var aggName = AggregationAdapter.adaptName(metric.metric(), facet);
+
+        aggs.put(aggName, isLast ? toTermsLeaf(metric, facet, limit) : toTerms(facet));
+
+        if (isLast) {
+            aggs.getJsonObject(aggName).put("aggs", measuresAdapter.adaptMeasures(metric));
+        } else {
+            aggs.getJsonObject(aggName).put("aggs", adaptFacets(metric, facets.subList(1, facets.size()), limit));
+        }
+
+        return aggs;
+    }
+
+    /**
+     * Only the innermost level carries {@code size} and {@code order}. Both rank buckets by a
+     * measure, and the measures hang off the leaf: Elasticsearch rejects the whole search when an
+     * order path names an aggregation absent from the level that declares it. {@code limit} belongs
+     * here for the same reason — applied at every level it would mean "top N at each depth" rather
+     * than "top N of the ranked dimension".
+     */
+    private JsonObject toTermsLeaf(MetricMeasuresQuery metric, Facet facet, Integer limit) {
+        var terms = new JsonObject().put("field", measuresAdapter.fieldResolver().fromFacet(facet));
+        // A null limit leaves Elasticsearch its default terms size of 10. Fine for the closed
+        // dimensions (operation, connector type); a caller ranking a high-cardinality one — connector
+        // id, application — must ask for the size it wants.
+        if (limit != null) {
+            terms.put("size", limit);
+        }
+        if (metric.sorts() != null && !metric.sorts().isEmpty()) {
+            var order = new JsonObject();
+            for (var sort : metric.sorts()) {
+                order.put(AggregationAdapter.adaptName(metric.metric(), sort.measure()), sort.order().name().toLowerCase());
+            }
+            terms.put("order", order);
+        }
+        return new JsonObject().put("terms", terms);
+    }
+
+    private JsonObject toTerms(Facet facet) {
+        return new JsonObject().put("terms", new JsonObject().put("field", measuresAdapter.fieldResolver().fromFacet(facet)));
+    }
+
+    /** Kept out of the class body so the facets and time-series adapters restrict identically. */
+    static final class MessageRequestIdFilter {
+
+        private MessageRequestIdFilter() {}
+
+        /**
+         * An empty id set means the first phase matched no connection, so the second must match no
+         * message. Both callers already return an empty response before reaching here; emitting a
+         * {@code terms} on an empty array rather than returning keeps that true of the adapter alone,
+         * because skipping the filter would widen the query instead of narrowing it.
+         */
+        static void restrictTo(JsonObject boolQuery, Set<String> requestIDs) {
+            var ids = requestIDs == null ? new ArrayList<String>() : new ArrayList<>(requestIDs);
+            var filters = boolQuery.getJsonArray("filter");
+            if (filters == null) {
+                filters = new JsonArray();
+                boolQuery.put("filter", filters);
+            }
+            filters.add(JsonObject.of("terms", JsonObject.of("request-id", new JsonArray(ids))));
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFieldResolver.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFieldResolver.java
@@ -38,13 +38,29 @@ public class MessageFieldResolver implements FieldResolver {
         };
     }
 
+    /**
+     * Only the dimensions a message document actually carries.
+     *
+     * <p>Deliberately not falling through to the HTTP resolver for the rest. It would answer
+     * {@code plan-id} or {@code application-id} — fields of the connection document, absent from
+     * this index — and Elasticsearch does not fail a terms aggregation on a field it cannot find:
+     * it returns no buckets. A breakdown that cannot work would render as an empty chart rather
+     * than an error, which is the harder failure to diagnose. Failing here keeps a drift between
+     * the catalog and this resolver visible.
+     *
+     * <p>{@code API} and {@code GATEWAY} do fall through, and are meant to: {@code api-id} and
+     * {@code gateway} are stamped on every message document.
+     */
     @Override
     public String fromFacet(Facet facet) {
         return switch (facet) {
             case MESSAGE_CONNECTOR_ID -> "connector-id";
             case MESSAGE_CONNECTOR_TYPE -> "connector-type";
             case MESSAGE_OPERATION_TYPE -> "operation";
-            default -> httpFieldResolver.fromFacet(facet);
+            case API, GATEWAY -> httpFieldResolver.fromFacet(facet);
+            default -> throw new UnsupportedOperationException(
+                "Message documents carry no %s dimension; it lives on the connection document".formatted(facet)
+            );
         };
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageMeasuresQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageMeasuresQueryAdapter.java
@@ -84,6 +84,24 @@ public class MessageMeasuresQueryAdapter {
         return JsonObject.of("terms", JsonObject.of("request-id", new JsonArray(requestIDsList)));
     }
 
+    /**
+     * Measure aggregations for one metric, without the surrounding query. Shared with the facets and
+     * time-series adapters so the three cannot disagree on how a message measure is built.
+     */
+    JsonObject adaptMeasures(MetricMeasuresQuery metric) {
+        var aggs = new JsonObject();
+        var field = fieldResolver.fromMetric(metric.metric());
+        for (var measure : metric.measures()) {
+            var aggName = AggregationAdapter.adaptName(metric.metric(), measure);
+            aggregate(aggName, field, measure).ifPresent(agg -> aggs.put(agg.keySet().iterator().next(), agg.values().iterator().next()));
+        }
+        return aggs;
+    }
+
+    FieldResolver fieldResolver() {
+        return fieldResolver;
+    }
+
     JsonObject adaptMetrics(List<MetricMeasuresQuery> metrics) {
         var aggs = new JsonObject();
         for (var metric : metrics) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageTimeSeriesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageTimeSeriesQueryAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.AggregationAdapter.TIME_SERIES_AGG_NAME;
+
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Message measures over time, optionally split by a dimension.
+ *
+ * <p>Like the facets adapter, this runs on the second phase of the message join and receives the
+ * request ids resolved from the connection documents.
+ */
+public class MessageTimeSeriesQueryAdapter {
+
+    private final MessageFacetsQueryAdapter facetsAdapter = new MessageFacetsQueryAdapter();
+    private final MessageMeasuresQueryAdapter measuresAdapter = new MessageMeasuresQueryAdapter();
+    private final FilterAdapter filterAdapter = new FilterAdapter(new MessageFieldResolver());
+    private final BoolQueryAdapter boolAdapter = new BoolQueryAdapter(filterAdapter);
+
+    public String adapt(TimeSeriesQuery query, Set<String> requestIDs) {
+        return json(query, requestIDs).toString();
+    }
+
+    private JsonObject json(TimeSeriesQuery query, Set<String> requestIDs) {
+        var boolQuery = boolAdapter.messageFilter(query);
+        MessageFacetsQueryAdapter.MessageRequestIdFilter.restrictTo(boolQuery, requestIDs);
+
+        return new JsonObject().put("size", 0).put("query", JsonObject.of("bool", boolQuery)).put("aggs", adaptTimeSeries(query));
+    }
+
+    JsonObject adaptTimeSeries(TimeSeriesQuery query) {
+        var aggs = new JsonObject();
+        for (var metric : query.metrics()) {
+            aggs.mergeIn(adaptTimeSeries(metric, query));
+        }
+        return aggs;
+    }
+
+    JsonObject adaptTimeSeries(MetricMeasuresQuery metric, TimeSeriesQuery query) {
+        var dateHistogram = DateHistogramAdapter.adapt(query.interval(), query.timeRange());
+
+        if (query.facets() != null && !query.facets().isEmpty()) {
+            dateHistogram.put("aggs", facetsAdapter.adaptFacets(List.of(metric), query.facets(), query.limit()));
+        } else {
+            dateHistogram.put("aggs", measuresAdapter.adaptMeasures(metric));
+        }
+
+        return new JsonObject().put(AggregationAdapter.adaptName(metric.metric(), TIME_SERIES_AGG_NAME), dateHistogram);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/TimeSeriesResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/TimeSeriesResponseAdapter.java
@@ -40,7 +40,7 @@ public class TimeSeriesResponseAdapter extends AbstractResponseAdapter {
         return new TimeSeriesResult(AggregationAdapter.toMetricsAndTimeSeries(aggregations, query));
     }
 
-    private TimeSeriesResult empty(TimeSeriesQuery query) {
+    public TimeSeriesResult empty(TimeSeriesQuery query) {
         return new TimeSeriesResult(emptyMetrics(query));
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.A2A_PROXY_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.ENTRYPOINT_FIELD;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_GET_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_POST_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_PROXY_ENTRYPOINT_ID;
@@ -274,6 +275,23 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
         assertThat(nestedMeasures).isNotNull();
     }
 
+    /**
+     * GMA-513 regression guard, from the side that broke.
+     *
+     * <p>{@code http-get} and {@code http-post} are Message API entrypoints as much as LLM/MCP ones
+     * — a plugin id says nothing about the api type. Adding them to the HTTP allow-list to fix
+     * LLM/MCP dashboards silently removed them here, because this query was that list's complement.
+     */
+    @Test
+    void should_not_exclude_connections_on_the_shared_http_entrypoints() throws JsonProcessingException {
+        var query = new MeasuresQuery(buildTimeRange(), buildFilters(), buildMetrics());
+
+        var jsonQuery = JSON.readTree(adapter.adaptRequestIDsQuery(query, null));
+
+        var filters = jsonQuery.at("/query/bool/filter").toString();
+        assertThat(filters).doesNotContain(HTTP_GET_ENTRYPOINT_ID).doesNotContain(HTTP_POST_ENTRYPOINT_ID);
+    }
+
     @Test
     void should_build_request_ids_query_with_composite_aggregation() throws JsonProcessingException {
         var timeRange = buildTimeRange();
@@ -290,35 +308,12 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
         assertThat(filterArray).isNotNull();
         assertThat(filterArray.isArray()).isTrue();
 
-        var messageFilter = filterArray.findValue("bool");
-        assertThat(messageFilter).isNotNull();
-
-        var mustNot = messageFilter.at("/must_not");
-        assertThat(mustNot).isNotNull();
-        assertThat(mustNot.isArray()).isTrue();
-
-        var httpFilterInMustNot = mustNot.at("/0/bool");
-        assertThat(httpFilterInMustNot).isNotNull();
-        var should = httpFilterInMustNot.at("/should");
-        assertThat(should).isNotNull();
-        assertThat(should.isArray()).isTrue();
-        assertThat(should.size()).isEqualTo(2);
-
-        var entrypointFilter = should.at("/0/terms/entrypoint-id");
-        assertThat(entrypointFilter).isNotNull();
-        assertThat(entrypointFilter.size()).isEqualTo(6);
-        assertThat(entrypointFilter.at("/0").asText()).isEqualTo(HTTP_GET_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/1").asText()).isEqualTo(HTTP_POST_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/2").asText()).isEqualTo(HTTP_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/3").asText()).isEqualTo(LLM_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/4").asText()).isEqualTo(MCP_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/5").asText()).isEqualTo(A2A_PROXY_ENTRYPOINT_ID);
-
-        var fieldMissingFilter = should.at("/1/bool/must_not/exists/field");
-        assertThat(fieldMissingFilter).isNotNull();
-        assertThat(fieldMissingFilter.asText()).isEqualTo("entrypoint-id");
-
-        assertThat(httpFilterInMustNot.at("/minimum_should_match").asInt()).isEqualTo(1);
+        // No entrypoint predicate. Which API a connection belongs to is already carried by the API
+        // filter every query gets, and the second phase keeps only request ids that have message
+        // documents. Guessing it from entrypoint ids is what made Message APIs on http-get /
+        // http-post invisible when GMA-513 added those ids to the HTTP side — this query used to be
+        // the complement of that list.
+        assertThat(filterArray.toString()).doesNotContain(ENTRYPOINT_FIELD);
 
         var aggs = jsonQuery.at("/aggs");
         assertThat(aggs).isNotEmpty();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFacetsQueryAdapterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.repository.analytics.engine.api.metric.Measure;
+import io.gravitee.repository.analytics.engine.api.metric.Metric;
+import io.gravitee.repository.analytics.engine.api.query.Facet;
+import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MessageFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
+
+    private final MessageFacetsQueryAdapter adapter = new MessageFacetsQueryAdapter();
+
+    private FacetsQuery sortedQuery(List<Facet> facets, Integer limit) {
+        return new FacetsQuery(
+            buildTimeRange(),
+            List.of(),
+            List.of(
+                new MetricMeasuresQuery(
+                    Metric.MESSAGES,
+                    Set.of(Measure.COUNT),
+                    List.of(new MetricMeasuresQuery.Sort(Measure.COUNT, MetricMeasuresQuery.Sort.Order.DESC))
+                )
+            ),
+            facets,
+            limit,
+            List.of()
+        );
+    }
+
+    private FacetsQuery query(List<Facet> facets, Integer limit) {
+        return new FacetsQuery(
+            buildTimeRange(),
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.MESSAGES, Set.of(Measure.COUNT))),
+            facets,
+            limit,
+            List.of()
+        );
+    }
+
+    @Test
+    void should_bucket_on_the_requested_dimension_and_hang_the_measures_off_it() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of(Facet.MESSAGE_OPERATION_TYPE), 10), Set.of("req-1")));
+
+        var bucket = json.at("/aggs").elements().next();
+        assertThat(bucket.at("/terms/field").asText()).isEqualTo("operation");
+        assertThat(bucket.at("/terms/size").asInt()).isEqualTo(10);
+        assertThat(bucket.at("/aggs").isEmpty()).isFalse();
+    }
+
+    /**
+     * Asserted by aggregation name, not by position: the response side resolves each child strictly
+     * by name, so walking the tree positionally would pass even if every level were keyed the same.
+     */
+    @Test
+    void should_nest_dimensions_outermost_first() throws JsonProcessingException {
+        var facets = List.of(Facet.MESSAGE_CONNECTOR_TYPE, Facet.MESSAGE_OPERATION_TYPE);
+
+        var json = JSON.readTree(adapter.adapt(query(facets, null), Set.of("req-1")));
+
+        var outer = json.at("/aggs/MESSAGES#MESSAGE_CONNECTOR_TYPE");
+        assertThat(outer.isMissingNode()).isFalse();
+        assertThat(outer.at("/terms/field").asText()).isEqualTo("connector-type");
+
+        var inner = outer.at("/aggs/MESSAGES#MESSAGE_OPERATION_TYPE");
+        assertThat(inner.isMissingNode()).isFalse();
+        assertThat(inner.at("/terms/field").asText()).isEqualTo("operation");
+
+        // Each level is keyed by its own facet: the parent's name must not reappear underneath it.
+        assertThat(outer.at("/aggs").has("MESSAGES#MESSAGE_CONNECTOR_TYPE")).isFalse();
+        // Measures hang off the innermost bucket, not the outer one.
+        assertThat(inner.at("/aggs").isEmpty()).isFalse();
+    }
+
+    /**
+     * Elasticsearch rejects the whole search when an order path names an aggregation absent from the
+     * level declaring it, and the measures only exist on the leaf.
+     */
+    @Test
+    void should_order_and_size_only_the_innermost_bucket() throws JsonProcessingException {
+        var facets = List.of(Facet.MESSAGE_CONNECTOR_TYPE, Facet.MESSAGE_OPERATION_TYPE);
+
+        var json = JSON.readTree(adapter.adapt(sortedQuery(facets, 5), Set.of("req-1")));
+
+        var outer = json.at("/aggs/MESSAGES#MESSAGE_CONNECTOR_TYPE");
+        assertThat(outer.at("/terms").has("order")).isFalse();
+        assertThat(outer.at("/terms").has("size")).isFalse();
+
+        var inner = outer.at("/aggs/MESSAGES#MESSAGE_OPERATION_TYPE");
+        assertThat(inner.at("/terms/order/MESSAGES#COUNT").asText()).isEqualTo("desc");
+        assertThat(inner.at("/terms/size").asInt()).isEqualTo(5);
+    }
+
+    @Test
+    void should_order_the_single_bucket_when_only_one_dimension_is_requested() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(sortedQuery(List.of(Facet.MESSAGE_OPERATION_TYPE), 5), Set.of("req-1")));
+
+        var bucket = json.at("/aggs/MESSAGES#MESSAGE_OPERATION_TYPE");
+        assertThat(bucket.at("/terms/order/MESSAGES#COUNT").asText()).isEqualTo("desc");
+        assertThat(bucket.at("/terms/size").asInt()).isEqualTo(5);
+    }
+
+    /**
+     * The message index carries no connection dimensions, so the second phase can only be narrowed
+     * by the request ids the first phase resolved.
+     */
+    @Test
+    void should_restrict_the_query_to_the_resolved_request_ids() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of(Facet.MESSAGE_OPERATION_TYPE), null), Set.of("req-1", "req-2")));
+
+        var filters = json.at("/query/bool/filter").toString();
+        assertThat(filters).contains("request-id").contains("req-1").contains("req-2");
+    }
+
+    @Test
+    void should_leave_elasticsearch_its_default_size_when_no_limit_is_asked_for() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of(Facet.MESSAGE_CONNECTOR_ID), null), Set.of("req-1")));
+
+        var bucket = json.at("/aggs").elements().next();
+        assertThat(bucket.at("/terms").has("size")).isFalse();
+    }
+
+    @Test
+    void should_aggregate_nothing_when_no_dimension_is_requested() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of(), null), Set.of("req-1")));
+
+        assertThat(json.at("/aggs").isEmpty()).isTrue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFieldResolverTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageFieldResolverTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.repository.analytics.engine.api.query.Facet;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MessageFieldResolverTest {
+
+    private final MessageFieldResolver resolver = new MessageFieldResolver();
+
+    @Test
+    void should_resolve_the_dimensions_a_message_document_carries() {
+        assertThat(resolver.fromFacet(Facet.MESSAGE_OPERATION_TYPE)).isEqualTo("operation");
+        assertThat(resolver.fromFacet(Facet.MESSAGE_CONNECTOR_TYPE)).isEqualTo("connector-type");
+        assertThat(resolver.fromFacet(Facet.MESSAGE_CONNECTOR_ID)).isEqualTo("connector-id");
+        assertThat(resolver.fromFacet(Facet.API)).isEqualTo("api-id");
+        assertThat(resolver.fromFacet(Facet.GATEWAY)).isEqualTo("gateway");
+    }
+
+    /**
+     * These live on the connection document, not on the message. Resolving them to their HTTP field
+     * names would aggregate on a field this index does not have — which Elasticsearch answers with
+     * no buckets rather than an error, turning a broken breakdown into an empty chart.
+     */
+    @ParameterizedTest
+    @EnumSource(value = Facet.class, names = { "APPLICATION", "PLAN", "TENANT", "ZONE" })
+    void should_refuse_a_dimension_the_message_index_does_not_carry(Facet facet) {
+        assertThatThrownBy(() -> resolver.fromFacet(facet))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining(facet.name());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageTimeSeriesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/MessageTimeSeriesQueryAdapterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.repository.analytics.engine.api.metric.Measure;
+import io.gravitee.repository.analytics.engine.api.metric.Metric;
+import io.gravitee.repository.analytics.engine.api.query.Facet;
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MessageTimeSeriesQueryAdapterTest extends AbstractQueryAdapterTest {
+
+    private final MessageTimeSeriesQueryAdapter adapter = new MessageTimeSeriesQueryAdapter();
+
+    private TimeSeriesQuery query(List<Facet> facets) {
+        return new TimeSeriesQuery(
+            buildTimeRange(),
+            List.of(),
+            60_000L,
+            List.of(new MetricMeasuresQuery(Metric.MESSAGES, Set.of(Measure.COUNT))),
+            facets,
+            null,
+            List.of()
+        );
+    }
+
+    @Test
+    void should_bucket_over_time_and_hang_the_measures_off_each_interval() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of()), Set.of("req-1")));
+
+        var series = json.at("/aggs").elements().next();
+        assertThat(series.has("date_histogram")).isTrue();
+        assertThat(series.at("/aggs").isEmpty()).isFalse();
+    }
+
+    @Test
+    void should_split_each_interval_by_the_requested_dimension() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of(Facet.MESSAGE_OPERATION_TYPE)), Set.of("req-1")));
+
+        var series = json.at("/aggs").elements().next();
+        var split = series.at("/aggs").elements().next();
+        assertThat(split.at("/terms/field").asText()).isEqualTo("operation");
+        // Measures sit under the split, so each interval yields one value per dimension value.
+        assertThat(split.at("/aggs").isEmpty()).isFalse();
+    }
+
+    @Test
+    void should_restrict_the_query_to_the_resolved_request_ids() throws JsonProcessingException {
+        var json = JSON.readTree(adapter.adapt(query(List.of()), Set.of("req-1", "req-2")));
+
+        var filters = json.at("/query/bool/filter").toString();
+        assertThat(filters).contains("request-id").contains("req-1").contains("req-2");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
@@ -152,6 +152,16 @@ public class NoOpAnalyticsRepository implements AnalyticsRepository {
     }
 
     @Override
+    public FacetsResult searchMessageFacets(QueryContext queryContext, FacetsQuery query) {
+        return new FacetsResult(List.of());
+    }
+
+    @Override
+    public TimeSeriesResult searchMessageTimeSeries(QueryContext queryContext, TimeSeriesQuery query) {
+        return new TimeSeriesResult(List.of());
+    }
+
+    @Override
     public MeasuresResult searchEventMetricsMeasures(QueryContext queryContext, MeasuresQuery query) {
         return new MeasuresResult(List.of());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/MessageDataPlaneQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/MessageDataPlaneQueryService.java
@@ -62,11 +62,15 @@ public class MessageDataPlaneQueryService implements AnalyticsEngineQueryService
 
     @Override
     public FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request) {
-        throw new UnsupportedOperationException("Facets are not supported for message analytics");
+        var query = AnalyticsMeasuresAdapter.INSTANCE.fromRequest(request);
+        var result = analyticsRepository.searchMessageFacets(context.getQueryContext(), query);
+        return AnalyticsMeasuresAdapter.INSTANCE.fromResult(result);
     }
 
     @Override
     public TimeSeriesResponse searchTimeSeries(ExecutionContext context, TimeSeriesRequest request) {
-        throw new UnsupportedOperationException("Time series are not supported for message analytics");
+        var query = AnalyticsMeasuresAdapter.INSTANCE.fromRequest(request);
+        var result = analyticsRepository.searchMessageTimeSeries(context.getQueryContext(), query);
+        return AnalyticsMeasuresAdapter.INSTANCE.fromResult(result);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -850,6 +850,12 @@ spec:
               - LLM_PROXY_MODEL
               - LLM_PROXY_PROVIDER
 
+        # The message index keys documents by request id and carries only the dimensions the gateway
+        # stamps on a message: operation, connector, api, gateway. It has no plan-id, app-id, tenant
+        # or zone — those live on the connection document. Declaring them here would advertise
+        # facets that silently return zero buckets, since Elasticsearch does not fail a terms
+        # aggregation on a field that does not exist. Faceting messages by application or plan needs
+        # the dimension carried across the request-id join first.
         - name: MESSAGE_PAYLOAD_SIZE
           label: Message Payload Size
           apis:
@@ -864,11 +870,7 @@ spec:
               - P99
           facets:
               - API
-              - APPLICATION
-              - PLAN
               - GATEWAY
-              - TENANT
-              - ZONE
               - MESSAGE_CONNECTOR_TYPE
               - MESSAGE_CONNECTOR_ID
               - MESSAGE_OPERATION_TYPE
@@ -892,11 +894,7 @@ spec:
               - COUNT
           facets:
               - API
-              - APPLICATION
-              - PLAN
               - GATEWAY
-              - TENANT
-              - ZONE
               - MESSAGE_CONNECTOR_TYPE
               - MESSAGE_CONNECTOR_ID
               - MESSAGE_OPERATION_TYPE
@@ -920,11 +918,7 @@ spec:
               - COUNT
           facets:
               - API
-              - APPLICATION
-              - PLAN
               - GATEWAY
-              - TENANT
-              - ZONE
               - MESSAGE_CONNECTOR_TYPE
               - MESSAGE_CONNECTOR_ID
               - MESSAGE_OPERATION_TYPE
@@ -953,11 +947,7 @@ spec:
               - P99
           facets:
               - API
-              - APPLICATION
-              - PLAN
               - GATEWAY
-              - TENANT
-              - ZONE
               - MESSAGE_CONNECTOR_TYPE
               - MESSAGE_CONNECTOR_ID
               - MESSAGE_OPERATION_TYPE


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-143

## Description

Message analytics were broken in a way nothing surfaced: **a Message API exposed over `http-get` or
`http-post` had none at all** — not a missing chart, zero everywhere, measures included. On top of
that, only measures were implemented; facets and time series threw.

### 1. Stop hiding Message APIs served over the shared HTTP entrypoints

The message query selected its connection documents with `must_not(httpFilter())`. That read as "not
a plain HTTP proxy" when it was written (GKO-1609, `db8442a2`, Nov 2025), because `httpFilter()` then
held a single id, `http-proxy`. It has been widened three times since, **each time for a need on the
HTTP side**, and each widening silently narrowed this one:

| Commit | Added to `httpFilter()` | Why |
|---|---|---|
| `db8442a2` | `http-proxy` | creation |
| `a67d1c50` — **GMA-513** | `http-get`, `http-post` | widgets returned 0 for LLM/MCP |
| `a610d378` | `a2a-proxy` | A2A support |

GMA-513 finished it: adding those two ids to fix LLM/MCP dashboards removed the same entrypoints from
the message side. Nothing caught it — no test covers this predicate from the message side.

The root cause is one predicate answering two opposite questions: "is this HTTP" and "is this
message", defined as its complement. Neither can move without moving the other.

**Removing it is safe rather than merely convenient.** Which API a connection belongs to is already
carried by the `API` filter `ApiTypeFilterTransformer` appends to *every* query, and the second phase
keeps only request ids that have message documents — an index no other api type writes to. The
predicate only ever narrowed the request-id set; it was never what made the result correct.

An entrypoint allow-list was the other option and is rejected on purpose: it restates the same guess,
and the next async connector would reproduce the bug. Entrypoint ids name plugins, not api types.

Adds the regression guard that was missing, stated from the side that broke.

### 2. Facets and time series

`MessageDataPlaneQueryService` answered measures and threw `UnsupportedOperationException` for the
other two, so a Message API could show totals and nothing else: no split by operation or connector,
no trend. Both new adapters run on the second phase of the message join and take the request ids the
first phase resolved. Measure building is shared with the measures adapter rather than copied.

### 3. A trap the wiring exposed

The catalog declared `APPLICATION`, `PLAN`, `TENANT` and `ZONE` as facets of every message metric,
and `MessageFieldResolver` delegated unknown facets to the HTTP resolver — which answers `plan-id`
and `application-id`, **fields the message index does not have**. Elasticsearch does not fail a terms
aggregation on a missing field; it returns no buckets. "Messages by application" would have rendered
as an empty chart with nothing to diagnose.

Verified against real documents:

| Facet | ES field | Buckets |
|---|---|---|
| `MESSAGE_OPERATION_TYPE` | `operation` | ✅ 2 |
| `MESSAGE_CONNECTOR_TYPE` | `connector-type` | ✅ 2 |
| `MESSAGE_CONNECTOR_ID` | `connector-id` | ✅ 3 |
| `API` / `GATEWAY` | `api-id` / `gateway` | ✅ |
| `APPLICATION` · `PLAN` · `TENANT` · `ZONE` | absent | ❌ **0** |

Fixed at both ends — the catalog declares only what the index carries, and the resolver throws
instead of delegating, so a future drift fails loudly. **Breaking messages down by application or
plan needs the dimension carried across the request-id join first**; until then those axes belong to
the `HTTP_*` metrics, which hold them on the connection document.

## Tests

815 green in `gravitee-apim-repository-elasticsearch`, Testcontainers suites included. New:
`MessageFacetsQueryAdapterTest`, `MessageTimeSeriesQueryAdapterTest`, `MessageFieldResolverTest`, and
the GMA-513 guard in `HTTPFacetsQueryAdapterTest`.

Verified on the SDK stack against an API built for it (`MSG http-post+http-get+sse -> kafka`):

| | Before | After |
|---|---|---|
| `MESSAGES` COUNT | **30** (the SSE messages only) | **260** |
| `MESSAGE_PAYLOAD_SIZE` AVG | 32 B | **45.9 B** |

The 45 `http-post` and 6 `http-get` message documents that were structurally invisible are now
counted.

## Additional context

- **Compatibility-sensitive**: `AnalyticsRepository` gains two methods (`NoOpAnalyticsRepository`
  updated); the analytics catalog drops four facets that never worked. `FacetsResponseAdapter.empty`
  and `TimeSeriesResponseAdapter.empty` become public, matching their `MeasuresResponseAdapter`
  sibling — they keep the requested metric names in an empty result, which rebuilding by hand would
  drop.
- **Worth a second opinion from whoever owns GMA-513** — the fix is in their blast radius, and the
  regression guard is written so the two concerns cannot collide again.
- Noticed while testing, out of scope here: a malformed filter (`"values"` instead of `"value"`) is
  silently ignored and answers 200 with zeros rather than being rejected.
- The logs half of ESM-143 is #19355.
