### PR TITLE
feat(console): expose CORS configuration for LLM proxy APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
@@ -161,15 +161,16 @@ describe('ApiV4MenuService', () => {
       expect(entrypoints.routerLink).toBe('v4/entrypoints');
     });
 
-    it('should render a single Entrypoints route (no tabs) for LLM_PROXY', () => {
+    it('should expose Entrypoints and CORS tabs for LLM_PROXY (no MCP Entrypoint, no Response Templates)', () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api-response_templates-r'] });
       service = TestBed.inject(ApiV4MenuService);
 
       const api = fakeApiV4({ type: 'LLM_PROXY', listeners: [httpListener] });
       const menu = service.getMenu(api);
       const entrypoints = menu.subMenuItems.find(item => item.displayName === 'Entrypoints');
 
-      expect(entrypoints.tabs).toBeUndefined();
-      expect(entrypoints.routerLink).toBe('v4/entrypoints');
+      expect(entrypoints.tabs?.map(t => t.displayName)).toEqual(['Entrypoints', 'CORS']);
+      expect(entrypoints.tabs?.map(t => t.routerLink)).toEqual(['v4/entrypoints', 'v4/cors']);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -159,7 +159,7 @@ export class ApiV4MenuService implements ApiMenuService {
       },
     };
 
-    if (api.type === 'NATIVE' || api.type === 'LLM_PROXY') {
+    if (api.type === 'NATIVE') {
       return {
         ...menuItem,
         routerLink: 'v4/entrypoints',
@@ -180,7 +180,7 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
-    if (api.type !== 'MCP_PROXY' && this.permissionService.hasAnyMatching(['api-response_templates-r'])) {
+    if (api.type !== 'MCP_PROXY' && api.type !== 'LLM_PROXY' && this.permissionService.hasAnyMatching(['api-response_templates-r'])) {
       tabs.push({
         displayName: 'Response Templates',
         routerLink: hasTcpListeners ? 'DISABLED' : 'response-templates',

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
@@ -325,6 +325,48 @@ describe('ApiCorsComponent', () => {
       });
     });
 
+    it('should enable and set CORS config on a LLM_PROXY API', async () => {
+      const api = fakeApiV4({
+        id: API_ID,
+        type: 'LLM_PROXY',
+        listeners: [{ type: 'HTTP', entrypoints: [{ type: 'llm-proxy' }], paths: [{ path: '/path' }] }],
+      });
+      expectApiGetRequest(api);
+      expectEntrypointsGetRequest([
+        ...ENTRYPOINTS_LIST,
+        { id: 'llm-proxy', supportedApiType: 'LLM_PROXY', name: 'LLM Proxy', availableFeatures: ['CORS'] },
+      ]);
+
+      expect(await loader.getAllHarnesses(DivHarness.with({ selector: '.banner.warning' }))).toEqual([]);
+
+      const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
+      expect(await enabledSlideToggle.isDisabled()).toEqual(false);
+      await enabledSlideToggle.toggle();
+
+      const allowOriginInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="allowOrigin"]' }));
+      await allowOriginInput.addTag('https://console.example.com');
+
+      const allowMethodsInput = await loader.getHarness(GioFormTagsInputHarness.with({ selector: '[formControlName="allowMethods"]' }));
+      await allowMethodsInput.addTag('POST');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expectApiGetRequest(api);
+      const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` });
+      expect(req.request.body.listeners[0].cors).toStrictEqual({
+        enabled: true,
+        allowMethods: ['POST'],
+        allowOrigin: ['https://console.example.com'],
+        allowHeaders: [],
+        allowCredentials: false,
+        exposeHeaders: [],
+        maxAge: -1,
+        allowPrivateNetwork: false,
+        runPolicies: false,
+      });
+    });
+
     it('should enable and set CORS config with a warning', async () => {
       const api = fakeApiV4({
         id: API_ID,

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.0.7</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.6</gravitee-reactor-mcp-proxy.version>
-    <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
+    <gravitee-reactor-llm-proxy.version>3.3.9</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14868

## Description

LLM proxy APIs are served by an HTTP listener and the gateway already honours its CORS configuration, but the console hid the CORS tab for this API type.

Expose the Entrypoints menu as tabs for LLM_PROXY, with Entrypoints and CORS. Response Templates stays excluded, as for MCP proxy APIs.

Bump gravitee-reactor-llm-proxy to 3.3.9, which declares the cors feature in the llm-proxy entrypoint manifest so that the CORS form is enabled.
