### PR TITLE
feat(console): import a portal navigation tree from a remote repository

### DIFF
--- a/gravitee-apim-console-webui/src/entities/fetcher/fetcher.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/fetcher/fetcher.fixture.ts
@@ -31,6 +31,11 @@ export function fakeFetcherListItem(attributes?: Partial<FetcherListItem>): Fetc
   };
 }
 
+/** The fetchers able to list a directory, what `GET /fetchers?import=true` returns: everything but the single-file HTTP one */
+export function fakeFilesFetcherList(): FetcherListItem[] {
+  return fakeFetcherList().filter(fetcher => fetcher.id !== 'http-fetcher');
+}
+
 export function fakeFetcherList(): FetcherListItem[] {
   return [
     {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -30,6 +30,8 @@ export interface PortalNavigationItemSource {
   lastFetchAttemptAt?: string;
   /** Read-only, server-managed. Absent when the last fetch succeeded. */
   lastFetchError?: string;
+  /** Read-only, server-managed. True on a folder managed by the navigation import: fetching it re-runs the import. */
+  subtreeImport?: boolean;
 }
 
 interface BasePortalNavigationItem<T extends PortalNavigationItemType> {
@@ -109,6 +111,25 @@ export function collectNodeIdsWithSourcedPageDescendants(items: PortalNavigation
   return nodeIds;
 }
 
+/**
+ * Ids of the containers the backend `_fetch` endpoint accepts: those carrying at least one sourced PAGE
+ * below them, plus the import-managed FOLDERs — an imported folder owns the source alone, its pages
+ * carry none, so it would be missing from the descendants-only set. `subtreeImport` is server-owned,
+ * so this is exactly the set the backend fetches, not an approximation of it.
+ */
+export function collectFetchableContainerIds(items: PortalNavigationItem[] | null | undefined): Set<string> {
+  const nodeIds = collectNodeIdsWithSourcedPageDescendants(items);
+
+  for (const item of items ?? []) {
+    const source = getPortalNavigationItemSource(item);
+    if (item.type === 'FOLDER' && source?.subtreeImport) {
+      nodeIds.add(item.id);
+    }
+  }
+
+  return nodeIds;
+}
+
 export interface PortalNavigationItemFetchResult {
   navigationItemId: string;
   title: string;
@@ -127,6 +148,18 @@ export interface PortalNavigationItemsFetchSummary {
 export interface FetchPortalNavigationItemResponse {
   item?: PortalNavigationItem;
   summary?: PortalNavigationItemsFetchSummary;
+}
+
+export interface ImportPortalNavigationRequest {
+  title: string;
+  parentId?: string;
+  visibility?: PortalVisibility;
+  source: PortalNavigationItemSource;
+}
+
+export interface ImportPortalNavigationResponse {
+  rootFolder: PortalNavigationFolder;
+  summary: PortalNavigationItemsFetchSummary;
 }
 
 interface BaseNewPortalNavigationItem<T extends PortalNavigationItemType> {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -477,6 +477,41 @@ describe('FlatTreeComponent', () => {
       expect(await harness.getMenuItemByTestId('fetch-all-button')).toBeNull();
     });
 
+    it('should emit fetchAll for an imported folder whose pages carry no source', async () => {
+      const actionSpy = jest.fn();
+      component.nodeMenuAction.subscribe(actionSpy);
+
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Imported Docs', order: 0, source: { ...source, subtreeImport: true } }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Imported Page', order: 0, parentId: 'f1' }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.selectFetchAllById('f1');
+      await fixture.whenStable();
+
+      expect(actionSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'fetchAll',
+          itemType: 'FOLDER',
+          node: expect.objectContaining({ id: 'f1' }),
+        }),
+      );
+    });
+
+    it('should not show Fetch All for a sourced folder the import does not manage', async () => {
+      fixture.componentRef.setInput('links', [
+        fakePortalNavigationFolder({ id: 'f1', title: 'Folder 1', order: 0, source: { type: 'http-fetcher', configuration: {} } }),
+        fakePortalNavigationPage({ id: 'p1', title: 'Plain Page', order: 0, parentId: 'f1' }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await harness.openMoreActionsMenuById('f1');
+      expect(await harness.getMenuItemByTestId('fetch-all-button')).toBeNull();
+    });
+
     it('should not show Fetch All for a sourced page itself', async () => {
       fixture.componentRef.setInput('links', [fakePortalNavigationPage({ id: 'p1', title: 'Sourced Page', order: 0, source })]);
       fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -36,7 +36,7 @@ import { CommonModule } from '@angular/common';
 import { CdkDragDrop, CdkDragMove, CdkDragStart, DragDropModule } from '@angular/cdk/drag-drop';
 
 import {
-  collectNodeIdsWithSourcedPageDescendants,
+  collectFetchableContainerIds,
   getPortalNavigationItemSource,
   PortalNavigationItem,
   PortalNavigationItemType,
@@ -191,8 +191,9 @@ export class FlatTreeComponent {
     return creationAllowedByNodeId;
   });
 
-  // "Fetch All" targets the sourced PAGE descendants, matching what the backend _fetch endpoint collects
-  private readonly nodeIdsWithSourcedPageDescendants = computed(() => collectNodeIdsWithSourcedPageDescendants(this.links()));
+  // "Fetch All" targets what the backend _fetch endpoint accepts: the sourced PAGE descendants, and the
+  // import-managed folders, whose re-import replaces the walk of individual sourced pages
+  private readonly fetchableContainerIds = computed(() => collectFetchableContainerIds(this.links()));
 
   publishStateByNodeId = computed(() => {
     const links = this.links();
@@ -246,7 +247,7 @@ export class FlatTreeComponent {
   isSourced = (node: FlatTreeNode) => !!node.data && !!getPortalNavigationItemSource(node.data);
 
   canFetchAll(node: FlatTreeNode): boolean {
-    return this.canUpdate && this.isContainer(node) && this.nodeIdsWithSourcedPageDescendants().has(node.id);
+    return this.canUpdate && this.isContainer(node) && this.fetchableContainerIds().has(node.id);
   }
 
   isPublishDisabled(node: SectionNode): boolean {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.html
@@ -1,0 +1,53 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div mat-dialog-title class="title">Import documentation from a repository</div>
+
+<mat-dialog-content class="import-navigation-dialog__content">
+  <gio-banner-info>
+    A folder bound to the source is created: its pages are fetched from the repository and stay read-only.
+    <span gioBannerBody>
+      If a <code>.gravitee.json</code> manifest is present, the hierarchy follows it; otherwise the repository tree is mirrored.
+    </span>
+  </gio-banner-info>
+
+  <div class="form-field-title">Folder title</div>
+  <mat-form-field appearance="outline" class="import-navigation-dialog__title-field">
+    <mat-label>Title</mat-label>
+    <input matInput aria-label="Title" data-testid="import-title-input" [formControl]="titleControl" required />
+    @if (titleControl.hasError('required')) {
+      <mat-error>Title is required</mat-error>
+    }
+  </mat-form-field>
+
+  <div class="form-field-title">Source</div>
+  <navigation-item-source-editor [embedded]="true" [onlyFilesFetchers]="true" />
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="onCancel()">Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    data-testid="import-navigation-button"
+    [disabled]="importDisabled()"
+    (click)="onImport()"
+  >
+    Import
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.scss
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.import-navigation-dialog {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__title-field {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.component.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, viewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+
+import { NavigationItemSourceEditorComponent } from '../navigation-item-source-editor/navigation-item-source-editor.component';
+import { PortalNavigationItemSource } from '../../../entities/management-api-v2';
+
+export interface ImportNavigationDialogResult {
+  title: string;
+  source: PortalNavigationItemSource;
+}
+
+@Component({
+  selector: 'import-navigation-dialog',
+  templateUrl: './import-navigation-dialog.component.html',
+  styleUrls: ['./import-navigation-dialog.component.scss'],
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    GioBannerModule,
+    NavigationItemSourceEditorComponent,
+  ],
+})
+export class ImportNavigationDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<ImportNavigationDialogComponent, ImportNavigationDialogResult>);
+
+  readonly titleControl = new FormControl<string>('', { nonNullable: true, validators: Validators.required });
+
+  private readonly sourceEditor = viewChild(NavigationItemSourceEditorComponent);
+  private readonly titleStatus = toSignal(this.titleControl.statusChanges, { initialValue: this.titleControl.status });
+
+  readonly importDisabled = computed(() => {
+    const editor = this.sourceEditor();
+    return this.titleStatus() !== 'VALID' || !editor || editor.saveDisabled();
+  });
+
+  onImport() {
+    const editor = this.sourceEditor();
+    const source = editor?.buildSource();
+    if (this.titleControl.invalid || !editor || !source) {
+      return;
+    }
+    // A blank path used to import an empty folder; for a tree import it can only mean the repository root
+    const schemaProperties = Object.keys(editor.selectedSchema()?.properties ?? {});
+    const configuration = { ...((source.configuration ?? {}) as Record<string, unknown>) };
+    for (const key of schemaProperties.filter(property => property === 'filepath' || property === 'path')) {
+      const value = configuration[key];
+      if (value == null || String(value).trim() === '') {
+        configuration[key] = '/';
+      }
+    }
+    source.configuration = configuration;
+    this.dialogRef.close({ title: this.titleControl.value.trim(), source });
+  }
+
+  onCancel() {
+    this.dialogRef.close();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/import-navigation-dialog/import-navigation-dialog.harness.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { NavigationItemSourceEditorHarness } from '../navigation-item-source-editor/navigation-item-source-editor.harness';
+
+export class ImportNavigationDialogHarness extends ComponentHarness {
+  static hostSelector = 'import-navigation-dialog';
+
+  private readonly locateTitleInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="import-title-input"]' }));
+  private readonly locateImportButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="import-navigation-button"]' }));
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  private readonly locateSourceEditor = this.locatorFor(NavigationItemSourceEditorHarness);
+
+  async setTitle(title: string): Promise<void> {
+    const input = await this.locateTitleInput();
+    return input.setValue(title);
+  }
+
+  async getSourceEditor(): Promise<NavigationItemSourceEditorHarness> {
+    return this.locateSourceEditor();
+  }
+
+  async isImportButtonDisabled(): Promise<boolean> {
+    const button = await this.locateImportButton();
+    return button.isDisabled();
+  }
+
+  async clickImportButton(): Promise<void> {
+    const button = await this.locateImportButton();
+    return button.click();
+  }
+
+  async clickCancelButton(): Promise<void> {
+    const button = await this.locateCancelButton();
+    return button.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/navigation-item-source-editor/navigation-item-source-editor.component.ts
@@ -15,14 +15,14 @@
  */
 import { Component, computed, DestroyRef, effect, inject, input, output, signal } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { GioBannerModule, GioFormCronModule, GioFormJsonSchemaModule, GioJsonSchema } from '@gravitee/ui-particles-angular';
-import { catchError, debounceTime, map, tap } from 'rxjs/operators';
+import { catchError, debounceTime, map, switchMap, tap } from 'rxjs/operators';
 import { of, Subject, Subscription } from 'rxjs';
 import { DatePipe } from '@angular/common';
 import { isEqual } from 'lodash';
@@ -89,6 +89,8 @@ export class NavigationItemSourceEditorComponent {
   source = input<PortalNavigationItemSource | null>(null);
   disabled = input(false);
   embedded = input(false);
+  /** Restricts the picker to the fetchers an import can walk, as the legacy documentation import screen does */
+  onlyFilesFetchers = input(false);
 
   saveSource = output<PortalNavigationItemSource>();
   removeSource = output<void>();
@@ -109,20 +111,25 @@ export class NavigationItemSourceEditorComponent {
   private lastResetSource: PortalNavigationItemSource | null | undefined = undefined;
 
   readonly fetchers = toSignal(
-    this.fetcherService.getList().pipe(
-      map(fetchers =>
-        fetchers.map(
-          (fetcher): FetcherVM => ({
-            id: fetcher.id,
-            name: fetcher.name ?? fetcher.id,
-            schema: stripLegacyAutoFetchFromSchema(JSON.parse(fetcher.schema)),
+    // The input is only readable after construction, hence the reactive read rather than a plain call
+    toObservable(this.onlyFilesFetchers).pipe(
+      switchMap(onlyFilesFetchers =>
+        this.fetcherService.getList(onlyFilesFetchers).pipe(
+          map(fetchers =>
+            fetchers.map(
+              (fetcher): FetcherVM => ({
+                id: fetcher.id,
+                name: fetcher.name ?? fetcher.id,
+                schema: stripLegacyAutoFetchFromSchema(JSON.parse(fetcher.schema)),
+              }),
+            ),
+          ),
+          catchError(() => {
+            this.snackBarService.error('Failed to load the fetcher plugins');
+            return of([] as FetcherVM[]);
           }),
         ),
       ),
-      catchError(() => {
-        this.snackBarService.error('Failed to load the fetcher plugins');
-        return of([] as FetcherVM[]);
-      }),
     ),
     { initialValue: [] as FetcherVM[] },
   );

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -33,6 +33,15 @@
         >
           <mat-icon>{{ isAnyTreeNodeExpanded() ? 'unfold_less' : 'unfold_more' }}</mat-icon>
         </button>
+        <button
+          *gioPermission="{ anyOf: ['environment-documentation-u'] }"
+          mat-stroked-button
+          type="button"
+          data-testid="import-navigation-toolbar-button"
+          (click)="onImportNavigation()"
+        >
+          Import
+        </button>
         <ng-container *gioPermission="{ anyOf: ['environment-documentation-c'] }">
           <button
             mat-stroked-button

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -36,6 +36,7 @@ import { ApiSectionEditorDialogHarness } from './api-section-editor-dialog/api-s
 import { ApiProductSectionEditorDialogHarness } from './api-product-section-editor-dialog/api-product-section-editor-dialog.harness';
 import { OpenApiConfigDialogHarness } from './openapi-config-dialog/openapi-config-dialog.harness';
 import { PublishNavigationItemDialogHarness } from './publish-navigation-item-dialog/publish-navigation-item-dialog.harness';
+import { ImportNavigationDialogHarness } from './import-navigation-dialog/import-navigation-dialog.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { GioTestingPermissionProvider } from '../../shared/components/gio-permission/gio-permission.service';
@@ -66,7 +67,7 @@ import {
   UpdatePagePortalNavigationItem,
   UpdatePortalNavigationItem,
 } from '../../entities/management-api-v2';
-import { fakeFetcherList } from '../../entities/fetcher/fetcher.fixture';
+import { fakeFetcherList, fakeFilesFetcherList } from '../../entities/fetcher/fetcher.fixture';
 import {
   OpenApiDocExpansion,
   OpenApiViewer,
@@ -3452,10 +3453,14 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectGetFetchers() {
-    httpTestingController
-      .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema` })
-      .flush(fakeFetcherList());
+  // Several embedded source editors can ask for the same list within one test, hence match() over expectOne()
+  function expectGetFetchers(onlyFilesFetchers = false) {
+    const requests = httpTestingController.match({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema${onlyFilesFetchers ? '&import=true' : ''}`,
+    });
+    expect(requests.length).toBeGreaterThan(0);
+    requests.forEach(request => request.flush(onlyFilesFetchers ? fakeFilesFetcherList() : fakeFetcherList()));
 
     fixture.detectChanges();
   }
@@ -3593,11 +3598,11 @@ describe('PortalNavigationItemsComponent', () => {
   // The source editor shown for FOLDER items (and the External Source tab) loads the fetcher list on creation
   function flushPendingFetcherRequests() {
     const requests = httpTestingController.match(
-      request => request.method === 'GET' && request.url === `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema`,
+      request => request.method === 'GET' && request.url.startsWith(`${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema`),
     );
 
     const activeRequests = requests.filter(req => !req.cancelled);
-    activeRequests.forEach(req => req.flush(fakeFetcherList()));
+    activeRequests.forEach(req => req.flush(req.request.url.includes('import=true') ? fakeFilesFetcherList() : fakeFetcherList()));
 
     if (activeRequests.length > 0) {
       fixture.detectChanges();
@@ -4966,9 +4971,28 @@ describe('PortalNavigationItemsComponent', () => {
         expect(await harness.getFolderManagedBySourceBannerText()).toContain('Folder content from GitHub — read only');
       });
 
-      it('disables Fetch now on a sourced folder with no sourced page below it', async () => {
-        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR', source: githubSource });
+      it('enables Fetch now on an imported folder, whose pages carry no source of their own', async () => {
+        const folder = fakePortalNavigationFolder({
+          id: 'folder-1',
+          title: 'Imported Docs',
+          area: 'TOP_NAVBAR',
+          source: { ...githubSource, subtreeImport: true },
+        });
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+        flushPendingFetcherRequests();
+
+        expect(await harness.isFetchNowButtonDisabled()).toBe(false);
+      });
+
+      it('disables Fetch now on a sourced folder the import does not manage', async () => {
+        const folder = fakePortalNavigationFolder({
+          id: 'folder-1',
+          title: 'My Folder',
+          area: 'TOP_NAVBAR',
+          source: { type: 'http-fetcher', configuration: { url: 'https://example.com/page.md' } },
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+        flushPendingFetcherRequests();
 
         expect(await harness.isFetchNowButtonDisabled()).toBe(true);
       });
@@ -4998,35 +5022,28 @@ describe('PortalNavigationItemsComponent', () => {
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, sourcedChild] }));
       });
 
-      it('adds a source on the folder from the Edit dialog', async () => {
+      it('does not offer attaching a source to a folder that has none', async () => {
         const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR' });
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
 
         const dialog = await openEditDialog();
-        expect(await dialog.hasExternalSourceToggle()).toBe(true);
-        await dialog.toggleExternalSource();
-        fixture.detectChanges();
-        expectGetFetchers();
+        // Only the import can bind a folder to a file-listing source; the backend rejects an update doing it
+        expect(await dialog.hasExternalSourceToggle()).toBe(false);
+        await dialog.clickCancelButton();
+      });
 
-        const sourceEditor = await dialog.getSourceEditor();
-        await sourceEditor.selectType('HTTP');
+      it('restricts an import-managed folder source to directory-capable fetchers', async () => {
+        const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'My Folder', area: 'TOP_NAVBAR', source: githubSource });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder] }));
+
+        const dialog = await openEditDialog();
         await fixture.whenStable();
         fixture.detectChanges();
-        await sourceEditor.setSchemaFormInputValue('https://example.com/folder');
-        await dialog.clickSubmitButton();
-
-        const body = expectPutNavigationItemAndCaptureBody('folder-1', fakePortalNavigationFolder({ ...folder, source: githubSource }));
-        expect(body.type).toBe('FOLDER');
-        expect((body as UpdateFolderPortalNavigationItem).source).toEqual(
-          expect.objectContaining({
-            type: 'http-fetcher',
-            configuration: expect.objectContaining({ url: 'https://example.com/folder' }),
-          }),
-        );
-
-        await expectGetNavigationItems(
-          fakePortalNavigationItemsResponse({ items: [fakePortalNavigationFolder({ ...folder, source: githubSource })] }),
-        );
+        expect(await dialog.hasExternalSourceToggle()).toBe(true);
+        expect(await dialog.isExternalSourceToggleChecked()).toBe(true);
+        // The folder edit asks for the same restricted list as the import dialog
+        expectGetFetchers(true);
+        await dialog.clickCancelButton();
       });
     });
 
@@ -5112,6 +5129,117 @@ describe('PortalNavigationItemsComponent', () => {
           expectGetPageContent('content-1', 'Some content');
 
           expect(await harness.isFetchNowButtonVisible()).toBe(false);
+        });
+      });
+
+      describe('Import from a remote repository', () => {
+        const importedFolder = fakePortalNavigationFolder({
+          id: 'imported-folder',
+          title: 'Imported Docs',
+          area: 'TOP_NAVBAR',
+          source: githubSource,
+        });
+
+        beforeEach(async () => {
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [] }));
+        });
+
+        async function openImportDialog(): Promise<ImportNavigationDialogHarness> {
+          await harness.clickImportNavigationButton();
+          fixture.detectChanges();
+          return rootLoader.getHarness(ImportNavigationDialogHarness);
+        }
+
+        it('imports a documentation tree and navigates to the created folder', async () => {
+          const dialog = await openImportDialog();
+          expectGetFetchers(true);
+
+          await dialog.setTitle('Imported Docs');
+          const sourceEditor = await dialog.getSourceEditor();
+          await sourceEditor.selectType('GIT');
+          await fixture.whenStable();
+          fixture.detectChanges();
+
+          expect(await dialog.isImportButtonDisabled()).toBe(true);
+          await sourceEditor.setSchemaFormInputValue('https://example.com/repo.git');
+          await sourceEditor.setSchemaFormInputValue('/docs', 2);
+          expect(await dialog.isImportButtonDisabled()).toBe(false);
+          await dialog.clickImportButton();
+
+          const req = httpTestingController.expectOne({
+            method: 'POST',
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_import`,
+          });
+          expect(req.request.body).toEqual({
+            title: 'Imported Docs',
+            source: expect.objectContaining({
+              type: 'git-fetcher',
+              configuration: expect.objectContaining({ repository: 'https://example.com/repo.git', path: '/docs' }),
+            }),
+          });
+          req.flush({
+            rootFolder: importedFolder,
+            summary: fakePortalNavigationItemsFetchSummary({ succeeded: 3, failed: 0 }),
+          });
+          fixture.detectChanges();
+
+          expect(snackBarSuccessSpy).toHaveBeenCalledWith(expect.stringContaining('3 pages'));
+          expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: 'imported-folder' } }));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [importedFolder] }));
+        });
+
+        it('shows a failure summary when some files fail to import', async () => {
+          const dialog = await openImportDialog();
+          expectGetFetchers(true);
+
+          await dialog.setTitle('Imported Docs');
+          const sourceEditor = await dialog.getSourceEditor();
+          await sourceEditor.selectType('GIT');
+          await fixture.whenStable();
+          fixture.detectChanges();
+          await sourceEditor.setSchemaFormInputValue('https://example.com/repo.git');
+          await sourceEditor.setSchemaFormInputValue('/docs', 2);
+          await dialog.clickImportButton();
+
+          httpTestingController
+            .expectOne({
+              method: 'POST',
+              url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_import`,
+            })
+            .flush({
+              rootFolder: importedFolder,
+              summary: fakePortalNavigationItemsFetchSummary({
+                succeeded: 1,
+                failed: 1,
+                results: [
+                  { navigationItemId: 'nav-1', title: 'Intro', success: true },
+                  {
+                    navigationItemId: 'nav-2',
+                    title: 'Legacy',
+                    success: false,
+                    error: 'Unsupported file extension for /docs/legacy.adoc.',
+                  },
+                ],
+              }),
+            });
+          fixture.detectChanges();
+
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2'));
+          expect(snackBarErrorSpy).toHaveBeenCalledWith(expect.stringContaining('"Legacy"'));
+          await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [importedFolder] }));
+        });
+
+        it('does not call the backend when the dialog is cancelled', async () => {
+          const dialog = await openImportDialog();
+          expectGetFetchers(true);
+
+          await dialog.clickCancelButton();
+          fixture.detectChanges();
+
+          httpTestingController.expectNone({
+            method: 'POST',
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_import`,
+          });
         });
       });
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -66,12 +66,16 @@ import {
   PublishNavigationItemDialogResult,
 } from './publish-navigation-item-dialog/publish-navigation-item-dialog.component';
 import { ImportFileError, IMPORTABLE_FILE_EXTENSIONS, readImportedFile, validateImportFile } from './portal-page-content-import.util';
+import {
+  ImportNavigationDialogComponent,
+  ImportNavigationDialogResult,
+} from './import-navigation-dialog/import-navigation-dialog.component';
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { FlatTreeComponent, NodeMenuActionEvent, NodeMovedEvent, SectionNode } from '../components/flat-tree/flat-tree.component';
 import {
-  collectNodeIdsWithSourcedPageDescendants,
+  collectFetchableContainerIds,
   FetchPortalNavigationItemResponse,
   getPortalNavigationItemSource,
   NewPortalNavigationItem,
@@ -270,8 +274,8 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   });
   readonly isContentEditingLocked = computed(() => !!this.selectedItemSource() || !!this.parentSourcedFolder());
   readonly isFetching = signal(false);
-  // A folder carries a source but is never fetched itself: only the sourced pages below it are.
-  // Fetching one without such a page is rejected by the backend, so the action stays disabled.
+  // A folder bound to a file-listing source is fetched as a re-import; any other container is only a walk
+  // over the sourced pages below it, which the backend rejects when there is none.
   readonly canFetchSelectedItem = computed(() => {
     const navItem = this.selectedNavigationItem()?.data;
     if (!navItem) {
@@ -279,7 +283,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     }
     return navItem.type === 'PAGE'
       ? !!getPortalNavigationItemSource(navItem)
-      : collectNodeIdsWithSourcedPageDescendants(this.menuLinks()).has(navItem.id);
+      : collectFetchableContainerIds(this.menuLinks()).has(navItem.id);
   });
   readonly importFileDisabled = computed(() => this.actionsDisabled() || this.isContentEditingLocked());
   protected readonly importFileAccept = IMPORTABLE_FILE_EXTENSIONS.join(',');
@@ -979,6 +983,38 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     }
   }
 
+  onImportNavigation() {
+    this.checkUnsavedChangesAndRun(() => {
+      this.matDialog
+        .open<ImportNavigationDialogComponent, void, ImportNavigationDialogResult>(ImportNavigationDialogComponent, {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+        })
+        .afterClosed()
+        .pipe(
+          filter((result): result is ImportNavigationDialogResult => !!result),
+          switchMap(result => this.portalNavigationItemsService.importNavigation({ title: result.title, source: result.source })),
+          catchError(error => {
+            // HTTP errors are already caught by HttpErrorInterceptor and displayed in the snackbar
+            if (!(error instanceof HttpErrorResponse)) {
+              this.snackBarService.error('Failed to import the documentation tree');
+            }
+            return EMPTY;
+          }),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe(response => {
+          const { succeeded, failed, results } = response.summary;
+          if (failed > 0) {
+            this.snackBarService.error(`Imported ${succeeded} of ${succeeded + failed} pages — ${this.describeFailedResults(results)}`);
+          } else {
+            this.snackBarService.success(`Successfully imported ${succeeded} page${succeeded === 1 ? '' : 's'}`);
+          }
+          this.refreshMenuList.next(1);
+          this.navigateToItemByNavId(response.rootFolder.id);
+        });
+    });
+  }
+
   onImportFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
@@ -1085,9 +1121,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     if (response.summary) {
       const { succeeded, failed, results } = response.summary;
       if (failed > 0) {
-        const failedTitles = results.filter(result => !result.success).map(result => `"${result.title}"`);
-        const failedList = failedTitles.slice(0, 3).join(', ') + (failedTitles.length > 3 ? ', …' : '');
-        this.snackBarService.error(`Fetched ${succeeded} of ${succeeded + failed} pages — failed: ${failedList}`);
+        this.snackBarService.error(`Fetched ${succeeded} of ${succeeded + failed} pages — ${this.describeFailedResults(results)}`);
       } else if (succeeded > 0) {
         this.snackBarService.success(`Successfully fetched ${succeeded} page${succeeded === 1 ? '' : 's'}`);
       } else {
@@ -1107,6 +1141,19 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     }
 
     this.snackBarService.error('Unexpected fetch response from the server');
+  }
+
+  /** Names what failed: the lone failure's error when nothing was imported at all, the failing titles otherwise */
+  private describeFailedResults(results: ReadonlyArray<{ title: string; success: boolean; error?: string }>): string {
+    const failures = results.filter(result => !result.success);
+    if (failures.length === 1 && failures.length === results.length && failures[0].error) {
+      return `failed: ${failures[0].error}`;
+    }
+    if (failures.length === 0) {
+      return 'some files failed';
+    }
+    const titles = failures.map(result => `"${result.title}"`);
+    return `failed: ${titles.slice(0, 3).join(', ')}${titles.length > 3 ? ', …' : ''}`;
   }
 
   onDeleteSection(node: SectionNode): Observable<void> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -58,6 +58,9 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   );
   private readonly getFetchNowButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="fetch-now-button"]' }));
   private readonly getImportFileButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="import-file-button"]' }));
+  private readonly getImportNavigationButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="import-navigation-toolbar-button"]' }),
+  );
   private readonly getContentManagedBySourceBanner = this.locatorForOptional('[data-testid="content-managed-by-source-banner"]');
   private readonly getContentManagedByParentBanner = this.locatorForOptional('[data-testid="content-managed-by-parent-banner"]');
   private readonly getContentFetchErrorBanner = this.locatorForOptional('[data-testid="content-fetch-error-banner"]');
@@ -287,6 +290,11 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async isPageNotFoundDisplayed(): Promise<boolean> {
     const emptyState = await this.getPageNotFoundEmptyState();
     return emptyState !== null;
+  }
+
+  async clickImportNavigationButton(): Promise<void> {
+    const button = await this.getImportNavigationButton();
+    return button.click();
   }
 
   async isImportFileButtonVisible(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.html
@@ -134,7 +134,8 @@
           Link to external source
         </mat-slide-toggle>
         @if (useExternalSource()) {
-          <navigation-item-source-editor [embedded]="true" [source]="initialSource" />
+          <!-- A folder source drives a re-import: only directory-capable fetchers can back it -->
+          <navigation-item-source-editor [embedded]="true" [source]="initialSource" [onlyFilesFetchers]="type === 'FOLDER'" />
         } @else if (initialSource) {
           <gio-banner-warning data-testid="source-removal-warning">
             The external source will be removed

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -188,7 +188,15 @@ export class SectionEditorDialogComponent implements OnInit {
   }
 
   canConfigureSourceOnEdit(): boolean {
-    return this.mode === 'edit' && (this.type === 'PAGE' || this.type === 'FOLDER');
+    if (this.mode !== 'edit') {
+      return false;
+    }
+    // A folder only gets a source through the import (the backend rejects attaching one by update):
+    // offer the source section solely on import-managed folders, to edit or remove their source
+    if (this.type === 'FOLDER') {
+      return !!this.initialSource;
+    }
+    return this.type === 'PAGE';
   }
 
   isExternalSourceActive(): boolean {

--- a/gravitee-apim-console-webui/src/services-ngx/fetcher.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/fetcher.service.spec.ts
@@ -63,5 +63,21 @@ describe('FetcherService', () => {
 
       req.flush(fetcherListItem);
     });
+
+    it('should ask for the file-listing fetchers only', done => {
+      const fetcherListItem = [fakeFetcherListItem({ id: 'github-fetcher' })];
+
+      fetcherService.getList(true).subscribe(fetchers => {
+        expect(fetchers).toEqual(fetcherListItem);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema&import=true`,
+          method: 'GET',
+        })
+        .flush(fetcherListItem);
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/fetcher.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/fetcher.service.ts
@@ -29,7 +29,12 @@ export class FetcherService {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
-  getList(): Observable<FetcherListItem[]> {
-    return this.http.get<FetcherListItem[]>(`${this.constants.env.baseURL}/fetchers?expand=schema`);
+  /**
+   * @param onlyFilesFetchers keep only the fetchers able to list a directory (FilesFetcher), the ones an import can walk
+   */
+  getList(onlyFilesFetchers = false): Observable<FetcherListItem[]> {
+    return this.http.get<FetcherListItem[]>(
+      `${this.constants.env.baseURL}/fetchers?expand=schema${onlyFilesFetchers ? '&import=true' : ''}`,
+    );
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -225,6 +225,31 @@ describe('PortalNavigationItemService', () => {
     });
   });
 
+  describe('importNavigation', () => {
+    it('should post the import request and return the created folder with its summary', done => {
+      const request = {
+        title: 'Imported Docs',
+        source: { type: 'github-fetcher', configuration: { repository: 'docs' } },
+      };
+      const response = {
+        rootFolder: fakePortalNavigationFolder({ id: 'folder-1', title: 'Imported Docs' }),
+        summary: fakePortalNavigationItemsFetchSummary(),
+      };
+
+      service.importNavigation(request).subscribe(result => {
+        expect(result).toEqual(response);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_import`,
+      });
+      expect(req.request.body).toEqual(request);
+      req.flush(response);
+    });
+  });
+
   describe('fetchNavigationItem', () => {
     it('should return the fetched item for a sourced page', done => {
       const fetchedPage = fakePortalNavigationPage({ id: 'page-1' });

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -20,6 +20,8 @@ import { Observable } from 'rxjs';
 import { Constants } from '../entities/Constants';
 import {
   FetchPortalNavigationItemResponse,
+  ImportPortalNavigationRequest,
+  ImportPortalNavigationResponse,
   NewPortalNavigationItem,
   PortalArea,
   PortalNavigationItem,
@@ -67,6 +69,10 @@ export class PortalNavigationItemService {
       updatePortalNavigationItem,
       { params },
     );
+  }
+
+  public importNavigation(request: ImportPortalNavigationRequest): Observable<ImportPortalNavigationResponse> {
+    return this.http.post<ImportPortalNavigationResponse>(`${this.constants.env.v2BaseURL}/portal-navigation-items/_import`, request);
   }
 
   public fetchNavigationItem(portalNavigationItemId: string): Observable<FetchPortalNavigationItemResponse> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -2566,17 +2566,20 @@ components:
         navigationItemId:
           type: string
           format: uuid
-          description: The unique ID of the fetched PAGE navigation item.
+          description: >
+            The unique ID of the fetched PAGE navigation item. Absent when the failure is not tied to
+            an item: a repository import reports a file it could not import, or a listing that failed
+            before any item was reached.
           example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
         title:
           type: string
-          description: The title of the fetched PAGE navigation item.
+          description: The title of the fetched PAGE navigation item, or of the file the import failed on.
         success:
           type: boolean
         error:
           type: string
           description: Why the fetch failed. Absent when the fetch succeeded.
-      required: [ navigationItemId, title, success ]
+      required: [ title, success ]
     PortalNavigationPage:
       description: Portal navigation item of type PAGE
       allOf:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -1097,6 +1097,43 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /portal-navigation-items/_import:
+    post:
+      tags:
+        - Portal Navigation Items
+      summary: Import a documentation tree from a remote repository
+      description: |
+        User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+        Creates a FOLDER bound to a file-listing source (e.g. a git repository), lists the remote files
+        and builds the FOLDER/PAGE hierarchy below it. When a `.gravitee.json` manifest is present in the
+        repository the hierarchy follows it, otherwise the remote tree is mirrored. The source is carried
+        by the root folder only: its subtree is read-only, and re-fetching the folder re-runs the import.
+        Unlike `_bulk`, which creates items from an explicit list, `_import` builds that list from the repository.
+        The fetcher configuration must point at the directory to walk (e.g. `/` for the repository root):
+        a configuration without a path lists nothing and the import fails.
+      operationId: importPortalNavigation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportPortalNavigationRequest"
+        required: true
+      responses:
+        "200":
+          description: Import result. A file failing to import does not abort the others; per-file failures are reported in the summary.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportPortalNavigationResponse"
+        "400":
+          description: Invalid target, source configuration, or a source that cannot list files
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          $ref: "#/components/responses/Error"
+
   /portal-navigation-items/_default-pages:
     post:
       tags:
@@ -1215,8 +1252,8 @@ paths:
       description: |
         User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
         On a PAGE carrying an external source, fetches the page content and returns the updated item.
-        On a container item such as a FOLDER, fetches every PAGE descendant carrying an external source and returns a success/failure summary.
-        A source carried by the FOLDER itself is not fetched yet: only the sources of the PAGE items below it are.
+        On a FOLDER bound to a file-listing source (created by `_import`), re-runs the import and returns a per-file summary.
+        On any other container item, fetches every PAGE descendant carrying an external source and returns a success/failure summary.
       operationId: fetchPortalNavigationItem
       parameters:
         - name: navId
@@ -2465,6 +2502,13 @@ components:
           type: string
           readOnly: true
           description: Error message of the last failed fetch. Absent when the last fetch succeeded.
+        subtreeImport:
+          type: boolean
+          readOnly: true
+          default: false
+          description: >
+            Whether the folder carrying this source is managed by the navigation import: fetching it
+            re-runs the import over its subtree. Only ever set by the import endpoint.
       required: [ type, configuration ]
     FetchPortalNavigationItemResponse:
       type: object
@@ -2474,9 +2518,36 @@ components:
           $ref: "#/components/schemas/PortalNavigationItem"
         summary:
           $ref: "#/components/schemas/PortalNavigationItemsFetchSummary"
+    ImportPortalNavigationRequest:
+      type: object
+      description: Import of a remote documentation tree into a new sourced folder.
+      properties:
+        title:
+          type: string
+          description: Title of the root folder created for the import.
+        parentId:
+          type: string
+          format: uuid
+          description: >
+            The unique ID of the navigation item the root folder is created under. The folder takes the
+            parent's portal area; without a parent it is created at the top level of the top navbar.
+        visibility:
+          $ref: "#/components/schemas/PortalVisibility"
+        source:
+          $ref: "#/components/schemas/PortalNavigationItemSource"
+      required: [ title, source ]
+    ImportPortalNavigationResponse:
+      type: object
+      description: Result of a portal navigation import.
+      properties:
+        rootFolder:
+          $ref: "#/components/schemas/PortalNavigationItem"
+        summary:
+          $ref: "#/components/schemas/PortalNavigationItemsFetchSummary"
+      required: [ rootFolder, summary ]
     PortalNavigationItemsFetchSummary:
       type: object
-      description: Success/failure summary of fetching every sourced PAGE descendant of a container item.
+      description: Per-page success/failure summary of a subtree fetch or of a repository import.
       properties:
         succeeded:
           type: integer

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -17,8 +17,10 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.use_case.FetchPortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ImportPortalNavigationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.v4.listener.ListenerType;
@@ -33,6 +35,8 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolde
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.FetchPortalNavigationItemResponse;
+import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationRequest;
+import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationResponse;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemApiSummary;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemFetchResult;
@@ -174,6 +178,34 @@ public interface PortalNavigationItemsMapper {
 
     FetchPortalNavigationItemResponse map(FetchPortalNavigationItemUseCase.Output output);
 
+    PortalNavigationItemFetchResult map(PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult result);
+
+    default ImportPortalNavigationResponse map(ImportPortalNavigationUseCase.Output output) {
+        var results = output.result().files().stream().map(this::map).toList();
+        var succeeded = (int) output
+            .result()
+            .files()
+            .stream()
+            .filter(file -> file.success())
+            .count();
+        return new ImportPortalNavigationResponse()
+            .rootFolder(map((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) output.rootFolder()))
+            .summary(new PortalNavigationItemsFetchSummary().succeeded(succeeded).failed(results.size() - succeeded).results(results));
+    }
+
+    default ImportPortalNavigationUseCase.Input map(String organizationId, String environmentId, ImportPortalNavigationRequest request) {
+        return ImportPortalNavigationUseCase.Input.builder()
+            .organizationId(organizationId)
+            .environmentId(environmentId)
+            .title(request.getTitle())
+            .parentId(map(request.getParentId()))
+            .visibility(map(request.getVisibility()))
+            .source(map(request.getSource()))
+            .build();
+    }
+
+    io.gravitee.apim.core.portal_page.model.PortalVisibility map(io.gravitee.rest.api.management.v2.rest.model.PortalVisibility visibility);
+
     // Hand-built because the fetch state is readOnly in the OpenAPI spec: the generated model only
     // exposes it through its @JsonCreator constructor, which MapStruct cannot target.
     default io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource map(
@@ -185,7 +217,8 @@ public interface PortalNavigationItemsMapper {
         return new io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource(
             DateMapper.INSTANCE.map(source.getLastFetchedAt()),
             DateMapper.INSTANCE.map(source.getLastFetchAttemptAt()),
-            source.getLastFetchError()
+            source.getLastFetchError(),
+            source.isSubtreeImport()
         )
             .type(source.getSourceType())
             .configuration(ConfigurationSerializationMapper.INSTANCE.deserializeConfiguration(source.getSourceConfiguration()))
@@ -199,6 +232,7 @@ public interface PortalNavigationItemsMapper {
     @Mapping(target = "lastFetchedAt", ignore = true)
     @Mapping(target = "lastFetchAttemptAt", ignore = true)
     @Mapping(target = "lastFetchError", ignore = true)
+    @Mapping(target = "subtreeImport", ignore = true)
     io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource map(
         io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource source
     );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -20,12 +20,14 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.use_case.BulkCreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ImportPortalNavigationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalNavigationItemsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItems;
+import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationRequest;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemApiSummary;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponseMetadata;
@@ -75,6 +77,9 @@ public class PortalNavigationItemsResource extends AbstractResource {
 
     @Inject
     private SeedDefaultPagesForPortalNavigationItemsUseCase seedDefaultPagesForPortalNavigationItemsUseCase;
+
+    @Inject
+    private ImportPortalNavigationUseCase importPortalNavigationUseCase;
 
     private final PortalNavigationItemsMapper mapper = PortalNavigationItemsMapper.INSTANCE;
 
@@ -155,6 +160,21 @@ public class PortalNavigationItemsResource extends AbstractResource {
         );
 
         return Response.ok(new PortalNavigationItemsResponse().items(mapper.map(output.items()))).build();
+    }
+
+    @Path("_import")
+    @POST
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.UPDATE }) })
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response importPortalNavigation(@Valid @NotNull final ImportPortalNavigationRequest importPortalNavigationRequest) {
+        final var executionContext = GraviteeContext.getExecutionContext();
+
+        final var output = importPortalNavigationUseCase.execute(
+            mapper.map(executionContext.getOrganizationId(), executionContext.getEnvironmentId(), importPortalNavigationRequest)
+        );
+
+        return Response.ok(mapper.map(output)).build();
     }
 
     @Path("_default-pages")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -397,7 +397,8 @@ class PortalNavigationItemsMapperTest {
                 new io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource(
                     OffsetDateTime.parse("2026-07-17T10:00:00Z"),
                     OffsetDateTime.parse("2026-07-17T11:00:00Z"),
-                    "injected error"
+                    "injected error",
+                    true
                 )
                     .type("github-fetcher")
                     .configuration(new java.util.LinkedHashMap<>(Map.of("repository", "docs")))
@@ -411,6 +412,8 @@ class PortalNavigationItemsMapperTest {
             // a forged attempt date would let a client push its page's next auto-fetch arbitrarily far out
             assertThat(source.getLastFetchAttemptAt()).isNull();
             assertThat(source.getLastFetchError()).isNull();
+            // a forged marker would turn the folder's next fetch into a subtree-replacing re-import
+            assertThat(source.isSubtreeImport()).isFalse();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemResource_FetchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemResource_FetchTest.java
@@ -165,7 +165,7 @@ class PortalNavigationItemResource_FetchTest extends AbstractResourceTest {
     }
 
     private void seed(PortalNavigationItem item) {
-        ((PortalNavigationItemsQueryServiceInMemory) portalNavigationItemsQueryService).storage().add(item);
+        // The query fake shares the crud storage: creating through the crud service is enough
         portalNavigationItemCrudService.create(item);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_ImportTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_ImportTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationRequest;
+import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemSource;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemsResource_ImportTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "environment-id";
+
+    @Inject
+    private EnvironmentService environmentService;
+
+    @Inject
+    private PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+
+    @Inject
+    private PortalNavigationItemCrudService portalNavigationItemCrudService;
+
+    @Inject
+    private PortalPageContentCrudService portalPageContentCrudService;
+
+    @Inject
+    private PortalPageContentQueryService portalPageContentQueryService;
+
+    @Inject
+    private PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService;
+
+    private WebTarget target;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/portal-navigation-items/_import";
+    }
+
+    @BeforeEach
+    public void setUp() {
+        target = rootTarget();
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        ((PortalNavigationItemsQueryServiceInMemory) portalNavigationItemsQueryService).initWith(List.of());
+        ((PortalNavigationItemsCrudServiceInMemory) portalNavigationItemCrudService).initWith(List.of());
+        ((PortalPageContentCrudServiceInMemory) portalPageContentCrudService).initWith(List.of());
+        ((PortalPageContentQueryServiceInMemory) portalPageContentQueryService).initWith(List.of());
+        ((PortalNavigationItemSourceDomainServiceInMemory) portalNavigationItemSourceDomainService).resetFileListing();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    private ImportPortalNavigationRequest aRequest() {
+        return new ImportPortalNavigationRequest()
+            .title("Imported Docs")
+            .source(
+                new PortalNavigationItemSource()
+                    .type("http-fetcher")
+                    .configuration(
+                        Map.of("url", "https://example.com/repo", "token", PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA)
+                    )
+            );
+    }
+
+    private Response importNavigation(ImportPortalNavigationRequest request) {
+        return target.request().post(Entity.json(request));
+    }
+
+    @Test
+    void should_import_the_remote_tree_and_return_the_root_folder_with_a_masked_source() {
+        var sourceDomainService = (PortalNavigationItemSourceDomainServiceInMemory) portalNavigationItemSourceDomainService;
+        sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+        sourceDomainService.givenRemoteFile("/docs/spec.yaml", "openapi: 3.0.3");
+
+        Response response = importNavigation(aRequest());
+
+        assertThat(response).hasStatus(OK_200);
+        var body = response.readEntity(ImportPortalNavigationResponse.class);
+        var rootFolder = (io.gravitee.rest.api.management.v2.rest.model.PortalNavigationFolder) body.getRootFolder().getActualInstance();
+        assertThat(rootFolder.getTitle()).isEqualTo("Imported Docs");
+        assertThat(rootFolder.getSource()).isNotNull();
+        assertThat(rootFolder.getSource().getLastFetchedAt()).isNotNull();
+        assertThat((Map<String, Object>) rootFolder.getSource().getConfiguration()).containsEntry(
+            "token",
+            PortalNavigationItemSourceDomainServiceInMemory.SENSITIVE_DATA_REPLACEMENT
+        );
+        assertThat(body.getSummary().getSucceeded()).isEqualTo(2);
+        assertThat(body.getSummary().getFailed()).isZero();
+    }
+
+    @Test
+    void should_return_400_when_the_source_cannot_list_files() {
+        // The in-memory source only supports file listing once a remote file is registered
+        assertThat(importNavigation(aRequest())).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_403_when_user_lacks_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        assertThat(importNavigation(aRequest())).hasStatus(FORBIDDEN_403);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_ImportTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_ImportTest.java
@@ -154,6 +154,51 @@ class PortalNavigationItemsResource_ImportTest extends AbstractResourceTest {
     }
 
     @Test
+    void should_report_a_file_failure_without_a_navigation_item_id() {
+        // A failed file reached no item: the result carries no id, and the response must still be
+        // valid against the contract generated clients are built from
+        var sourceDomainService = (PortalNavigationItemSourceDomainServiceInMemory) portalNavigationItemSourceDomainService;
+        sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+        sourceDomainService.givenRemoteFile("/docs/broken.md", "# Broken");
+        sourceDomainService.failFileFetch("/docs/broken.md");
+
+        Response response = importNavigation(aRequest());
+
+        assertThat(response).hasStatus(OK_200);
+        var summary = response.readEntity(ImportPortalNavigationResponse.class).getSummary();
+        assertThat(summary.getSucceeded()).isEqualTo(1);
+        assertThat(summary.getFailed()).isEqualTo(1);
+        assertThat(summary.getResults())
+            .filteredOn(result -> !result.getSuccess())
+            .singleElement()
+            .satisfies(result -> {
+                assertThat(result.getNavigationItemId()).isNull();
+                assertThat(result.getTitle()).isEqualTo("broken");
+                assertThat(result.getError()).isNotBlank();
+            });
+    }
+
+    @Test
+    void should_report_a_listing_failure_as_an_item_less_result() {
+        var sourceDomainService = (PortalNavigationItemSourceDomainServiceInMemory) portalNavigationItemSourceDomainService;
+        sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+        sourceDomainService.failNextListFilesWith(new RuntimeException("cannot reach repository"));
+
+        Response response = importNavigation(aRequest());
+
+        assertThat(response).hasStatus(OK_200);
+        var summary = response.readEntity(ImportPortalNavigationResponse.class).getSummary();
+        assertThat(summary.getFailed()).isEqualTo(1);
+        assertThat(summary.getResults())
+            .singleElement()
+            .satisfies(result -> {
+                assertThat(result.getSuccess()).isFalse();
+                assertThat(result.getNavigationItemId()).isNull();
+                assertThat(result.getError()).contains("Unable to list files");
+            });
+    }
+
+    @Test
     void should_return_400_when_the_source_cannot_list_files() {
         // The in-memory source only supports file listing once a remote file is registered
         assertThat(importNavigation(aRequest())).hasStatus(BAD_REQUEST_400);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -571,7 +571,8 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
                 new PortalNavigationItemSource(
                     OffsetDateTime.parse("2026-07-17T10:00:00Z"),
                     OffsetDateTime.parse("2026-07-17T11:00:00Z"),
-                    "forged error"
+                    "forged error",
+                    true
                 )
                     .type("github-fetcher")
                     .configuration(Map.of("repository", "docs"))
@@ -595,6 +596,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(body.getSource().getLastFetchedAt()).isNull();
         assertThat(body.getSource().getLastFetchAttemptAt()).isNull();
         assertThat(body.getSource().getLastFetchError()).isNull();
+        assertThat(body.getSource().getSubtreeImport()).isFalse();
 
         // And storage reflects the same
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
@@ -603,6 +605,7 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         assertThat(updated.getSource().getLastFetchedAt()).isNull();
         assertThat(updated.getSource().getLastFetchAttemptAt()).isNull();
         assertThat(updated.getSource().getLastFetchError()).isNull();
+        assertThat(updated.getSource().isSubtreeImport()).isFalse();
     }
 
     @Test
@@ -633,7 +636,9 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
 
         // When: PUT keeping the same source origin (clients never send the readOnly fields back)
         BaseUpdatePortalNavigationItem payload = new UpdatePortalNavigationPage()
-            .source(new PortalNavigationItemSource(null, null, null).type("github-fetcher").configuration(Map.of("repository", "docs")))
+            .source(
+                new PortalNavigationItemSource(null, null, null, null).type("github-fetcher").configuration(Map.of("repository", "docs"))
+            )
             .title("Sourced Page")
             .order(0)
             .type(PortalNavigationItemType.PAGE)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -38,6 +38,7 @@ import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationManifestParserInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
@@ -199,6 +200,7 @@ import io.gravitee.apim.core.portal_page.domain_service.OpenApiContentTransforme
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiProductVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
@@ -214,6 +216,7 @@ import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseC
 import io.gravitee.apim.core.portal_page.use_case.DeletePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.FetchPortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ImportPortalNavigationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
@@ -1432,13 +1435,52 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService,
         PortalNavigationSourcedItemsDomainService portalNavigationSourcedItemsDomainService,
         PortalNavigationItemDomainService domainService,
-        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService,
+        PortalNavigationBulkImportDomainService portalNavigationBulkImportDomainService
     ) {
         return new FetchPortalNavigationItemUseCase(
             portalNavigationItemsQueryService,
             portalNavigationSourcedItemsDomainService,
             domainService,
-            portalNavigationItemSourceDomainService
+            portalNavigationItemSourceDomainService,
+            portalNavigationBulkImportDomainService
+        );
+    }
+
+    @Bean
+    public PortalNavigationBulkImportDomainService portalNavigationBulkImportDomainService(
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService,
+        PortalNavigationItemDomainService domainService,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalNavigationItemCrudService portalNavigationItemCrudService,
+        PortalPageContentCrudService portalPageContentCrudService,
+        PortalPageContentQueryService portalPageContentQueryService
+    ) {
+        return new PortalNavigationBulkImportDomainService(
+            portalNavigationItemSourceDomainService,
+            new PortalNavigationManifestParserInMemory(),
+            domainService,
+            portalNavigationItemsQueryService,
+            portalNavigationItemCrudService,
+            portalPageContentCrudService,
+            portalPageContentQueryService
+        );
+    }
+
+    @Bean
+    public ImportPortalNavigationUseCase importPortalNavigationUseCase(
+        PortalNavigationItemValidatorService portalNavigationItemValidatorService,
+        PortalNavigationItemDomainService domainService,
+        PortalNavigationItemSourceDomainService portalNavigationItemSourceDomainService,
+        PortalNavigationBulkImportDomainService portalNavigationBulkImportDomainService,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+    ) {
+        return new ImportPortalNavigationUseCase(
+            portalNavigationItemValidatorService,
+            domainService,
+            portalNavigationItemSourceDomainService,
+            portalNavigationBulkImportDomainService,
+            portalNavigationItemsQueryService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.validation.ValidationDepth;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.ImportedFileContentType;
@@ -299,6 +300,20 @@ public class PortalNavigationBulkImportDomainService {
         boolean fromManifest
     ) {
         try {
+            // Fails closed rather than creating a page the tree can no longer protect: past this many
+            // levels the walk looking for a sourced ancestor gives up, and the imported page stops
+            // being recognised as source-managed and read-only.
+            if (destinationDepthOf(entry.destinationPath()) >= ValidationDepth.MAX_TREE_DEPTH) {
+                return BulkImportResult.FileImportResult.failure(
+                    entry.title(),
+                    "Destination %s of %s nests more than %d levels below the imported folder.".formatted(
+                        entry.destinationPath(),
+                        entry.sourcePath(),
+                        ValidationDepth.MAX_TREE_DEPTH - 1
+                    )
+                );
+            }
+
             // Nothing is looked up or created before the file is known to be a document: resolving the
             // destination creates the folders along the way, and a repository's .github/workflows has
             // no business showing up in the navigation tree.
@@ -468,6 +483,17 @@ public class PortalNavigationBulkImportDomainService {
                 itemsToVisit.addAll(queryService.findByParentIdAndEnvironmentId(rootFolder.getEnvironmentId(), item.getId()));
             }
         }
+    }
+
+    /** Number of folder levels the destination adds below the imported root folder. */
+    private static int destinationDepthOf(String destinationPath) {
+        var depth = 0;
+        for (var pathElement : destinationPath.split("/")) {
+            if (!pathElement.isBlank()) {
+                depth++;
+            }
+        }
+        return depth;
     }
 
     private static String unsupportedDocumentError(String sourcePath) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
@@ -50,7 +50,8 @@ import lombok.RequiredArgsConstructor;
  * Imports a remote documentation tree behind a {@code FilesFetcher} source into the subtree of the
  * folder carrying that source. The folder owns the sync: imported children carry no source of their
  * own and are read-only by inheritance. Re-running the import re-lists the files, updates matched
- * pages, creates new ones and removes the previously imported items that no longer exist remotely.
+ * pages, creates new ones and — when every entry imported successfully — removes the previously
+ * imported items that no longer exist remotely.
  */
 @DomainService
 @CustomLog
@@ -144,7 +145,20 @@ public class PortalNavigationBulkImportDomainService {
             );
             return failListing(rootFolder, "The source of type %s listed no importable files.".formatted(source.getSourceType()));
         }
-        deleteOrphans(rootFolder, touchedItemIds);
+        if (results.stream().allMatch(BulkImportResult.FileImportResult::success)) {
+            deleteOrphans(rootFolder, touchedItemIds);
+        } else {
+            // A partial run has an incomplete picture of the remote tree: an entry that failed touched
+            // nothing, so the page it stands for looks orphaned. Deleting it would lose content the run
+            // never proved gone remotely — a manifest renaming a.md from "Old" to "New" while the fetch
+            // transiently fails wipes the last good "Old" page. Stale items are kept until a run
+            // reconciles the whole subtree successfully.
+            log.warn(
+                "Portal navigation folder [id={}, sourceType={}] imported partially: keeping the items no longer backed by the source",
+                rootFolder.getId().json(),
+                source.getSourceType()
+            );
+        }
 
         stampFetchOutcome(source, results);
         crudService.update(rootFolder);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
@@ -132,7 +132,18 @@ public class PortalNavigationBulkImportDomainService {
         }
 
         var touchedItemIds = new HashSet<PortalNavigationItemId>();
-        var results = importEntries(rootFolder, entries, touchedItemIds);
+        var results = importEntries(rootFolder, entries, touchedItemIds, resolved.fromManifest());
+        if (results.isEmpty()) {
+            // Every mirrored entry turned out not to be a document once fetched — a repository whose
+            // only JSON and YAML are package.json, lock files and CI workflows. Same wipe risk as an
+            // empty listing: deleteOrphans would empty the subtree.
+            log.warn(
+                "Portal navigation folder [id={}, sourceType={}] holds no importable document: leaving its subtree untouched",
+                rootFolder.getId().json(),
+                source.getSourceType()
+            );
+            return failListing(rootFolder, "The source of type %s listed no importable files.".formatted(source.getSourceType()));
+        }
         deleteOrphans(rootFolder, touchedItemIds);
 
         stampFetchOutcome(source, results);
@@ -164,7 +175,8 @@ public class PortalNavigationBulkImportDomainService {
     private List<BulkImportResult.FileImportResult> importEntries(
         PortalNavigationFolder rootFolder,
         List<ImportEntry> entries,
-        Set<PortalNavigationItemId> touchedItemIds
+        Set<PortalNavigationItemId> touchedItemIds,
+        boolean fromManifest
     ) {
         var folderIdsByPath = new HashMap<String, PortalNavigationItemId>();
         var results = new ArrayList<BulkImportResult.FileImportResult>();
@@ -186,7 +198,10 @@ public class PortalNavigationBulkImportDomainService {
                 );
                 continue;
             }
-            results.add(importEntry(rootFolder, entry, folderIdsByPath, touchedItemIds));
+            var result = importEntry(rootFolder, entry, folderIdsByPath, touchedItemIds, fromManifest);
+            if (result != null) {
+                results.add(result);
+            }
         }
         return results;
     }
@@ -250,36 +265,51 @@ public class PortalNavigationBulkImportDomainService {
         return new ResolvedEntries(
             files
                 .stream()
-                .filter(file -> ImportedFileContentType.from(file, null).isPresent())
+                .filter(ImportedFileContentType::isImportable)
                 .map(file -> new ImportEntry(file, baseNameOf(file), parentPathOf(file)))
                 .toList(),
             false
         );
     }
 
+    /**
+     * @return the outcome to report, or {@code null} when the entry holds no document and is left
+     *         out of the import altogether.
+     */
+    @Nullable
     private BulkImportResult.FileImportResult importEntry(
         PortalNavigationFolder rootFolder,
         ImportEntry entry,
         Map<String, PortalNavigationItemId> folderIdsByPath,
-        Set<PortalNavigationItemId> touchedItemIds
+        Set<PortalNavigationItemId> touchedItemIds,
+        boolean fromManifest
     ) {
         try {
+            // Nothing is looked up or created before the file is known to be a document: resolving the
+            // destination creates the folders along the way, and a repository's .github/workflows has
+            // no business showing up in the navigation tree.
+            var content = sourceDomainService.fetchFileContent(rootFolder.getSource(), entry.sourcePath());
+            var contentType = ImportedFileContentType.from(entry.sourcePath(), content).orElse(null);
+            if (contentType == null) {
+                if (fromManifest) {
+                    // The manifest named this file: not importing it is a failure the author must see
+                    return BulkImportResult.FileImportResult.failure(entry.title(), unsupportedDocumentError(entry.sourcePath()));
+                }
+                // A mirrored file that merely shares an extension with a spec — package.json, a CI
+                // workflow. It is not a document, so it is left out of the import rather than reported
+                // as a failure on every run.
+                log.debug(
+                    "Skipping non-document file [{}] below portal navigation folder [id={}]",
+                    entry.sourcePath(),
+                    rootFolder.getId().json()
+                );
+                return null;
+            }
+
             var parentId = resolveTargetFolder(rootFolder, entry.destinationPath(), folderIdsByPath, touchedItemIds);
             var existingPage = findChildPageByTitle(rootFolder.getEnvironmentId(), parentId, entry.title());
             if (existingPage != null) {
                 touchedItemIds.add(existingPage.getId());
-            }
-
-            var content = sourceDomainService.fetchFileContent(rootFolder.getSource(), entry.sourcePath());
-            var contentType = ImportedFileContentType.from(entry.sourcePath(), content).orElse(null);
-            if (contentType == null) {
-                return BulkImportResult.FileImportResult.failure(
-                    entry.title(),
-                    "Unsupported file extension for %s.".formatted(entry.sourcePath())
-                );
-            }
-
-            if (existingPage != null) {
                 updatePageContent(existingPage, contentType, content);
                 return BulkImportResult.FileImportResult.success(existingPage.getId().id(), entry.title());
             }
@@ -424,6 +454,12 @@ public class PortalNavigationBulkImportDomainService {
                 itemsToVisit.addAll(queryService.findByParentIdAndEnvironmentId(rootFolder.getEnvironmentId(), item.getId()));
             }
         }
+    }
+
+    private static String unsupportedDocumentError(String sourcePath) {
+        return "Cannot determine the type of %s: expected a .md file, or a document declaring a root \"openapi\", \"swagger\" or \"asyncapi\" property.".formatted(
+            sourcePath
+        );
     }
 
     private static String baseNameOf(String filePath) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationBulkImportDomainService.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.ImportedFileContentType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationManifestParser;
+import io.gravitee.common.utils.TimeProvider;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Imports a remote documentation tree behind a {@code FilesFetcher} source into the subtree of the
+ * folder carrying that source. The folder owns the sync: imported children carry no source of their
+ * own and are read-only by inheritance. Re-running the import re-lists the files, updates matched
+ * pages, creates new ones and removes the previously imported items that no longer exist remotely.
+ */
+@DomainService
+@CustomLog
+@RequiredArgsConstructor
+public class PortalNavigationBulkImportDomainService {
+
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
+    private final PortalNavigationManifestParser manifestParser;
+    private final PortalNavigationItemDomainService itemDomainService;
+    private final PortalNavigationItemsQueryService queryService;
+    private final PortalNavigationItemCrudService crudService;
+    private final PortalPageContentCrudService pageContentCrudService;
+    private final PortalPageContentQueryService pageContentQueryService;
+
+    public BulkImportResult importSubtree(PortalNavigationFolder rootFolder) {
+        var source = importManagedSourceOf(rootFolder);
+        source.registerFetchAttempt();
+
+        final List<String> files;
+        try {
+            files = sourceDomainService.listFiles(source);
+        } catch (Exception e) {
+            log.warn(
+                "Failed to list files of portal navigation folder [id={}, sourceType={}]",
+                rootFolder.getId().json(),
+                source.getSourceType(),
+                e
+            );
+            // Built here rather than taken from the exception: the stored message is returned by the
+            // API, and an arbitrary one may quote the configuration and its secrets.
+            return failListing(rootFolder, "Unable to list files from source type %s.".formatted(source.getSourceType()));
+        }
+
+        if (files.isEmpty()) {
+            // A silently failing fetcher answers an empty listing too; mirroring it would wipe the subtree
+            log.warn(
+                "Portal navigation folder [id={}, sourceType={}] listed no files: leaving its subtree untouched",
+                rootFolder.getId().json(),
+                source.getSourceType()
+            );
+            return failListing(rootFolder, "The source of type %s listed no files.".formatted(source.getSourceType()));
+        }
+
+        final ResolvedEntries resolved;
+        try {
+            resolved = resolveEntries(source, files);
+        } catch (Exception e) {
+            // The manifest lookup refetches from the source and parses: a network incident or a broken
+            // manifest here must leave the same trail as a listing failure, not surface a raw error
+            // while an import-managed folder sits in the tree with nothing stamped on its source.
+            log.warn(
+                "Failed to resolve the entries of portal navigation folder [id={}, sourceType={}]",
+                rootFolder.getId().json(),
+                source.getSourceType(),
+                e
+            );
+            return failListing(
+                rootFolder,
+                "Unable to read the %s manifest from source type %s.".formatted(manifestParser.manifestFileName(), source.getSourceType())
+            );
+        }
+
+        var entries = resolved.entries();
+        if (entries.isEmpty()) {
+            // Same wipe risk one level down: files were listed but none is importable (unsupported
+            // types only, or a manifest with no pages) — deleteOrphans would then empty the subtree.
+            // The two causes call for different fixes on the repository side, so name the right one.
+            log.warn(
+                "Portal navigation folder [id={}, sourceType={}] listed no importable files: leaving its subtree untouched",
+                rootFolder.getId().json(),
+                source.getSourceType()
+            );
+            return failListing(
+                rootFolder,
+                resolved.fromManifest()
+                    ? "The %s manifest of the source lists no importable pages.".formatted(manifestParser.manifestFileName())
+                    : "The source of type %s listed no importable files.".formatted(source.getSourceType())
+            );
+        }
+
+        var touchedItemIds = new HashSet<PortalNavigationItemId>();
+        var results = importEntries(rootFolder, entries, touchedItemIds);
+        deleteOrphans(rootFolder, touchedItemIds);
+
+        stampFetchOutcome(source, results);
+        crudService.update(rootFolder);
+
+        return new BulkImportResult(List.copyOf(results));
+    }
+
+    private PortalNavigationItemSource importManagedSourceOf(PortalNavigationFolder rootFolder) {
+        var source = rootFolder.getSource();
+        if (source == null) {
+            throw InvalidPortalNavigationItemDataException.noSourceConfigured(rootFolder.getId().json());
+        }
+        if (!source.isSubtreeImport()) {
+            // Deleting the orphans of a folder the import does not own would destroy hand-made content
+            throw new IllegalStateException(
+                "Folder %s is not managed by the navigation import: refusing to re-import its subtree.".formatted(rootFolder.getId().json())
+            );
+        }
+        return source;
+    }
+
+    private BulkImportResult failListing(PortalNavigationFolder rootFolder, String error) {
+        rootFolder.getSource().setLastFetchError(error);
+        crudService.update(rootFolder);
+        return BulkImportResult.listingFailure(rootFolder.getTitle(), error);
+    }
+
+    private List<BulkImportResult.FileImportResult> importEntries(
+        PortalNavigationFolder rootFolder,
+        List<ImportEntry> entries,
+        Set<PortalNavigationItemId> touchedItemIds
+    ) {
+        var folderIdsByPath = new HashMap<String, PortalNavigationItemId>();
+        var results = new ArrayList<BulkImportResult.FileImportResult>();
+        var seenTitles = new HashSet<String>();
+        for (var entry : entries) {
+            // Two entries landing on the same (destination, title) — api.md next to api.yaml, or two
+            // manifest pages sharing name and dest — would silently overwrite each other's content
+            // while both report success; failing the second one keeps every failure visible
+            if (!seenTitles.add(entry.destinationPath() + "/" + entry.title())) {
+                results.add(
+                    BulkImportResult.FileImportResult.failure(
+                        entry.title(),
+                        "Duplicate title %s under %s: %s collides with an earlier entry.".formatted(
+                            entry.title(),
+                            entry.destinationPath().isEmpty() ? "the root folder" : entry.destinationPath(),
+                            entry.sourcePath()
+                        )
+                    )
+                );
+                continue;
+            }
+            results.add(importEntry(rootFolder, entry, folderIdsByPath, touchedItemIds));
+        }
+        return results;
+    }
+
+    private void stampFetchOutcome(PortalNavigationItemSource source, List<BulkImportResult.FileImportResult> results) {
+        var failed = results
+            .stream()
+            .filter(result -> !result.success())
+            .count();
+        if (failed == 0) {
+            source.setLastFetchedAt(TimeProvider.instantNow());
+            source.setLastFetchError(null);
+            return;
+        }
+        // A partial import is still a fetch: the imported pages are current, the error lists the rest
+        if (failed < results.size()) {
+            source.setLastFetchedAt(TimeProvider.instantNow());
+        }
+        source.setLastFetchError(
+            "Failed to import %d of %d files from source type %s.".formatted(failed, results.size(), source.getSourceType())
+        );
+    }
+
+    private ResolvedEntries resolveEntries(PortalNavigationItemSource source, List<String> files) {
+        var manifestFileName = manifestParser.manifestFileName();
+        // The manifest can live below the fetcher's configured root ("/docs/.gravitee.json"), as in
+        // the legacy documentation import — but only under its exact file name, so "my.gravitee.json"
+        // cannot hijack the import. The least deep match wins: the outcome must not depend on the
+        // listing order of the fetcher.
+        var manifestPath = files
+            .stream()
+            .filter(file -> manifestFileName.equals(file) || file.endsWith("/" + manifestFileName))
+            .min(
+                Comparator.comparingLong((String file) ->
+                    file
+                        .chars()
+                        .filter(c -> c == '/')
+                        .count()
+                ).thenComparing(Comparator.naturalOrder())
+            );
+        if (manifestPath.isPresent()) {
+            var manifestContent = sourceDomainService.fetchFileContent(source, manifestPath.get());
+            return new ResolvedEntries(
+                manifestParser
+                    .parse(manifestContent)
+                    .stream()
+                    .map(page ->
+                        new ImportEntry(
+                            page.src(),
+                            isBlank(page.name()) ? baseNameOf(page.src()) : page.name(),
+                            isBlank(page.dest()) ? parentPathOf(page.src()) : page.dest()
+                        )
+                    )
+                    .toList(),
+                true
+            );
+        }
+        // Without a manifest the remote tree is mirrored as-is; files of unsupported types are ignored.
+        // Paths are taken as listed by the fetcher — legacy-import parity: the configured root directory
+        // belongs to the plugin's opaque configuration, so it cannot be stripped and becomes folder levels.
+        return new ResolvedEntries(
+            files
+                .stream()
+                .filter(file -> ImportedFileContentType.from(file, null).isPresent())
+                .map(file -> new ImportEntry(file, baseNameOf(file), parentPathOf(file)))
+                .toList(),
+            false
+        );
+    }
+
+    private BulkImportResult.FileImportResult importEntry(
+        PortalNavigationFolder rootFolder,
+        ImportEntry entry,
+        Map<String, PortalNavigationItemId> folderIdsByPath,
+        Set<PortalNavigationItemId> touchedItemIds
+    ) {
+        try {
+            var parentId = resolveTargetFolder(rootFolder, entry.destinationPath(), folderIdsByPath, touchedItemIds);
+            var existingPage = findChildPageByTitle(rootFolder.getEnvironmentId(), parentId, entry.title());
+            if (existingPage != null) {
+                touchedItemIds.add(existingPage.getId());
+            }
+
+            var content = sourceDomainService.fetchFileContent(rootFolder.getSource(), entry.sourcePath());
+            var contentType = ImportedFileContentType.from(entry.sourcePath(), content).orElse(null);
+            if (contentType == null) {
+                return BulkImportResult.FileImportResult.failure(
+                    entry.title(),
+                    "Unsupported file extension for %s.".formatted(entry.sourcePath())
+                );
+            }
+
+            if (existingPage != null) {
+                updatePageContent(existingPage, contentType, content);
+                return BulkImportResult.FileImportResult.success(existingPage.getId().id(), entry.title());
+            }
+
+            var createdPage = createPage(rootFolder, parentId, entry.title(), contentType, content);
+            touchedItemIds.add(createdPage.getId());
+            return BulkImportResult.FileImportResult.success(createdPage.getId().id(), entry.title());
+        } catch (Exception e) {
+            log.warn("Failed to import file [{}] below portal navigation folder [id={}]", entry.sourcePath(), rootFolder.getId().json(), e);
+            return BulkImportResult.FileImportResult.failure(entry.title(), "Unable to import file %s.".formatted(entry.sourcePath()));
+        }
+    }
+
+    private PortalNavigationItemId resolveTargetFolder(
+        PortalNavigationFolder rootFolder,
+        String destinationPath,
+        Map<String, PortalNavigationItemId> folderIdsByPath,
+        Set<PortalNavigationItemId> touchedItemIds
+    ) {
+        touchedItemIds.add(rootFolder.getId());
+        var currentParentId = rootFolder.getId();
+        var currentPath = "";
+        for (var pathElement : destinationPath.split("/")) {
+            if (pathElement.isBlank()) {
+                continue;
+            }
+            currentPath = currentPath + "/" + pathElement;
+            var knownFolderId = folderIdsByPath.get(currentPath);
+            if (knownFolderId != null) {
+                currentParentId = knownFolderId;
+                continue;
+            }
+            var folderId = findOrCreateChildFolder(rootFolder, currentParentId, pathElement);
+            folderIdsByPath.put(currentPath, folderId);
+            touchedItemIds.add(folderId);
+            currentParentId = folderId;
+        }
+        return currentParentId;
+    }
+
+    private PortalNavigationItemId findOrCreateChildFolder(
+        PortalNavigationFolder rootFolder,
+        PortalNavigationItemId parentId,
+        String title
+    ) {
+        var existing = queryService
+            .findByParentIdAndEnvironmentId(rootFolder.getEnvironmentId(), parentId)
+            .stream()
+            .filter(PortalNavigationFolder.class::isInstance)
+            .filter(item -> title.equals(item.getTitle()))
+            .findFirst();
+        if (existing.isPresent()) {
+            return existing.get().getId();
+        }
+        var created = itemDomainService.create(
+            rootFolder.getOrganizationId(),
+            rootFolder.getEnvironmentId(),
+            CreatePortalNavigationItem.builder()
+                .title(title)
+                .type(PortalNavigationItemType.FOLDER)
+                .area(rootFolder.getArea())
+                .parentId(parentId)
+                .visibility(rootFolder.getVisibility())
+                .published(rootFolder.getPublished())
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .build()
+        );
+        return created.getId();
+    }
+
+    @Nullable
+    private PortalNavigationPage findChildPageByTitle(String environmentId, PortalNavigationItemId parentId, String title) {
+        return queryService
+            .findByParentIdAndEnvironmentId(environmentId, parentId)
+            .stream()
+            .filter(PortalNavigationPage.class::isInstance)
+            .map(PortalNavigationPage.class::cast)
+            .filter(page -> title.equals(page.getTitle()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private void updatePageContent(PortalNavigationPage page, PortalPageContentType contentType, String content) {
+        var existingContent = pageContentQueryService
+            .findById(page.getPortalPageContentId())
+            .orElseThrow(() -> new IllegalStateException("Page content not found for imported page " + page.getId().json()));
+        var updatedContent = PortalPageContent.of(
+            contentType,
+            existingContent.getId(),
+            existingContent.getOrganizationId(),
+            existingContent.getEnvironmentId(),
+            content,
+            existingContent.getAutomationMetadata()
+        );
+        pageContentCrudService.update(updatedContent);
+    }
+
+    private PortalNavigationItem createPage(
+        PortalNavigationFolder rootFolder,
+        PortalNavigationItemId parentId,
+        String title,
+        PortalPageContentType contentType,
+        String content
+    ) {
+        var pageContent = PortalPageContent.of(
+            contentType,
+            PortalPageContentId.random(),
+            rootFolder.getOrganizationId(),
+            rootFolder.getEnvironmentId(),
+            content,
+            null
+        );
+        var createdContent = pageContentCrudService.create(pageContent);
+        return itemDomainService.create(
+            rootFolder.getOrganizationId(),
+            rootFolder.getEnvironmentId(),
+            CreatePortalNavigationItem.builder()
+                .title(title)
+                .type(PortalNavigationItemType.PAGE)
+                .area(rootFolder.getArea())
+                .parentId(parentId)
+                .visibility(rootFolder.getVisibility())
+                .published(rootFolder.getPublished())
+                .contentType(contentType)
+                .portalPageContentId(createdContent.getId())
+                .build()
+        );
+    }
+
+    /**
+     * The subtree mirrors the remote listing: items imported by a previous run and no longer backed
+     * by a remote file are removed. An untouched item's descendants are all untouched (a touched one
+     * would have marked its whole ancestor chain), so removing the top-most untouched items suffices.
+     */
+    private void deleteOrphans(PortalNavigationFolder rootFolder, Set<PortalNavigationItemId> touchedItemIds) {
+        var itemsToVisit = new ArrayList<>(queryService.findByParentIdAndEnvironmentId(rootFolder.getEnvironmentId(), rootFolder.getId()));
+        while (!itemsToVisit.isEmpty()) {
+            var item = itemsToVisit.removeFirst();
+            if (!touchedItemIds.contains(item.getId())) {
+                itemDomainService.deleteWithDescendants(item);
+            } else if (item instanceof PortalNavigationFolder) {
+                itemsToVisit.addAll(queryService.findByParentIdAndEnvironmentId(rootFolder.getEnvironmentId(), item.getId()));
+            }
+        }
+    }
+
+    private static String baseNameOf(String filePath) {
+        var fileName = filePath.substring(filePath.lastIndexOf('/') + 1);
+        var extensionIndex = fileName.lastIndexOf('.');
+        return extensionIndex <= 0 ? fileName : fileName.substring(0, extensionIndex);
+    }
+
+    private static String parentPathOf(String filePath) {
+        var separatorIndex = filePath.lastIndexOf('/');
+        return separatorIndex <= 0 ? "" : filePath.substring(0, separatorIndex);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private record ImportEntry(String sourcePath, String title, String destinationPath) {}
+
+    /** The import entries plus where they come from: a manifest parsing to zero pages is its own failure mode */
+    private record ResolvedEntries(List<ImportEntry> entries, boolean fromManifest) {}
+
+    public record BulkImportResult(List<FileImportResult> files) {
+        public static BulkImportResult listingFailure(String rootTitle, String error) {
+            return new BulkImportResult(List.of(FileImportResult.failure(rootTitle, error)));
+        }
+
+        public record FileImportResult(@Nullable UUID navigationItemId, String title, boolean success, @Nullable String error) {
+            static FileImportResult success(UUID navigationItemId, String title) {
+                return new FileImportResult(navigationItemId, title, true, null);
+            }
+
+            static FileImportResult failure(String title, String error) {
+                return new FileImportResult(null, title, false, error);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemSourceDomainService.java
@@ -16,9 +16,16 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import java.util.List;
 
 public interface PortalNavigationItemSourceDomainService {
     String fetchContent(PortalNavigationItemSource source);
+
+    boolean supportsFileListing(PortalNavigationItemSource source);
+
+    List<String> listFiles(PortalNavigationItemSource source);
+
+    String fetchFileContent(PortalNavigationItemSource source, String filepath);
 
     void removeSensitiveData(PortalNavigationItemSource source);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.CreateValidat
 import io.gravitee.apim.core.portal_page.domain_service.validation.DuplicateApiIdsInPayloadRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.DuplicateApiProductIdsInPayloadRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ExternalSourceItemTypeRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.FileListingSourceOnFolderRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.HomepageUniquenessRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.LinkUrlRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.PageContentExistsRule;
@@ -80,6 +81,7 @@ public class PortalNavigationItemValidatorService {
         var sourceConfigurationRule = new SourceConfigurationRule(portalNavigationItemSourceDomainService::validateSourceConfiguration);
         var sourceAutomationExclusivityRule = new SourceAutomationExclusivityRule(navigationItemsQueryService, pageContentQueryService);
         var sourcedItemReadOnlyRule = new SourcedItemReadOnlyRule(new SourcedAncestorFinder(navigationItemsQueryService));
+        var fileListingSourceOnFolderRule = new FileListingSourceOnFolderRule(portalNavigationItemSourceDomainService::supportsFileListing);
 
         this.createRules = List.of(
             new UniqueItemIdRule(navigationItemsQueryService),
@@ -106,7 +108,8 @@ public class PortalNavigationItemValidatorService {
             externalSourceItemTypeRule,
             sourceConfigurationRule,
             sourceAutomationExclusivityRule,
-            sourcedItemReadOnlyRule
+            sourcedItemReadOnlyRule,
+            fileListingSourceOnFolderRule
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/FileListingSourceOnFolderRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/FileListingSourceOnFolderRule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A folder driven by a file-listing source mirrors a remote repository: fetching it re-runs the
+ * import, which deletes every child the import does not know about. Such folders are only created
+ * through the import endpoint, which stamps their source; attaching a file-listing source to any
+ * other folder by update is rejected, so hand-made children can never end up under an import's
+ * authority. An import-managed folder keeps accepting updates of its own source.
+ */
+@RequiredArgsConstructor
+public class FileListingSourceOnFolderRule implements UpdatePortalNavigationItemValidationRule {
+
+    private final Predicate<PortalNavigationItemSource> supportsFileListing;
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem.getType() == PortalNavigationItemType.FOLDER && toUpdate.getSource() != null;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        var importManaged = existingItem.getSource() != null && existingItem.getSource().isSubtreeImport();
+        if (supportsFileListing.test(toUpdate.getSource())) {
+            if (!importManaged) {
+                throw InvalidPortalNavigationItemDataException.fileListingSourceOnlyCreatedByImport(existingItem.getId().json());
+            }
+            return;
+        }
+        // The symmetric hole: fetching an import-managed folder re-runs the import, which starts by
+        // listing the source — a source that cannot list files would break the folder at the next fetch
+        if (importManaged) {
+            throw InvalidPortalNavigationItemDataException.importManagedFolderNeedsFileListingSource(existingItem.getId().json());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ValidationDepth.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ValidationDepth.java
@@ -20,12 +20,13 @@ import lombok.CustomLog;
 
 /**
  * Navigation trees are shallow by design; this bound only exists so that a corrupted parent chain
- * cannot loop forever.
+ * cannot loop forever. Anything that builds a chain — the repository import — must stay under it,
+ * because the walks give up rather than fail when they reach it.
  */
 @CustomLog
-final class ValidationDepth {
+public final class ValidationDepth {
 
-    static final int MAX_TREE_DEPTH = 50;
+    public static final int MAX_TREE_DEPTH = 50;
 
     private ValidationDepth() {}
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -61,6 +61,22 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
         );
     }
 
+    public static InvalidPortalNavigationItemDataException fileListingSourceOnlyCreatedByImport(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "A file-listing source cannot be attached to folder %s: fetching such a folder replaces its children with the remote tree. Import the repository into a new folder instead.".formatted(
+                itemId
+            )
+        );
+    }
+
+    public static InvalidPortalNavigationItemDataException importManagedFolderNeedsFileListingSource(String itemId) {
+        return new InvalidPortalNavigationItemDataException(
+            "Folder %s is managed by the navigation import: its source must be able to list files. Pick a repository fetcher, or remove the source to detach the folder.".formatted(
+                itemId
+            )
+        );
+    }
+
     public static InvalidPortalNavigationItemDataException sourcedItemCannotBeRenamedOrMoved(String itemId) {
         return new InvalidPortalNavigationItemDataException(
             "Navigation item %s is managed by an external source and cannot be renamed or moved. Remove the source first.".formatted(itemId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemSourceException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemSourceException.java
@@ -48,6 +48,16 @@ public class InvalidPortalNavigationItemSourceException extends ValidationDomain
         );
     }
 
+    public static InvalidPortalNavigationItemSourceException sourceCannotListFiles(String sourceType) {
+        return new InvalidPortalNavigationItemSourceException(
+            "The source type %s cannot list files: a files fetcher is required.".formatted(sourceType)
+        );
+    }
+
+    public static InvalidPortalNavigationItemSourceException invalidManifest(Throwable cause) {
+        return new InvalidPortalNavigationItemSourceException("The .gravitee.json manifest cannot be read.", cause);
+    }
+
     public static InvalidPortalNavigationItemSourceException cronRequiredForAutoFetch() {
         return new InvalidPortalNavigationItemSourceException("A fetch cron expression is required when auto-fetch is enabled.");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentType.java
@@ -15,31 +15,66 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import jakarta.annotation.Nullable;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 /** Maps an imported file to a {@link PortalPageContentType}, from its extension and content. */
 public final class ImportedFileContentType {
 
-    /** An API spec is AsyncAPI when it declares the asyncapi version field, OpenAPI otherwise. */
-    private static final Pattern ASYNCAPI_MARKER = Pattern.compile("(?m)^\\s*\"?asyncapi\"?\\s*:");
+    /** YAML is a superset of JSON: the same reader parses both spec flavours. */
+    private static final YAMLMapper YAML = new YAMLMapper();
+
+    // No AsciiDoc content type in the NG portal: .adoc is rejected rather than rendered broken
+    private static final Set<String> IMPORTABLE_EXTENSIONS = Set.of("md", "yaml", "yml", "json");
 
     private ImportedFileContentType() {}
 
-    public static Optional<PortalPageContentType> from(String fileName, String content) {
-        var extension = extensionOf(fileName);
-        return switch (extension) {
-            // No AsciiDoc content type in the NG portal: .adoc is rejected rather than rendered broken
+    /** Whether the file can be imported at all, without having to fetch its content. */
+    public static boolean isImportable(String fileName) {
+        return IMPORTABLE_EXTENSIONS.contains(extensionOf(fileName));
+    }
+
+    /**
+     * The content type of an importable file, empty when the document is not one the portal renders.
+     * A {@code .yaml}/{@code .yml}/{@code .json} file is only a spec when its root object declares
+     * {@code asyncapi}, {@code openapi} or {@code swagger}: sharing an extension with a spec is not
+     * enough, a repository holds plenty of other JSON and YAML.
+     */
+    public static Optional<PortalPageContentType> from(String fileName, @Nullable String content) {
+        return switch (extensionOf(fileName)) {
             case "md" -> Optional.of(PortalPageContentType.GRAVITEE_MARKDOWN);
-            case "yaml", "yml", "json" -> Optional.of(
-                content != null && ASYNCAPI_MARKER.matcher(content).find() ? PortalPageContentType.ASYNCAPI : PortalPageContentType.OPENAPI
-            );
+            case "yaml", "yml", "json" -> specTypeOf(content);
             default -> Optional.empty();
         };
     }
 
-    private static String extensionOf(String fileName) {
+    private static Optional<PortalPageContentType> specTypeOf(@Nullable String content) {
+        if (content == null || content.isBlank()) {
+            return Optional.empty();
+        }
+        final JsonNode root;
+        try {
+            root = YAML.readTree(content);
+        } catch (Exception e) {
+            // Not parseable as YAML nor JSON: it cannot be a spec
+            return Optional.empty();
+        }
+        if (root == null || !root.isObject()) {
+            return Optional.empty();
+        }
+        // Read on the root object only: an `asyncapi` key nested in an OpenAPI document — a response
+        // example, a vendor extension — must not decide the type of the whole file.
+        if (root.has("asyncapi")) {
+            return Optional.of(PortalPageContentType.ASYNCAPI);
+        }
+        return root.has("openapi") || root.has("swagger") ? Optional.of(PortalPageContentType.OPENAPI) : Optional.empty();
+    }
+
+    private static String extensionOf(@Nullable String fileName) {
         if (fileName == null) {
             return "";
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/** Maps an imported file to a {@link PortalPageContentType}, from its extension and content. */
+public final class ImportedFileContentType {
+
+    /** An API spec is AsyncAPI when it declares the asyncapi version field, OpenAPI otherwise. */
+    private static final Pattern ASYNCAPI_MARKER = Pattern.compile("(?m)^\\s*\"?asyncapi\"?\\s*:");
+
+    private ImportedFileContentType() {}
+
+    public static Optional<PortalPageContentType> from(String fileName, String content) {
+        var extension = extensionOf(fileName);
+        return switch (extension) {
+            // No AsciiDoc content type in the NG portal: .adoc is rejected rather than rendered broken
+            case "md" -> Optional.of(PortalPageContentType.GRAVITEE_MARKDOWN);
+            case "yaml", "yml", "json" -> Optional.of(
+                content != null && ASYNCAPI_MARKER.matcher(content).find() ? PortalPageContentType.ASYNCAPI : PortalPageContentType.OPENAPI
+            );
+            default -> Optional.empty();
+        };
+    }
+
+    private static String extensionOf(String fileName) {
+        if (fileName == null) {
+            return "";
+        }
+        var separatorIndex = fileName.lastIndexOf('.');
+        return separatorIndex < 0 ? "" : fileName.substring(separatorIndex + 1).toLowerCase(Locale.ROOT);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemSource.java
@@ -52,6 +52,14 @@ public class PortalNavigationItemSource {
     @Nullable
     private String lastFetchError;
 
+    /**
+     * Set by the import: fetching this folder re-imports the subtree, deleting what the import no
+     * longer knows. Server-owned, never read from a payload, so a hand-made sourced folder is never
+     * mistaken for an import target.
+     */
+    @Builder.Default
+    private boolean subtreeImport = false;
+
     public void registerFetchAttempt() {
         this.lastFetchAttemptAt = TimeProvider.instantNow();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -63,9 +63,8 @@ public interface PortalNavigationItemsQueryService {
      * is a node-wide job and does not run inside an environment context.
      */
     default List<PortalNavigationItem> findAllWithAutoFetchEnabled() {
-        // Restricted to PAGE in the query rather than in the caller: only a PAGE owns content that the
-        // scheduler knows how to refresh.
-        return search(PortalNavigationItemQueryCriteria.builder().useAutoFetch(true).type(PortalNavigationItemType.PAGE).build());
+        // PAGEs and FOLDERs both qualify: the auto-fetch use case decides what a refresh means per type
+        return search(PortalNavigationItemQueryCriteria.builder().useAutoFetch(true).build());
     }
 
     default Optional<PortalNavigationPage> findNavigationPageByPortalPageContentId(String environmentId, PortalPageContentId contentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationManifestParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationManifestParser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.service_provider;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+/** Parses the Gravitee descriptor ({@code .gravitee.json}) of a remote documentation repository. */
+public interface PortalNavigationManifestParser {
+    String manifestFileName();
+
+    /**
+     * @throws io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException when the manifest cannot be read
+     */
+    List<ManifestPage> parse(String manifestContent);
+
+    /**
+     * One documentation page declared by the manifest. The descriptor's {@code homepage} flag is
+     * ignored for portal navigation imports.
+     *
+     * @param src  path of the file in the repository
+     * @param name display name; falls back to the file base name when blank
+     * @param dest target folder path; falls back to the file's parent path when blank
+     */
+    record ManifestPage(String src, @Nullable String name, @Nullable String dest) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCase.java
@@ -16,8 +16,11 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import lombok.CustomLog;
@@ -36,27 +39,73 @@ public class AutoFetchPortalNavigationItemsUseCase {
     private final PortalNavigationItemsQueryService queryService;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
     private final PortalNavigationItemDomainService domainService;
+    private final PortalNavigationBulkImportDomainService bulkImportDomainService;
 
     public Output execute() {
-        var duePages = queryService
+        var dueItems = queryService
             .findAllWithAutoFetchEnabled()
             .stream()
-            .filter(PortalNavigationPage.class::isInstance)
-            .map(PortalNavigationPage.class::cast)
-            .filter(page -> page.getSource() != null)
-            .filter(page -> sourceDomainService.isAutoFetchDue(page.getSource()))
+            .filter(item -> item.getSource() != null)
+            .filter(this::isAutoFetchable)
+            .filter(item -> sourceDomainService.isAutoFetchDue(item.getSource()))
             .toList();
 
         int succeeded = 0;
         int failed = 0;
-        for (var page : duePages) {
-            if (fetch(page)) {
+        for (var item : dueItems) {
+            var fetched = switch (item) {
+                case PortalNavigationPage page -> fetch(page);
+                case PortalNavigationFolder folder -> reimport(folder);
+                default -> true;
+            };
+            if (fetched) {
                 succeeded++;
             } else {
                 failed++;
             }
         }
         return new Output(succeeded, failed);
+    }
+
+    /**
+     * A folder is auto-fetchable only when the navigation import set it up: its fetch is a re-import,
+     * which deletes what the import does not know. Folders sourced by hand before imports existed
+     * carry no marker and must never be picked up here. Runs after the null-source filter: the
+     * source can be dereferenced.
+     */
+    private boolean isAutoFetchable(PortalNavigationItem item) {
+        return switch (item) {
+            case PortalNavigationPage page -> true;
+            case PortalNavigationFolder folder -> folder.getSource().isSubtreeImport();
+            default -> false;
+        };
+    }
+
+    /** Never throws: one failing folder must not stop the items after it. */
+    private boolean reimport(PortalNavigationFolder folder) {
+        try {
+            log.debug(
+                "Auto-importing portal navigation folder [id={}, title={}, environmentId={}]",
+                folder.getId().json(),
+                folder.getTitle(),
+                folder.getEnvironmentId()
+            );
+            return bulkImportDomainService
+                .importSubtree(folder)
+                .files()
+                .stream()
+                .allMatch(file -> file.success());
+        } catch (Exception e) {
+            log.warn(
+                "Failed to auto-import portal navigation folder [id={}, title={}, environmentId={}, sourceType={}]",
+                folder.getId().json(),
+                folder.getTitle(),
+                folder.getEnvironmentId(),
+                folder.getSource() == null ? null : folder.getSource().getSourceType(),
+                e
+            );
+            return false;
+        }
     }
 
     /** Never throws: one failing page must not stop the ones after it. */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCase.java
@@ -16,11 +16,13 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
@@ -32,9 +34,9 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Re-runs the fetch of a navigation item: a sourced PAGE is fetched on its own, any other item
- * fetches every sourced PAGE below it. A page failing to fetch never blocks the others; an internal
- * inconsistency aborts the run.
+ * Re-runs the fetch of a navigation item: a sourced PAGE is fetched on its own, an import-managed
+ * FOLDER re-runs its import, any other item fetches every sourced PAGE below it. A page failing to
+ * fetch never blocks the others; an internal inconsistency aborts the run.
  */
 @UseCase
 @RequiredArgsConstructor
@@ -44,6 +46,7 @@ public class FetchPortalNavigationItemUseCase {
     private final PortalNavigationSourcedItemsDomainService sourcedItemsDomainService;
     private final PortalNavigationItemDomainService domainService;
     private final PortalNavigationItemSourceDomainService sourceDomainService;
+    private final PortalNavigationBulkImportDomainService bulkImportDomainService;
 
     public Output execute(Input input) {
         var item = queryService.findByIdAndEnvironmentId(input.environmentId(), PortalNavigationItemId.of(input.navigationItemId()));
@@ -54,7 +57,19 @@ public class FetchPortalNavigationItemUseCase {
         if (item instanceof PortalNavigationPage page && page.getSource() != null) {
             return Output.ofItem(fetchSingle(page));
         }
+        if (item instanceof PortalNavigationFolder folder && folder.getSource() != null && folder.getSource().isSubtreeImport()) {
+            return Output.ofSummary(reimportSubtree(folder));
+        }
         return Output.ofSummary(fetchDescendants(input.environmentId(), item));
+    }
+
+    private List<PageFetchResult> reimportSubtree(PortalNavigationFolder folder) {
+        return bulkImportDomainService
+            .importSubtree(folder)
+            .files()
+            .stream()
+            .map(file -> new PageFetchResult(file.navigationItemId(), file.title(), file.success(), file.error()))
+            .toList();
     }
 
     private PortalNavigationItem fetchSingle(PortalNavigationPage page) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCase.java
@@ -124,5 +124,6 @@ public class FetchPortalNavigationItemUseCase {
         }
     }
 
-    public record PageFetchResult(UUID navigationItemId, String title, boolean success, @Nullable String error) {}
+    /** A repository import reports failures that reached no item at all: their id is null. */
+    public record PageFetchResult(@Nullable UUID navigationItemId, String title, boolean success, @Nullable String error) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSourceDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Creates a folder bound to a file-listing source and imports the remote documentation tree below
+ * it. Unlike the bulk creation endpoint, which creates items from an explicit list, the import
+ * builds that list from the remote repository.
+ */
+@RequiredArgsConstructor
+@UseCase
+public class ImportPortalNavigationUseCase {
+
+    private final PortalNavigationItemValidatorService validatorService;
+    private final PortalNavigationItemDomainService domainService;
+    private final PortalNavigationItemSourceDomainService sourceDomainService;
+    private final PortalNavigationBulkImportDomainService bulkImportDomainService;
+    private final PortalNavigationItemsQueryService queryService;
+
+    public Output execute(Input input) {
+        // The caller never picks an area: under a parent it can only be the parent's, and the
+        // area validators would otherwise reject a mismatch the caller has no way to understand.
+        // An unknown parent falls back to the default so ParentRule reports it, instead of an NPE here.
+        var parent = input.parentId() == null ? null : queryService.findByIdAndEnvironmentId(input.environmentId(), input.parentId());
+        var area = parent == null ? PortalArea.TOP_NAVBAR : parent.getArea();
+        var itemToCreate = CreatePortalNavigationItem.builder()
+            .title(input.title())
+            .type(PortalNavigationItemType.FOLDER)
+            .area(area)
+            .parentId(input.parentId())
+            .visibility(input.visibility() == null ? PortalVisibility.PRIVATE : input.visibility())
+            .published(false)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .source(input.source())
+            .build();
+
+        validatorService.validateAll(List.of(itemToCreate), input.environmentId());
+        if (!sourceDomainService.supportsFileListing(input.source())) {
+            throw InvalidPortalNavigationItemSourceException.sourceCannotListFiles(input.source().getSourceType());
+        }
+        // The marker is what later routes a fetch of this folder to a re-import
+        input.source().setSubtreeImport(true);
+
+        var rootFolder = (PortalNavigationFolder) domainService.create(input.organizationId(), input.environmentId(), itemToCreate);
+        var result = bulkImportDomainService.importSubtree(rootFolder);
+
+        // The import stamps the fetch state on the root folder: return the persisted version
+        var importedRoot = (PortalNavigationFolder) queryService.findByIdAndEnvironmentId(input.environmentId(), rootFolder.getId());
+        if (importedRoot.getSource() != null) {
+            sourceDomainService.removeSensitiveData(importedRoot.getSource());
+        }
+        return new Output(importedRoot, result);
+    }
+
+    @Builder
+    public record Input(
+        String organizationId,
+        String environmentId,
+        String title,
+        @Nullable PortalNavigationItemId parentId,
+        @Nullable PortalVisibility visibility,
+        PortalNavigationItemSource source
+    ) {}
+
+    public record Output(PortalNavigationFolder rootFolder, PortalNavigationBulkImportDomainService.BulkImportResult result) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
@@ -50,6 +50,10 @@ public class UpdatePortalNavigationItemUseCase {
         if (existing.getSource() != null && toUpdate.getSource() != null) {
             sourceDomainService.mergeSensitiveData(existing.getSource(), toUpdate.getSource());
         }
+        // The import marker is server-owned: carried over from the stored source, never taken from a payload
+        if (toUpdate.getSource() != null) {
+            toUpdate.getSource().setSubtreeImport(existing.getSource() != null && existing.getSource().isSubtreeImport());
+        }
         validatorService.validateToUpdate(toUpdate, existing);
         var updatedItem = domainService.update(toUpdate, existing, input.propagatePublishToChildren());
         if (updatedItem.getSource() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -43,6 +43,7 @@ public interface PortalNavigationItemAdapter {
     String LAST_FETCHED_AT = "lastFetchedAt";
     String LAST_FETCH_ATTEMPT_AT = "lastFetchAttemptAt";
     String LAST_FETCH_ERROR = "lastFetchError";
+    String SUBTREE_IMPORT = "subtreeImport";
 
     default PortalNavigationItem toEntity(io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem) {
         return switch (portalNavigationItem.getType()) {
@@ -252,6 +253,9 @@ public interface PortalNavigationItemAdapter {
         if (source.getLastFetchError() != null) {
             sourceNode.put(LAST_FETCH_ERROR, source.getLastFetchError());
         }
+        if (source.isSubtreeImport()) {
+            sourceNode.put(SUBTREE_IMPORT, true);
+        }
     }
 
     @Named("parsePortalPageContentId")
@@ -306,6 +310,8 @@ public interface PortalNavigationItemAdapter {
                         : null
                 )
                 .lastFetchError(sourceNode.hasNonNull(LAST_FETCH_ERROR) ? sourceNode.get(LAST_FETCH_ERROR).asText() : null)
+                // Absent on rows stored before the navigation import existed: they are not import targets
+                .subtreeImport(sourceNode.path(SUBTREE_IMPORT).asBoolean(false))
                 .build();
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid source in configuration for PortalNavigationItem", e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationItemSourceDomainServiceImpl.java
@@ -25,6 +25,8 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.fetcher.api.Fetcher;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.FilepathAwareFetcherConfiguration;
+import io.gravitee.fetcher.api.FilesFetcher;
 import io.gravitee.fetcher.api.Sensitive;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
@@ -35,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,6 +71,44 @@ public class PortalNavigationItemSourceDomainServiceImpl implements PortalNaviga
         var fetcher = loadFetcher(source).orElseThrow(() ->
             InvalidPortalNavigationItemSourceException.unknownSourceType(source.getSourceType())
         );
+        return readContent(fetcher, source);
+    }
+
+    @Override
+    public boolean supportsFileListing(PortalNavigationItemSource source) {
+        try {
+            return loadFetcher(source).filter(FilesFetcher.class::isInstance).isPresent();
+        } catch (Exception e) {
+            log.warn("Unable to determine file-listing support of portal page source [type={}]", source.getSourceType(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<String> listFiles(PortalNavigationItemSource source) {
+        var fetcher = loadFetcher(source).orElseThrow(() ->
+            InvalidPortalNavigationItemSourceException.unknownSourceType(source.getSourceType())
+        );
+        if (!(fetcher instanceof FilesFetcher filesFetcher)) {
+            throw InvalidPortalNavigationItemSourceException.sourceCannotListFiles(source.getSourceType());
+        }
+        try {
+            var files = filesFetcher.files();
+            return files == null ? List.of() : Arrays.stream(files).filter(Objects::nonNull).toList();
+        } catch (FetcherException e) {
+            throw new TechnicalDomainException("unable to list files from source type " + source.getSourceType(), e);
+        }
+    }
+
+    @Override
+    public String fetchFileContent(PortalNavigationItemSource source, String filepath) {
+        var fetcher = loadFetcher(source).orElseThrow(() ->
+            InvalidPortalNavigationItemSourceException.unknownSourceType(source.getSourceType())
+        );
+        if (!(fetcher.getConfiguration() instanceof FilepathAwareFetcherConfiguration filepathAwareConfiguration)) {
+            throw InvalidPortalNavigationItemSourceException.sourceCannotListFiles(source.getSourceType());
+        }
+        filepathAwareConfiguration.setFilepath(filepath);
         return readContent(fetcher, source);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationManifestParserImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationManifestParserImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationManifestParser;
+import io.gravitee.rest.api.service.GraviteeDescriptorService;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class PortalNavigationManifestParserImpl implements PortalNavigationManifestParser {
+
+    private final GraviteeDescriptorService graviteeDescriptorService;
+
+    @Override
+    public String manifestFileName() {
+        return graviteeDescriptorService.descriptorName();
+    }
+
+    @Override
+    public List<ManifestPage> parse(String manifestContent) {
+        try {
+            var descriptor = graviteeDescriptorService.read(manifestContent);
+            if (descriptor.getDocumentation() == null || descriptor.getDocumentation().getPages() == null) {
+                return List.of();
+            }
+            return descriptor
+                .getDocumentation()
+                .getPages()
+                .stream()
+                .map(page -> new ManifestPage(page.getSrc(), page.getName(), page.getDest()))
+                .toList();
+        } catch (Exception e) {
+            throw InvalidPortalNavigationItemSourceException.invalidManifest(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemSourceDomainServiceInMemory.java
@@ -19,7 +19,10 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemSour
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.scheduling.support.CronExpression;
 
@@ -33,6 +36,11 @@ public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNa
 
     private RuntimeException fetchFailure;
     private String lastValidatedConfiguration;
+
+    private boolean filesCapable = false;
+    private final Map<String, String> remoteFiles = new LinkedHashMap<>();
+    private final Set<String> fileFetchFailures = new HashSet<>();
+    private RuntimeException listFilesFailure;
 
     public void failNextFetchWith(RuntimeException failure) {
         this.fetchFailure = failure;
@@ -51,6 +59,59 @@ public class PortalNavigationItemSourceDomainServiceInMemory implements PortalNa
             throw failure;
         }
         return MARKDOWN;
+    }
+
+    @Override
+    public boolean supportsFileListing(PortalNavigationItemSource source) {
+        return filesCapable;
+    }
+
+    @Override
+    public java.util.List<String> listFiles(PortalNavigationItemSource source) {
+        if (listFilesFailure != null) {
+            var failure = listFilesFailure;
+            listFilesFailure = null;
+            throw failure;
+        }
+        return java.util.List.copyOf(remoteFiles.keySet());
+    }
+
+    @Override
+    public String fetchFileContent(PortalNavigationItemSource source, String filepath) {
+        if (fileFetchFailures.remove(filepath)) {
+            throw new RuntimeException("failed to fetch " + filepath);
+        }
+        var content = remoteFiles.get(filepath);
+        if (content == null) {
+            throw new RuntimeException("no such remote file " + filepath);
+        }
+        return content;
+    }
+
+    /** Makes {@link #supportsFileListing} answer true and registers a remote file with its content. */
+    public void givenRemoteFile(String filepath, String content) {
+        filesCapable = true;
+        remoteFiles.put(filepath, content);
+    }
+
+    public void removeRemoteFile(String filepath) {
+        remoteFiles.remove(filepath);
+    }
+
+    public void failNextListFilesWith(RuntimeException failure) {
+        this.listFilesFailure = failure;
+    }
+
+    public void failFileFetch(String filepath) {
+        fileFetchFailures.add(filepath);
+    }
+
+    /** Clears the file-listing state; shared instances (Spring test contexts) call it between tests. */
+    public void resetFileListing() {
+        filesCapable = false;
+        remoteFiles.clear();
+        fileFetchFailures.clear();
+        listFilesFailure = null;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationManifestParserInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationManifestParserInMemory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationManifestParser;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PortalNavigationManifestParserInMemory implements PortalNavigationManifestParser {
+
+    public static final String MANIFEST_FILE_NAME = ".gravitee.json";
+
+    private final List<ManifestPage> pages = new ArrayList<>();
+    private boolean failOnParse = false;
+
+    public void willParse(List<ManifestPage> manifestPages) {
+        pages.clear();
+        pages.addAll(manifestPages);
+    }
+
+    public void failOnParse() {
+        this.failOnParse = true;
+    }
+
+    @Override
+    public String manifestFileName() {
+        return MANIFEST_FILE_NAME;
+    }
+
+    @Override
+    public List<ManifestPage> parse(String manifestContent) {
+        if (failOnParse) {
+            throw InvalidPortalNavigationItemSourceException.invalidManifest(new RuntimeException("unreadable manifest"));
+        }
+        return List.copyOf(pages);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -541,8 +541,16 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    public PortalNavigationItemsQueryService portalNavigationItemsQueryService() {
-        return new PortalNavigationItemsQueryServiceInMemory();
+    public PortalNavigationManifestParserInMemory portalNavigationManifestParser() {
+        return new PortalNavigationManifestParserInMemory();
+    }
+
+    @Bean
+    public PortalNavigationItemsQueryService portalNavigationItemsQueryService(
+        PortalNavigationItemsCrudServiceInMemory portalNavigationItemsCrudService
+    ) {
+        // Shares the crud storage so items created during a request are queryable, as with a real repository
+        return new PortalNavigationItemsQueryServiceInMemory(portalNavigationItemsCrudService.storage());
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentTypeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/ImportedFileContentTypeTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ImportedFileContentTypeTest {
+
+    @Nested
+    class Importable {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "guide.md", "spec.yaml", "spec.yml", "spec.json", "SPEC.JSON", "docs/nested/guide.md" })
+        void should_accept_the_extensions_the_portal_renders(String fileName) {
+            assertThat(ImportedFileContentType.isImportable(fileName)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "legacy.adoc", "logo.png", "Makefile", "archive.tar.gz" })
+        void should_reject_any_other_extension(String fileName) {
+            assertThat(ImportedFileContentType.isImportable(fileName)).isFalse();
+        }
+    }
+
+    @Nested
+    class Markdown {
+
+        @Test
+        void should_map_markdown_from_its_extension_alone() {
+            assertThat(ImportedFileContentType.from("guide.md", null)).contains(PortalPageContentType.GRAVITEE_MARKDOWN);
+        }
+    }
+
+    @Nested
+    class Specs {
+
+        @Test
+        void should_detect_openapi_from_the_root_property() {
+            assertThat(ImportedFileContentType.from("petstore.yaml", "openapi: 3.0.3\ninfo:\n  title: Petstore")).contains(
+                PortalPageContentType.OPENAPI
+            );
+        }
+
+        @Test
+        void should_detect_swagger_from_the_root_property() {
+            assertThat(ImportedFileContentType.from("petstore.json", "{\"swagger\": \"2.0\", \"info\": {}}")).contains(
+                PortalPageContentType.OPENAPI
+            );
+        }
+
+        @Test
+        void should_detect_asyncapi_from_the_root_property() {
+            assertThat(ImportedFileContentType.from("events.yaml", "asyncapi: 3.0.0\ninfo:\n  title: Events")).contains(
+                PortalPageContentType.ASYNCAPI
+            );
+        }
+
+        @Test
+        void should_detect_asyncapi_in_a_compact_json_document() {
+            // A single-line JSON spec: nothing puts the asyncapi key at the start of a line
+            assertThat(ImportedFileContentType.from("events.json", "{\"asyncapi\":\"3.0.0\",\"info\":{}}")).contains(
+                PortalPageContentType.ASYNCAPI
+            );
+        }
+
+        @Test
+        void should_not_let_a_nested_asyncapi_key_reclassify_an_openapi_document() {
+            var openApiMentioningAsyncApi = """
+                openapi: 3.0.3
+                info:
+                  title: Petstore
+                components:
+                  schemas:
+                    Link:
+                      properties:
+                        asyncapi: { type: string }
+                """;
+            assertThat(ImportedFileContentType.from("petstore.yaml", openApiMentioningAsyncApi)).contains(PortalPageContentType.OPENAPI);
+        }
+    }
+
+    @Nested
+    class NotADocument {
+
+        @Test
+        void should_reject_a_json_file_that_is_not_a_spec() {
+            // The repository file that made every mirror import create a broken OpenAPI page
+            assertThat(ImportedFileContentType.from("package.json", "{\"name\": \"docs\", \"version\": \"1.0.0\"}")).isEmpty();
+        }
+
+        @Test
+        void should_reject_a_yaml_file_that_is_not_a_spec() {
+            assertThat(ImportedFileContentType.from("ci.yml", "name: build\non:\n  push:\n    branches: [master]")).isEmpty();
+        }
+
+        @Test
+        void should_reject_a_document_that_parses_to_something_else_than_an_object() {
+            assertThat(ImportedFileContentType.from("list.yaml", "- one\n- two")).isEmpty();
+        }
+
+        @Test
+        void should_reject_an_unparseable_document() {
+            assertThat(ImportedFileContentType.from("broken.yaml", "openapi: [3.0.3\n  bad: {")).isEmpty();
+        }
+
+        @Test
+        void should_reject_a_spec_extension_without_content() {
+            assertThat(ImportedFileContentType.from("spec.yaml", null)).isEmpty();
+            assertThat(ImportedFileContentType.from("spec.yaml", "   ")).isEmpty();
+        }
+
+        @Test
+        void should_reject_an_unsupported_extension() {
+            assertThat(ImportedFileContentType.from("legacy.adoc", "= Legacy")).isEmpty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/AutoFetchPortalNavigationItemsUseCaseTest.java
@@ -21,10 +21,12 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalNavigationManifestParserInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
@@ -54,6 +56,7 @@ class AutoFetchPortalNavigationItemsUseCaseTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:34:56Z");
 
     private PortalNavigationItemsCrudServiceInMemory crudService;
+    private PortalNavigationItemsQueryServiceInMemory queryService;
     private PortalPageContentCrudServiceInMemory pageContentCrudService;
     private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
     private AutoFetchPortalNavigationItemsUseCase useCase;
@@ -68,7 +71,7 @@ class AutoFetchPortalNavigationItemsUseCaseTest {
         TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
         var storage = new ArrayList<PortalNavigationItem>();
         crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
-        var queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
+        queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
         pageContentCrudService = new PortalPageContentCrudServiceInMemory();
         sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
 
@@ -80,7 +83,16 @@ class AutoFetchPortalNavigationItemsUseCaseTest {
             new ApiCrudServiceInMemory(),
             sourceDomainService
         );
-        useCase = new AutoFetchPortalNavigationItemsUseCase(queryService, sourceDomainService, domainService);
+        var bulkImportDomainService = new PortalNavigationBulkImportDomainService(
+            sourceDomainService,
+            new PortalNavigationManifestParserInMemory(),
+            domainService,
+            queryService,
+            crudService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage())
+        );
+        useCase = new AutoFetchPortalNavigationItemsUseCase(queryService, sourceDomainService, domainService, bulkImportDomainService);
     }
 
     @Test
@@ -134,6 +146,36 @@ class AutoFetchPortalNavigationItemsUseCaseTest {
         assertThat(output.failed()).isZero();
         assertThat(withoutAutoFetch.getSource().getLastFetchedAt()).isNull();
         assertThat(withoutAutoFetch.getSource().getLastFetchAttemptAt()).isNull();
+    }
+
+    @Test
+    void should_reimport_folders_bound_to_a_file_listing_source() {
+        var folder = aFolder("Imported Docs", autoFetchSource().subtreeImport(true).build());
+        sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isEqualTo(1);
+        assertThat(output.failed()).isZero();
+        assertThat(folder.getSource().getLastFetchedAt()).isNotNull();
+        assertThat(queryService.findByParentIdAndEnvironmentId(folder.getEnvironmentId(), folder.getId()))
+            .singleElement()
+            .satisfies(item -> assertThat(item.getTitle()).isEqualTo("docs"));
+    }
+
+    @Test
+    void should_never_reimport_a_sourced_folder_the_import_did_not_create() {
+        // Representable before imports existed: a hand-sourced auto-fetch folder. Picking it up
+        // on upgrade would replace its subtree with the remote tree, without any user action.
+        var folder = aFolder("Legacy Folder", autoFetchSource().build());
+        sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+
+        var output = useCase.execute();
+
+        assertThat(output.succeeded()).isZero();
+        assertThat(output.failed()).isZero();
+        assertThat(folder.getSource().getLastFetchAttemptAt()).isNull();
+        assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, folder.getId())).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/FetchPortalNavigationItemUseCaseTest.java
@@ -23,10 +23,12 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalNavigationManifestParserInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -73,11 +75,21 @@ class FetchPortalNavigationItemUseCaseTest {
             new ApiCrudServiceInMemory(),
             sourceDomainService
         );
+        var bulkImportDomainService = new PortalNavigationBulkImportDomainService(
+            sourceDomainService,
+            new PortalNavigationManifestParserInMemory(),
+            domainService,
+            queryService,
+            crudService,
+            pageContentCrudService,
+            PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage())
+        );
         useCase = new FetchPortalNavigationItemUseCase(
             queryService,
             new PortalNavigationSourcedItemsDomainService(queryService),
             domainService,
-            sourceDomainService
+            sourceDomainService,
+            bulkImportDomainService
         );
     }
 
@@ -203,6 +215,49 @@ class FetchPortalNavigationItemUseCaseTest {
                 .isInstanceOf(InvalidPortalNavigationItemDataException.class)
                 .hasMessageContaining("No page below navigation item")
                 .hasMessageNotContaining("has no external source configured");
+        }
+    }
+
+    @Nested
+    class ImportedFolder {
+
+        @Test
+        void should_reimport_the_subtree_of_an_import_managed_folder() {
+            var folder = aFolder("Imported Docs", null, aSource().subtreeImport(true).build());
+            sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+
+            var summary = execute(folder).summary();
+
+            assertThat(summary.succeeded()).isEqualTo(1);
+            assertThat(summary.failed()).isZero();
+            assertThat(summary.results())
+                .singleElement()
+                .satisfies(result -> assertThat(result.title()).isEqualTo("guide"));
+            var docsFolder = queryService
+                .findByParentIdAndEnvironmentId(ENV_ID, folder.getId())
+                .stream()
+                .filter(item -> "docs".equals(item.getTitle()))
+                .findFirst()
+                .orElseThrow();
+            assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, docsFolder.getId()))
+                .singleElement()
+                .satisfies(item -> assertThat(item.getTitle()).isEqualTo("guide"));
+        }
+
+        @Test
+        void should_walk_descendants_of_a_sourced_folder_the_import_did_not_create() {
+            // A folder sourced by hand keeps the historical fetch semantics: its own source is
+            // never fetched, so its hand-made children can never be replaced by a remote tree
+            var folder = aFolder("Legacy Folder", null, aSource().build());
+            var child = aPage("Sourced Child", folder.getId(), aSource().build());
+            sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+
+            var summary = execute(folder).summary();
+
+            assertThat(summary.results())
+                .singleElement()
+                .satisfies(result -> assertThat(result.title()).isEqualTo("Sourced Child"));
+            assertThat(queryService.findByParentIdAndEnvironmentId(ENV_ID, folder.getId())).containsExactly(child);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalNavigationManifestParserInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.exception.ParentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemSource;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationManifestParser;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ImportPortalNavigationUseCaseTest {
+
+    private static final String ORG_ID = "org-id";
+    private static final String ENV_ID = "env-id";
+
+    private ImportPortalNavigationUseCase useCase;
+    private PortalNavigationItemsCrudServiceInMemory crudService;
+    private PortalNavigationItemsQueryServiceInMemory queryService;
+    private PortalPageContentCrudServiceInMemory pageContentCrudService;
+    private PortalNavigationItemSourceDomainServiceInMemory sourceDomainService;
+    private PortalNavigationManifestParserInMemory manifestParser;
+
+    @BeforeEach
+    void setUp() {
+        var storage = new ArrayList<PortalNavigationItem>();
+        crudService = new PortalNavigationItemsCrudServiceInMemory(storage);
+        queryService = new PortalNavigationItemsQueryServiceInMemory(storage);
+        pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+        sourceDomainService = new PortalNavigationItemSourceDomainServiceInMemory();
+        manifestParser = new PortalNavigationManifestParserInMemory();
+
+        var pageContentQueryService = PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage());
+        var domainService = new PortalNavigationItemDomainService(
+            crudService,
+            queryService,
+            pageContentCrudService,
+            pageContentQueryService,
+            new ApiCrudServiceInMemory(),
+            sourceDomainService
+        );
+        var validatorService = new PortalNavigationItemValidatorService(
+            queryService,
+            pageContentQueryService,
+            new ApiProductQueryServiceInMemory(),
+            sourceDomainService
+        );
+        var bulkImportDomainService = new PortalNavigationBulkImportDomainService(
+            sourceDomainService,
+            manifestParser,
+            domainService,
+            queryService,
+            crudService,
+            pageContentCrudService,
+            pageContentQueryService
+        );
+        useCase = new ImportPortalNavigationUseCase(
+            validatorService,
+            domainService,
+            sourceDomainService,
+            bulkImportDomainService,
+            queryService
+        );
+    }
+
+    private ImportPortalNavigationUseCase.Output execute(String title) {
+        return execute(title, null);
+    }
+
+    private ImportPortalNavigationUseCase.Output execute(String title, PortalNavigationItemId parentId) {
+        return useCase.execute(
+            ImportPortalNavigationUseCase.Input.builder()
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .title(title)
+                .parentId(parentId)
+                .visibility(PortalVisibility.PRIVATE)
+                .source(aSource())
+                .build()
+        );
+    }
+
+    private PortalNavigationItemSource aSource() {
+        return PortalNavigationItemSource.builder().sourceType("github-fetcher").sourceConfiguration("{\"repository\":\"docs\"}").build();
+    }
+
+    @Nested
+    class WithoutManifest {
+
+        @Test
+        void should_mirror_the_remote_tree_and_ignore_unsupported_files() {
+            sourceDomainService.givenRemoteFile("/docs/getting-started.md", "# Getting started");
+            sourceDomainService.givenRemoteFile("/docs/advanced/tuning.md", "# Tuning");
+            sourceDomainService.givenRemoteFile("/specs/petstore.yaml", "openapi: 3.0.3");
+            sourceDomainService.givenRemoteFile("/logo.png", "binary");
+            // No AsciiDoc content type in the NG portal: rendering .adoc as markdown leaks raw syntax
+            sourceDomainService.givenRemoteFile("/docs/notes.adoc", "= AsciiDoc");
+
+            var output = execute("Imported Docs");
+
+            var root = output.rootFolder();
+            assertThat(root.getTitle()).isEqualTo("Imported Docs");
+            assertThat(root.getSource()).isNotNull();
+            // The marker is what routes later fetches of this folder to a re-import
+            assertThat(root.getSource().isSubtreeImport()).isTrue();
+            assertThat(root.getSource().getLastFetchedAt()).isNotNull();
+            assertThat(root.getSource().getLastFetchError()).isNull();
+
+            var docsFolder = childFolder(root.getId(), "docs");
+            var advancedFolder = childFolder(docsFolder.getId(), "advanced");
+            var specsFolder = childFolder(root.getId(), "specs");
+            assertThat(childPage(docsFolder.getId(), "getting-started").getSource()).isNull();
+            assertThat(contentOf(childPage(docsFolder.getId(), "getting-started"))).isInstanceOf(GraviteeMarkdownPageContent.class);
+            assertThat(contentOf(childPage(advancedFolder.getId(), "tuning"))).isInstanceOf(GraviteeMarkdownPageContent.class);
+            assertThat(contentOf(childPage(specsFolder.getId(), "petstore"))).isInstanceOf(OpenApiPageContent.class);
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactlyInAnyOrder(tuple("getting-started", true), tuple("tuning", true), tuple("petstore", true));
+        }
+
+        @Test
+        void should_fail_the_second_entry_colliding_on_the_same_destination_and_title() {
+            // api.md and api.yaml both land as "api" under /docs: importing both would silently
+            // overwrite one with the other while reporting two successes on the same item
+            sourceDomainService.givenRemoteFile("/docs/api.md", "# Api");
+            sourceDomainService.givenRemoteFile("/docs/api.yaml", "openapi: 3.0.3");
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactlyInAnyOrder(tuple("api", true), tuple("api", false));
+            assertThat(output.result().files())
+                .filteredOn(file -> !file.success())
+                .singleElement()
+                .satisfies(file -> assertThat(file.error()).contains("Duplicate title"));
+        }
+
+        @Test
+        void should_detect_asyncapi_specs_from_their_content() {
+            sourceDomainService.givenRemoteFile("/specs/events.yaml", "asyncapi: 3.0.0");
+
+            var output = execute("Imported Docs");
+
+            var specsFolder = childFolder(output.rootFolder().getId(), "specs");
+            assertThat(contentOf(childPage(specsFolder.getId(), "events"))).isInstanceOf(AsyncApiPageContent.class);
+        }
+
+        @Test
+        void should_report_per_file_failures_without_aborting_the_import() {
+            sourceDomainService.givenRemoteFile("/docs/ok.md", "# Ok");
+            sourceDomainService.givenRemoteFile("/docs/broken.md", "# Broken");
+            sourceDomainService.failFileFetch("/docs/broken.md");
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactlyInAnyOrder(tuple("ok", true), tuple("broken", false));
+            assertThat(output.rootFolder().getSource().getLastFetchError()).contains("1 of 2");
+        }
+
+        @Test
+        void should_record_listing_failure_on_the_root_folder_instead_of_failing_the_creation() {
+            sourceDomainService.givenRemoteFile("/docs/ok.md", "# Ok");
+            sourceDomainService.failNextListFilesWith(new RuntimeException("cannot reach repository"));
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.rootFolder().getSource().getLastFetchError()).contains("Unable to list files");
+            assertThat(output.rootFolder().getSource().getLastFetchError()).doesNotContain("cannot reach repository");
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+
+        @Test
+        void should_record_an_empty_listing_as_a_failure_instead_of_importing_nothing() {
+            // Files-capable source whose listing comes back empty — as a silently failing fetcher answers
+            sourceDomainService.givenRemoteFile("/docs/gone.md", "# Gone");
+            sourceDomainService.removeRemoteFile("/docs/gone.md");
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains("listed no files");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+
+        @Test
+        void should_record_a_listing_without_importable_files_as_a_failure() {
+            // Only unsupported types listed: importing "successfully nothing" would hide the problem
+            sourceDomainService.givenRemoteFile("/docs/notes.adoc", "= AsciiDoc");
+            sourceDomainService.givenRemoteFile("/logo.png", "binary");
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains("no importable files");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+    }
+
+    @Nested
+    class WithManifest {
+
+        @Test
+        void should_follow_the_manifest_hierarchy() {
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/content/intro.md", "# Intro");
+            sourceDomainService.givenRemoteFile("/content/api.yaml", "openapi: 3.0.3");
+            manifestParser.willParse(
+                List.of(
+                    new PortalNavigationManifestParser.ManifestPage("/content/intro.md", "Introduction", "/guides"),
+                    new PortalNavigationManifestParser.ManifestPage("/content/api.yaml", null, null)
+                )
+            );
+
+            var output = execute("Imported Docs");
+
+            var root = output.rootFolder();
+            var guidesFolder = childFolder(root.getId(), "guides");
+            assertThat(childPage(guidesFolder.getId(), "Introduction")).isNotNull();
+            // No dest in the manifest: the file's parent path is mirrored
+            var contentFolder = childFolder(root.getId(), "content");
+            assertThat(contentOf(childPage(contentFolder.getId(), "api"))).isInstanceOf(OpenApiPageContent.class);
+        }
+
+        @Test
+        void should_follow_a_manifest_below_the_repository_root() {
+            // A fetcher rooted in a subdirectory lists its files with the prefix, manifest included
+            sourceDomainService.givenRemoteFile("/docs/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.willParse(List.of(new PortalNavigationManifestParser.ManifestPage("/docs/intro.md", "Introduction", "/guides")));
+
+            var output = execute("Imported Docs");
+
+            var guidesFolder = childFolder(output.rootFolder().getId(), "guides");
+            assertThat(childPage(guidesFolder.getId(), "Introduction")).isNotNull();
+            assertThat(findChild(output.rootFolder().getId(), "docs")).isNull();
+        }
+
+        @Test
+        void should_read_the_least_deep_manifest_when_several_directories_carry_one() {
+            // The deeper manifest is listed first: taking the first match would read it
+            sourceDomainService.givenRemoteFile("/docs/.gravitee.json", "{nested manifest}");
+            sourceDomainService.failFileFetch("/docs/.gravitee.json");
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.willParse(List.of(new PortalNavigationManifestParser.ManifestPage("/docs/intro.md", "Introduction", "/guides")));
+
+            var output = execute("Imported Docs");
+
+            var guidesFolder = childFolder(output.rootFolder().getId(), "guides");
+            assertThat(childPage(guidesFolder.getId(), "Introduction")).isNotNull();
+        }
+
+        @Test
+        void should_not_treat_a_file_merely_suffixed_like_the_manifest_as_the_manifest() {
+            sourceDomainService.givenRemoteFile("/docs/my.gravitee.json", "{\"not\":\"a manifest\"}");
+            sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+            manifestParser.willParse(
+                List.of(new PortalNavigationManifestParser.ManifestPage("/docs/guide.md", "From Manifest", "/from-manifest"))
+            );
+
+            var output = execute("Imported Docs");
+
+            // The manifest was not detected: the remote tree is mirrored instead of following willParse
+            var docsFolder = childFolder(output.rootFolder().getId(), "docs");
+            assertThat(childPage(docsFolder.getId(), "guide")).isNotNull();
+            assertThat(findChild(output.rootFolder().getId(), "from-manifest")).isNull();
+        }
+
+        @Test
+        void should_fail_a_manifest_page_pointing_at_an_unsupported_file() {
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/legacy.adoc", "= Legacy");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.willParse(
+                List.of(
+                    new PortalNavigationManifestParser.ManifestPage("/docs/legacy.adoc", "Legacy", "/guides"),
+                    new PortalNavigationManifestParser.ManifestPage("/docs/intro.md", "Introduction", "/guides")
+                )
+            );
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactlyInAnyOrder(tuple("Legacy", false), tuple("Introduction", true));
+
+            // A partial import is still a fetch: the imported pages are current, the error lists the rest
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchedAt()).isNotNull();
+            assertThat(source.getLastFetchError()).contains("Failed to import 1 of 2");
+        }
+
+        @Test
+        void should_record_a_manifest_without_pages_as_a_failure() {
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.willParse(List.of());
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains(".gravitee.json manifest").contains("no importable pages");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+
+        @Test
+        void should_record_a_manifest_fetch_failure_on_the_source_instead_of_failing_the_import() {
+            // The network incident most likely in practice: the listing works, the manifest fetch does not
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            sourceDomainService.failFileFetch("/.gravitee.json");
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains(".gravitee.json manifest");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(source.getLastFetchAttemptAt()).isNotNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+
+        @Test
+        void should_record_a_manifest_parse_failure_on_the_source_instead_of_failing_the_import() {
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{not a manifest}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.failOnParse();
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains(".gravitee.json manifest");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void should_reject_a_source_that_cannot_list_files() {
+            // No remote file registered: the in-memory source is not files-capable
+            assertThatThrownBy(() -> execute("Imported Docs"))
+                .isInstanceOf(InvalidPortalNavigationItemSourceException.class)
+                .hasMessageContaining("cannot list files");
+            assertThat(queryService.storage()).isEmpty();
+        }
+
+        @Test
+        void should_derive_the_parent_area_and_reject_an_import_below_the_homepage() {
+            // The caller never picks an area: deriving it from the parent means a homepage parent is
+            // rejected by the homepage rules — the area can only hold one item — instead of an
+            // area-mismatch error about a choice the caller never made
+            sourceDomainService.givenRemoteFile("/docs/ok.md", "# Ok");
+            var parent = PortalNavigationFolder.builder()
+                .id(PortalNavigationItemId.random())
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .title("Homepage Folder")
+                .segment("homepage-folder")
+                .area(PortalArea.HOMEPAGE)
+                .order(0)
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .build();
+            crudService.create(parent);
+
+            assertThatThrownBy(() -> execute("Imported Docs", parent.getId())).isInstanceOf(HomepageAlreadyExistsException.class);
+            // Nothing created besides the pre-existing parent
+            assertThat(queryService.storage()).hasSize(1);
+        }
+
+        @Test
+        void should_reject_an_import_below_an_unknown_parent() {
+            // The area derivation looks the parent up before validation runs: an unknown id must
+            // still surface as the validation error, not as an NPE
+            sourceDomainService.givenRemoteFile("/docs/ok.md", "# Ok");
+
+            assertThatThrownBy(() -> execute("Imported Docs", PortalNavigationItemId.random())).isInstanceOf(ParentNotFoundException.class);
+            assertThat(queryService.storage()).isEmpty();
+        }
+
+        @Test
+        void should_reject_an_import_below_a_sourced_folder() {
+            sourceDomainService.givenRemoteFile("/docs/ok.md", "# Ok");
+            var sourcedFolder = PortalNavigationFolder.builder()
+                .id(PortalNavigationItemId.random())
+                .organizationId(ORG_ID)
+                .environmentId(ENV_ID)
+                .title("Managed Folder")
+                .segment("managed-folder")
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .source(aSource())
+                .build();
+            crudService.create(sourcedFolder);
+
+            assertThatThrownBy(() -> execute("Imported Docs", sourcedFolder.getId())).isInstanceOf(
+                InvalidPortalNavigationItemDataException.class
+            );
+        }
+    }
+
+    @Nested
+    class Reimport {
+
+        @Test
+        void should_update_create_and_delete_pages_to_mirror_the_remote_listing() {
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept v1");
+            sourceDomainService.givenRemoteFile("/docs/removed.md", "# Removed");
+            var root = execute("Imported Docs").rootFolder();
+            var docsFolder = childFolder(root.getId(), "docs");
+            var keptPageId = childPage(docsFolder.getId(), "kept").getId();
+
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept v2");
+            sourceDomainService.givenRemoteFile("/docs/added.md", "# Added");
+            sourceDomainService.removeRemoteFile("/docs/removed.md");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files()).allMatch(file -> file.success());
+            var refreshedDocsFolder = childFolder(root.getId(), "docs");
+            assertThat(refreshedDocsFolder.getId()).isEqualTo(docsFolder.getId());
+            var keptPage = childPage(refreshedDocsFolder.getId(), "kept");
+            assertThat(keptPage.getId()).isEqualTo(keptPageId);
+            assertThat(((GraviteeMarkdownPageContent) contentOf(keptPage)).getContent().value()).isEqualTo("# Kept v2");
+            assertThat(childPage(refreshedDocsFolder.getId(), "added")).isNotNull();
+            assertThat(findChild(refreshedDocsFolder.getId(), "removed")).isNull();
+        }
+
+        @Test
+        void should_keep_the_imported_pages_when_a_re_import_lists_no_files() {
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept");
+            var root = execute("Imported Docs").rootFolder();
+            var docsFolder = childFolder(root.getId(), "docs");
+
+            // A flaky fetcher can answer an empty listing without failing; it must not wipe the subtree
+            sourceDomainService.removeRemoteFile("/docs/kept.md");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+            assertThat(childPage(docsFolder.getId(), "kept")).isNotNull();
+            var refreshedRoot = (PortalNavigationFolder) queryService.findByIdAndEnvironmentId(ENV_ID, root.getId());
+            assertThat(refreshedRoot.getSource().getLastFetchError()).contains("listed no files");
+        }
+
+        @Test
+        void should_keep_the_imported_pages_when_a_re_import_lists_only_unsupported_files() {
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept");
+            var root = execute("Imported Docs").rootFolder();
+            var docsFolder = childFolder(root.getId(), "docs");
+
+            // The remote tree now only carries unsupported types (e.g. every page moved to .adoc)
+            sourceDomainService.removeRemoteFile("/docs/kept.md");
+            sourceDomainService.givenRemoteFile("/docs/kept.adoc", "= Kept");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+            assertThat(childPage(docsFolder.getId(), "kept")).isNotNull();
+            var refreshedRoot = (PortalNavigationFolder) queryService.findByIdAndEnvironmentId(ENV_ID, root.getId());
+            assertThat(refreshedRoot.getSource().getLastFetchError()).contains("no importable files");
+        }
+
+        private PortalNavigationBulkImportDomainService.BulkImportResult reimportSubtree(PortalNavigationItemId rootId) {
+            var bulkImportDomainService = new PortalNavigationBulkImportDomainService(
+                sourceDomainService,
+                manifestParser,
+                new PortalNavigationItemDomainService(
+                    crudService,
+                    queryService,
+                    pageContentCrudService,
+                    PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage()),
+                    new ApiCrudServiceInMemory(),
+                    sourceDomainService
+                ),
+                queryService,
+                crudService,
+                pageContentCrudService,
+                PortalPageContentQueryServiceInMemory.sharing(pageContentCrudService.storage())
+            );
+            return bulkImportDomainService.importSubtree((PortalNavigationFolder) queryService.findByIdAndEnvironmentId(ENV_ID, rootId));
+        }
+    }
+
+    private PortalNavigationFolder childFolder(PortalNavigationItemId parentId, String title) {
+        var found = findChild(parentId, title);
+        assertThat(found).as("folder '%s' below %s", title, parentId).isInstanceOf(PortalNavigationFolder.class);
+        return (PortalNavigationFolder) found;
+    }
+
+    private PortalNavigationPage childPage(PortalNavigationItemId parentId, String title) {
+        var found = findChild(parentId, title);
+        assertThat(found).as("page '%s' below %s", title, parentId).isInstanceOf(PortalNavigationPage.class);
+        return (PortalNavigationPage) found;
+    }
+
+    private PortalNavigationItem findChild(PortalNavigationItemId parentId, String title) {
+        return queryService
+            .findByParentIdAndEnvironmentId(ENV_ID, parentId)
+            .stream()
+            .filter(item -> title.equals(item.getTitle()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private Object contentOf(PortalNavigationPage page) {
+        return pageContentCrudService
+            .storage()
+            .stream()
+            .filter(content -> content.getId().equals(page.getPortalPageContentId()))
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
@@ -31,6 +31,8 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationBulkImportDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedAncestorFinder;
+import io.gravitee.apim.core.portal_page.domain_service.validation.ValidationDepth;
 import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
@@ -475,6 +477,60 @@ class ImportPortalNavigationUseCaseTest {
             assertThat(output.result().files())
                 .singleElement()
                 .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+    }
+
+    @Nested
+    class DestinationDepth {
+
+        @Test
+        void should_still_protect_a_page_imported_at_the_deepest_allowed_destination() {
+            var output = importAtDestinationDepth(ValidationDepth.MAX_TREE_DEPTH - 1);
+
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isTrue());
+            // The invariant the bound exists for: the read-only walk must still reach the sourced root
+            var importedPage = deepestPageOf(output.rootFolder());
+            assertThat(new SourcedAncestorFinder(queryService).findSourcedAncestor(ENV_ID, importedPage)).hasValueSatisfying(ancestor ->
+                assertThat(ancestor.getId()).isEqualTo(output.rootFolder().getId())
+            );
+        }
+
+        @Test
+        void should_reject_a_destination_that_reaches_the_sourced_ancestor_limit() {
+            // One level deeper the walk gives up before reaching the root: the page would silently
+            // stop being source-managed, so the entry fails instead of being created
+            var output = importAtDestinationDepth(ValidationDepth.MAX_TREE_DEPTH);
+
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> {
+                    assertThat(file.success()).isFalse();
+                    assertThat(file.error()).contains("nests more than");
+                });
+            assertThat(findChild(output.rootFolder().getId(), "level-1")).isNull();
+        }
+
+        private ImportPortalNavigationUseCase.Output importAtDestinationDepth(int depth) {
+            var destination = new StringBuilder();
+            for (var level = 1; level <= depth; level++) {
+                destination.append("/level-").append(level);
+            }
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/deep.md", "# Deep");
+            manifestParser.willParse(
+                List.of(new PortalNavigationManifestParser.ManifestPage("/docs/deep.md", "Deep", destination.toString()))
+            );
+            return execute("Imported Docs");
+        }
+
+        private PortalNavigationPage deepestPageOf(PortalNavigationFolder rootFolder) {
+            PortalNavigationItem current = rootFolder;
+            while (current instanceof PortalNavigationFolder folder) {
+                current = queryService.findByParentIdAndEnvironmentId(ENV_ID, folder.getId()).getFirst();
+            }
+            return (PortalNavigationPage) current;
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
@@ -189,6 +189,47 @@ class ImportPortalNavigationUseCaseTest {
         }
 
         @Test
+        void should_leave_out_mirrored_files_that_are_not_documents() {
+            // Sharing an extension with a spec is not enough: these used to be imported as broken
+            // OpenAPI pages, and reporting them as failures on every run would be just as wrong
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            sourceDomainService.givenRemoteFile("/package.json", "{\"name\": \"docs\", \"version\": \"1.0.0\"}");
+            sourceDomainService.givenRemoteFile("/.github/workflows/ci.yml", "name: build\non:\n  push:\n    branches: [master]");
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactly(tuple("intro", true));
+            assertThat(findChild(output.rootFolder().getId(), "package")).isNull();
+            // Nor the folders that only existed to hold them
+            assertThat(findChild(output.rootFolder().getId(), ".github")).isNull();
+            // A clean import, not a partial one: nothing was left to report
+            assertThat(output.rootFolder().getSource().getLastFetchError()).isNull();
+            assertThat(output.rootFolder().getSource().getLastFetchedAt()).isNotNull();
+        }
+
+        @Test
+        void should_record_a_listing_whose_files_hold_no_document_as_a_failure() {
+            // Every listed file has a spec extension but none is a spec: importing "successfully
+            // nothing" would empty the subtree on a re-import
+            sourceDomainService.givenRemoteFile("/package.json", "{\"name\": \"docs\"}");
+            sourceDomainService.givenRemoteFile("/ci.yml", "name: build");
+
+            var output = execute("Imported Docs");
+
+            var source = output.rootFolder().getSource();
+            assertThat(source.getLastFetchError()).contains("no importable files");
+            assertThat(source.getLastFetchedAt()).isNull();
+            assertThat(output.result().files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+        }
+
+        @Test
         void should_detect_asyncapi_specs_from_their_content() {
             sourceDomainService.givenRemoteFile("/specs/events.yaml", "asyncapi: 3.0.0");
 
@@ -357,6 +398,33 @@ class ImportPortalNavigationUseCaseTest {
             var source = output.rootFolder().getSource();
             assertThat(source.getLastFetchedAt()).isNotNull();
             assertThat(source.getLastFetchError()).contains("Failed to import 1 of 2");
+        }
+
+        @Test
+        void should_fail_a_manifest_page_pointing_at_a_file_that_is_not_a_document() {
+            // Mirror mode leaves such a file out silently; a manifest named it, so the author must see it
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/config.json", "{\"name\": \"docs\"}");
+            sourceDomainService.givenRemoteFile("/docs/intro.md", "# Intro");
+            manifestParser.willParse(
+                List.of(
+                    new PortalNavigationManifestParser.ManifestPage("/config.json", "Config", "/guides"),
+                    new PortalNavigationManifestParser.ManifestPage("/docs/intro.md", "Introduction", "/guides")
+                )
+            );
+
+            var output = execute("Imported Docs");
+
+            assertThat(output.result().files())
+                .extracting(
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::title,
+                    PortalNavigationBulkImportDomainService.BulkImportResult.FileImportResult::success
+                )
+                .containsExactlyInAnyOrder(tuple("Config", false), tuple("Introduction", true));
+            assertThat(output.result().files())
+                .filteredOn(file -> !file.success())
+                .singleElement()
+                .satisfies(file -> assertThat(file.error()).contains("Cannot determine the type of /config.json"));
         }
 
         @Test
@@ -534,6 +602,26 @@ class ImportPortalNavigationUseCaseTest {
             // The remote tree now only carries unsupported types (e.g. every page moved to .adoc)
             sourceDomainService.removeRemoteFile("/docs/kept.md");
             sourceDomainService.givenRemoteFile("/docs/kept.adoc", "= Kept");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+            assertThat(childPage(docsFolder.getId(), "kept")).isNotNull();
+            var refreshedRoot = (PortalNavigationFolder) queryService.findByIdAndEnvironmentId(ENV_ID, root.getId());
+            assertThat(refreshedRoot.getSource().getLastFetchError()).contains("no importable files");
+        }
+
+        @Test
+        void should_keep_the_imported_pages_when_a_re_import_holds_no_document() {
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept");
+            var root = execute("Imported Docs").rootFolder();
+            var docsFolder = childFolder(root.getId(), "docs");
+
+            // The listing is no longer empty, but nothing in it is a document
+            sourceDomainService.removeRemoteFile("/docs/kept.md");
+            sourceDomainService.givenRemoteFile("/package.json", "{\"name\": \"docs\"}");
 
             var result = reimportSubtree(root.getId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ImportPortalNavigationUseCaseTest.java
@@ -575,6 +575,53 @@ class ImportPortalNavigationUseCaseTest {
         }
 
         @Test
+        void should_keep_the_last_good_page_when_a_renamed_entry_fails_to_fetch() {
+            sourceDomainService.givenRemoteFile("/.gravitee.json", "{manifest}");
+            sourceDomainService.givenRemoteFile("/docs/a.md", "# A");
+            manifestParser.willParse(List.of(new PortalNavigationManifestParser.ManifestPage("/docs/a.md", "Old", "/guides")));
+            var root = execute("Imported Docs").rootFolder();
+            var guidesFolder = childFolder(root.getId(), "guides");
+            var lastGoodPageId = childPage(guidesFolder.getId(), "Old").getId();
+
+            // The manifest renames the page and fetching the file transiently fails on that same run:
+            // nothing is touched under either title, and pruning would delete the last good page
+            manifestParser.willParse(List.of(new PortalNavigationManifestParser.ManifestPage("/docs/a.md", "New", "/guides")));
+            sourceDomainService.failFileFetch("/docs/a.md");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files())
+                .singleElement()
+                .satisfies(file -> assertThat(file.success()).isFalse());
+            assertThat(childPage(guidesFolder.getId(), "Old").getId()).isEqualTo(lastGoodPageId);
+        }
+
+        @Test
+        void should_defer_pruning_until_every_entry_imported_successfully() {
+            sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept");
+            sourceDomainService.givenRemoteFile("/docs/flaky.md", "# Flaky");
+            sourceDomainService.givenRemoteFile("/docs/removed.md", "# Removed");
+            var root = execute("Imported Docs").rootFolder();
+            var docsFolder = childFolder(root.getId(), "docs");
+
+            sourceDomainService.removeRemoteFile("/docs/removed.md");
+            sourceDomainService.failFileFetch("/docs/flaky.md");
+
+            var result = reimportSubtree(root.getId());
+
+            assertThat(result.files())
+                .filteredOn(file -> !file.success())
+                .hasSize(1);
+            assertThat(childPage(docsFolder.getId(), "removed")).isNotNull();
+
+            // The next clean run reconciles the subtree and prunes what the remote no longer holds
+            var cleanResult = reimportSubtree(root.getId());
+
+            assertThat(cleanResult.files()).allMatch(file -> file.success());
+            assertThat(findChild(docsFolder.getId(), "removed")).isNull();
+        }
+
+        @Test
         void should_keep_the_imported_pages_when_a_re_import_lists_no_files() {
             sourceDomainService.givenRemoteFile("/docs/kept.md", "# Kept");
             var root = execute("Imported Docs").rootFolder();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
@@ -1135,6 +1135,72 @@ class UpdatePortalNavigationItemUseCaseTest {
         }
 
         @Test
+        void should_reject_attaching_a_file_listing_source_to_a_folder() {
+            // Fetching such a folder re-imports the subtree; only the import endpoint may create one
+            sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Folder");
+            folder.markAsRoot();
+            var child = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Child Page", folder.getId());
+            queryService.storage().addAll(List.of(folder, child));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("file-listing source");
+        }
+
+        @Test
+        void should_accept_attaching_a_source_that_cannot_list_files_to_a_folder_with_children() {
+            // The in-memory source is not files-capable by default: such a source cannot trigger a re-import
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Folder");
+            folder.markAsRoot();
+            var child = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Child Page", folder.getId());
+            queryService.storage().addAll(List.of(folder, child));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            assertDoesNotThrow(() -> useCase.execute(input));
+        }
+
+        @Test
+        void should_accept_updating_the_source_of_an_import_managed_folder_and_keep_its_marker() {
+            sourceDomainService.givenRemoteFile("/docs/guide.md", "# Guide");
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Imported Docs")
+                .toBuilder()
+                .source(aSource().toBuilder().subtreeImport(true).build())
+                .build();
+            folder.markAsRoot();
+            var child = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Imported Page", folder.getId());
+            queryService.storage().addAll(List.of(folder, child));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            var output = useCase.execute(input);
+
+            // The payload carries no marker: it must be carried over from the stored source
+            assertThat(output.updatedItem().getSource().isSubtreeImport()).isTrue();
+        }
+
+        @Test
+        void should_reject_updating_an_import_managed_folder_to_a_source_that_cannot_list_files() {
+            // The in-memory source is not files-capable by default: such a source cannot re-run the import
+            var folder = PortalNavigationItemFixtures.aFolder(SOURCED_FOLDER_ID, "Imported Docs")
+                .toBuilder()
+                .source(aSource().toBuilder().subtreeImport(true).build())
+                .build();
+            folder.markAsRoot();
+            var child = PortalNavigationItemFixtures.aPage(CHILD_PAGE_ID, "Imported Page", folder.getId());
+            queryService.storage().addAll(List.of(folder, child));
+
+            var input = anUpdateInput(folder, anUpdateKeeping(folder).source(aSource()).build());
+
+            var error = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
+
+            assertThat(error).hasMessageContaining("must be able to list files");
+        }
+
+        @Test
         void should_reject_invalid_cron_expression_on_update() {
             var page = givenASourcedPage();
             var invalidSource = PortalNavigationItemSource.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -453,6 +453,7 @@ class PortalNavigationItemAdapterTest {
                 .lastFetchedAt(LAST_FETCHED_AT)
                 .lastFetchAttemptAt(LAST_FETCH_ATTEMPT_AT)
                 .lastFetchError("boom")
+                .subtreeImport(true)
                 .build();
         }
 
@@ -477,6 +478,7 @@ class PortalNavigationItemAdapterTest {
             assertThat(source.get("lastFetchedAt").asText()).isEqualTo(LAST_FETCHED_AT.toString());
             assertThat(source.get("lastFetchAttemptAt").asText()).isEqualTo(LAST_FETCH_ATTEMPT_AT.toString());
             assertThat(source.get("lastFetchError").asText()).isEqualTo("boom");
+            assertThat(source.get("subtreeImport").asBoolean()).isTrue();
         }
 
         @Test
@@ -530,7 +532,8 @@ class PortalNavigationItemAdapterTest {
                     "fetchCron": "0 */10 * * * *",
                     "lastFetchedAt": "2026-07-17T10:00:00Z",
                     "lastFetchAttemptAt": "2026-07-17T11:00:00Z",
-                    "lastFetchError": "boom"
+                    "lastFetchError": "boom",
+                    "subtreeImport": true
                   }
                 }
                 """
@@ -549,6 +552,7 @@ class PortalNavigationItemAdapterTest {
             assertThat(entity.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
             assertThat(entity.getSource().getLastFetchAttemptAt()).isEqualTo(LAST_FETCH_ATTEMPT_AT);
             assertThat(entity.getSource().getLastFetchError()).isEqualTo("boom");
+            assertThat(entity.getSource().isSubtreeImport()).isTrue();
         }
 
         /** Items stored before the key existed: no migration, the field simply reads as absent. */
@@ -582,6 +586,8 @@ class PortalNavigationItemAdapterTest {
             // Then
             assertThat(entity.getSource().getLastFetchAttemptAt()).isNull();
             assertThat(entity.getSource().getLastFetchedAt()).isEqualTo(LAST_FETCHED_AT);
+            // A pre-import row must never read as an import target
+            assertThat(entity.getSource().isSubtreeImport()).isFalse();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationManifestParserImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/portal_page/PortalNavigationManifestParserImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemSourceException;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationManifestParser;
+import io.gravitee.rest.api.service.impl.GraviteeDescriptorServiceImpl;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/** Exercises the real descriptor reading, which every other test replaces with an in-memory parser. */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationManifestParserImplTest {
+
+    private final PortalNavigationManifestParserImpl parser = new PortalNavigationManifestParserImpl(new GraviteeDescriptorServiceImpl());
+
+    @Test
+    void should_expose_the_gravitee_descriptor_file_name() {
+        assertThat(parser.manifestFileName()).isEqualTo(".gravitee.json");
+    }
+
+    @Test
+    void should_parse_the_documentation_pages_of_a_version_1_descriptor() {
+        var manifest = """
+            {
+              "version": 1,
+              "documentation": {
+                "pages": [
+                  { "src": "/docs/intro.md", "name": "Introduction", "dest": "/guides" },
+                  { "src": "/docs/api.yaml" }
+                ]
+              }
+            }
+            """;
+
+        assertThat(parser.parse(manifest))
+            .extracting(
+                PortalNavigationManifestParser.ManifestPage::src,
+                PortalNavigationManifestParser.ManifestPage::name,
+                PortalNavigationManifestParser.ManifestPage::dest
+            )
+            .containsExactly(tuple("/docs/intro.md", "Introduction", "/guides"), tuple("/docs/api.yaml", null, null));
+    }
+
+    @Test
+    void should_return_no_pages_when_the_descriptor_declares_no_documentation() {
+        assertThat(parser.parse("{ \"version\": 1 }")).isEmpty();
+    }
+
+    @Test
+    void should_reject_a_descriptor_with_an_unsupported_version() {
+        assertThatThrownBy(() -> parser.parse("{ \"version\": 2 }")).isInstanceOf(InvalidPortalNavigationItemSourceException.class);
+    }
+
+    @Test
+    void should_reject_an_unreadable_descriptor() {
+        assertThatThrownBy(() -> parser.parse("not json at all")).isInstanceOf(InvalidPortalNavigationItemSourceException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
@@ -408,9 +408,10 @@ class PortalNavigationItemsQueryServiceImplTest {
             assertThat(result).hasSize(1);
             var capturedCriteria = criteriaCaptor.getValue();
             assertThat(capturedCriteria.getUseAutoFetch()).isTrue();
-            // node-wide job, so no environment restriction, but only a PAGE owns content to refresh
+            // node-wide job, so no environment restriction; no type restriction either, since
+            // sourced PAGEs are re-fetched and imported FOLDERs re-imported
             assertThat(capturedCriteria.getEnvironmentId()).isNull();
-            assertThat(capturedCriteria.getType()).isEqualTo("PAGE");
+            assertThat(capturedCriteria.getType()).isNull();
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-92

## Description

Import a portal navigation subtree from a remote repository (GitHub, GitLab) in one action.

**Backend** — `POST /v2/portal-navigation-items/_import` (`ENVIRONMENT_DOCUMENTATION[UPDATE]`) walks a files fetcher and creates the navigation tree:
- a `.gravitee.json` manifest drives the hierarchy when present, otherwise the remote tree is mirrored; unsupported file types are ignored and `.adoc` is rejected, as the NG portal has no AsciiDoc content type.
- the source lands on the created root folder only, marked `subtreeImport` — server-owned, read-only in the REST schema and kept coherent by `FileListingSourceOnFolderRule`. Children carry no source and are read-only; re-fetching the folder re-runs the import, updating contents in place and pruning orphans.
- failures are visible and never destructive: a listing or manifest failure is stamped on the source and leaves the existing subtree untouched; per-file failures are reported without aborting the run.

**Console** — an Import button in *Portal > Navigation* opens an "Import documentation from a repository" dialog (folder title + source editor limited to the directory-capable fetchers). On import, a success or per-file failure snackbar, then navigation to the created folder. The imported folder shows the read-only source banner with *Fetch now*; its children show "Managed by parent folder". Fetchable containers are read from the server-owned `subtreeImport` marker, so the set matches exactly what `_fetch` accepts.

## Additional context

This change is security-sensitive: it adds an authenticated endpoint that fetches content from an external repository. Three points worth a reviewer's attention — the endpoint is gated by `ENVIRONMENT_DOCUMENTATION[UPDATE]`, the fetcher configuration may hold credentials and is never included in error messages, and a failed fetch leaves the already-imported pages untouched instead of pruning them.

https://github.com/user-attachments/assets/86ed12a5-63c4-4417-8080-ae7dc3c6221a