### PR TITLE
fix(helm): expose es.lifecycle.policies.eventMetrics for the gateway

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -9,6 +9,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - Add `gateway.kafka.routingHostMode.virtualClusterBrokerDomainPattern`, a broker domain pattern applied to Kafka APIs backed by a Virtual Cluster only. Such APIs advertise rewritten broker ids, and setting their pattern separately keeps the domains of the other Kafka APIs on the gateway unchanged. Optional: when unset, Virtual Clusters follow `brokerDomainPattern`. Two placeholders come with it, usable in either pattern: `{realBrokerId}` (the id configured on the backend broker) and `{clusterIndex}` (the backend's position in the Virtual Cluster).
 - Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
+- Add `es.lifecycle.policies.eventMetrics`, the ILM policy for the `gravitee-event-metrics-*` data streams. The gateway already read this key, but the chart did not render it under `es.lifecycle`, so it could only be set by hand through `gateway.env` (APIM-14875).
 
 ### 4.12.0
 - Add support for Kubernetes Gateway API HTTPRoute for all components (API, Gateway, User Interface, Portal).

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -13,6 +13,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - Add `gateway.kafka.routingHostMode.virtualClusterBrokerDomainPattern`, a broker domain pattern applied to Kafka APIs backed by a Virtual Cluster only. Such APIs advertise rewritten broker ids, and setting their pattern separately keeps the domains of the other Kafka APIs on the gateway unchanged. Optional: when unset, Virtual Clusters follow `brokerDomainPattern`. Two placeholders come with it, usable in either pattern: `{realBrokerId}` (the id configured on the backend broker) and `{clusterIndex}` (the backend's position in the Virtual Cluster).
 - Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
+- Add `es.lifecycle.policies.eventMetrics`, the ILM policy for the `gravitee-event-metrics-*` data streams. The gateway already read this key, but the chart did not render it under `es.lifecycle`, so it could only be set by hand through `gateway.env` (APIM-14875).
 
 ### 4.12.0
 - Add support for Kubernetes Gateway API HTTPRoute for all components (API, Gateway, User Interface, Portal).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -53,3 +53,5 @@ annotations:
       links:
         - name: Github Issue
           url: https://github.com/gravitee-io/issues/issues/11583
+    - kind: added
+      description: "`es.lifecycle.policies.eventMetrics` sets the ILM policy for the gravitee-event-metrics-* data streams, which the chart previously could not render"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -63,3 +63,8 @@ annotations:
       links:
         - name: Github PR
           url: https://github.com/gravitee-io/gravitee-api-management/pull/19547
+    - kind: added
+      description: "`es.lifecycle.policies.eventMetrics` sets the ILM policy for the gravitee-event-metrics-* data streams, which the chart previously could not render"
+      links:
+        - name: Github PR
+          url: https://github.com/gravitee-io/gravitee-api-management/pull/19361

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -671,6 +671,7 @@ data:
             request: {{ .Values.es.lifecycle.policies.request }}
             health: {{ .Values.es.lifecycle.policies.health }}
             log: {{ .Values.es.lifecycle.policies.log }}
+            event_metrics: {{ .Values.es.lifecycle.policies.eventMetrics }}
         {{- end }}
         {{- if (eq .Values.es.security.enabled true) }}
         security:

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -713,6 +713,7 @@ data:
             request: {{ .Values.es.lifecycle.policies.request }}
             health: {{ .Values.es.lifecycle.policies.health }}
             log: {{ .Values.es.lifecycle.policies.log }}
+            event_metrics: {{ .Values.es.lifecycle.policies.eventMetrics }}
         {{- end }}
         {{- if (eq .Values.es.security.enabled true) }}
         security:

--- a/helm/tests/gateway/configmap_es_reporter_test.yaml
+++ b/helm/tests/gateway/configmap_es_reporter_test.yaml
@@ -140,6 +140,7 @@ tests:
             request: request
             health: health
             log: log
+            eventMetrics: eventMetrics
     asserts:
       - hasDocuments:
           count: 1
@@ -163,6 +164,7 @@ tests:
                     request: request
                     health: health
                     log: log
+                    event_metrics: eventMetrics
                 index: gravitee
                 settings:
                   number_of_replicas: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -372,6 +372,7 @@ es:
       request: my_policy ## ILM policy for the gravitee-request-* indexes
       health: my_policy ## ILM policy for the gravitee-health-* indexes
       log: my_policy ## ILM policy for the gravitee-log-* indexes
+      eventMetrics: "" ## ILM policy for the gravitee-event-metrics-* data streams. Unset by default: the gateway ignores this key today, so nothing depends on it yet.
     # http:
       # timeout: 10000
   ssl:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -372,6 +372,7 @@ es:
       request: my_policy ## ILM policy for the gravitee-request-* indexes
       health: my_policy ## ILM policy for the gravitee-health-* indexes
       log: my_policy ## ILM policy for the gravitee-log-* indexes
+      eventMetrics: "" ## ILM policy for the gravitee-event-metrics-* data streams. Unset by default, unlike its siblings: no deployment can be relying on it yet, and an empty value renders a key the gateway ignores.
     # http:
       # timeout: 10000
   ssl:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14875

## Description

The gateway reads `reporters.elasticsearch.lifecycle.policies.event_metrics`, but the chart rendered only `monitor` / `request` / `health` / `log` under `es.lifecycle`, so the key could only be set by hand through `gateway.env`. Adds `es.lifecycle.policies.eventMetrics` to `values.yaml` and the gateway configmap, with CHANGELOG and artifacthub entries.

Defaults to `""`, unlike the four siblings which default to the `my_policy` placeholder. The siblings have an installed base; this key has none. Defaulting it empty means no existing `es.lifecycle.enabled` deployment gets a placeholder policy attached to its event-metrics stream on upgrade — it renders as `event_metrics:` (null), which the gateway ignores.

## Compatibility

The gateway honours this key on master (#19421), so unlike when this PR was opened, the chart key is live rather than inert: a policy set here takes effect on deploy, including its delete phase. Nothing renders at all unless `es.lifecycle.enabled` is set and the key is given a value.

## Tests

`helm/tests/gateway/configmap_es_reporter_test.yaml` sets the new key and asserts it renders under `es.lifecycle`. Full chart suite green.

## Related

Reporter: #19350 pins the gateway-side behaviour with test coverage. The two are independent — the earlier merge-order note no longer applies.
