### PR TITLE
fix(reporter): bound additional-metrics keyword values with ignore_above

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -266,7 +266,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -97,7 +97,8 @@
                     "path_match": "additional-metrics.keyword_*",
                     "match_mapping_type": "string",
                     "mapping": {
-                        "type": "keyword"
+                        "type": "keyword",
+                        "ignore_above": 1024
                     }
                 }
             },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -272,7 +272,8 @@
                     "path_match": "additional-metrics.keyword_*",
                     "match_mapping_type": "string",
                     "mapping": {
-                        "type": "keyword"
+                        "type": "keyword",
+                        "ignore_above": 1024
                     }
                 }
             },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -267,7 +267,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -98,7 +98,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -273,7 +273,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
@@ -267,7 +267,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
@@ -98,7 +98,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
@@ -273,7 +273,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
@@ -267,7 +267,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
@@ -98,7 +98,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
@@ -273,7 +273,8 @@
                         "path_match": "additional-metrics.keyword_*",
                         "match_mapping_type": "string",
                         "mapping": {
-                            "type": "keyword"
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexTemplateTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexTemplateTest.java
@@ -24,11 +24,14 @@ import io.gravitee.apim.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
 import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
 import io.gravitee.common.templating.FreeMarkerComponent;
 import io.gravitee.elasticsearch.utils.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Asserts what the es{@code 7,8,9}x index templates actually render: the configured lifecycle property names
@@ -87,6 +90,48 @@ class IndexTemplateTest {
             .contains("\"index.lifecycle.rollover_alias\"")
             .doesNotContain("\"\":")
             .doesNotContain("\"  index.lifecycle.rollover_alias  \"");
+    }
+
+    /**
+     * Every rendered template whose dynamic templates map {@code additional-metrics.keyword_*}. OpenSearch has
+     * no preparer this harness can drive, so its templates are covered by the sibling test that reads them off
+     * the classpath.
+     */
+    static Stream<Arguments> es_trees_and_types_carrying_additional_keyword_metrics() {
+        return Stream.of("es7x", "es8x", "es9x").flatMap(esDir ->
+            Stream.of(Type.REQUEST, Type.V4_METRICS, Type.V4_MESSAGE_METRICS).map(type -> Arguments.of(esDir, type))
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} bounds additional-metrics.keyword_* with ignore_above")
+    @MethodSource("es_trees_and_types_carrying_additional_keyword_metrics")
+    void should_bound_additional_keyword_metrics_so_one_oversized_value_cannot_break_indexing(String esDir, Type type) {
+        // additional-metrics.keyword_* carries values a client controls — the Kafka client.id arrives before
+        // authentication and the wire format allows 32767 bytes of it. Lucene's term limit is 32766, so an
+        // unbounded keyword makes Elasticsearch reject the bulk item and the connection record is lost.
+        // Defence in depth: the gateway bounds client.id at the source, this covers every keyword_* metric,
+        // including ones other plugins add later.
+        assertThat(preparerFor(esDir, configurationWithPolicies()).generateIndexTemplate(type))
+            .contains("\"additional-metrics.keyword_*\"")
+            .contains("\"ignore_above\"");
+    }
+
+    @ParameterizedTest(name = "{0} templates bound additional-metrics.keyword_* with ignore_above")
+    @ValueSource(strings = { "es7x", "es8x", "es9x", "opensearch" })
+    void should_bound_additional_keyword_metrics_in_every_template_family(String esDir) throws Exception {
+        // Read off the classpath rather than rendered, so OpenSearch — which has no preparer to drive — is
+        // covered by the same invariant as the rest.
+        var templates = List.of("index-template-request.ftl", "index-template-v4-metrics.ftl", "index-template-v4-message-metrics.ftl");
+
+        for (var template : templates) {
+            var path = "/freemarker/" + esDir + "/mapping/" + template;
+            try (var in = IndexTemplateTest.class.getResourceAsStream(path)) {
+                assertThat(in).as("%s is on the classpath", path).isNotNull();
+                var body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                assertThat(body).as("%s maps additional-metrics.keyword_*", path).contains("\"additional-metrics.keyword_*\"");
+                assertThat(body).as("%s bounds it with ignore_above", path).contains("\"ignore_above\"");
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Elasticsearch half of [ESM-137](https://gravitee.atlassian.net/browse/ESM-137). The gateway half is gravitee-io/gravitee-reactor-native-kafka#405.

## Why

`additional-metrics.keyword_*` carries values a client controls. The Kafka `client.id` arrives on the **first frame of the handshake, before authentication**, and the wire format accepts up to **32767 bytes** of it. The dynamic template mapped it as a plain `keyword` with **no ceiling**, in all four template families:

```json
"additional_keyword_metrics": {
    "path_match": "additional-metrics.keyword_*",
    "match_mapping_type": "string",
    "mapping": { "type": "keyword" }
}
```

Lucene's term limit is 32766 bytes, so a value near the top of the allowed range makes Elasticsearch **reject the bulk item** — the client erasing its own connection audit record.

## Layering

This is **defence in depth**, not the primary fix. `ignore_above` stops the value being *indexed*; it is still stored in `_source` and returned on read, so the document stays inflated. Bounding at the gateway (#405) is what keeps the payload out.

What this layer buys, and #405 does not:

- covers **every** `keyword_*` additional metric, including ones other plugins add later;
- protects a cluster fronted by a gateway that has not been upgraded.

## The value

`1024` rather than the Elasticsearch default of `256`: generous for any real keyword metric, two orders of magnitude below the term limit. A value above it stops being indexed, not stored — the trade is searchability of an abnormal value against the health of the index.

## Coverage

12 templates, 4 families × 3 index kinds. Tested twice over:

- rendered through the preparers for `es7x` / `es8x` / `es9x`;
- read off the classpath for all four families, **including `opensearch`**, which has no preparer this harness can drive.

Verified to fail when the ceiling is removed from a single template.

[ESM-137]: https://gravitee.atlassian.net/browse/ESM-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ