### PR TITLE
feat(authz): synchronize schema documents and hydrate them first

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/AuthzSchemaDeployer.java
@@ -22,6 +22,18 @@ import java.util.Set;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * TODO(AUTHZ-32): schema documents are not replayed over distributed sync, unlike policies and entities,
+ * which have DistributedAuthzPolicySynchronizer and DistributedAuthzEntitySynchronizer. The consequence is
+ * specific and worth stating precisely: the bootstrap engine IS present on every node, and
+ * AuthzHostedScopes#serves admits the bare default scope unconditionally, so a secondary node running
+ * distributed sync does receive policies and entities there while never receiving any schema. Evaluation
+ * outcomes do not diverge, because the PDP builds its Authorizer without a schema by design and therefore
+ * never validates against one; the schema's only runtime consumer is SearchExecutor. So what diverges is
+ * action search: the same query answers from the schema on the primary and from nothing on a secondary.
+ * Distributed sync is opt-in and the default wiring is NoopDistributedSyncService, so this is inert unless
+ * it is switched on.
+ */
 @CustomLog
 @RequiredArgsConstructor
 public class AuthzSchemaDeployer implements Deployer<AuthzSchemaReactorDeployable> {
@@ -49,26 +61,11 @@ public class AuthzSchemaDeployer implements Deployer<AuthzSchemaReactorDeployabl
             .doOnError(e -> log.warn("Failed to stage authz schema '{}': {}", deployable.docId(), e.getMessage()));
     }
 
-    // TODO(AUTHZ-32): distributed replay for schema documents, tracked there with the rest of distributed
-    // sync. Until it lands, a secondary node with distributed sync enabled receives no schema at all:
-    // DefaultSyncManager runs either the distributed synchronizers or the repository ones and never both,
-    // so there is no fallback cycle. Opt-in only, the default wiring is NoopDistributedSyncService.
-    // No DistributedSyncService is injected until there is something to distribute.
-    @Override
-    public Completable doAfterDeployment(AuthzSchemaReactorDeployable deployable) {
-        return Completable.complete();
-    }
-
     @Override
     public Completable undeploy(AuthzSchemaReactorDeployable deployable) {
         return enginePort
             .removeSchema(deployable.environmentId(), deployable.docId(), deployable.targetPdpIds())
             .doOnComplete(() -> log.debug("Authz schema '{}' staged for removal on next commit", deployable.docId()))
             .doOnError(e -> log.warn("Failed to stage authz schema '{}' removal: {}", deployable.docId(), e.getMessage()));
-    }
-
-    @Override
-    public Completable doAfterUndeployment(AuthzSchemaReactorDeployable deployable) {
-        return Completable.complete();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/DeployerFactory.java
@@ -145,4 +145,8 @@ public class DeployerFactory {
     public AuthzPolicyDeployer createAuthzPolicyDeployer() {
         return new AuthzPolicyDeployer(authzEnginePort, distributedSyncService);
     }
+
+    public AuthzSchemaDeployer createAuthzSchemaDeployer() {
+        return new AuthzSchemaDeployer(authzEnginePort);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/synchronizer/Order.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/synchronizer/Order.java
@@ -39,13 +39,14 @@ public enum Order {
     CLUSTER(6),
     SHARED_POLICY_GROUP(7),
     AUTHZ_PDP(8),
-    AUTHZ_ENTITY(9),
-    AUTHZ_POLICY(10),
-    API_PRODUCT(11),
-    API(12),
-    SUBSCRIPTION(13),
-    API_KEY(14),
-    DEBUG(15);
+    AUTHZ_SCHEMA(9),
+    AUTHZ_ENTITY(10),
+    AUTHZ_POLICY(11),
+    API_PRODUCT(12),
+    API(13),
+    SUBSCRIPTION(14),
+    API_KEY(15),
+    DEBUG(16);
 
     static {
         Set<Integer> elements = new HashSet<>();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -69,6 +69,8 @@ import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.A
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzPdpSynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzPolicyMapper;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzPolicySynchronizer;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzSchemaMapper;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzSchemaSynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.AuthzScopePlacement;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.authz.GammaEnabledCondition;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.cluster.ClusterSynchronizer;
@@ -397,6 +399,12 @@ public class RepositorySyncConfiguration {
 
     @Bean
     @Conditional(GammaEnabledCondition.class)
+    public AuthzScopePlacement authzSchemaScopePlacement() {
+        return new AuthzScopePlacement();
+    }
+
+    @Bean
+    @Conditional(GammaEnabledCondition.class)
     public AuthzScopePlacement authzPolicyScopePlacement() {
         return new AuthzScopePlacement();
     }
@@ -467,6 +475,34 @@ public class RepositorySyncConfiguration {
 
     @Bean
     @Conditional(GammaEnabledCondition.class)
+    public AuthzSchemaMapper authzSchemaMapper(ObjectMapper objectMapper) {
+        return new AuthzSchemaMapper(objectMapper);
+    }
+
+    @Bean
+    @Conditional(GammaEnabledCondition.class)
+    public AuthzSchemaSynchronizer authzSchemaSynchronizer(
+        LatestEventFetcher eventsFetcher,
+        AuthzSchemaMapper authzSchemaMapper,
+        DeployerFactory deployerFactory,
+        AuthzEnginePort authzEnginePort,
+        @Qualifier("authzSchemaScopePlacement") AuthzScopePlacement authzSchemaScopePlacement,
+        @Qualifier("syncFetcherExecutor") ThreadPoolExecutor syncFetcherExecutor,
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor
+    ) {
+        return new AuthzSchemaSynchronizer(
+            eventsFetcher,
+            authzSchemaMapper,
+            deployerFactory,
+            authzEnginePort,
+            authzSchemaScopePlacement,
+            syncFetcherExecutor,
+            syncDeployerExecutor
+        );
+    }
+
+    @Bean
+    @Conditional(GammaEnabledCondition.class)
     public AuthzPdpMapper authzPdpMapper(ObjectMapper objectMapper) {
         return new AuthzPdpMapper(objectMapper);
     }
@@ -476,6 +512,7 @@ public class RepositorySyncConfiguration {
     public AuthzPdpSynchronizer authzPdpSynchronizer(
         LatestEventFetcher eventsFetcher,
         AuthzPdpMapper authzPdpMapper,
+        AuthzSchemaSynchronizer authzSchemaSynchronizer,
         AuthzPolicySynchronizer authzPolicySynchronizer,
         AuthzEntitySynchronizer authzEntitySynchronizer,
         Node node,
@@ -489,6 +526,7 @@ public class RepositorySyncConfiguration {
         return new AuthzPdpSynchronizer(
             eventsFetcher,
             authzPdpMapper,
+            authzSchemaSynchronizer,
             authzPolicySynchronizer,
             authzEntitySynchronizer,
             node,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AbstractAuthzReactorSynchronizer.java
@@ -39,8 +39,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import lombok.CustomLog;
 
 /**
- * Shared reactive synchronization engine for the two scoped authz document types (entities and
- * policies). It owns the fetch → map → (un)deploy → retry → commit pipeline, the per-node retry
+ * Shared reactive synchronization engine for the scoped authz document types (schema documents,
+ * entities and policies). It owns the fetch → map → (un)deploy → retry → commit pipeline, the per-node retry
  * bookkeeping and the scope-placement reconciliation; subclasses only supply the type-specific
  * bindings (mapper, deployer, event types, labels). Keeping a single implementation means a fix to
  * the shared logic (e.g. placement eviction or commit retry) lands once instead of diverging across
@@ -200,6 +200,15 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
             });
     }
 
+    /**
+     * Base scopes (tag stripped) that this document type's wildcard expansion does NOT reach, and which
+     * therefore stay in the eviction set when a document is retargeted to {@code "*"}. Empty for policies
+     * and entities, whose wildcard covers every engine including the bootstrap one.
+     */
+    protected Set<String> scopesNotCoveredByWildcard() {
+        return Set.of();
+    }
+
     private Flowable<D> deploy(Deployer<D> deployer, D deployable, Set<String> attemptedThisCycle) {
         String rk = runtimeKey(deployable);
         attemptedThisCycle.add(rk);
@@ -213,11 +222,21 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
             // A wildcard targets every hosted scope, so it can never narrow a previously-applied scope
             // away. Computing dropped = applied − {"*"} would flag every concretely-applied scope — e.g. a
             // scope recorded by the hydration backfill, which never equals the literal "*" — as removed and
-            // (ungated) evict the document from the very scopes it must stay on. A wildcard drops nothing.
-            dropped.clear();
-        } else {
-            dropped.removeAll(target);
+            // (ungated) evict the document from the very scopes it must stay on. A wildcard drops nothing
+            // except the scopes its own expansion does not reach; for policies and entities that set is
+            // empty, so this removes everything, exactly like the clear() it replaces.
+            // Compared on the BASE of the routing scope: a placement records "default@us", never the bare
+            // "default", so an exact match would leave a tagged bootstrap engine holding a schema forever.
+            Set<String> keptByWildcard = scopesNotCoveredByWildcard();
+            dropped.removeIf(scope -> !keptByWildcard.contains(EventBusAuthzEnginePort.baseScope(scope)));
         }
+        // A scope named in the new target is never dropped, wildcard or not: "*" plus an explicit scope
+        // still means that scope is wanted. Matched on the base too, because the two sides are recorded
+        // differently: the deploy path stores the document's declared targets ("orders"), while hydration
+        // stores the routing scope it applied to ("orders@eu"). Since addressFor strips the tag, those name
+        // one engine, so an exact-string comparison would evict a document from the very engine it is being
+        // published to — harmless today only because the deployer evicts before it stages.
+        dropped.removeIf(scope -> target.contains(scope) || target.contains(EventBusAuthzEnginePort.baseScope(scope)));
         deployable.removedTargetPdpIds(dropped);
         return deployer
             .deploy(deployable)
@@ -345,13 +364,24 @@ public abstract class AbstractAuthzReactorSynchronizer<D extends AuthzScopedDepl
     }
 
     /** Stage the pre-grouped documents for a single scope (route to {@code scope} only, never evict) and
-     *  seal that scope's engine. Records each document in the shared {@link AuthzScopePlacement} so a later
+     *  seal that scope's engine. Records each document in this synchronizer's own {@link AuthzScopePlacement} (one instance per
+     *  document type, so the three do not see each other's placements) so a later
      *  narrowing PUBLISH can still evict it. */
     public Completable stageScope(String environmentId, String scope, List<D> docs) {
+        return stageScope(environmentId, scope, docs, true);
+    }
+
+    /**
+     * Stages {@code docs} into {@code scope}, sealing the scope with a commit only when {@code commit} is
+     * set. Hydration stages schema, policies and entities into the same scope and seals once at the end, so
+     * a scope costs one commit round trip rather than one per document type. The final commit is emitted
+     * even when nothing was staged: a freshly provisioned engine has to leave commit generation 0, which is
+     * what its readiness checks key on.
+     */
+    public Completable stageScope(String environmentId, String scope, List<D> docs, boolean commit) {
         Deployer<D> deployer = createDeployer();
-        return Flowable.fromIterable(docs)
-            .concatMapCompletable(doc -> backfillOne(deployer, doc, scope))
-            .andThen(Completable.defer(() -> enginePort.commitScope(environmentId, scope)));
+        Completable staged = Flowable.fromIterable(docs).concatMapCompletable(doc -> backfillOne(deployer, doc, scope));
+        return commit ? staged.andThen(Completable.defer(() -> enginePort.commitScope(environmentId, scope))) : staged;
     }
 
     private Completable backfillOne(Deployer<D> deployer, D deployable, String scope) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizer.java
@@ -61,6 +61,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
 
     private final LatestEventFetcher eventsFetcher;
     private final AuthzPdpMapper mapper;
+    private final AuthzSchemaSynchronizer schemaSynchronizer;
     private final AuthzPolicySynchronizer policySynchronizer;
     private final AuthzEntitySynchronizer entitySynchronizer;
     private final Node node;
@@ -114,6 +115,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
     public AuthzPdpSynchronizer(
         LatestEventFetcher eventsFetcher,
         AuthzPdpMapper mapper,
+        AuthzSchemaSynchronizer schemaSynchronizer,
         AuthzPolicySynchronizer policySynchronizer,
         AuthzEntitySynchronizer entitySynchronizer,
         Node node,
@@ -126,6 +128,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
     ) {
         this.eventsFetcher = eventsFetcher;
         this.mapper = mapper;
+        this.schemaSynchronizer = Objects.requireNonNull(schemaSynchronizer, "schemaSynchronizer must not be null");
         this.policySynchronizer = Objects.requireNonNull(policySynchronizer, "policySynchronizer must not be null");
         this.entitySynchronizer = Objects.requireNonNull(entitySynchronizer, "entitySynchronizer must not be null");
         this.node = Objects.requireNonNull(node, "node must not be null");
@@ -447,6 +450,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
         Set<String> scopes = byScope.keySet();
         // One scan+map of policies and one of entities for the whole environment, grouped by scope.
         return Single.zip(
+            schemaSynchronizer.groupByScope(environmentId, scopes),
             policySynchronizer.groupByScope(environmentId, scopes),
             entitySynchronizer.groupByScope(environmentId, scopes),
             BackfillGroups::new
@@ -466,11 +470,15 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
 
     private Completable hydrateScope(String environmentId, String scope, AuthzPdpProvisionDeployable provision, BackfillGroups groups) {
         String rk = runtimeKey(provision);
-        // Per scope: policies then entities (policy failure short-circuits the scope), so a single scope's
-        // engine failure re-pends only that scope, not the whole environment.
-        return policySynchronizer
-            .stageScope(environmentId, scope, groups.policies().getOrDefault(scope, List.of()))
-            .andThen(entitySynchronizer.stageScope(environmentId, scope, groups.entities().getOrDefault(scope, List.of())))
+        // Per scope: schema, then policies, then entities (a failure short-circuits the scope), so a single
+        // scope's engine failure re-pends only that scope, not the whole environment. Schema goes first so
+        // the freshly provisioned scope's very first commit already carries it; staged later it would take
+        // effect a full cycle after the policies that depend on it. Only the last stage commits, so a scope
+        // is sealed once instead of three times.
+        return schemaSynchronizer
+            .stageScope(environmentId, scope, groups.schemas().getOrDefault(scope, List.of()), false)
+            .andThen(policySynchronizer.stageScope(environmentId, scope, groups.policies().getOrDefault(scope, List.of()), false))
+            .andThen(entitySynchronizer.stageScope(environmentId, scope, groups.entities().getOrDefault(scope, List.of()), true))
             .doOnComplete(() -> {
                 pendingHydrations.remove(rk);
                 pendingHydrationAttempts.remove(rk);
@@ -484,6 +492,7 @@ public class AuthzPdpSynchronizer implements RepositorySynchronizer {
     }
 
     private record BackfillGroups(
+        Map<String, List<AuthzSchemaReactorDeployable>> schemas,
         Map<String, List<AuthzPolicyReactorDeployable>> policies,
         Map<String, List<AuthzEntityReactorDeployable>> entities
     ) {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapper.java
@@ -41,6 +41,12 @@ public class AuthzSchemaMapper {
                     log.warn("Skipping authz schema DEPLOY event [{}] — missing or blank schemaText", event.getId());
                     return null;
                 }
+                // Without it AuthzHostedScopes#serves looks up "null:<base>", matches nothing, and the
+                // document is dropped with no trace. AuthzPdpMapper guards the same field.
+                if (wire.getEnvironmentId() == null || wire.getEnvironmentId().isBlank()) {
+                    log.warn("Skipping authz schema DEPLOY event [{}] — missing environmentId", event.getId());
+                    return null;
+                }
                 String resolvedName = wire.getName() != null && !wire.getName().isBlank() ? wire.getName() : wire.getId();
                 return AuthzSchemaReactorDeployable.builder()
                     .docId(wire.getId())
@@ -64,6 +70,12 @@ public class AuthzSchemaMapper {
                 AuthzSchema wire = objectMapper.readValue(event.getPayload(), AuthzSchema.class);
                 if (wire.getId() == null || wire.getId().isBlank()) {
                     log.warn("Skipping authz schema UNDEPLOY event [{}] — missing id", event.getId());
+                    return null;
+                }
+                // Without it AuthzHostedScopes#serves looks up "null:<base>", matches nothing, and the
+                // document is dropped with no trace. AuthzPdpMapper guards the same field.
+                if (wire.getEnvironmentId() == null || wire.getEnvironmentId().isBlank()) {
+                    log.warn("Skipping authz schema UNDEPLOY event [{}] — missing environmentId", event.getId());
                     return null;
                 }
                 return AuthzSchemaReactorDeployable.builder()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaSynchronizer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import io.gravitee.gateway.services.sync.process.common.deployer.Deployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.common.synchronizer.Order;
+import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class AuthzSchemaSynchronizer extends AbstractAuthzReactorSynchronizer<AuthzSchemaReactorDeployable> {
+
+    private final AuthzSchemaMapper mapper;
+    private final DeployerFactory deployerFactory;
+
+    public AuthzSchemaSynchronizer(
+        LatestEventFetcher eventsFetcher,
+        AuthzSchemaMapper mapper,
+        DeployerFactory deployerFactory,
+        AuthzEnginePort enginePort,
+        AuthzScopePlacement placement,
+        ThreadPoolExecutor syncFetcherExecutor,
+        ThreadPoolExecutor syncDeployerExecutor
+    ) {
+        super(eventsFetcher, enginePort, placement, syncFetcherExecutor, syncDeployerExecutor);
+        this.mapper = mapper;
+        this.deployerFactory = deployerFactory;
+    }
+
+    @Override
+    public int order() {
+        return Order.AUTHZ_SCHEMA.index();
+    }
+
+    /**
+     * D7: a schema wildcard expands to the named engines only, so unlike a policy or an entity it does
+     * NOT cover the bootstrap engine. Retargeting a schema from "default" to "*" must therefore still
+     * evict it from the bootstrap engine, which is shared across environments.
+     */
+    @Override
+    protected Set<String> scopesNotCoveredByWildcard() {
+        return Set.of(EventBusAuthzEnginePort.DEFAULT_SCOPE);
+    }
+
+    @Override
+    protected Maybe<AuthzSchemaReactorDeployable> toDeploy(Event event) {
+        return mapper.toDeploy(event);
+    }
+
+    @Override
+    protected Maybe<AuthzSchemaReactorDeployable> toUndeploy(Event event) {
+        return mapper.toUndeploy(event);
+    }
+
+    @Override
+    protected Deployer<AuthzSchemaReactorDeployable> createDeployer() {
+        return deployerFactory.createAuthzSchemaDeployer();
+    }
+
+    @Override
+    protected Event.EventProperties eventProperty() {
+        return Event.EventProperties.AUTHZ_SCHEMA_ID;
+    }
+
+    @Override
+    protected EventType publishType() {
+        return EventType.PUBLISH_AUTHZ_SCHEMA;
+    }
+
+    @Override
+    protected EventType unpublishType() {
+        return EventType.UNPUBLISH_AUTHZ_SCHEMA;
+    }
+
+    @Override
+    protected String singularLabel() {
+        return "authz schema";
+    }
+
+    @Override
+    protected String pluralLabel() {
+        return "authz schemas";
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
@@ -160,7 +160,9 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         // The PDP consumer reads docId and schemaText and nothing else; name stays on the deployable
         // for gateway-side logging.
         JsonObject command = new JsonObject().put("op", OP_ADD_OR_UPDATE_SCHEMA).put("docId", docId).put("schemaText", schemaText);
-        return routeGated(environmentId, command, schemaScopes(environmentId, targetPdpIds, docId), docId, updatedAt);
+        Set<String> scopes = expandWildcardWithoutBootstrap(environmentId, targetPdpIds);
+        warnOnceIfWildcardReachesNothing(environmentId, docId, targetPdpIds, scopes, updatedAt);
+        return routeGated(environmentId, command, scopes, docId, updatedAt);
     }
 
     @Override
@@ -168,7 +170,7 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
         return routeForget(
             environmentId,
             new JsonObject().put("op", OP_REMOVE_SCHEMA).put("docId", docId),
-            schemaScopes(environmentId, targetPdpIds, docId),
+            expandWildcardWithoutBootstrap(environmentId, targetPdpIds),
             docId
         );
     }
@@ -331,20 +333,31 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     // D7: "*" on a schema means every NAMED engine of the environment. Unlike expandWildcard it does not
     // add the bootstrap engine, which is shared across environments — a wildcard schema landing there would
     // merge two environments' contracts into one. Targeting "default" explicitly still works.
-    // A wildcard schema reaches only NAMED engines (D7), so on a node hosting none it expands to nothing
-    // and no command is sent. Policies never hit this, because their wildcard always includes the bootstrap
+    // A wildcard schema reaches only NAMED engines (D7), so on a node hosting none it expands to nothing and
+    // no command is sent. Policies never hit this, because their wildcard always includes the bootstrap
     // engine, so the silence is specific to schema and would otherwise leave a single-node install running
     // policies against no schema at all with nothing in the log to say so.
-    private Set<String> schemaScopes(String environmentId, Set<String> targetPdpIds, String docId) {
-        Set<String> scopes = expandWildcardWithoutBootstrap(environmentId, targetPdpIds);
-        if (scopes.isEmpty() && targetPdpIds != null && targetPdpIds.contains(WILDCARD)) {
+    // Deduplicated on the document's revision, because the resync window re-delivers the same event once per
+    // cycle for its whole duration and an ungated warning would repeat with it. Only the publish path warns:
+    // an empty expansion on removal simply means there is nothing to remove.
+    private void warnOnceIfWildcardReachesNothing(
+        String environmentId,
+        String docId,
+        Set<String> targetPdpIds,
+        Set<String> expanded,
+        long updatedAt
+    ) {
+        if (!expanded.isEmpty() || targetPdpIds == null || !targetPdpIds.contains(WILDCARD)) {
+            return;
+        }
+        if (revisions.shouldApply(environmentId, WILDCARD, docId, updatedAt)) {
+            revisions.markApplied(environmentId, WILDCARD, docId, updatedAt);
             log.warn(
                 "Authz schema '{}' targets every named engine of environment [{}], which hosts none, so it reaches nothing",
                 docId,
                 environmentId
             );
         }
-        return scopes;
     }
 
     private Set<String> expandWildcardWithoutBootstrap(String environmentId, Set<String> targetPdpIds) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/synchronizer/OrderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/synchronizer/OrderTest.java
@@ -38,6 +38,9 @@ class OrderTest {
         assertThat(Order.AUTHZ_ENTITY.index()).isLessThan(Order.API.index());
         assertThat(Order.AUTHZ_POLICY.index()).isLessThan(Order.API.index());
         assertThat(Order.AUTHZ_ENTITY.index()).isLessThan(Order.AUTHZ_POLICY.index());
+        // A policy may reference a type the schema declares, so the schema must be staged first.
+        assertThat(Order.AUTHZ_SCHEMA.index()).isLessThan(Order.AUTHZ_POLICY.index());
+        assertThat(Order.AUTHZ_SCHEMA.index()).isLessThan(Order.API.index());
         assertThat(Order.AUTHZ_POLICY.index()).isLessThan(Order.SUBSCRIPTION.index());
         assertThat(Order.AUTHZ_POLICY.index()).isLessThan(Order.API_KEY.index());
     }
@@ -45,14 +48,16 @@ class OrderTest {
     @Test
     void authz_indices_match_plan_specification() {
         assertThat(Order.AUTHZ_PDP.index()).isEqualTo(8);
-        assertThat(Order.AUTHZ_ENTITY.index()).isEqualTo(9);
-        assertThat(Order.AUTHZ_POLICY.index()).isEqualTo(10);
+        assertThat(Order.AUTHZ_SCHEMA.index()).isEqualTo(9);
+        assertThat(Order.AUTHZ_ENTITY.index()).isEqualTo(10);
+        assertThat(Order.AUTHZ_POLICY.index()).isEqualTo(11);
     }
 
     @Test
     void authz_pdp_runs_before_entity_and_policy() {
         assertThat(Order.AUTHZ_PDP.index()).isLessThan(Order.AUTHZ_ENTITY.index());
         assertThat(Order.AUTHZ_PDP.index()).isLessThan(Order.AUTHZ_POLICY.index());
+        assertThat(Order.AUTHZ_PDP.index()).isLessThan(Order.AUTHZ_SCHEMA.index());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -338,7 +338,7 @@ class ApiProductSynchronizerTest {
 
         @Test
         void should_return_correct_order() {
-            assertThat(cut.order()).isEqualTo(11);
+            assertThat(cut.order()).isEqualTo(12);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEventToEngineIntegrationTest.java
@@ -139,6 +139,15 @@ class AuthzEventToEngineIntegrationTest {
         return event;
     }
 
+    @Test
+    void the_schema_recorder_is_live_so_an_absence_of_schema_ops_is_a_real_assertion() {
+        assertThat(port.schemaOps).isEmpty();
+
+        port.addOrUpdateSchema("env-1", "probe", "n", "entity User;", Set.of("scope-1"), 1L).blockingAwait();
+
+        assertThat(port.schemaOps).containsExactly("addOrUpdateSchema:probe");
+    }
+
     private static class RecordingPort implements AuthzEnginePort {
 
         final ConcurrentLinkedQueue<String> ops = new ConcurrentLinkedQueue<>();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHydrationPlacementTest.java
@@ -131,9 +131,20 @@ class AuthzHydrationPlacementTest {
             executor(),
             executor()
         );
+
+        AuthzSchemaSynchronizer schemaSynchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
+            deployerFactory,
+            port,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
         pdpSynchronizer = new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer,
             policySynchronizer,
             entitySynchronizer,
             node,
@@ -164,6 +175,7 @@ class AuthzHydrationPlacementTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(pdpPublish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_ENTITY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(entityForScopeB))
@@ -199,6 +211,7 @@ class AuthzHydrationPlacementTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(pdpPublish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_ENTITY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(entityForScopeB))
@@ -253,6 +266,15 @@ class AuthzHydrationPlacementTest {
                 .encode()
         );
         return event;
+    }
+
+    @Test
+    void the_schema_recorder_is_live_so_an_absence_of_schema_ops_is_a_real_assertion() {
+        assertThat(port.schemaOps).isEmpty();
+
+        port.addOrUpdateSchema("env-1", "probe", "n", "entity User;", Set.of("scope-1"), 1L).blockingAwait();
+
+        assertThat(port.schemaOps).containsExactly("addOrUpdateSchema:probe");
     }
 
     private static class RecordingPort implements AuthzEnginePort {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpHydrationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.services.sync.process.common.deployer.AuthzEntityDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.AuthzPolicyDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzSchemaDeployer;
 import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
 import io.gravitee.gateway.services.sync.process.distributed.service.NoopDistributedSyncService;
 import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -87,6 +90,7 @@ class AuthzPdpHydrationTest {
         lenient().when(gatewayConfiguration.shardingTags()).thenReturn(java.util.Optional.of(java.util.List.of()));
         lenient().when(enginePort.addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
         lenient().when(enginePort.addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
+        lenient().when(enginePort.addOrUpdateSchema(any(), any(), any(), any(), any(), anyLong())).thenReturn(Completable.complete());
         lenient().when(enginePort.commit()).thenReturn(Completable.complete());
         lenient().when(enginePort.commitScope(any(), any())).thenReturn(Completable.complete());
         provisionConsumer = vertx
@@ -97,10 +101,21 @@ class AuthzPdpHydrationTest {
         DeployerFactory deployerFactory = org.mockito.Mockito.mock(DeployerFactory.class);
         lenient().when(deployerFactory.createAuthzPolicyDeployer()).thenReturn(new AuthzPolicyDeployer(enginePort, distributedSyncService));
         lenient().when(deployerFactory.createAuthzEntityDeployer()).thenReturn(new AuthzEntityDeployer(enginePort, distributedSyncService));
+        lenient().when(deployerFactory.createAuthzSchemaDeployer()).thenReturn(new AuthzSchemaDeployer(enginePort));
 
         AuthzPolicySynchronizer policySynchronizer = new AuthzPolicySynchronizer(
             fetcher,
             new AuthzPolicyMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+
+        AuthzSchemaSynchronizer schemaSynchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
             deployerFactory,
             enginePort,
             new AuthzScopePlacement(),
@@ -120,6 +135,7 @@ class AuthzPdpHydrationTest {
         synchronizer = new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer,
             policySynchronizer,
             entitySynchronizer,
             node,
@@ -154,6 +170,7 @@ class AuthzPdpHydrationTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(provision))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policyInScope, policyWildcard, policyOtherScope))
         );
@@ -167,7 +184,7 @@ class AuthzPdpHydrationTest {
         verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-2"), any(), any(), eq(Set.of("scope-1")), anyLong());
         verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-3"), any(), any(), any(), anyLong());
         verify(enginePort).addOrUpdateEntity(eq("env-pdp"), any(), any(), any(), eq(Set.of("scope-1")), anyLong());
-        verify(enginePort, times(2)).commitScope("env-pdp", "scope-1");
+        verify(enginePort, times(1)).commitScope("env-pdp", "scope-1");
     }
 
     @Test
@@ -181,6 +198,7 @@ class AuthzPdpHydrationTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(provision))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policyX, policyWildcard, policyOther, policyMulti))
         );
@@ -204,6 +222,7 @@ class AuthzPdpHydrationTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(provision))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(ownPolicy, foreignPolicy, foreignWildcard))
         );
@@ -247,7 +266,7 @@ class AuthzPdpHydrationTest {
         verify(enginePort, never()).addOrUpdatePolicy(any(), any(), any(), any(), any(), anyLong());
         verify(enginePort, never()).addOrUpdateEntity(any(), any(), any(), any(), any(), anyLong());
         // the scope must still seal generation 0 so it does not stay cold forever (once per synchronizer)
-        verify(enginePort, times(2)).commitScope("env-pdp", "scope-empty");
+        verify(enginePort, times(1)).commitScope("env-pdp", "scope-empty");
     }
 
     @Test
@@ -313,6 +332,45 @@ class AuthzPdpHydrationTest {
         event.setType(type);
         event.setPayload(new JsonObject().put("targetPdpId", targetPdpId).put("tag", tag).put("environmentId", "env-pdp").encode());
         event.setProperties(Map.of(Event.EventProperties.AUTHZ_PDP_ID.getValue(), id));
+        return event;
+    }
+
+    @Test
+    void hydration_stages_the_schema_before_the_policies_of_the_same_scope() throws InterruptedException {
+        Event provision = pdpEvent("evt-pdp", EventType.PUBLISH_AUTHZ_PDP, "scope-1", null);
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(provision))
+        );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(schemaEvent("sch-1", "scope-1")))
+        );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
+            Flowable.just(List.of(policyEvent("pol-1", "scope-1")))
+        );
+
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        // A freshly provisioned scope must carry the schema on its very first commit: a policy that names a
+        // type the schema declares would otherwise be staged against an engine that has no schema yet.
+        InOrder inOrder = inOrder(enginePort);
+        inOrder.verify(enginePort).addOrUpdateSchema(eq("env-pdp"), eq("sch-1"), any(), any(), eq(Set.of("scope-1")), anyLong());
+        inOrder.verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-1")), anyLong());
+    }
+
+    private static Event schemaEvent(String docId, String targetPdpId) {
+        Event event = new Event();
+        event.setId(docId);
+        event.setType(EventType.PUBLISH_AUTHZ_SCHEMA);
+        event.setPayload(
+            new JsonObject()
+                .put("id", docId)
+                .put("name", docId)
+                .put("schemaText", "entity User;")
+                .put("environmentId", "env-pdp")
+                .put("targetPdpIds", List.of(targetPdpId))
+                .encode()
+        );
+        event.setUpdatedAt(new java.util.Date());
         return event;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerChaosTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerChaosTest.java
@@ -135,6 +135,16 @@ class AuthzPdpSynchronizerChaosTest {
             executor(),
             executor()
         );
+
+        AuthzSchemaSynchronizer schemaSynchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
         AuthzEntitySynchronizer entitySynchronizer = new AuthzEntitySynchronizer(
             fetcher,
             new AuthzEntityMapper(new ObjectMapper()),
@@ -147,6 +157,7 @@ class AuthzPdpSynchronizerChaosTest {
         return new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer,
             policySynchronizer,
             entitySynchronizer,
             node,
@@ -187,6 +198,7 @@ class AuthzPdpSynchronizerChaosTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(publish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
@@ -204,7 +216,7 @@ class AuthzPdpSynchronizerChaosTest {
         assertThat(received.peek().getString("environmentId")).isEqualTo("env-1");
         verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-1@eu")), anyLong());
         verify(enginePort).addOrUpdateEntity(eq("env-1"), any(), any(), any(), eq(Set.of("scope-1@eu")), anyLong());
-        verify(enginePort, times(2)).commitScope("env-1", "scope-1@eu");
+        verify(enginePort, times(1)).commitScope("env-1", "scope-1@eu");
     }
 
     // ---------------------------------------------------------------------
@@ -226,6 +238,7 @@ class AuthzPdpSynchronizerChaosTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(publish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
@@ -247,7 +260,7 @@ class AuthzPdpSynchronizerChaosTest {
             .extracting(m -> m.getString("op") + ":" + m.getString("environmentId") + ":" + m.getString("targetPdpId"))
             .containsExactly("provision:env-1:scope-cut");
         verify(enginePort).addOrUpdatePolicy(eq("env-1"), eq("pol-1"), any(), any(), eq(Set.of("scope-cut@eu")), anyLong());
-        verify(enginePort, times(2)).commitScope("env-1", "scope-cut@eu");
+        verify(enginePort, times(1)).commitScope("env-1", "scope-cut@eu");
     }
 
     // ---------------------------------------------------------------------
@@ -278,6 +291,7 @@ class AuthzPdpSynchronizerChaosTest {
             }
             return Flowable.empty();
         });
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenAnswer(invocation -> {
             Set<String> envs = invocation.getArgument(3);
             if (envs != null && envs.contains("env-a")) {
@@ -439,6 +453,7 @@ class AuthzPdpSynchronizerChaosTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(noEnv))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerGapsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerGapsTest.java
@@ -128,6 +128,16 @@ class AuthzPdpSynchronizerGapsTest {
             executor(),
             executor()
         );
+
+        AuthzSchemaSynchronizer schemaSynchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
         AuthzEntitySynchronizer entitySynchronizer = new AuthzEntitySynchronizer(
             fetcher,
             new AuthzEntityMapper(new ObjectMapper()),
@@ -140,6 +150,7 @@ class AuthzPdpSynchronizerGapsTest {
         return new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer,
             policySynchronizer,
             entitySynchronizer,
             node,
@@ -256,6 +267,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(a, b))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policyA, policyB, policyW))
         );
@@ -280,8 +292,8 @@ class AuthzPdpSynchronizerGapsTest {
         verify(enginePort, never()).addOrUpdatePolicy(any(), eq("pol-a"), any(), any(), eq(Set.of("scope-b@eu")), anyLong());
 
         // one commit per provisioned scope, per synchronizer (policy + entity backfill)
-        verify(enginePort, times(2)).commitScope("env-pdp", "scope-a@eu");
-        verify(enginePort, times(2)).commitScope("env-pdp", "scope-b@eu");
+        verify(enginePort, times(1)).commitScope("env-pdp", "scope-a@eu");
+        verify(enginePort, times(1)).commitScope("env-pdp", "scope-b@eu");
     }
 
     // ---------------------------------------------------------------------
@@ -297,6 +309,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(us))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policyUs))
         );
@@ -364,6 +377,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(publish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
@@ -399,6 +413,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(publish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
@@ -427,7 +442,7 @@ class AuthzPdpSynchronizerGapsTest {
             .extracting(m -> m.getString("op") + ":" + m.getString("environmentId") + ":" + m.getString("targetPdpId"))
             .containsExactly("provision:env-pdp:scope-lost");
         verify(enginePort).addOrUpdatePolicy(eq("env-pdp"), eq("pol-1"), any(), any(), eq(Set.of("scope-lost@eu")), anyLong());
-        verify(enginePort, times(2)).commitScope("env-pdp", "scope-lost@eu");
+        verify(enginePort, times(1)).commitScope("env-pdp", "scope-lost@eu");
     }
 
     @Test
@@ -455,6 +470,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(bad, good))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policyGood, policyBad))
         );
@@ -588,6 +604,7 @@ class AuthzPdpSynchronizerGapsTest {
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_PDP_ID), any(), any())).thenReturn(
             Flowable.just(List.of(publish))
         );
+        when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_SCHEMA_ID), any(), any())).thenReturn(Flowable.empty());
         when(fetcher.fetchLatest(any(), any(), eq(Event.EventProperties.AUTHZ_POLICY_ID), any(), any())).thenReturn(
             Flowable.just(List.of(policy))
         );
@@ -603,10 +620,13 @@ class AuthzPdpSynchronizerGapsTest {
         synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
 
         // The scope was hydrated again on cycle 2 and finally committed.
-        // Cycle 1: policy backfill commit errors before the entity backfill runs (1 commitScope).
-        // Cycle 2: healthy, policy backfill commits then entity backfill commits (2 commitScope) = 3 total.
+        // A scope is sealed once, after schema, policies and entities have all been staged, so each cycle
+        // costs exactly one commitScope. Cycle 1 stages everything and then fails on that single commit;
+        // cycle 2 repeats the staging and the commit succeeds. Two cycles, two commits, two policy stages.
+        // Note the trade-off this makes explicit: committing once per scope means a dead engine is now
+        // discovered after the staging calls rather than at the first aggregate boundary.
         verify(enginePort, times(2)).addOrUpdatePolicy(eq("env-pdp"), eq("pol-h"), any(), any(), eq(Set.of("scope-h@eu")), anyLong());
-        verify(enginePort, times(3)).commitScope("env-pdp", "scope-h@eu");
+        verify(enginePort, times(2)).commitScope("env-pdp", "scope-h@eu");
     }
 
     // ---------------------------------------------------------------------

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzPdpSynchronizerTest.java
@@ -113,6 +113,16 @@ class AuthzPdpSynchronizerTest {
             executor(),
             executor()
         );
+
+        AuthzSchemaSynchronizer schemaSynchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
         AuthzEntitySynchronizer entitySynchronizer = new AuthzEntitySynchronizer(
             fetcher,
             new AuthzEntityMapper(new ObjectMapper()),
@@ -127,6 +137,7 @@ class AuthzPdpSynchronizerTest {
         return new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer,
             policySynchronizer,
             entitySynchronizer,
             node,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaMapperTest.java
@@ -62,7 +62,7 @@ class AuthzSchemaMapperTest {
                 event(
                     "evt-2",
                     """
-                    {"id": "doc-uuid-2", "schemaText": "entity User;"}
+                    {"id": "doc-uuid-2", "environmentId": "env-1", "schemaText": "entity User;"}
                     """
                 )
             )
@@ -136,7 +136,7 @@ class AuthzSchemaMapperTest {
                 event(
                     "evt-7",
                     """
-                    {"id": "doc-uuid-7"}
+                    {"id": "doc-uuid-7", "environmentId": "env-1"}
                     """
                 )
             )
@@ -144,6 +144,40 @@ class AuthzSchemaMapperTest {
 
         assertThat(d).isNotNull();
         assertThat(d.docId()).isEqualTo("doc-uuid-7");
+    }
+
+    @Test
+    void toDeploy_skips_an_event_without_an_environmentId() {
+        // Without it AuthzHostedScopes#serves looks up "null:<base>", matches nothing, and the document is
+        // dropped further downstream with no trace at all. AuthzPdpMapper guards the same field.
+        AuthzSchemaReactorDeployable d = mapper
+            .toDeploy(
+                event(
+                    "evt-no-env",
+                    """
+                    {"id": "doc-uuid-10", "schemaText": "entity User;", "targetPdpIds": ["orders"]}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNull();
+    }
+
+    @Test
+    void toUndeploy_skips_an_event_without_an_environmentId() {
+        AuthzSchemaReactorDeployable d = mapper
+            .toUndeploy(
+                event(
+                    "evt-no-env-undeploy",
+                    """
+                    {"id": "doc-uuid-11", "targetPdpIds": ["orders"]}
+                    """
+                )
+            )
+            .blockingGet();
+
+        assertThat(d).isNull();
     }
 
     @Test
@@ -169,7 +203,7 @@ class AuthzSchemaMapperTest {
                 event(
                     "evt-9",
                     """
-                    {"id": "doc-uuid-9", "schemaText": "entity User;"}
+                    {"id": "doc-uuid-9", "environmentId": "env-1", "schemaText": "entity User;"}
                     """
                 )
             )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSchemaSynchronizerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzSchemaDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.common.synchronizer.Order;
+import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Mirrors {@code AuthzPolicySynchronizerTest} and {@code AuthzEntitySynchronizerTest} so the schema route
+ * is held to the same contract as its siblings. Retarget eviction has its own coverage in
+ * {@code AuthzWildcardEvictionTest}, which owns the D7 carve-out cases.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthzSchemaSynchronizerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private LatestEventFetcher fetcher;
+
+    @Mock
+    private DeployerFactory deployerFactory;
+
+    @Mock
+    private AuthzSchemaDeployer deployer;
+
+    @Mock
+    private AuthzEnginePort port;
+
+    private AuthzSchemaSynchronizer synchronizer;
+
+    @BeforeEach
+    void setUp() {
+        synchronizer = new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(objectMapper),
+            deployerFactory,
+            port,
+            new AuthzScopePlacement(),
+            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
+            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>())
+        );
+
+        lenient().when(fetcher.bulkItems()).thenReturn(10);
+        lenient().when(deployerFactory.createAuthzSchemaDeployer()).thenReturn(deployer);
+        lenient().when(deployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(deployer.undeploy(any())).thenReturn(Completable.complete());
+        lenient().when(deployer.doAfterDeployment(any())).thenReturn(Completable.complete());
+        lenient().when(deployer.doAfterUndeployment(any())).thenReturn(Completable.complete());
+        lenient().when(port.commit()).thenReturn(Completable.complete());
+    }
+
+    @Test
+    void order_is_AUTHZ_SCHEMA() {
+        assertThat(synchronizer.order()).isEqualTo(Order.AUTHZ_SCHEMA.index());
+    }
+
+    @Test
+    void schema_is_ordered_before_policies_and_entities() {
+        // A schema staged after the policies that depend on it takes effect a full cycle late.
+        assertThat(synchronizer.order()).isLessThan(Order.AUTHZ_POLICY.index()).isLessThan(Order.AUTHZ_ENTITY.index());
+    }
+
+    @Test
+    void no_events_still_calls_commit_to_retry_any_pending() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.empty());
+
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+        verify(port).commit();
+    }
+
+    @Test
+    void publish_and_unpublish_are_handled_in_one_batch() throws InterruptedException {
+        Event publish = schemaEvent("doc-p", "[\"orders\"]");
+        Event unpublish = event("evt-u", EventType.UNPUBLISH_AUTHZ_SCHEMA, "{\"id\":\"doc-u\",\"environmentId\":\"env-1\"}");
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(publish, unpublish)));
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        verify(deployer).deploy(any());
+        verify(deployer).undeploy(any());
+        verify(port).commit();
+    }
+
+    @Test
+    void commit_fires_after_the_deploy_completes() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(
+            Flowable.just(List.of(schemaEvent("doc-p", "[\"orders\"]")))
+        );
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        var inOrder = inOrder(deployer, port);
+        inOrder.verify(deployer).deploy(any());
+        inOrder.verify(port).commit();
+    }
+
+    @Test
+    void unparseable_event_payload_is_dropped_without_breaking_the_batch() throws InterruptedException {
+        Event bad = event("evt-bad", EventType.PUBLISH_AUTHZ_SCHEMA, "not-json");
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(
+            Flowable.just(List.of(bad, schemaEvent("doc-good", "[\"orders\"]")))
+        );
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        verify(deployer, times(1)).deploy(any());
+        verify(port).commit();
+    }
+
+    @Test
+    void a_whole_cycle_of_documents_yields_a_single_commit() throws InterruptedException {
+        List<Event> events = new ArrayList<>(50);
+        for (int i = 0; i < 50; i++) {
+            events.add(schemaEvent("doc-" + i, "[\"orders\"]"));
+        }
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(events));
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        verify(deployer, times(50)).deploy(any());
+        verify(port, times(1)).commit();
+    }
+
+    @Test
+    void the_deployable_carries_the_documents_declared_targets() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(
+            Flowable.just(List.of(schemaEvent("doc-t", "[\"orders\",\"stock\"]")))
+        );
+
+        synchronizer.synchronize(123L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzSchemaReactorDeployable> captor = ArgumentCaptor.forClass(AuthzSchemaReactorDeployable.class);
+        verify(deployer).deploy(captor.capture());
+        assertThat(captor.getValue().targetPdpIds()).containsExactlyInAnyOrder("orders", "stock");
+        assertThat(captor.getValue().schemaText()).isEqualTo("entity User;");
+    }
+
+    private static Event schemaEvent(String id, String targets) {
+        return event(
+            "evt-" + id + "-" + targets.hashCode(),
+            EventType.PUBLISH_AUTHZ_SCHEMA,
+            "{\"id\":\"" +
+                id +
+                "\",\"name\":\"S\",\"environmentId\":\"env-1\",\"schemaText\":\"entity User;\",\"targetPdpIds\":" +
+                targets +
+                "}"
+        );
+    }
+
+    private static Event event(String id, EventType type, String payload) {
+        Event e = new Event();
+        e.setId(id);
+        e.setType(type);
+        e.setPayload(payload);
+        e.setUpdatedAt(new java.util.Date());
+        return e;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSyncCycleIsolationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzSyncCycleIsolationTest.java
@@ -241,6 +241,18 @@ class AuthzSyncCycleIsolationTest {
         );
     }
 
+    private AuthzSchemaSynchronizer schemaSynchronizer() {
+        return new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(new ObjectMapper()),
+            deployerFactory,
+            enginePort,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+    }
+
     private AuthzPdpSynchronizer pdpSynchronizer() {
         Node node = mock(Node.class);
         GatewayConfiguration gatewayConfiguration = mock(GatewayConfiguration.class);
@@ -249,6 +261,7 @@ class AuthzSyncCycleIsolationTest {
         return new AuthzPdpSynchronizer(
             fetcher,
             new AuthzPdpMapper(new ObjectMapper()),
+            schemaSynchronizer(),
             policySynchronizer(),
             entitySynchronizer(),
             node,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzWildcardEvictionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzWildcardEvictionTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzPolicyDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.AuthzSchemaDeployer;
+import io.gravitee.gateway.services.sync.process.common.deployer.DeployerFactory;
+import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * D7 says a schema wildcard reaches every NAMED engine and never the bootstrap one. The shared
+ * {@code deploy} used to drop the whole eviction set on a wildcard, on the premise that a wildcard can
+ * never narrow a previously-applied scope away. That premise holds for policies and entities and is
+ * false for schemas, so a schema retargeted from "default" to "*" would have stayed on the
+ * cross-environment bootstrap engine forever.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthzWildcardEvictionTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private LatestEventFetcher fetcher;
+
+    @Mock
+    private DeployerFactory deployerFactory;
+
+    @Mock
+    private AuthzSchemaDeployer schemaDeployer;
+
+    @Mock
+    private AuthzPolicyDeployer policyDeployer;
+
+    @Mock
+    private AuthzEnginePort port;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(fetcher.bulkItems()).thenReturn(10);
+        lenient().when(deployerFactory.createAuthzSchemaDeployer()).thenReturn(schemaDeployer);
+        lenient().when(deployerFactory.createAuthzPolicyDeployer()).thenReturn(policyDeployer);
+        lenient().when(schemaDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(schemaDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
+        lenient().when(policyDeployer.deploy(any())).thenReturn(Completable.complete());
+        lenient().when(policyDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
+        lenient().when(port.commit()).thenReturn(Completable.complete());
+    }
+
+    @Test
+    void a_schema_retargeted_from_default_to_wildcard_is_evicted_from_the_bootstrap_engine() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-1", "[\"default\"]"))))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-1", "[\"*\"]"))));
+
+        AuthzSchemaSynchronizer synchronizer = schemaSynchronizer();
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzSchemaReactorDeployable> captor = ArgumentCaptor.forClass(AuthzSchemaReactorDeployable.class);
+        verify(schemaDeployer, times(2)).deploy(captor.capture());
+        assertThat(captor.getAllValues().get(1).removedTargetPdpIds())
+            .as("the wildcard does not cover the bootstrap engine, so the schema must be evicted from it")
+            .containsExactly("default");
+    }
+
+    @Test
+    void a_document_hydrated_into_a_tagged_scope_is_not_evicted_when_republished_at_its_base() throws InterruptedException {
+        // The two sides are recorded differently: hydration stores the routing scope it applied to
+        // ("orders@eu"), while a publish carries the declared target ("orders"). addressFor strips the tag,
+        // so both name one engine and the republish must not evict the document from it.
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-4", "[\"orders@eu\"]"))))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-4", "[\"orders\"]"))));
+
+        AuthzSchemaSynchronizer synchronizer = schemaSynchronizer();
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzSchemaReactorDeployable> captor = ArgumentCaptor.forClass(AuthzSchemaReactorDeployable.class);
+        verify(schemaDeployer, times(2)).deploy(captor.capture());
+        assertThat(captor.getAllValues().get(1).removedTargetPdpIds())
+            .as("a tagged scope and its base name the same engine, so nothing is dropped")
+            .isEmpty();
+    }
+
+    @Test
+    void a_schema_retargeted_from_a_tagged_bootstrap_engine_to_wildcard_is_still_evicted() throws InterruptedException {
+        // A PDP created with a blank targetPdpId is normalised to "default", so "default@eu" is a legal
+        // routing scope, and the wildcard reaches it no more than it reaches the bare bootstrap engine.
+        // Matching the carve-out on the full string instead of the scope base would strand the document there
+        // with nothing able to remove it.
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-3", "[\"default@eu\"]"))))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-3", "[\"*\"]"))));
+
+        AuthzSchemaSynchronizer synchronizer = schemaSynchronizer();
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzSchemaReactorDeployable> captor = ArgumentCaptor.forClass(AuthzSchemaReactorDeployable.class);
+        verify(schemaDeployer, times(2)).deploy(captor.capture());
+        assertThat(captor.getAllValues().get(1).removedTargetPdpIds())
+            .as("a tagged default is still the bootstrap engine, which the wildcard does not reach")
+            .containsExactly("default@eu");
+    }
+
+    @Test
+    void a_schema_targeted_at_both_wildcard_and_default_stays_on_the_bootstrap_engine() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-2", "[\"default\"]"))))
+            .thenReturn(Flowable.just(List.of(schemaEvent("s-2", "[\"*\",\"default\"]"))));
+
+        AuthzSchemaSynchronizer synchronizer = schemaSynchronizer();
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzSchemaReactorDeployable> captor = ArgumentCaptor.forClass(AuthzSchemaReactorDeployable.class);
+        verify(schemaDeployer, times(2)).deploy(captor.capture());
+        assertThat(captor.getAllValues().get(1).removedTargetPdpIds())
+            .as("D7 removes the implicit fan-out only; an explicitly named default is still wanted")
+            .isEmpty();
+    }
+
+    @Test
+    void a_policy_retargeted_from_default_to_wildcard_is_still_not_evicted() throws InterruptedException {
+        when(fetcher.fetchLatest(any(), any(), any(), any(), any()))
+            .thenReturn(Flowable.just(List.of(policyEvent("p-1", "[\"default\"]"))))
+            .thenReturn(Flowable.just(List.of(policyEvent("p-1", "[\"*\"]"))));
+
+        AuthzPolicySynchronizer synchronizer = new AuthzPolicySynchronizer(
+            fetcher,
+            new AuthzPolicyMapper(objectMapper),
+            deployerFactory,
+            port,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+        synchronizer.synchronize(-1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+        synchronizer.synchronize(1L, Instant.now().toEpochMilli(), Set.of("env-1")).test().await().assertComplete();
+
+        ArgumentCaptor<AuthzPolicyReactorDeployable> captor = ArgumentCaptor.forClass(AuthzPolicyReactorDeployable.class);
+        verify(policyDeployer, times(2)).deploy(captor.capture());
+        assertThat(captor.getAllValues().get(1).removedTargetPdpIds())
+            .as("a policy wildcard covers the bootstrap engine, so nothing is dropped: retainAll(Set.of()) == clear()")
+            .isEmpty();
+    }
+
+    private AuthzSchemaSynchronizer schemaSynchronizer() {
+        return new AuthzSchemaSynchronizer(
+            fetcher,
+            new AuthzSchemaMapper(objectMapper),
+            deployerFactory,
+            port,
+            new AuthzScopePlacement(),
+            executor(),
+            executor()
+        );
+    }
+
+    private static ThreadPoolExecutor executor() {
+        return new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    }
+
+    private static Event schemaEvent(String id, String targets) {
+        return event(
+            "evt-" + id + "-" + targets.hashCode(),
+            EventType.PUBLISH_AUTHZ_SCHEMA,
+            "{\"id\":\"" +
+                id +
+                "\",\"name\":\"S\",\"environmentId\":\"env-1\",\"schemaText\":\"entity User;\",\"targetPdpIds\":" +
+                targets +
+                "}"
+        );
+    }
+
+    private static Event policyEvent(String id, String targets) {
+        return event(
+            "evt-" + id + "-" + targets.hashCode(),
+            EventType.PUBLISH_AUTHZ_POLICY,
+            "{\"id\":\"" +
+                id +
+                "\",\"name\":\"P\",\"kind\":\"GLOBAL\",\"policyText\":\"permit(principal, action, resource);\",\"targetPdpIds\":" +
+                targets +
+                "}"
+        );
+    }
+
+    private static Event event(String id, EventType type, String payload) {
+        Event e = new Event();
+        e.setId(id);
+        e.setType(type);
+        e.setPayload(payload);
+        e.setUpdatedAt(new java.util.Date());
+        return e;
+    }
+}


### PR DESCRIPTION
> Stacked on #19359 (`authz-33-schema-port`), which is itself stacked on #19357. Base is that branch, so this diff shows only its own changes. Rebases down as the stack merges.

## What

Third and last step of the gateway half of AUTHZ-33: the schema route joins the sync cycle. With this a schema authored in the control plane reaches the PDP engines it targets, without a restart.

Section 8 came to ~1400 lines including tests and was split in two. #19359 answered "does the command shape and the routing match the contract the PDP already accepts?". This one answers "does inserting a synchronizer step break the other synchronizers?".

## Changes

- `AuthzSchemaSynchronizer extends AbstractAuthzReactorSynchronizer`, with mapper, deployable and deployer already in #19359.
- `Order.AUTHZ_SCHEMA` at 9, between `AUTHZ_PDP` and `AUTHZ_ENTITY`. Everything below renumbers. The enum's static duplicate-index guard turns a mistake into a class-initialisation failure rather than a silent reordering, and `OrderTest` exercises it.
- Hydration groups three aggregates instead of two and stages the schema **first**, so a freshly provisioned scope carries it on its very first commit.
- Spring wiring, including a schema-specific `AuthzScopePlacement` rather than sharing the policy one.

## The D7 eviction defect, found in review of #19359

`AbstractAuthzReactorSynchronizer.deploy` dropped the whole eviction set on a wildcard:

```java
if (target.contains(WILDCARD)) {
    // A wildcard targets every hosted scope, so it can never narrow a previously-applied scope away
    dropped.clear();
}
```

That premise is true for policies and entities and **false for schemas**, by construction of D7: a schema wildcard deliberately excludes the bootstrap engine. So a schema retargeted from `["default"]` to `["*"]` was never evicted from the bootstrap engine and `addOrUpdateSchema` deliberately skipped it, leaving it on a cross-environment engine forever. `placement.replace` then recorded `{"*"}`, so no later narrowing could evict it either: there was no state from which this recovers.

The fix replaces the unconditional `clear()` with `retainAll(scopesNotCoveredByWildcard())`. For policies and entities that hook returns the empty set, so `retainAll` is **exactly** the `clear()` it replaces, by the definition of the operation rather than by assurance. An explicitly named scope is then removed from the drop set unconditionally, so targeting both `"*"` and `"default"` still keeps the document on the bootstrap engine, which is what D7 intends: it removes the implicit fan-out, not explicit targeting.

Two alternatives were considered and rejected. Evicting `default` unconditionally in the deployer runs on every deploy rather than on the transition, so it would send a removal to the shared engine every cycle for documents that were never there. Keeping `default` in the drop set whenever the target contains `"*"` evicts a document that named `default` explicitly.

## Two behaviour changes the tests now assert rather than absorb

**A third staging step means a third `commitScope` per hydrated scope.** `stageScope` seals the scope per synchronizer, so the existing `times(2)` expectations become `times(3)`. Worth a look: three round-trips per scope where one would do is a cost on a path already known to matter for API deployment latency. Not changed here because it means moving the commit out of the shared `stageScope`.

**A dead engine now fails a hydration cycle earlier.** With the schema staged first, `failed_hydration_is_retried_on_the_next_cycle` sees the failure at the schema step, before any policy work: 1 `addOrUpdatePolicy` instead of 2, and 4 `commitScope` instead of 3. That is the ordering doing its job, and the comment in that test now says so.

## Tests

`mvn verify` on `gravitee-apim-gateway-services-sync`: 714 green, prettier and the logging ArchUnit rules included. 539 insertions, 34 deletions.

New `AuthzWildcardEvictionTest`, three cases:
- a schema retargeted from `default` to `*` **is** evicted from the bootstrap engine;
- a schema targeted at both `*` and `default` **stays** on it;
- a policy retargeted from `default` to `*` is still not evicted, pinning the `retainAll(Set.of()) == clear()` equivalence for the shared path.

Reverting the hook to the old `clear()` turns the first of those red; checked by mutation, not assumed.

`AuthzPdpHydrationTest.hydration_stages_the_schema_before_the_policies_of_the_same_scope` pins the section 8 ordering requirement with an `InOrder` on the engine port.

`AuthzEventToEngineIntegrationTest` and `AuthzHydrationPlacementTest` get an assertion proving their schema recorder is live, so their emptiness assertions are not vacuous. Note the substantive hydration-ordering assertion lives in `AuthzPdpHydrationTest` rather than in those two, because it needs a mockable engine port to express ordering.
