### PR TITLE
feat(authz): route schema documents to the PDP engines

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common.deployer;
+
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEnginePort;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzSchemaReactorDeployable;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.Set;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@CustomLog
+@RequiredArgsConstructor
+public class AuthzSchemaDeployer implements Deployer<AuthzSchemaReactorDeployable> {
+
+    private final AuthzEnginePort enginePort;
+
+    @Override
+    public Completable deploy(AuthzSchemaReactorDeployable deployable) {
+        Set<String> removed = deployable.removedTargetPdpIds();
+        Completable eviction = removed == null || removed.isEmpty()
+            ? Completable.complete()
+            : enginePort.removeSchema(deployable.environmentId(), deployable.docId(), removed);
+        return eviction
+            .andThen(
+                enginePort.addOrUpdateSchema(
+                    deployable.environmentId(),
+                    deployable.docId(),
+                    deployable.name(),
+                    deployable.schemaText(),
+                    deployable.targetPdpIds(),
+                    deployable.updatedAt()
+                )
+            )
+            .doOnComplete(() -> log.debug("Authz schema '{}' staged for next commit", deployable.docId()))
+            .doOnError(e -> log.warn("Failed to stage authz schema '{}': {}", deployable.docId(), e.getMessage()));
+    }
+
+    // TODO(AUTHZ-32): distributed replay for schema documents, tracked there with the rest of distributed
+    // sync. Until it lands, a secondary node with distributed sync enabled receives no schema at all:
+    // DefaultSyncManager runs either the distributed synchronizers or the repository ones and never both,
+    // so there is no fallback cycle. Opt-in only, the default wiring is NoopDistributedSyncService.
+    // No DistributedSyncService is injected until there is something to distribute.
+    @Override
+    public Completable doAfterDeployment(AuthzSchemaReactorDeployable deployable) {
+        return Completable.complete();
+    }
+
+    @Override
+    public Completable undeploy(AuthzSchemaReactorDeployable deployable) {
+        return enginePort
+            .removeSchema(deployable.environmentId(), deployable.docId(), deployable.targetPdpIds())
+            .doOnComplete(() -> log.debug("Authz schema '{}' staged for removal on next commit", deployable.docId()))
+            .doOnError(e -> log.warn("Failed to stage authz schema '{}' removal: {}", deployable.docId(), e.getMessage()));
+    }
+
+    @Override
+    public Completable doAfterUndeployment(AuthzSchemaReactorDeployable deployable) {
+        return Completable.complete();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEnginePort.java
@@ -43,6 +43,17 @@ public interface AuthzEnginePort {
 
     Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds);
 
+    Completable addOrUpdateSchema(
+        String environmentId,
+        String docId,
+        String name,
+        String schemaText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    );
+
+    Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds);
+
     Completable commit();
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
@@ -31,9 +31,12 @@ import java.util.stream.Collectors;
  * declares and hitting {@code NO_HANDLERS} on scopes that live on other nodes.
  *
  * <p>The global {@code default} scope (no tag) is always served (the bootstrap engine present on every
- * node). The {@code *} wildcard is expanded by the engine port to {@link #hostedFor(String)} plus
- * {@code default} and routed per-scope, so each node delivers a wildcard document to exactly the engines
- * it hosts.
+ * node). The {@code *} wildcard is expanded by the engine port and routed per-scope, so each node delivers
+ * a wildcard document to exactly the engines it hosts. Policies and entities expand to
+ * {@link #hostedFor(String)} plus {@code default}; <strong>schema documents expand to
+ * {@link #hostedFor(String)} only</strong>, because the bootstrap engine is shared across environments and
+ * a wildcard schema landing there would merge two environments' contracts into one. Targeting
+ * {@code default} explicitly still reaches it.
  *
  * <p>Tag gating mirrors API sharding ({@link io.gravitee.common.util.EnvironmentUtils#hasMatchingTags}):
  * an untagged gateway is a catch-all that serves every scope, a tagged gateway serves a scope whose tag

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gamma.definition.authz.AuthzSchema;
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import io.gravitee.repository.management.model.Event;
+import io.reactivex.rxjava3.core.Maybe;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@CustomLog
+@RequiredArgsConstructor
+public class AuthzSchemaMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public Maybe<AuthzSchemaReactorDeployable> toDeploy(Event event) {
+        return Maybe.fromCallable(() -> {
+            try {
+                AuthzSchema wire = objectMapper.readValue(event.getPayload(), AuthzSchema.class);
+                if (wire.getId() == null || wire.getId().isBlank()) {
+                    log.warn("Skipping authz schema DEPLOY event [{}] — missing id", event.getId());
+                    return null;
+                }
+                if (wire.getSchemaText() == null || wire.getSchemaText().isBlank()) {
+                    log.warn("Skipping authz schema DEPLOY event [{}] — missing or blank schemaText", event.getId());
+                    return null;
+                }
+                String resolvedName = wire.getName() != null && !wire.getName().isBlank() ? wire.getName() : wire.getId();
+                return AuthzSchemaReactorDeployable.builder()
+                    .docId(wire.getId())
+                    .name(resolvedName)
+                    .schemaText(wire.getSchemaText())
+                    .environmentId(wire.getEnvironmentId())
+                    .targetPdpIds(AuthzWire.targetPdpIdsOrEmpty(wire.getTargetPdpIds()))
+                    .updatedAt(event.getUpdatedAt() != null ? event.getUpdatedAt().getTime() : 0L)
+                    .syncAction(SyncAction.DEPLOY)
+                    .build();
+            } catch (Exception e) {
+                log.error("Unable to extract authz schema from PUBLISH event [{}]", event.getId(), e);
+                return null;
+            }
+        });
+    }
+
+    public Maybe<AuthzSchemaReactorDeployable> toUndeploy(Event event) {
+        return Maybe.fromCallable(() -> {
+            try {
+                AuthzSchema wire = objectMapper.readValue(event.getPayload(), AuthzSchema.class);
+                if (wire.getId() == null || wire.getId().isBlank()) {
+                    log.warn("Skipping authz schema UNDEPLOY event [{}] — missing id", event.getId());
+                    return null;
+                }
+                return AuthzSchemaReactorDeployable.builder()
+                    .docId(wire.getId())
+                    .name(wire.getId())
+                    .environmentId(wire.getEnvironmentId())
+                    .targetPdpIds(AuthzWire.targetPdpIdsOrEmpty(wire.getTargetPdpIds()))
+                    .syncAction(SyncAction.UNDEPLOY)
+                    .build();
+            } catch (Exception e) {
+                log.error("Unable to extract authz schema from UNPUBLISH event [{}]", event.getId(), e);
+                return null;
+            }
+        });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaReactorDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaReactorDeployable.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import java.util.Set;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Builder
+@Getter
+@Setter
+@Accessors(fluent = true)
+@EqualsAndHashCode
+@ToString(exclude = "schemaText")
+public class AuthzSchemaReactorDeployable implements AuthzScopedDeployable {
+
+    private String docId;
+    private long updatedAt;
+    // Carried for gateway-side logging only; the bus command sends docId and schemaText, nothing else.
+    private String name;
+    private String schemaText;
+    private String environmentId;
+    private Set<String> targetPdpIds;
+    // Scopes to evict on this deploy (applied placement − new target); gateway-internal, not on the wire.
+    private Set<String> removedTargetPdpIds;
+    private SyncAction syncAction;
+
+    @Override
+    public String id() {
+        return docId;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
@@ -47,6 +47,8 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     static final String OP_REMOVE_ENTITY = "removeEntity";
     static final String OP_ADD_OR_UPDATE_POLICY = "addOrUpdatePolicy";
     static final String OP_REMOVE_POLICY = "removePolicy";
+    static final String OP_ADD_OR_UPDATE_SCHEMA = "addOrUpdateSchema";
+    static final String OP_REMOVE_SCHEMA = "removeSchema";
     static final String OP_COMMIT = "commit";
 
     // Vertx default reply timeout is 30s — long enough to wedge a sync cycle when the PDP service
@@ -106,12 +108,17 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         if (parents != null && !parents.isEmpty()) {
             command.put("parents", new JsonArray(parents));
         }
-        return routeGated(environmentId, command, targetPdpIds, uid, updatedAt);
+        return routeGated(environmentId, command, expandWildcard(environmentId, targetPdpIds), uid, updatedAt);
     }
 
     @Override
     public Completable removeEntity(String environmentId, String uid, Set<String> targetPdpIds) {
-        return routeForget(environmentId, new JsonObject().put("op", OP_REMOVE_ENTITY).put("uid", uid), targetPdpIds, uid);
+        return routeForget(
+            environmentId,
+            new JsonObject().put("op", OP_REMOVE_ENTITY).put("uid", uid),
+            expandWildcard(environmentId, targetPdpIds),
+            uid
+        );
     }
 
     @Override
@@ -128,12 +135,42 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
             .put("docId", docId)
             .put("name", name)
             .put("policyText", policyText);
-        return routeGated(environmentId, command, targetPdpIds, docId, updatedAt);
+        return routeGated(environmentId, command, expandWildcard(environmentId, targetPdpIds), docId, updatedAt);
     }
 
     @Override
     public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
-        return routeForget(environmentId, new JsonObject().put("op", OP_REMOVE_POLICY).put("docId", docId), targetPdpIds, docId);
+        return routeForget(
+            environmentId,
+            new JsonObject().put("op", OP_REMOVE_POLICY).put("docId", docId),
+            expandWildcard(environmentId, targetPdpIds),
+            docId
+        );
+    }
+
+    @Override
+    public Completable addOrUpdateSchema(
+        String environmentId,
+        String docId,
+        String name,
+        String schemaText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    ) {
+        // The PDP consumer reads docId and schemaText and nothing else; name stays on the deployable
+        // for gateway-side logging.
+        JsonObject command = new JsonObject().put("op", OP_ADD_OR_UPDATE_SCHEMA).put("docId", docId).put("schemaText", schemaText);
+        return routeGated(environmentId, command, schemaScopes(environmentId, targetPdpIds, docId), docId, updatedAt);
+    }
+
+    @Override
+    public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+        return routeForget(
+            environmentId,
+            new JsonObject().put("op", OP_REMOVE_SCHEMA).put("docId", docId),
+            schemaScopes(environmentId, targetPdpIds, docId),
+            docId
+        );
     }
 
     @Override
@@ -219,12 +256,12 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         pendingByAddress.computeIfAbsent(address, k -> ConcurrentHashMap.newKeySet()).addAll(refs);
     }
 
-    private Completable routeGated(String environmentId, JsonObject command, Set<String> targetPdpIds, String docId, long updatedAt) {
-        if (targetPdpIds == null || targetPdpIds.isEmpty()) {
+    private Completable routeGated(String environmentId, JsonObject command, Set<String> scopes, String docId, long updatedAt) {
+        if (scopes.isEmpty()) {
             return Completable.complete();
         }
         List<Completable> sends = new ArrayList<>();
-        for (String scope : expandWildcard(environmentId, targetPdpIds)) {
+        for (String scope : scopes) {
             if (!hostedScopes.serves(environmentId, scope)) {
                 continue;
             }
@@ -249,12 +286,12 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         return Completable.merge(sends);
     }
 
-    private Completable routeForget(String environmentId, JsonObject command, Set<String> targetPdpIds, String docId) {
-        if (targetPdpIds == null || targetPdpIds.isEmpty()) {
+    private Completable routeForget(String environmentId, JsonObject command, Set<String> scopes, String docId) {
+        if (scopes.isEmpty()) {
             return Completable.complete();
         }
         List<Completable> sends = new ArrayList<>();
-        for (String scope : expandWildcard(environmentId, targetPdpIds)) {
+        for (String scope : scopes) {
             if (!hostedScopes.serves(environmentId, scope)) {
                 continue;
             }
@@ -278,6 +315,9 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     // default engine. Expanding to those and routing per-scope gives confirmed, retried delivery — unlike a
     // fire-and-forget broadcast — and a scope provisioned later is backfilled by the hydration path.
     private Set<String> expandWildcard(String environmentId, Set<String> targetPdpIds) {
+        if (targetPdpIds == null || targetPdpIds.isEmpty()) {
+            return Set.of();
+        }
         if (!targetPdpIds.contains(WILDCARD)) {
             return targetPdpIds;
         }
@@ -285,6 +325,38 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         expanded.remove(WILDCARD);
         expanded.addAll(hostedScopes.hostedFor(environmentId));
         expanded.add(DEFAULT_SCOPE);
+        return expanded;
+    }
+
+    // D7: "*" on a schema means every NAMED engine of the environment. Unlike expandWildcard it does not
+    // add the bootstrap engine, which is shared across environments — a wildcard schema landing there would
+    // merge two environments' contracts into one. Targeting "default" explicitly still works.
+    // A wildcard schema reaches only NAMED engines (D7), so on a node hosting none it expands to nothing
+    // and no command is sent. Policies never hit this, because their wildcard always includes the bootstrap
+    // engine, so the silence is specific to schema and would otherwise leave a single-node install running
+    // policies against no schema at all with nothing in the log to say so.
+    private Set<String> schemaScopes(String environmentId, Set<String> targetPdpIds, String docId) {
+        Set<String> scopes = expandWildcardWithoutBootstrap(environmentId, targetPdpIds);
+        if (scopes.isEmpty() && targetPdpIds != null && targetPdpIds.contains(WILDCARD)) {
+            log.warn(
+                "Authz schema '{}' targets every named engine of environment [{}], which hosts none, so it reaches nothing",
+                docId,
+                environmentId
+            );
+        }
+        return scopes;
+    }
+
+    private Set<String> expandWildcardWithoutBootstrap(String environmentId, Set<String> targetPdpIds) {
+        if (targetPdpIds == null || targetPdpIds.isEmpty()) {
+            return Set.of();
+        }
+        if (!targetPdpIds.contains(WILDCARD)) {
+            return targetPdpIds;
+        }
+        Set<String> expanded = new LinkedHashSet<>(targetPdpIds);
+        expanded.remove(WILDCARD);
+        expanded.addAll(hostedScopes.hostedFor(environmentId));
         return expanded;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/NoopAuthzEnginePort.java
@@ -57,6 +57,23 @@ public class NoopAuthzEnginePort implements AuthzEnginePort {
     }
 
     @Override
+    public Completable addOrUpdateSchema(
+        String environmentId,
+        String docId,
+        String name,
+        String schemaText,
+        Set<String> targetPdpIds,
+        long updatedAt
+    ) {
+        return Completable.complete();
+    }
+
+    @Override
+    public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+        return Completable.complete();
+    }
+
+    @Override
     public Completable commit() {
         return Completable.complete();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzEntityDeployerTest.java
@@ -157,6 +157,22 @@ class AuthzEntityDeployerTest {
             .build();
     }
 
+    @Test
+    void deploying_and_undeploying_an_entity_never_reaches_the_schema_ops() {
+        AuthzEntityReactorDeployable d = principal("idp.am.alice");
+
+        deployer.deploy(d).blockingAwait();
+        deployer.undeploy(d).blockingAwait();
+
+        assertThat(port.entityOps).isNotEmpty();
+        assertThat(port.schemaOps).as("the schema route is separate; an entity must never stage a schema").isEmpty();
+
+        // The assertion above is only worth anything if the recorder actually records; prove it here,
+        // otherwise gutting the recorder would leave the guard silently green.
+        port.addOrUpdateSchema("env-1", "probe", "n", "entity User;", Set.of("orders"), 1L).blockingAwait();
+        assertThat(port.schemaOps).containsExactly("addOrUpdateSchema:probe");
+    }
+
     private static class RecordingPort implements AuthzEnginePort {
 
         record EntityOp(String op, String uid, Map<String, Object> attributes, List<String> parents, Set<String> targetPdpIds) {}
@@ -196,6 +212,27 @@ class AuthzEntityDeployerTest {
 
         @Override
         public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
+            return Completable.complete();
+        }
+
+        final ConcurrentLinkedQueue<String> schemaOps = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Completable addOrUpdateSchema(
+            String environmentId,
+            String docId,
+            String name,
+            String schemaText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            schemaOps.add("addOrUpdateSchema:" + docId);
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+            schemaOps.add("removeSchema:" + docId);
             return Completable.complete();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzPolicyDeployerTest.java
@@ -204,6 +204,22 @@ class AuthzPolicyDeployerTest {
             .build();
     }
 
+    @Test
+    void deploying_and_undeploying_a_policy_never_reaches_the_schema_ops() {
+        AuthzPolicyReactorDeployable d = global("doc-schema-guard", "Default deny", "permit(p,a,r);");
+
+        deployer.deploy(d).blockingAwait();
+        deployer.undeploy(d).blockingAwait();
+
+        assertThat(port.policyOps).isNotEmpty();
+        assertThat(port.schemaOps).as("the schema route is separate; a policy must never stage a schema").isEmpty();
+
+        // The assertion above is only worth anything if the recorder actually records; prove it here,
+        // otherwise gutting the recorder would leave the guard silently green.
+        port.addOrUpdateSchema("env-1", "probe", "n", "entity User;", Set.of("orders"), 1L).blockingAwait();
+        assertThat(port.schemaOps).containsExactly("addOrUpdateSchema:probe");
+    }
+
     private static class RecordingPort implements AuthzEnginePort {
 
         record PolicyOp(String op, String docId, String name, String policyText, Set<String> targetPdpIds) {}
@@ -243,6 +259,27 @@ class AuthzPolicyDeployerTest {
         @Override
         public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
             policyOps.add(new PolicyOp("removePolicy", docId, null, null, targetPdpIds));
+            return Completable.complete();
+        }
+
+        final ConcurrentLinkedQueue<String> schemaOps = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Completable addOrUpdateSchema(
+            String environmentId,
+            String docId,
+            String name,
+            String schemaText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            schemaOps.add("addOrUpdateSchema:" + docId);
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+            schemaOps.add("removeSchema:" + docId);
             return Completable.complete();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.common.deployer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzEnginePort;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzSchemaReactorDeployable;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.subjects.CompletableSubject;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AuthzSchemaDeployerTest {
+
+    private RecordingPort port;
+    private AuthzSchemaDeployer deployer;
+
+    @BeforeEach
+    void setUp() {
+        port = new RecordingPort();
+        deployer = new AuthzSchemaDeployer(port);
+    }
+
+    @Test
+    void deploy_stages_the_document_against_its_targets() {
+        deployer.deploy(schema("doc-1", "Fleet schema", "entity User;", Set.of("orders"), null)).blockingAwait();
+
+        assertThat(port.ops).hasSize(1);
+        RecordingPort.SchemaOp op = port.ops.peek();
+        assertThat(op.op()).isEqualTo("addOrUpdateSchema");
+        assertThat(op.docId()).isEqualTo("doc-1");
+        assertThat(op.name()).isEqualTo("Fleet schema");
+        assertThat(op.schemaText()).isEqualTo("entity User;");
+        assertThat(op.targetPdpIds()).containsExactly("orders");
+    }
+
+    @Test
+    void deploy_does_not_start_staging_until_the_eviction_has_completed() {
+        // Ordering, proven by holding the eviction open. Asserting only the recorded sequence is not enough:
+        // with both sources synchronous, even a concurrent operator like mergeWith produces remove-then-add,
+        // so such a test stays green after the sequencing is broken.
+        port.removeGate = CompletableSubject.create();
+
+        deployer.deploy(schema("doc-2", "n", "entity User;", Set.of("orders"), Set.of("stock"))).subscribe();
+
+        assertThat(port.ops)
+            .extracting(RecordingPort.SchemaOp::op)
+            .as("staging must not begin while the eviction is still in flight")
+            .containsExactly("removeSchema");
+
+        port.removeGate.onComplete();
+
+        assertThat(port.ops).extracting(RecordingPort.SchemaOp::op).containsExactly("removeSchema", "addOrUpdateSchema");
+    }
+
+    @Test
+    void deploy_evicts_dropped_scopes_before_staging_the_new_targets() {
+        deployer.deploy(schema("doc-2", "n", "entity User;", Set.of("orders"), Set.of("stock"))).blockingAwait();
+
+        assertThat(port.ops).hasSize(2);
+        assertThat(port.ops)
+            .extracting(RecordingPort.SchemaOp::op)
+            .as("eviction must precede staging, otherwise a retarget leaves the schema live on the old engine")
+            .containsExactly("removeSchema", "addOrUpdateSchema");
+        assertThat(port.ops.peek().targetPdpIds()).containsExactly("stock");
+    }
+
+    @Test
+    void deploy_without_dropped_scopes_does_not_emit_a_removal() {
+        deployer.deploy(schema("doc-3", "n", "entity User;", Set.of("orders"), Set.of())).blockingAwait();
+
+        assertThat(port.ops).extracting(RecordingPort.SchemaOp::op).containsExactly("addOrUpdateSchema");
+    }
+
+    @Test
+    void undeploy_removes_the_document_from_its_targets() {
+        AuthzSchemaReactorDeployable d = schema("doc-4", "n", "entity User;", Set.of("orders", "stock"), null);
+        d.syncAction(SyncAction.UNDEPLOY);
+
+        deployer.undeploy(d).blockingAwait();
+
+        assertThat(port.ops).hasSize(1);
+        assertThat(port.ops.peek().op()).isEqualTo("removeSchema");
+        assertThat(port.ops.peek().docId()).isEqualTo("doc-4");
+        assertThat(port.ops.peek().targetPdpIds()).containsExactlyInAnyOrder("orders", "stock");
+    }
+
+    @Test
+    void the_deployer_never_touches_the_policy_or_entity_paths() {
+        deployer.deploy(schema("doc-5", "n", "entity User;", Set.of("orders"), Set.of("stock"))).blockingAwait();
+
+        assertThat(port.otherOps).isEmpty();
+    }
+
+    private static AuthzSchemaReactorDeployable schema(
+        String docId,
+        String name,
+        String schemaText,
+        Set<String> targets,
+        Set<String> removed
+    ) {
+        return AuthzSchemaReactorDeployable.builder()
+            .docId(docId)
+            .name(name)
+            .schemaText(schemaText)
+            .environmentId("env-1")
+            .targetPdpIds(targets)
+            .removedTargetPdpIds(removed)
+            .updatedAt(1L)
+            .syncAction(SyncAction.DEPLOY)
+            .build();
+    }
+
+    private static class RecordingPort implements AuthzEnginePort {
+
+        record SchemaOp(String op, String docId, String name, String schemaText, Set<String> targetPdpIds) {}
+
+        final ConcurrentLinkedQueue<SchemaOp> ops = new ConcurrentLinkedQueue<>();
+        /** When set, removeSchema does not complete until the test releases it. */
+        CompletableSubject removeGate;
+        final ConcurrentLinkedQueue<String> otherOps = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Completable addOrUpdateEntity(
+            String environmentId,
+            String uid,
+            Map<String, Object> attributes,
+            List<String> parents,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            otherOps.add("addOrUpdateEntity");
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removeEntity(String environmentId, String uid, Set<String> targetPdpIds) {
+            otherOps.add("removeEntity");
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable addOrUpdatePolicy(
+            String environmentId,
+            String docId,
+            String name,
+            String policyText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            otherOps.add("addOrUpdatePolicy");
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
+            otherOps.add("removePolicy");
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable addOrUpdateSchema(
+            String environmentId,
+            String docId,
+            String name,
+            String schemaText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            // Recorded on subscribe, not when the chain is assembled: Java evaluates this call's arguments
+            // before andThen() runs, so recording in the method body makes any ordering assertion vacuous.
+            return Completable.fromAction(() -> ops.add(new SchemaOp("addOrUpdateSchema", docId, name, schemaText, targetPdpIds)));
+        }
+
+        @Override
+        public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+            return Completable.fromAction(() -> ops.add(new SchemaOp("removeSchema", docId, null, null, targetPdpIds))).andThen(
+                removeGate == null ? Completable.complete() : removeGate
+            );
+        }
+
+        @Override
+        public Completable commit() {
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable commitScope(String environmentId, String targetPdpId) {
+            return Completable.complete();
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
@@ -100,6 +100,7 @@ class AuthzEventToEngineIntegrationTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(port.ops).containsExactly("addOrUpdateEntity:Resource::\"api.bookings\"", "commit");
+        assertThat(port.schemaOps).as("an entity event must not reach the schema route").isEmpty();
     }
 
     @Test
@@ -123,6 +124,7 @@ class AuthzEventToEngineIntegrationTest {
         synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         assertThat(port.ops).containsExactly("addOrUpdatePolicy:doc-1", "commit");
+        assertThat(port.schemaOps).as("a policy event must not reach the schema route").isEmpty();
     }
 
     private static ThreadPoolExecutor executor() {
@@ -176,6 +178,27 @@ class AuthzEventToEngineIntegrationTest {
         @Override
         public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
             ops.add("removePolicy:" + docId);
+            return Completable.complete();
+        }
+
+        final ConcurrentLinkedQueue<String> schemaOps = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Completable addOrUpdateSchema(
+            String environmentId,
+            String docId,
+            String name,
+            String schemaText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            schemaOps.add("addOrUpdateSchema:" + docId);
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+            schemaOps.add("removeSchema:" + docId);
             return Completable.complete();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
@@ -186,6 +186,7 @@ class AuthzHydrationPlacementTest {
 
         assertThat(port.ops).contains("removeEntity:" + ENGINE_UID + ":[scope-b]");
         assertThat(entityPlacement.applied(ENV + ":" + ENTITY_ID)).containsExactly("scope-a");
+        assertThat(port.schemaOps).as("an entity retarget must not reach the schema route").isEmpty();
     }
 
     @Test
@@ -221,6 +222,7 @@ class AuthzHydrationPlacementTest {
 
         assertThat(port.ops).noneMatch(op -> op.startsWith("removeEntity:"));
         assertThat(port.ops).contains("addOrUpdateEntity:" + ENGINE_UID + ":[*]");
+        assertThat(port.schemaOps).as("an entity widen must not reach the schema route").isEmpty();
     }
 
     private static ThreadPoolExecutor executor() {
@@ -292,6 +294,27 @@ class AuthzHydrationPlacementTest {
         @Override
         public Completable removePolicy(String environmentId, String docId, Set<String> targetPdpIds) {
             ops.add("removePolicy:" + docId);
+            return Completable.complete();
+        }
+
+        final ConcurrentLinkedQueue<String> schemaOps = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Completable addOrUpdateSchema(
+            String environmentId,
+            String docId,
+            String name,
+            String schemaText,
+            Set<String> targetPdpIds,
+            long updatedAt
+        ) {
+            schemaOps.add("addOrUpdateSchema:" + docId);
+            return Completable.complete();
+        }
+
+        @Override
+        public Completable removeSchema(String environmentId, String docId, Set<String> targetPdpIds) {
+            schemaOps.add("removeSchema:" + docId);
             return Completable.complete();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapperTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
+import io.gravitee.repository.management.model.Event;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+class AuthzSchemaMapperTest {
+
+    private final AuthzSchemaMapper mapper = new AuthzSchemaMapper(new ObjectMapper());
+
+    @Test
+    void toDeploy_yields_a_deployable_carrying_the_schema_source_and_targets() {
+        Event event = event(
+            "evt-1",
+            """
+            {
+              "id": "doc-uuid-1",
+              "name": "Fleet schema",
+              "schemaText": "namespace ds { entity Car; }",
+              "environmentId": "env-1",
+              "targetPdpIds": ["stock@eu", "orders"]
+            }
+            """
+        );
+        event.setUpdatedAt(new Date(1_700_000_000_000L));
+
+        AuthzSchemaReactorDeployable d = mapper.toDeploy(event).blockingGet();
+
+        assertThat(d).isNotNull();
+        assertThat(d.docId()).isEqualTo("doc-uuid-1");
+        assertThat(d.name()).isEqualTo("Fleet schema");
+        assertThat(d.schemaText()).isEqualTo("namespace ds { entity Car; }");
+        assertThat(d.environmentId()).isEqualTo("env-1");
+        assertThat(d.targetPdpIds()).containsExactlyInAnyOrder("stock@eu", "orders");
+        assertThat(d.updatedAt()).isEqualTo(1_700_000_000_000L);
+        assertThat(d.syncAction()).isEqualTo(SyncAction.DEPLOY);
+    }
+
+    @Test
+    void toDeploy_falls_back_to_the_id_when_the_name_is_missing() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toDeploy(
+                event(
+                    "evt-2",
+                    """
+                    {"id": "doc-uuid-2", "schemaText": "entity User;"}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d.name()).isEqualTo("doc-uuid-2");
+    }
+
+    @Test
+    void toDeploy_skips_an_event_without_an_id() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toDeploy(
+                event(
+                    "evt-3",
+                    """
+                    {"schemaText": "entity User;"}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNull();
+    }
+
+    @Test
+    void toDeploy_skips_an_event_whose_schemaText_is_blank() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toDeploy(
+                event(
+                    "evt-4",
+                    """
+                    {"id": "doc-uuid-4", "schemaText": "   "}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).as("a blank document would flip the engine out of the no-schema state for nothing").isNull();
+    }
+
+    @Test
+    void toDeploy_skips_an_unparseable_payload_instead_of_failing_the_cycle() {
+        AuthzSchemaReactorDeployable d = mapper.toDeploy(event("evt-5", "{not json")).blockingGet();
+
+        assertThat(d).isNull();
+    }
+
+    @Test
+    void toUndeploy_needs_only_the_id_and_the_targets() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toUndeploy(
+                event(
+                    "evt-6",
+                    """
+                    {"id": "doc-uuid-6", "environmentId": "env-1", "targetPdpIds": ["orders"]}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNotNull();
+        assertThat(d.docId()).isEqualTo("doc-uuid-6");
+        assertThat(d.targetPdpIds()).containsExactly("orders");
+        assertThat(d.syncAction()).isEqualTo(SyncAction.UNDEPLOY);
+    }
+
+    @Test
+    void toUndeploy_does_not_require_schemaText() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toUndeploy(
+                event(
+                    "evt-7",
+                    """
+                    {"id": "doc-uuid-7"}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNotNull();
+        assertThat(d.docId()).isEqualTo("doc-uuid-7");
+    }
+
+    @Test
+    void toUndeploy_skips_an_event_without_an_id() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toUndeploy(
+                event(
+                    "evt-8",
+                    """
+                    {"name": "orphan"}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNull();
+    }
+
+    @Test
+    void an_absent_target_set_maps_to_empty_not_null() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toDeploy(
+                event(
+                    "evt-9",
+                    """
+                    {"id": "doc-uuid-9", "schemaText": "entity User;"}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d.targetPdpIds()).isNotNull().isEmpty();
+    }
+
+    private static Event event(String id, String payload) {
+        Event event = new Event();
+        event.setId(id);
+        event.setPayload(payload);
+        return event;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortSchemaTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortSchemaTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class EventBusAuthzEnginePortSchemaTest {
+
+    private static final String DEFAULT_ADDRESS = "service:authz-pdp:sync";
+    private static final String SCHEMA_TEXT = "entity User;";
+
+    private Vertx vertx;
+    private final ConcurrentLinkedQueue<String> hits = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<JsonObject> commands = new ConcurrentLinkedQueue<>();
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() {
+        vertx.close();
+    }
+
+    private EventBusAuthzEnginePort portServingAll() {
+        return new EventBusAuthzEnginePort(vertx, HostedScopesFixtures.servingAll(), new AuthzAppliedRevisions());
+    }
+
+    private void recordAndReplyOn(String address) {
+        vertx
+            .eventBus()
+            .<JsonObject>consumer(address, msg -> {
+                hits.add(address);
+                commands.add(msg.body());
+                msg.reply(new JsonObject().put("commitGeneration", 1L));
+            });
+    }
+
+    @Test
+    void the_add_command_carries_only_docId_and_schemaText() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "fleet schema", SCHEMA_TEXT, Set.of("api-a"), 1L).blockingAwait();
+
+        JsonObject command = commands.poll();
+        assertThat(command.getString("op")).isEqualTo("addOrUpdateSchema");
+        assertThat(command.getString("docId")).isEqualTo("s1");
+        assertThat(command.getString("schemaText")).isEqualTo(SCHEMA_TEXT);
+        assertThat(command.fieldNames())
+            .as("the PDP consumer reads only docId and schemaText, so name must not go on the bus")
+            .containsExactlyInAnyOrder("op", "docId", "schemaText");
+    }
+
+    @Test
+    void the_remove_command_carries_only_docId() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+
+        portServingAll().removeSchema("env-1", "s1", Set.of("api-a")).blockingAwait();
+
+        JsonObject command = commands.poll();
+        assertThat(command.getString("op")).isEqualTo("removeSchema");
+        assertThat(command.fieldNames()).containsExactlyInAnyOrder("op", "docId");
+    }
+
+    @Test
+    void a_scoped_schema_reaches_its_env_namespaced_address_only() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("api-a"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:api-a");
+    }
+
+    @Test
+    void a_tagged_scope_addresses_the_base_engine_with_the_tag_stripped() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:stock");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:stock@eu");
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock@eu"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:stock");
+    }
+
+    @Test
+    void two_tag_variants_of_one_engine_send_twice_to_the_same_address_idempotently() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:stock");
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock@eu", "stock@us"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:stock", "service:authz-pdp:sync:scope:env-1:stock");
+        assertThat(commands)
+            .extracting(c -> c.getString("docId"))
+            .containsExactly("s1", "s1");
+    }
+
+    @Test
+    void a_scope_this_node_does_not_serve_is_not_routed() {
+        AuthzHostedScopes hosted = new AuthzHostedScopes();
+        hosted.markHosted("env-1", "api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
+
+        new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions())
+            .addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("api-b"), 1L)
+            .blockingAwait();
+
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void wildcard_reaches_every_hosted_engine_but_never_the_bootstrap_engine() {
+        // D7: "*" on a schema means every NAMED engine of the environment. The default engine is shared
+        // across environments, so a wildcard schema must not land on it.
+        AuthzHostedScopes hosted = new AuthzHostedScopes();
+        hosted.markHosted("env-1", "api-a");
+        hosted.markHosted("env-1", "api-b");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-b");
+        recordAndReplyOn(DEFAULT_ADDRESS);
+
+        new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions())
+            .addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("*"), 1L)
+            .blockingAwait();
+
+        assertThat(hits).containsExactlyInAnyOrder("service:authz-pdp:sync:scope:env-1:api-a", "service:authz-pdp:sync:scope:env-1:api-b");
+        assertThat(hits).as("the bootstrap engine is cross-environment, D7 excludes it").doesNotContain(DEFAULT_ADDRESS);
+    }
+
+    @Test
+    void wildcard_removal_also_spares_the_bootstrap_engine() {
+        AuthzHostedScopes hosted = new AuthzHostedScopes();
+        hosted.markHosted("env-1", "api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn(DEFAULT_ADDRESS);
+
+        new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions()).removeSchema("env-1", "s1", Set.of("*")).blockingAwait();
+
+        assertThat(hits).containsExactly("service:authz-pdp:sync:scope:env-1:api-a");
+    }
+
+    @Test
+    void an_explicit_default_target_still_reaches_the_bootstrap_engine() {
+        // D7 removes the IMPLICIT bootstrap fan-out only. Targeting "default" by name is a documented,
+        // cross-environment choice and stays possible.
+        recordAndReplyOn(DEFAULT_ADDRESS);
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("default"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly(DEFAULT_ADDRESS);
+    }
+
+    @Test
+    void an_empty_target_set_sends_nothing() {
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+
+        portServingAll().addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of(), 1L).blockingAwait();
+
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void a_policy_wildcard_still_reaches_the_bootstrap_engine() {
+        // Regression: the schema-specific expansion must not change the shared policy path.
+        AuthzHostedScopes hosted = new AuthzHostedScopes();
+        hosted.markHosted("env-1", "api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn(DEFAULT_ADDRESS);
+
+        new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions())
+            .addOrUpdatePolicy("env-1", "p1", "n", "permit(principal, action, resource);", Set.of("*"), 1L)
+            .blockingAwait();
+
+        assertThat(hits).contains(DEFAULT_ADDRESS);
+    }
+
+    @Test
+    void an_entity_wildcard_still_reaches_the_bootstrap_engine() {
+        AuthzHostedScopes hosted = new AuthzHostedScopes();
+        hosted.markHosted("env-1", "api-a");
+        recordAndReplyOn("service:authz-pdp:sync:scope:env-1:api-a");
+        recordAndReplyOn(DEFAULT_ADDRESS);
+
+        new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions())
+            .addOrUpdateEntity("env-1", "User::\"alice\"", java.util.Map.of(), List.of(), Set.of("*"), 1L)
+            .blockingAwait();
+
+        assertThat(hits).contains(DEFAULT_ADDRESS);
+    }
+}


### PR DESCRIPTION
> Stacked on #19357 (`authz-33-schema-wire`). Base is that branch, so this diff shows only its own changes. Rebases onto `master` once #19357 merges.

## What

Second step of the gateway half of AUTHZ-33: the engine-port contract and the deployment path for schema documents. Nothing produces an `AuthzSchemaReactorDeployable` yet, so this is inert until the synchronizer lands in the next PR, and it merges independently — same shape as the wire PR.

Section 8 came to ~1400 lines including tests, so it is split in two along the line where the two halves fail differently. This half asks "does the command shape and the routing match the contract the PDP already accepts?". The next asks "does inserting a synchronizer step break the other synchronizers?".

## Changes

- `AuthzEnginePort` gains `addOrUpdateSchema` / `removeSchema`, implemented in `EventBusAuthzEnginePort` and `NoopAuthzEnginePort`.
- `AuthzSchemaReactorDeployable`, `AuthzSchemaMapper`, `AuthzSchemaDeployer`, mirroring their policy counterparts.

## Three things worth a careful look

**The bus command carries `docId` and `schemaText` and nothing else.** The PDP half of AUTHZ-33 is already merged and its consumer reads exactly those two fields. A `name` on the command would be dropped silently, so it stays on the deployable, where the gateway uses it for logging. Section 7 of the spec lists `name` in the port signature; that is right for the event record and wrong for the command.

**D7 gets its own expansion rather than a flag inside the shared one.** `expandWildcard` is shared with policies and entities and unconditionally adds the bootstrap scope. Schema needs the opposite, so `expandWildcardWithoutBootstrap` sits beside it and `routeGated` / `routeForget` now take already-expanded scopes. The alternative, a mode flag threaded through the shared method, puts the policy and entity paths one boolean away from silently losing their bootstrap fan-out.

`*` on a schema therefore reaches every named engine the node hosts and never the bootstrap engine, which is shared across environments. Targeting `default` by name still works and is still cross-environment; D7 removes the implicit fan-out only.

**Distributed replay for schema is deferred and marked.** `DistributedSyncService` has a per-type overload, and reaching parity with authz policy needs a `DistributedEventType`, a distributed mapper and a `DistributedAuthzSchemaSynchronizer`. None of that is in section 8. `AuthzSchemaDeployer.doAfterDeployment` therefore returns `complete()` with a `TODO(AUTHZ-33)` naming what is missing.

Consequence while it stands, stated precisely: a secondary node with distributed sync enabled receives **no schema at all**, not a delayed one. `DefaultSyncManager` runs either the distributed synchronizers or the repository ones and never both, so there is no fallback cycle to pick it up. Policies and entities are unaffected because they have distributed synchronizers. Under D5 an engine with no schema behaves as it does today, so the same request would resolve a bare action name on the primary and not on the secondary, silently.

Distributed sync is opt-in and the default wiring is `NoopDistributedSyncService`, so the default deployment is untouched. That lowers the urgency, not the obligation: this belongs to the definition of done for AUTHZ-33 and lands as its own PR after the synchronizer, where the reviewer's question is "does a secondary end up with the same effective schema as the primary?" rather than "does inserting a step break the other synchronizers?".

## Tests

`mvn verify` on `gravitee-apim-gateway-services-sync`: 708 tests green, prettier and the logging ArchUnit rules included.

New: `EventBusAuthzEnginePortSchemaTest` (12), `AuthzSchemaMapperTest` (9), `AuthzSchemaDeployerTest` (5).

Both load-bearing assertions were checked by mutation rather than assumed:

- pointing the schema ops back at the shared `expandWildcard` (undoing D7) turns `wildcard_reaches_every_hosted_engine_but_never_the_bootstrap_engine` and `wildcard_removal_also_spares_the_bootstrap_engine` red;
- adding `name` to the command turns `the_add_command_carries_only_docId_and_schemaText` red.

The port test also carries two regression cases asserting that a policy wildcard and an entity wildcard still reach the bootstrap engine, since that is what the shared expansion could have lost.

The four hand-written `AuthzEnginePort` implementations in tests get recording queues rather than empty stubs, and `AuthzPolicyDeployerTest` / `AuthzEntityDeployerTest` now assert that neither path emits a schema command.
