### PR TITLE
refactor(portal-next): consolidate portal folder and listing validation upfront through shared rule set

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -84,8 +84,7 @@ public class PortalNavigationSyncDomainService {
             creates.addAll(foldersToCreate(plan, area, idFactory, portalId));
             updates.addAll(foldersToUpdate(plan, idFactory));
         }
-        validatorService.validateAll(creates, auditInfo.environmentId());
-        validatorService.validateAllUpdates(updates);
+        validatorService.validate(creates, updates, auditInfo.environmentId());
     }
 
     private void syncArea(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -17,6 +17,9 @@ package io.gravitee.apim.core.portal.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationOwnership;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlan;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
@@ -26,14 +29,21 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.model.PortalNavigationStructure;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -43,6 +53,7 @@ public class PortalNavigationSyncDomainService {
     private final PortalNavigationItemsQueryService queryService;
     private final AutomationManagedNavigationItemsQueryService automationManagedNavigationItemsQueryService;
     private final NavigationSyncPlanExecutor planExecutor;
+    private final PortalNavigationValidator validatorService;
 
     public void sync(
         AuditInfo auditInfo,
@@ -61,9 +72,20 @@ public class PortalNavigationSyncDomainService {
         PortalNavigationStructure previouslyPersisted,
         PortalNavigationStructure desired
     ) {
+        List<CreatePortalNavigationItem> creates = new ArrayList<>();
+        List<PendingUpdate> updates = new ArrayList<>();
         for (var area : allAreas(previouslyPersisted, desired)) {
-            planForArea(auditInfo, portalId, area, previouslyPersisted.forArea(area), desired.forArea(area));
+            var previousPaths = previouslyPersisted.forArea(area);
+            var desiredPaths = desired.forArea(area);
+            rejectUnsupportedArea(area);
+            var ctx = buildSyncContext(auditInfo, portalId, area, previousPaths, desiredPaths);
+            var plan = buildSyncPlan(ctx, desiredPaths);
+            var idFactory = portalIdFolderFactory(auditInfo, portalId);
+            creates.addAll(foldersToCreate(plan, area, idFactory, portalId));
+            updates.addAll(foldersToUpdate(plan, idFactory));
         }
+        validatorService.validateAll(creates, auditInfo.environmentId());
+        validatorService.validateAllUpdates(updates);
     }
 
     private void syncArea(
@@ -80,20 +102,80 @@ public class PortalNavigationSyncDomainService {
             auditInfo,
             area,
             null,
-            path -> PortalNavigationItemId.forPortalFolder(auditInfo, portalId.toString(), path),
+            portalIdFolderFactory(auditInfo, portalId),
             ctx.ownership().asDeleteStrategy()
         );
     }
 
-    private void planForArea(
-        AuditInfo auditInfo,
-        PortalId portalId,
+    private static List<CreatePortalNavigationItem> foldersToCreate(
+        NavigationSyncPlan plan,
         PortalArea area,
-        List<NavigationPath> previousPaths,
-        List<NavigationPath> desiredPaths
+        Function<String, PortalNavigationItemId> idFactory,
+        PortalId portalId
     ) {
-        rejectUnsupportedArea(area);
-        buildSyncPlan(buildSyncContext(auditInfo, portalId, area, previousPaths, desiredPaths), desiredPaths);
+        return plan
+            .actions()
+            .stream()
+            .filter(FolderActions.CreateFolder.class::isInstance)
+            .map(FolderActions.CreateFolder.class::cast)
+            .map(FolderActions.CreateFolder::desired)
+            .map(df -> toCreateItem(df, area, idFactory, portalId))
+            .toList();
+    }
+
+    private static List<PendingUpdate> foldersToUpdate(NavigationSyncPlan plan, Function<String, PortalNavigationItemId> idFactory) {
+        return plan
+            .actions()
+            .stream()
+            .filter(FolderActions.UpdateFolder.class::isInstance)
+            .map(FolderActions.UpdateFolder.class::cast)
+            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory), action.existing()))
+            .toList();
+    }
+
+    private static UpdatePortalNavigationItem toUpdateItem(
+        FolderActions.DesiredFolder df,
+        Function<String, PortalNavigationItemId> idFactory
+    ) {
+        return UpdatePortalNavigationItem.builder()
+            .title(df.title())
+            .segment(df.segment().value())
+            .type(PortalNavigationItemType.FOLDER)
+            .order(df.order())
+            .parentId(df.parentPath() == null ? null : idFactory.apply(df.parentPath()))
+            .build();
+    }
+
+    private static CreatePortalNavigationItem toCreateItem(
+        FolderActions.DesiredFolder df,
+        PortalArea area,
+        Function<String, PortalNavigationItemId> idFactory,
+        PortalId portalId
+    ) {
+        return CreatePortalNavigationItem.builder()
+            .id(idFactory.apply(df.path()))
+            .title(df.title())
+            .segment(df.segment().value())
+            .area(area)
+            .type(PortalNavigationItemType.FOLDER)
+            .order(df.order())
+            .parentId(df.parentPath() == null ? null : idFactory.apply(df.parentPath()))
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .automationMetadata(
+                new AutomationMetadata(
+                    AutomationMetadata.ReferenceType.PORTAL,
+                    portalId.toString(),
+                    null,
+                    Optional.of(df.path()),
+                    Optional.empty()
+                )
+            )
+            .build();
+    }
+
+    private static Function<String, PortalNavigationItemId> portalIdFolderFactory(AuditInfo auditInfo, PortalId portalId) {
+        return path -> PortalNavigationItemId.forPortalFolder(auditInfo, portalId.toString(), path);
     }
 
     private static void rejectUnsupportedArea(PortalArea area) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation;
+
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import java.util.List;
+
+/** Runs the shared rule set over desired items and updates before any mutation. */
+public interface PortalNavigationValidator {
+    void validateAll(List<CreatePortalNavigationItem> items, String environmentId);
+
+    void validateOne(CreatePortalNavigationItem item, String environmentId);
+
+    void validateToUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existing);
+
+    default void validateAllUpdates(List<PendingUpdate> updates) {
+        for (var update : updates) {
+            validateToUpdate(update.toUpdate(), update.existing());
+        }
+    }
+
+    record PendingUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existing) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationValidator.java
@@ -22,17 +22,13 @@ import java.util.List;
 
 /** Runs the shared rule set over desired items and updates before any mutation. */
 public interface PortalNavigationValidator {
+    void validate(List<CreatePortalNavigationItem> creates, List<PendingUpdate> updates, String environmentId);
+
     void validateAll(List<CreatePortalNavigationItem> items, String environmentId);
 
     void validateOne(CreatePortalNavigationItem item, String environmentId);
 
     void validateToUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existing);
-
-    default void validateAllUpdates(List<PendingUpdate> updates) {
-        for (var update : updates) {
-            validateToUpdate(update.toUpdate(), update.existing());
-        }
-    }
 
     record PendingUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existing) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
@@ -19,7 +19,6 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.NavigationFolderMapper;
 import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
-import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
@@ -114,8 +113,6 @@ public final class NavigationSyncPlanExecutor {
         Function<String, PortalNavigationItemId> idFactory
     ) {
         final var folderId = idFactory.apply(df.path());
-        final var parentId = parent == null ? null : parent.getId();
-        rejectIfSegmentTakenByForeignItem(auditInfo, parentId, df.segment().value(), folderId, df.path());
         final var create = CreatePortalNavigationItem.builder()
             .id(folderId)
             .title(df.title())
@@ -129,21 +126,6 @@ public final class NavigationSyncPlanExecutor {
         return (PortalNavigationFolder) crudService.create(
             PortalNavigationItem.from(create, auditInfo.organizationId(), auditInfo.environmentId(), parent)
         );
-    }
-
-    private void rejectIfSegmentTakenByForeignItem(
-        AuditInfo auditInfo,
-        @Nullable PortalNavigationItemId parentId,
-        String segment,
-        PortalNavigationItemId expectedId,
-        String path
-    ) {
-        queryService
-            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
-            .filter(sibling -> !sibling.getId().equals(expectedId))
-            .ifPresent(squatter -> {
-                throw PathConflictException.folderPath(path);
-            });
     }
 
     private PortalNavigationFolder applyUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.NavigationFolderMapper;
 import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
+import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
@@ -113,6 +114,8 @@ public final class NavigationSyncPlanExecutor {
         Function<String, PortalNavigationItemId> idFactory
     ) {
         final var folderId = idFactory.apply(df.path());
+        final var parentId = parent == null ? null : parent.getId();
+        rejectIfSegmentTakenByForeignItem(auditInfo, parentId, df.segment().value(), folderId, df.path());
         final var create = CreatePortalNavigationItem.builder()
             .id(folderId)
             .title(df.title())
@@ -126,6 +129,21 @@ public final class NavigationSyncPlanExecutor {
         return (PortalNavigationFolder) crudService.create(
             PortalNavigationItem.from(create, auditInfo.organizationId(), auditInfo.environmentId(), parent)
         );
+    }
+
+    private void rejectIfSegmentTakenByForeignItem(
+        AuditInfo auditInfo,
+        @Nullable PortalNavigationItemId parentId,
+        String segment,
+        PortalNavigationItemId expectedId,
+        String path
+    ) {
+        queryService
+            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
+            .filter(sibling -> !sibling.getId().equals(expectedId))
+            .ifPresent(squatter -> {
+                throw PathConflictException.folderPath(path);
+            });
     }
 
     private PortalNavigationFolder applyUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -71,19 +71,22 @@ class ApiFolderSubtreeReconciler {
         planExecutor.execute(plan, auditInfo, navApi.getArea(), navApi, idMapper, deleteStrategy);
     }
 
-    void validateConflicts(AuditInfo auditInfo, String apiId, List<NavigationPath> desired, List<PortalNavigationItem> currentFolders) {
-        var safeDesired = desired == null ? List.<NavigationPath>of() : desired;
-        var ownership = ownership(auditInfo, apiId, safeDesired);
-        NavigationSyncPlanner.plan(safeDesired, currentFolders, safeDesired, ownership);
-    }
-
     ValidationItems itemsForValidation(
         AuditInfo auditInfo,
         String apiId,
         PortalNavigationApi navApi,
         List<PortalNavigationItem> currentFolders
     ) {
-        var desired = desiredPaths(apiId);
+        return itemsForValidation(auditInfo, apiId, navApi, desiredPaths(apiId), currentFolders);
+    }
+
+    ValidationItems itemsForValidation(
+        AuditInfo auditInfo,
+        String apiId,
+        PortalNavigationApi navApi,
+        List<NavigationPath> desired,
+        List<PortalNavigationItem> currentFolders
+    ) {
         var ownership = ownership(auditInfo, apiId, desired);
         var plan = NavigationSyncPlanner.plan(desired, currentFolders, List.of(), ownership);
         Function<String, PortalNavigationItemId> idFactory = path -> apiFolderId(auditInfo, apiId, path);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -19,21 +19,29 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationTreeWalker;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationVisitor;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationOwnership;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanner;
 import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +75,73 @@ class ApiFolderSubtreeReconciler {
         var safeDesired = desired == null ? List.<NavigationPath>of() : desired;
         var ownership = ownership(auditInfo, apiId, safeDesired);
         NavigationSyncPlanner.plan(safeDesired, currentFolders, safeDesired, ownership);
+    }
+
+    ValidationItems itemsForValidation(
+        AuditInfo auditInfo,
+        String apiId,
+        PortalNavigationApi navApi,
+        List<PortalNavigationItem> currentFolders
+    ) {
+        var desired = desiredPaths(apiId);
+        var ownership = ownership(auditInfo, apiId, desired);
+        var plan = NavigationSyncPlanner.plan(desired, currentFolders, List.of(), ownership);
+        Function<String, PortalNavigationItemId> idFactory = path -> apiFolderId(auditInfo, apiId, path);
+        var creates = plan
+            .actions()
+            .stream()
+            .filter(FolderActions.CreateFolder.class::isInstance)
+            .map(FolderActions.CreateFolder.class::cast)
+            .map(FolderActions.CreateFolder::desired)
+            .map(df -> toCreateItem(df, navApi.getArea(), idFactory, navApi.getId(), apiId))
+            .toList();
+        var updates = plan
+            .actions()
+            .stream()
+            .filter(FolderActions.UpdateFolder.class::isInstance)
+            .map(FolderActions.UpdateFolder.class::cast)
+            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory, navApi.getId()), action.existing()))
+            .toList();
+        return new ValidationItems(creates, updates);
+    }
+
+    record ValidationItems(List<CreatePortalNavigationItem> creates, List<PendingUpdate> updates) {}
+
+    private static CreatePortalNavigationItem toCreateItem(
+        FolderActions.DesiredFolder df,
+        PortalArea area,
+        Function<String, PortalNavigationItemId> idFactory,
+        PortalNavigationItemId navApiId,
+        String apiId
+    ) {
+        return CreatePortalNavigationItem.builder()
+            .id(idFactory.apply(df.path()))
+            .title(df.title())
+            .segment(df.segment().value())
+            .area(area)
+            .type(PortalNavigationItemType.FOLDER)
+            .order(df.order())
+            .parentId(df.parentPath() == null ? navApiId : idFactory.apply(df.parentPath()))
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .automationMetadata(
+                new AutomationMetadata(AutomationMetadata.ReferenceType.API, apiId, null, Optional.of(df.path()), Optional.empty())
+            )
+            .build();
+    }
+
+    private static UpdatePortalNavigationItem toUpdateItem(
+        FolderActions.DesiredFolder df,
+        Function<String, PortalNavigationItemId> idFactory,
+        PortalNavigationItemId navApiId
+    ) {
+        return UpdatePortalNavigationItem.builder()
+            .title(df.title())
+            .segment(df.segment().value())
+            .type(PortalNavigationItemType.FOLDER)
+            .order(df.order())
+            .parentId(df.parentPath() == null ? navApiId : idFactory.apply(df.parentPath()))
+            .build();
     }
 
     List<PortalNavigationItem> loadAllFoldersInEnv(String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -74,16 +74,18 @@ class ApiFolderSubtreeReconciler {
     ValidationItems itemsForValidation(
         AuditInfo auditInfo,
         String apiId,
-        PortalNavigationApi navApi,
+        PortalNavigationItemId navApiId,
+        PortalArea area,
         List<PortalNavigationItem> currentFolders
     ) {
-        return itemsForValidation(auditInfo, apiId, navApi, desiredPaths(apiId), currentFolders);
+        return itemsForValidation(auditInfo, apiId, navApiId, area, desiredPaths(apiId), currentFolders);
     }
 
     ValidationItems itemsForValidation(
         AuditInfo auditInfo,
         String apiId,
-        PortalNavigationApi navApi,
+        PortalNavigationItemId navApiId,
+        PortalArea area,
         List<NavigationPath> desired,
         List<PortalNavigationItem> currentFolders
     ) {
@@ -96,14 +98,14 @@ class ApiFolderSubtreeReconciler {
             .filter(FolderActions.CreateFolder.class::isInstance)
             .map(FolderActions.CreateFolder.class::cast)
             .map(FolderActions.CreateFolder::desired)
-            .map(df -> toCreateItem(df, navApi.getArea(), idFactory, navApi.getId(), apiId))
+            .map(df -> toCreateItem(df, area, idFactory, navApiId, apiId))
             .toList();
         var updates = plan
             .actions()
             .stream()
             .filter(FolderActions.UpdateFolder.class::isInstance)
             .map(FolderActions.UpdateFolder.class::cast)
-            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory, navApi.getId()), action.existing()))
+            .map(action -> new PendingUpdate(toUpdateItem(action.desired(), idFactory, navApiId), action.existing()))
             .toList();
         return new ValidationItems(creates, updates);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
+import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
@@ -57,6 +58,7 @@ class NavigationItemEntryMaterializer {
             applyUpdate(navApi, apiId, entry, parent);
             return (PortalNavigationApi) navigationItemCrudService.update(navApi);
         }
+        rejectIfSegmentTakenByForeignItem(auditInfo, parent, Slug.from(entry.apiHrid()).value(), navApiId, entry.location());
         var create = CreatePortalNavigationItem.builder()
             .id(navApiId)
             .title(entry.apiHrid())
@@ -122,6 +124,22 @@ class NavigationItemEntryMaterializer {
     private PortalNavigationItemId resolveParentId(AuditInfo auditInfo, PortalId portalId, String location) {
         var parent = resolveParent(auditInfo, portalId.toString(), location);
         return Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
+    }
+
+    private void rejectIfSegmentTakenByForeignItem(
+        AuditInfo auditInfo,
+        PortalNavigationItemContainer parent,
+        String segment,
+        PortalNavigationItemId expectedId,
+        String location
+    ) {
+        var parentId = Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
+        navigationItemsQueryService
+            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
+            .filter(sibling -> !sibling.getId().equals(expectedId))
+            .ifPresent(squatter -> {
+                throw PathConflictException.segmentTaken(PathConflictException.EntryKind.LISTING, location);
+            });
     }
 
     private static AutomationMetadata portalAutomationMetadata(PortalId portalId, String location) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
@@ -30,6 +31,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.slug.model.Slug;
 import java.util.Optional;
@@ -83,31 +85,53 @@ class NavigationItemEntryMaterializer {
         return navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId);
     }
 
+    PortalNavigationValidator.PendingUpdate updateForValidation(
+        AuditInfo auditInfo,
+        PortalId portalId,
+        PortalListingApiEntry entry,
+        PortalNavigationApi existing
+    ) {
+        var toUpdate = UpdatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.API)
+            .title(entry.apiHrid())
+            .segment(Slug.from(entry.apiHrid()).value())
+            .order(entry.order() != null ? entry.order() : 0)
+            .parentId(resolveParentId(auditInfo, portalId, entry.location()))
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+        return new PortalNavigationValidator.PendingUpdate(toUpdate, existing);
+    }
+
     CreatePortalNavigationItem itemForValidation(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
-        var navApiId = rowId(auditInfo, portalId, apiId);
-        var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
-        var parentId = Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
         return CreatePortalNavigationItem.builder()
-            .id(navApiId)
+            .id(rowId(auditInfo, portalId, apiId))
             .title(entry.apiHrid())
             .segment(Slug.from(entry.apiHrid()).value())
             .area(AREA)
             .type(PortalNavigationItemType.API)
             .order(entry.order() != null ? entry.order() : 0)
             .apiId(apiId)
-            .parentId(parentId)
+            .parentId(resolveParentId(auditInfo, portalId, entry.location()))
             .visibility(PortalVisibility.PUBLIC)
             .published(true)
-            .automationMetadata(
-                new AutomationMetadata(
-                    AutomationMetadata.ReferenceType.PORTAL,
-                    portalId.toString(),
-                    null,
-                    Optional.ofNullable(entry.location()),
-                    Optional.empty()
-                )
-            )
+            .automationMetadata(portalAutomationMetadata(portalId, entry.location()))
             .build();
+    }
+
+    private PortalNavigationItemId resolveParentId(AuditInfo auditInfo, PortalId portalId, String location) {
+        var parent = resolveParent(auditInfo, portalId.toString(), location);
+        return Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
+    }
+
+    private static AutomationMetadata portalAutomationMetadata(PortalId portalId, String location) {
+        return new AutomationMetadata(
+            AutomationMetadata.ReferenceType.PORTAL,
+            portalId.toString(),
+            null,
+            Optional.ofNullable(location),
+            Optional.empty()
+        );
     }
 
     private static void applyUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -17,12 +17,12 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
@@ -55,7 +55,6 @@ class NavigationItemEntryMaterializer {
             applyUpdate(navApi, apiId, entry, parent);
             return (PortalNavigationApi) navigationItemCrudService.update(navApi);
         }
-        rejectIfSegmentTakenByForeignItem(auditInfo, parent, Slug.from(entry.apiHrid()).value(), navApiId, entry.location());
         var create = CreatePortalNavigationItem.builder()
             .id(navApiId)
             .title(entry.apiHrid())
@@ -84,26 +83,31 @@ class NavigationItemEntryMaterializer {
         return navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId);
     }
 
-    void validateUpsertConflict(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
+    CreatePortalNavigationItem itemForValidation(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
         var navApiId = rowId(auditInfo, portalId, apiId);
         var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
-        rejectIfSegmentTakenByForeignItem(auditInfo, parent, Slug.from(entry.apiHrid()).value(), navApiId, entry.location());
-    }
-
-    private void rejectIfSegmentTakenByForeignItem(
-        AuditInfo auditInfo,
-        PortalNavigationItemContainer parent,
-        String segment,
-        PortalNavigationItemId expectedId,
-        String location
-    ) {
         var parentId = Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
-        navigationItemsQueryService
-            .findByParentIdAndSegment(auditInfo.environmentId(), parentId, segment)
-            .filter(sibling -> !sibling.getId().equals(expectedId))
-            .ifPresent(squatter -> {
-                throw PathConflictException.segmentTaken(PathConflictException.EntryKind.LISTING, location);
-            });
+        return CreatePortalNavigationItem.builder()
+            .id(navApiId)
+            .title(entry.apiHrid())
+            .segment(Slug.from(entry.apiHrid()).value())
+            .area(AREA)
+            .type(PortalNavigationItemType.API)
+            .order(entry.order() != null ? entry.order() : 0)
+            .apiId(apiId)
+            .parentId(parentId)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .automationMetadata(
+                new AutomationMetadata(
+                    AutomationMetadata.ReferenceType.PORTAL,
+                    portalId.toString(),
+                    null,
+                    Optional.ofNullable(entry.location()),
+                    Optional.empty()
+                )
+            )
+            .build();
     }
 
     private static void applyUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -123,14 +123,23 @@ public class PortalListingSyncDomainService {
                 List.of(navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry)),
                 List.of()
             );
-            case PortalNavigationApi navApi -> apiFolderSubtreeReconciler.itemsForValidation(
-                auditInfo,
-                apiId,
-                navApi,
-                apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId())
+            case PortalNavigationApi navApi -> mergeRowUpdate(
+                apiFolderSubtreeReconciler.itemsForValidation(
+                    auditInfo,
+                    apiId,
+                    navApi,
+                    apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId())
+                ),
+                navigationItemEntryMaterializer.updateForValidation(auditInfo, portalId, entry, navApi)
             );
             default -> throw PathConflictException.navigationIdTaken(PathConflictException.EntryKind.LISTING, entry.location());
         };
+    }
+
+    private static ValidationItems mergeRowUpdate(ValidationItems subtreeItems, PendingUpdate rowUpdate) {
+        var updates = new ArrayList<>(subtreeItems.updates());
+        updates.add(rowUpdate);
+        return new ValidationItems(subtreeItems.creates(), updates);
     }
 
     public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, List<NavigationPath> desired) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -17,20 +17,22 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_listing.domain_service.ApiFolderSubtreeReconciler.ValidationItems;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +52,7 @@ public class PortalListingSyncDomainService {
     private final ApiDocumentationSyncDomainService apiDocumentationSyncDomainService;
     private final NavigationItemEntryMaterializer navigationItemEntryMaterializer;
     private final ApiFolderSubtreeReconciler apiFolderSubtreeReconciler;
-    private final PortalNavigationItemValidatorService validatorService;
+    private final PortalNavigationValidator validatorService;
 
     public void sync(AuditInfo auditInfo, PortalId portalId, List<PortalListingApiEntry> previousEntries, PortalListing listing) {
         Set<String> newHrids = listing.getApis().stream().map(PortalListingApiEntry::apiHrid).collect(Collectors.toSet());
@@ -103,8 +105,7 @@ public class PortalListingSyncDomainService {
             creates.addAll(items.creates());
             updates.addAll(items.updates());
         }
-        validatorService.validateAll(creates, auditInfo.environmentId());
-        validatorService.validateAllUpdates(updates);
+        validatorService.validate(creates, updates, auditInfo.environmentId());
     }
 
     private ValidationItems itemsForEntry(
@@ -130,8 +131,13 @@ public class PortalListingSyncDomainService {
     }
 
     private ValidationItems validationItemsForNewRow(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
-        var create = navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry);
-        return new ValidationItems(List.of(create), List.of());
+        var rowCreate = navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry);
+        var navApiId = navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId);
+        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApiId, PortalArea.TOP_NAVBAR, List.of());
+        var creates = new ArrayList<CreatePortalNavigationItem>(subtree.creates().size() + 1);
+        creates.add(rowCreate);
+        creates.addAll(subtree.creates());
+        return new ValidationItems(creates, subtree.updates());
     }
 
     private ValidationItems validationItemsForExistingRow(
@@ -143,27 +149,34 @@ public class PortalListingSyncDomainService {
         List<PortalNavigationItem> envFolders
     ) {
         var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi, currentFolders);
+        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi.getId(), navApi.getArea(), currentFolders);
         var rowUpdate = navigationItemEntryMaterializer.updateForValidation(auditInfo, portalId, entry, navApi);
         var updates = new ArrayList<>(subtree.updates());
         updates.add(rowUpdate);
         return new ValidationItems(subtree.creates(), updates);
     }
 
-    public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, List<NavigationPath> desired) {
+    public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, @Nullable List<NavigationPath> desired) {
         var navApis = apiFolderSubtreeReconciler.navApiRowsFor(auditInfo, apiId);
         if (navApis.isEmpty()) return;
+        var safeDesired = desired == null ? List.<NavigationPath>of() : desired;
         var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
         List<CreatePortalNavigationItem> creates = new ArrayList<>();
         List<PendingUpdate> updates = new ArrayList<>();
         for (var navApi : navApis) {
             var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-            var items = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi, desired, currentFolders);
+            var items = apiFolderSubtreeReconciler.itemsForValidation(
+                auditInfo,
+                apiId,
+                navApi.getId(),
+                navApi.getArea(),
+                safeDesired,
+                currentFolders
+            );
             creates.addAll(items.creates());
             updates.addAll(items.updates());
         }
-        validatorService.validateAll(creates, auditInfo.environmentId());
-        validatorService.validateAllUpdates(updates);
+        validatorService.validate(creates, updates, auditInfo.environmentId());
     }
 
     private void materializeApiDocs(AuditInfo auditInfo, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -17,15 +17,21 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.domain_service.ApiFolderSubtreeReconciler.ValidationItems;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
 import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
 import io.gravitee.apim.core.portal_page.domain_service.ApiDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,6 +50,7 @@ public class PortalListingSyncDomainService {
     private final ApiDocumentationSyncDomainService apiDocumentationSyncDomainService;
     private final NavigationItemEntryMaterializer navigationItemEntryMaterializer;
     private final ApiFolderSubtreeReconciler apiFolderSubtreeReconciler;
+    private final PortalNavigationItemValidatorService validatorService;
 
     public void sync(AuditInfo auditInfo, PortalId portalId, List<PortalListingApiEntry> previousEntries, PortalListing listing) {
         Set<String> newHrids = listing.getApis().stream().map(PortalListingApiEntry::apiHrid).collect(Collectors.toSet());
@@ -89,22 +96,41 @@ public class PortalListingSyncDomainService {
     public void validateForConflicts(AuditInfo auditInfo, PortalId portalId, PortalListing listing) {
         if (listing.getApis().isEmpty()) return;
         var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
+        List<CreatePortalNavigationItem> creates = new ArrayList<>();
+        List<PendingUpdate> updates = new ArrayList<>();
         for (var entry : listing.getApis()) {
-            var apiId = entry.apiId(auditInfo);
-            var existing = navigationItemEntryMaterializer.findExistingRow(
-                auditInfo,
-                navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId)
-            );
-            if (existing != null && !(existing instanceof PortalNavigationApi)) {
-                throw PathConflictException.navigationIdTaken(PathConflictException.EntryKind.LISTING, entry.location());
-            }
-            navigationItemEntryMaterializer.validateUpsertConflict(auditInfo, portalId, apiId, entry);
-            if (existing instanceof PortalNavigationApi navApi) {
-                var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-                var desired = apiFolderSubtreeReconciler.desiredPaths(apiId);
-                apiFolderSubtreeReconciler.validateConflicts(auditInfo, apiId, desired, currentFolders);
-            }
+            var items = itemsForEntry(auditInfo, portalId, envFolders, entry);
+            creates.addAll(items.creates());
+            updates.addAll(items.updates());
         }
+        validatorService.validateAll(creates, auditInfo.environmentId());
+        validatorService.validateAllUpdates(updates);
+    }
+
+    private ValidationItems itemsForEntry(
+        AuditInfo auditInfo,
+        PortalId portalId,
+        List<PortalNavigationItem> envFolders,
+        PortalListingApiEntry entry
+    ) {
+        var apiId = entry.apiId(auditInfo);
+        var existing = navigationItemEntryMaterializer.findExistingRow(
+            auditInfo,
+            navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId)
+        );
+        return switch (existing) {
+            case null -> new ValidationItems(
+                List.of(navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry)),
+                List.of()
+            );
+            case PortalNavigationApi navApi -> apiFolderSubtreeReconciler.itemsForValidation(
+                auditInfo,
+                apiId,
+                navApi,
+                apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId())
+            );
+            default -> throw PathConflictException.navigationIdTaken(PathConflictException.EntryKind.LISTING, entry.location());
+        };
     }
 
     public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, List<NavigationPath> desired) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainService.java
@@ -114,42 +114,56 @@ public class PortalListingSyncDomainService {
         PortalListingApiEntry entry
     ) {
         var apiId = entry.apiId(auditInfo);
-        var existing = navigationItemEntryMaterializer.findExistingRow(
-            auditInfo,
-            navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId)
-        );
+        var existing = findExistingRow(auditInfo, portalId, apiId);
         return switch (existing) {
-            case null -> new ValidationItems(
-                List.of(navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry)),
-                List.of()
-            );
-            case PortalNavigationApi navApi -> mergeRowUpdate(
-                apiFolderSubtreeReconciler.itemsForValidation(
-                    auditInfo,
-                    apiId,
-                    navApi,
-                    apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId())
-                ),
-                navigationItemEntryMaterializer.updateForValidation(auditInfo, portalId, entry, navApi)
-            );
+            case null -> validationItemsForNewRow(auditInfo, portalId, apiId, entry);
+            case PortalNavigationApi navApi -> validationItemsForExistingRow(auditInfo, portalId, apiId, entry, navApi, envFolders);
             default -> throw PathConflictException.navigationIdTaken(PathConflictException.EntryKind.LISTING, entry.location());
         };
     }
 
-    private static ValidationItems mergeRowUpdate(ValidationItems subtreeItems, PendingUpdate rowUpdate) {
-        var updates = new ArrayList<>(subtreeItems.updates());
+    private PortalNavigationItem findExistingRow(AuditInfo auditInfo, PortalId portalId, String apiId) {
+        return navigationItemEntryMaterializer.findExistingRow(
+            auditInfo,
+            navigationItemEntryMaterializer.rowId(auditInfo, portalId, apiId)
+        );
+    }
+
+    private ValidationItems validationItemsForNewRow(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
+        var create = navigationItemEntryMaterializer.itemForValidation(auditInfo, portalId, apiId, entry);
+        return new ValidationItems(List.of(create), List.of());
+    }
+
+    private ValidationItems validationItemsForExistingRow(
+        AuditInfo auditInfo,
+        PortalId portalId,
+        String apiId,
+        PortalListingApiEntry entry,
+        PortalNavigationApi navApi,
+        List<PortalNavigationItem> envFolders
+    ) {
+        var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
+        var subtree = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi, currentFolders);
+        var rowUpdate = navigationItemEntryMaterializer.updateForValidation(auditInfo, portalId, entry, navApi);
+        var updates = new ArrayList<>(subtree.updates());
         updates.add(rowUpdate);
-        return new ValidationItems(subtreeItems.creates(), updates);
+        return new ValidationItems(subtree.creates(), updates);
     }
 
     public void validateApiFolderConflictsForApi(AuditInfo auditInfo, String apiId, List<NavigationPath> desired) {
         var navApis = apiFolderSubtreeReconciler.navApiRowsFor(auditInfo, apiId);
         if (navApis.isEmpty()) return;
         var envFolders = apiFolderSubtreeReconciler.loadAllFoldersInEnv(auditInfo.environmentId());
+        List<CreatePortalNavigationItem> creates = new ArrayList<>();
+        List<PendingUpdate> updates = new ArrayList<>();
         for (var navApi : navApis) {
             var currentFolders = apiFolderSubtreeReconciler.collectFolderDescendantsFrom(envFolders, navApi.getId());
-            apiFolderSubtreeReconciler.validateConflicts(auditInfo, apiId, desired, currentFolders);
+            var items = apiFolderSubtreeReconciler.itemsForValidation(auditInfo, apiId, navApi, desired, currentFolders);
+            creates.addAll(items.creates());
+            updates.addAll(items.updates());
         }
+        validatorService.validateAll(creates, auditInfo.environmentId());
+        validatorService.validateAllUpdates(updates);
     }
 
     private void materializeApiDocs(AuditInfo auditInfo, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -133,7 +133,7 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
         List<PendingSegmentClaim> pendingSegmentClaims = collectPendingSegmentClaims(creates, updates);
 
         CreateValidationContext createCtx = new CreateValidationContext(navigationItems, itemsById, pendingItemsById, pendingSegmentClaims);
-        UpdateValidationContext updateCtx = new UpdateValidationContext(navigationItems, itemsById, pendingSegmentClaims);
+        UpdateValidationContext updateCtx = new UpdateValidationContext(navigationItems, itemsById, pendingItemsById, pendingSegmentClaims);
 
         for (BulkCreatePortalNavigationItemValidationRule rule : bulkCreateRules) {
             rule.validate(creates, environmentId, createCtx);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -108,6 +108,7 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
             new ApiItemUpdateRule(apiProductQueryService),
             new ApiProductItemUpdateRule(),
             parentRule,
+            segmentConflictRule,
             linkUrlRule,
             externalSourceItemTypeRule,
             sourceConfigurationRule,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.HomepageUniqu
 import io.gravitee.apim.core.portal_page.domain_service.validation.LinkUrlRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.PageContentExistsRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ParentRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.PendingSegmentClaim;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SegmentConflictRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourceAutomationExclusivityRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourceConfigurationRule;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @DomainService
 public class PortalNavigationItemValidatorService implements PortalNavigationValidator {
@@ -119,53 +121,60 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
     }
 
     @Override
-    public void validateAll(List<CreatePortalNavigationItem> items, String environmentId) {
-        List<PortalNavigationItem> navigationItems = hasApiOrApiProductItems(items) ? fetchAllNavigationItems(environmentId) : List.of();
+    public void validate(List<CreatePortalNavigationItem> creates, List<PendingUpdate> updates, String environmentId) {
+        List<PortalNavigationItem> navigationItems = shouldFetch(creates, updates) ? fetchAllNavigationItems(environmentId) : List.of();
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById = navigationItems
             .stream()
             .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById = items
+        Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById = creates
             .stream()
             .filter(item -> item.getId() != null)
             .collect(Collectors.toMap(CreatePortalNavigationItem::getId, Function.identity(), (first, ignored) -> first));
-        CreateValidationContext ctx = new CreateValidationContext(navigationItems, itemsById, pendingItemsById);
+        List<PendingSegmentClaim> pendingSegmentClaims = collectPendingSegmentClaims(creates, updates);
+
+        CreateValidationContext createCtx = new CreateValidationContext(navigationItems, itemsById, pendingItemsById, pendingSegmentClaims);
+        UpdateValidationContext updateCtx = new UpdateValidationContext(navigationItems, itemsById, pendingSegmentClaims);
 
         for (BulkCreatePortalNavigationItemValidationRule rule : bulkCreateRules) {
-            rule.validate(items, environmentId, ctx);
+            rule.validate(creates, environmentId, createCtx);
         }
+        for (CreatePortalNavigationItem item : creates) {
+            applyValidationRules(item, createCtx, environmentId);
+        }
+        for (PendingUpdate pending : updates) {
+            applyValidationRules(pending, updateCtx);
+        }
+    }
 
-        for (CreatePortalNavigationItem item : items) {
-            for (CreatePortalNavigationItemValidationRule rule : createRules) {
-                if (rule.appliesTo(item)) {
-                    rule.validate(item, environmentId, ctx);
-                }
-            }
-        }
+    @Override
+    public void validateAll(List<CreatePortalNavigationItem> items, String environmentId) {
+        validate(items, List.of(), environmentId);
     }
 
     @Override
     public void validateOne(CreatePortalNavigationItem item, String environmentId) {
-        validateAll(List.of(item), environmentId);
+        validate(List.of(item), List.of(), environmentId);
     }
 
     @Override
     public void validateToUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
-        List<PortalNavigationItem> navigationItems;
-        Map<PortalNavigationItemId, PortalNavigationItem> itemsById;
-        if (existingItem instanceof PortalNavigationItemContainer) {
-            navigationItems = fetchAllNavigationItems(existingItem.getEnvironmentId());
-            itemsById = navigationItems.stream().collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        } else {
-            navigationItems = List.of();
-            itemsById = Map.of();
-        }
-        UpdateValidationContext ctx = new UpdateValidationContext(navigationItems, itemsById);
+        validate(List.of(), List.of(new PendingUpdate(toUpdate, existingItem)), existingItem.getEnvironmentId());
+    }
 
-        for (UpdatePortalNavigationItemValidationRule rule : updateRules) {
-            if (rule.appliesTo(toUpdate, existingItem)) {
-                rule.validate(toUpdate, existingItem, ctx);
-            }
-        }
+    private static List<PendingSegmentClaim> collectPendingSegmentClaims(
+        List<CreatePortalNavigationItem> creates,
+        List<PendingUpdate> updates
+    ) {
+        var fromCreates = creates
+            .stream()
+            .filter(c -> c.getId() != null)
+            .map(PendingSegmentClaim::forCreate);
+        var fromUpdates = updates.stream().map(u -> PendingSegmentClaim.forUpdate(u.existing(), u.toUpdate()));
+        return Stream.concat(fromCreates, fromUpdates).toList();
+    }
+
+    private static boolean shouldFetch(List<CreatePortalNavigationItem> creates, List<PendingUpdate> updates) {
+        return (hasApiOrApiProductItems(creates) || updates.stream().anyMatch(u -> u.existing() instanceof PortalNavigationItemContainer));
     }
 
     private List<PortalNavigationItem> fetchAllNavigationItems(String environmentId) {
@@ -173,9 +182,25 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
         return navigationItemsQueryService.search(criteria);
     }
 
-    private boolean hasApiOrApiProductItems(List<CreatePortalNavigationItem> items) {
+    private static boolean hasApiOrApiProductItems(List<CreatePortalNavigationItem> items) {
         return items
             .stream()
             .anyMatch(item -> item.getType() == PortalNavigationItemType.API || item.getType() == PortalNavigationItemType.API_PRODUCT);
+    }
+
+    private void applyValidationRules(PendingUpdate pending, UpdateValidationContext updateCtx) {
+        for (UpdatePortalNavigationItemValidationRule rule : updateRules) {
+            if (rule.appliesTo(pending.toUpdate(), pending.existing())) {
+                rule.validate(pending.toUpdate(), pending.existing(), updateCtx);
+            }
+        }
+    }
+
+    private void applyValidationRules(CreatePortalNavigationItem item, CreateValidationContext createCtx, String environmentId) {
+        for (CreatePortalNavigationItemValidationRule rule : createRules) {
+            if (rule.appliesTo(item)) {
+                rule.validate(item, environmentId, createCtx);
+            }
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiDocumentationAreaRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemCreateRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ApiItemUpdateRule;
@@ -33,6 +34,7 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.HomepageUniqu
 import io.gravitee.apim.core.portal_page.domain_service.validation.LinkUrlRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.PageContentExistsRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.ParentRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SegmentConflictRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourceAutomationExclusivityRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourceConfigurationRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedAncestorFinder;
@@ -57,7 +59,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @DomainService
-public class PortalNavigationItemValidatorService {
+public class PortalNavigationItemValidatorService implements PortalNavigationValidator {
 
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
     private final List<BulkCreatePortalNavigationItemValidationRule> bulkCreateRules;
@@ -76,6 +78,7 @@ public class PortalNavigationItemValidatorService {
         // Rules applied on both update and create
         var titleRequiredRule = new TitleRequiredRule();
         var parentRule = new ParentRule(navigationItemsQueryService);
+        var segmentConflictRule = new SegmentConflictRule(navigationItemsQueryService);
         var linkUrlRule = new LinkUrlRule();
         var externalSourceItemTypeRule = new ExternalSourceItemTypeRule();
         var sourceConfigurationRule = new SourceConfigurationRule(portalNavigationItemSourceDomainService::validateSourceConfiguration);
@@ -93,6 +96,7 @@ public class PortalNavigationItemValidatorService {
             new ApiDocumentationAreaRule(),
             linkUrlRule,
             parentRule,
+            segmentConflictRule,
             externalSourceItemTypeRule,
             sourceConfigurationRule,
             sourceAutomationExclusivityRule,
@@ -113,6 +117,7 @@ public class PortalNavigationItemValidatorService {
         );
     }
 
+    @Override
     public void validateAll(List<CreatePortalNavigationItem> items, String environmentId) {
         List<PortalNavigationItem> navigationItems = hasApiOrApiProductItems(items) ? fetchAllNavigationItems(environmentId) : List.of();
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById = navigationItems
@@ -137,10 +142,12 @@ public class PortalNavigationItemValidatorService {
         }
     }
 
+    @Override
     public void validateOne(CreatePortalNavigationItem item, String environmentId) {
         validateAll(List.of(item), environmentId);
     }
 
+    @Override
     public void validateToUpdate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
         List<PortalNavigationItem> navigationItems;
         Map<PortalNavigationItemId, PortalNavigationItem> itemsById;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -24,11 +24,9 @@ import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +69,7 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
         ParentHierarchyValidation.ensureAcyclic(item.getId(), item.getParentId(), ctx.itemsById(), ctx.pendingItemsById());
 
         var parentId = parentItem.getId().toString();
-        if (!isContainer(parentItem.getType())) {
+        if (!parentItem.getType().isContainer()) {
             throw new ParentTypeMismatchException(parentId);
         }
         if (!Objects.equals(parentItem.getArea(), item.getArea())) {
@@ -91,12 +89,6 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
         }
     }
 
-    private boolean isContainer(PortalNavigationItemType type) {
-        return (
-            type == PortalNavigationItemType.FOLDER || type == PortalNavigationItemType.API || type == PortalNavigationItemType.API_PRODUCT
-        );
-    }
-
     @Override
     public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
         return toUpdate.getParentId() != null;
@@ -104,7 +96,13 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
 
     @Override
     public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
-        ParentHierarchyValidation.ensureAcyclic(existingItem.getId(), toUpdate.getParentId(), ctx.itemsById(), Map.of());
+        ParentHierarchyValidation.ensureAcyclic(existingItem.getId(), toUpdate.getParentId(), ctx.itemsById(), ctx.pendingItemsById());
+
+        var pendingParent = ctx.pendingItemsById().get(toUpdate.getParentId());
+        if (pendingParent != null) {
+            validatePendingParent(toUpdate, existingItem, pendingParent);
+            return;
+        }
 
         validateParent(
             toUpdate.getParentId(),
@@ -114,6 +112,32 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             toUpdate.getVisibility(),
             existingItem.getAutomationMetadata() != null
         );
+    }
+
+    private void validatePendingParent(
+        UpdatePortalNavigationItem toUpdate,
+        PortalNavigationItem existingItem,
+        CreatePortalNavigationItem parentItem
+    ) {
+        var parentId = parentItem.getId().toString();
+        if (!parentItem.getType().isContainer()) {
+            throw new ParentTypeMismatchException(parentId);
+        }
+        if (!Objects.equals(parentItem.getArea(), existingItem.getArea())) {
+            throw new ParentAreaMismatchException(parentId);
+        }
+
+        boolean itemPublished = Boolean.TRUE.equals(toUpdate.getPublished());
+        boolean parentPublished = Boolean.TRUE.equals(parentItem.getPublished());
+        if (itemPublished && !parentPublished) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId);
+        }
+
+        var itemVisibility = toUpdate.getVisibility() != null ? toUpdate.getVisibility() : PortalVisibility.PUBLIC;
+        var parentVisibility = parentItem.getVisibility() != null ? parentItem.getVisibility() : PortalVisibility.PUBLIC;
+        if (PortalVisibility.PUBLIC.equals(itemVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId);
+        }
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PendingSegmentClaim.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PendingSegmentClaim.java
@@ -18,19 +18,19 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import java.util.List;
-import java.util.Map;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 
 /**
- * Context built once per create validation (single or bulk) to hold shared data and avoid repeated fetches.
+ * A (parent, segment) slot that a create or update in the current validation batch intends to occupy.
+ * Shared between {@link CreateValidationContext} and {@link UpdateValidationContext} so that segment-conflict
+ * detection can spot collisions across the two sides of a single mixed batch.
  */
-public record CreateValidationContext(
-    List<PortalNavigationItem> navigationItems,
-    Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
-    Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById,
-    List<PendingSegmentClaim> pendingSegmentClaims
-) {
-    public static CreateValidationContext empty() {
-        return new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of());
+public record PendingSegmentClaim(PortalNavigationItemId id, PortalNavigationItemId parentId, String segment) {
+    public static PendingSegmentClaim forCreate(CreatePortalNavigationItem create) {
+        return new PendingSegmentClaim(create.getId(), create.getParentId(), create.getSegment());
+    }
+
+    public static PendingSegmentClaim forUpdate(PortalNavigationItem existing, UpdatePortalNavigationItem update) {
+        return new PendingSegmentClaim(existing.getId(), update.getParentId(), update.getSegment());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
@@ -17,7 +17,9 @@ package io.gravitee.apim.core.portal_page.domain_service.validation;
 
 import io.gravitee.apim.core.portal.exception.PathConflictException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.EnumSet;
 import java.util.Objects;
@@ -26,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 
 /** Rejects items whose (parent, segment) is already claimed — by the DB or by another item in the same batch. */
 @RequiredArgsConstructor
-public class SegmentConflictRule implements CreatePortalNavigationItemValidationRule {
+public class SegmentConflictRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
 
     private static final Set<PortalNavigationItemType> SEGMENT_CHECKED_TYPES = EnumSet.of(
         PortalNavigationItemType.FOLDER,
@@ -52,6 +54,28 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
         }
     }
 
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        if (toUpdate.getSegment() == null) {
+            return false;
+        }
+        return SEGMENT_CHECKED_TYPES.contains(existingItem.getType());
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        if (
+            collidesWithPersistedSibling(
+                existingItem.getId(),
+                toUpdate.getParentId(),
+                toUpdate.getSegment(),
+                existingItem.getEnvironmentId()
+            )
+        ) {
+            throw exceptionFor(existingItem);
+        }
+    }
+
     private static boolean collidesWithPendingBatch(CreatePortalNavigationItem item, CreateValidationContext ctx) {
         return ctx
             .pendingItemsById()
@@ -66,9 +90,18 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
     }
 
     private boolean collidesWithPersistedSibling(CreatePortalNavigationItem item, String environmentId) {
+        return collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId);
+    }
+
+    private boolean collidesWithPersistedSibling(
+        io.gravitee.apim.core.portal_page.model.PortalNavigationItemId itemId,
+        io.gravitee.apim.core.portal_page.model.PortalNavigationItemId parentId,
+        String segment,
+        String environmentId
+    ) {
         return navigationItemsQueryService
-            .findByParentIdAndSegment(environmentId, item.getParentId(), item.getSegment())
-            .filter(sibling -> !sibling.getId().equals(item.getId()))
+            .findByParentIdAndSegment(environmentId, parentId, segment)
+            .filter(sibling -> !sibling.getId().equals(itemId))
             .isPresent();
     }
 
@@ -76,11 +109,22 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
         var location = item.getAutomationMetadata() != null
             ? item.getAutomationMetadata().location().orElse(item.getSegment())
             : item.getSegment();
-        return switch (item.getType()) {
+        return exceptionFor(item.getType(), location);
+    }
+
+    private static PathConflictException exceptionFor(PortalNavigationItem existing) {
+        var location = existing.getAutomationMetadata() != null
+            ? existing.getAutomationMetadata().location().orElse(existing.getSegment())
+            : existing.getSegment();
+        return exceptionFor(existing.getType(), location);
+    }
+
+    private static PathConflictException exceptionFor(PortalNavigationItemType type, String location) {
+        return switch (type) {
             case FOLDER -> PathConflictException.folderPath(location);
             case LINK -> PathConflictException.segmentTaken(PathConflictException.EntryKind.LINK, location);
             case API, API_PRODUCT -> PathConflictException.segmentTaken(PathConflictException.EntryKind.LISTING, location);
-            default -> throw new IllegalStateException("SegmentConflictRule does not apply to " + item.getType());
+            default -> throw new IllegalStateException("SegmentConflictRule does not apply to " + type);
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal.exception.PathConflictException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+/** Rejects items whose (parent, segment) is already claimed — by the DB or by another item in the same batch. */
+@RequiredArgsConstructor
+public class SegmentConflictRule implements CreatePortalNavigationItemValidationRule {
+
+    private static final Set<PortalNavigationItemType> SEGMENT_CHECKED_TYPES = EnumSet.of(
+        PortalNavigationItemType.FOLDER,
+        PortalNavigationItemType.LINK,
+        PortalNavigationItemType.API,
+        PortalNavigationItemType.API_PRODUCT
+    );
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        if (item.getSegment() == null || item.getId() == null) {
+            return false;
+        }
+        return SEGMENT_CHECKED_TYPES.contains(item.getType());
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        if (collidesWithPendingBatch(item, ctx) || collidesWithPersistedSibling(item, environmentId)) {
+            throw exceptionFor(item);
+        }
+    }
+
+    private static boolean collidesWithPendingBatch(CreatePortalNavigationItem item, CreateValidationContext ctx) {
+        return ctx
+            .pendingItemsById()
+            .values()
+            .stream()
+            .anyMatch(
+                other ->
+                    !Objects.equals(other.getId(), item.getId()) &&
+                    Objects.equals(other.getParentId(), item.getParentId()) &&
+                    Objects.equals(other.getSegment(), item.getSegment())
+            );
+    }
+
+    private boolean collidesWithPersistedSibling(CreatePortalNavigationItem item, String environmentId) {
+        return navigationItemsQueryService
+            .findByParentIdAndSegment(environmentId, item.getParentId(), item.getSegment())
+            .filter(sibling -> !sibling.getId().equals(item.getId()))
+            .isPresent();
+    }
+
+    private static PathConflictException exceptionFor(CreatePortalNavigationItem item) {
+        var location = item.getAutomationMetadata() != null
+            ? item.getAutomationMetadata().location().orElse(item.getSegment())
+            : item.getSegment();
+        return switch (item.getType()) {
+            case FOLDER -> PathConflictException.folderPath(location);
+            case LINK -> PathConflictException.segmentTaken(PathConflictException.EntryKind.LINK, location);
+            case API, API_PRODUCT -> PathConflictException.segmentTaken(PathConflictException.EntryKind.LISTING, location);
+            default -> throw new IllegalStateException("SegmentConflictRule does not apply to " + item.getType());
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
@@ -16,12 +16,15 @@
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
 import io.gravitee.apim.core.portal.exception.PathConflictException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +52,10 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
 
     @Override
     public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
-        if (collidesWithPendingBatch(item, ctx) || collidesWithPersistedSibling(item, environmentId)) {
+        if (
+            collidesWithPendingBatch(item.getId(), item.getParentId(), item.getSegment(), ctx.pendingSegmentClaims()) ||
+            collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId)
+        ) {
             throw exceptionFor(item);
         }
     }
@@ -65,6 +71,7 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
     @Override
     public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
         if (
+            collidesWithPendingBatch(existingItem.getId(), toUpdate.getParentId(), toUpdate.getSegment(), ctx.pendingSegmentClaims()) ||
             collidesWithPersistedSibling(
                 existingItem.getId(),
                 toUpdate.getParentId(),
@@ -76,26 +83,25 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
         }
     }
 
-    private static boolean collidesWithPendingBatch(CreatePortalNavigationItem item, CreateValidationContext ctx) {
-        return ctx
-            .pendingItemsById()
-            .values()
+    private static boolean collidesWithPendingBatch(
+        PortalNavigationItemId itemId,
+        PortalNavigationItemId parentId,
+        String segment,
+        List<PendingSegmentClaim> claims
+    ) {
+        return claims
             .stream()
             .anyMatch(
-                other ->
-                    !Objects.equals(other.getId(), item.getId()) &&
-                    Objects.equals(other.getParentId(), item.getParentId()) &&
-                    Objects.equals(other.getSegment(), item.getSegment())
+                claim ->
+                    !Objects.equals(claim.id(), itemId) &&
+                    Objects.equals(claim.parentId(), parentId) &&
+                    Objects.equals(claim.segment(), segment)
             );
     }
 
-    private boolean collidesWithPersistedSibling(CreatePortalNavigationItem item, String environmentId) {
-        return collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId);
-    }
-
     private boolean collidesWithPersistedSibling(
-        io.gravitee.apim.core.portal_page.model.PortalNavigationItemId itemId,
-        io.gravitee.apim.core.portal_page.model.PortalNavigationItemId parentId,
+        PortalNavigationItemId itemId,
+        PortalNavigationItemId parentId,
         String segment,
         String environmentId
     ) {
@@ -106,17 +112,15 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
     }
 
     private static PathConflictException exceptionFor(CreatePortalNavigationItem item) {
-        var location = item.getAutomationMetadata() != null
-            ? item.getAutomationMetadata().location().orElse(item.getSegment())
-            : item.getSegment();
-        return exceptionFor(item.getType(), location);
+        return exceptionFor(item.getType(), resolveLocation(item.getAutomationMetadata(), item.getSegment()));
     }
 
     private static PathConflictException exceptionFor(PortalNavigationItem existing) {
-        var location = existing.getAutomationMetadata() != null
-            ? existing.getAutomationMetadata().location().orElse(existing.getSegment())
-            : existing.getSegment();
-        return exceptionFor(existing.getType(), location);
+        return exceptionFor(existing.getType(), resolveLocation(existing.getAutomationMetadata(), existing.getSegment()));
+    }
+
+    private static String resolveLocation(AutomationMetadata automationMetadata, String segment) {
+        return automationMetadata != null ? automationMetadata.location().orElse(segment) : segment;
     }
 
     private static PathConflictException exceptionFor(PortalNavigationItemType type, String location) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import java.util.List;
@@ -26,9 +27,10 @@ import java.util.Map;
 public record UpdateValidationContext(
     List<PortalNavigationItem> navigationItems,
     Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+    Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById,
     List<PendingSegmentClaim> pendingSegmentClaims
 ) {
     public static UpdateValidationContext empty() {
-        return new UpdateValidationContext(List.of(), Map.of(), List.of());
+        return new UpdateValidationContext(List.of(), Map.of(), Map.of(), List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
@@ -25,9 +25,10 @@ import java.util.Map;
  */
 public record UpdateValidationContext(
     List<PortalNavigationItem> navigationItems,
-    Map<PortalNavigationItemId, PortalNavigationItem> itemsById
+    Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
+    List<PendingSegmentClaim> pendingSegmentClaims
 ) {
     public static UpdateValidationContext empty() {
-        return new UpdateValidationContext(List.of(), Map.of());
+        return new UpdateValidationContext(List.of(), Map.of(), List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
@@ -20,5 +20,9 @@ public enum PortalNavigationItemType {
     FOLDER,
     LINK,
     API,
-    API_PRODUCT,
+    API_PRODUCT;
+
+    public boolean isContainer() {
+        return this == FOLDER || this == API || this == API_PRODUCT;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import inmemory.PortalListingCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
@@ -24,6 +25,7 @@ import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalArea;
@@ -64,7 +66,8 @@ class PortalNavigationListingDomainServiceTest {
         syncService = new PortalNavigationSyncDomainService(
             query,
             new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, query),
-            new NavigationSyncPlanExecutor(crud, query, pageContentCrud)
+            new NavigationSyncPlanExecutor(crud, query, pageContentCrud),
+            mock(PortalNavigationValidator.class)
         );
         listingService = new PortalNavigationListingDomainService(query);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -16,6 +16,9 @@
 package io.gravitee.apim.core.portal.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import inmemory.PortalListingCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
@@ -25,6 +28,7 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalArea;
@@ -66,6 +70,7 @@ class PortalNavigationSyncDomainServiceTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
     private final PortalPageContentQueryServiceInMemory pageContentQuery = new PortalPageContentQueryServiceInMemory();
     private final PortalListingCrudServiceInMemory portalListingCrud = new PortalListingCrudServiceInMemory();
+    private PortalNavigationValidator validator;
     private PortalNavigationSyncDomainService syncService;
 
     @BeforeEach
@@ -74,10 +79,12 @@ class PortalNavigationSyncDomainServiceTest {
         pageContentCrud.reset();
         pageContentQuery.reset();
         portalListingCrud.reset();
+        validator = mock(PortalNavigationValidator.class);
         syncService = new PortalNavigationSyncDomainService(
             query,
             new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, query),
-            new NavigationSyncPlanExecutor(crud, query, pageContentCrud)
+            new NavigationSyncPlanExecutor(crud, query, pageContentCrud),
+            validator
         );
     }
 
@@ -485,6 +492,58 @@ class PortalNavigationSyncDomainServiceTest {
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();
+    }
+
+    @Test
+    void validate_for_conflicts_routes_new_folders_as_creates_and_no_updates_when_db_is_empty() {
+        syncService.validateForConflicts(
+            AUDIT_INFO,
+            PORTAL_ID,
+            PortalNavigationStructure.empty(),
+            PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null)))
+        );
+
+        @SuppressWarnings("unchecked")
+        var creates = (List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem>) verifyValidateAll();
+        assertThat(creates)
+            .extracting(io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem::getSegment)
+            .containsExactly("a", "b");
+        assertThat(verifyValidateAllUpdates()).isEmpty();
+    }
+
+    @Test
+    void validate_for_conflicts_routes_existing_folders_as_updates_and_no_creates() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            PortalNavigationStructure.empty(),
+            PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null)))
+        );
+
+        syncService.validateForConflicts(
+            AUDIT_INFO,
+            PORTAL_ID,
+            PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null))),
+            PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null)))
+        );
+
+        @SuppressWarnings("unchecked")
+        var creates = (List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem>) verifyValidateAll();
+        assertThat(creates).isEmpty();
+        assertThat(verifyValidateAllUpdates()).hasSize(2);
+    }
+
+    private List<?> verifyValidateAll() {
+        var captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(validator).validateAll(captor.capture(), anyString());
+        return captor.getValue();
+    }
+
+    private List<PortalNavigationValidator.PendingUpdate> verifyValidateAllUpdates() {
+        @SuppressWarnings("unchecked")
+        var captor = org.mockito.ArgumentCaptor.forClass((Class<List<PortalNavigationValidator.PendingUpdate>>) (Class<?>) List.class);
+        verify(validator).validateAllUpdates(captor.capture());
+        return captor.getValue();
     }
 
     private Optional<PortalNavigationItem> findByPath(String path) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -503,12 +503,11 @@ class PortalNavigationSyncDomainServiceTest {
             PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null)))
         );
 
-        @SuppressWarnings("unchecked")
-        var creates = (List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem>) verifyValidateAll();
-        assertThat(creates)
+        var captured = verifyValidate();
+        assertThat(captured.creates())
             .extracting(io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem::getSegment)
             .containsExactly("a", "b");
-        assertThat(verifyValidateAllUpdates()).isEmpty();
+        assertThat(captured.updates()).isEmpty();
     }
 
     @Test
@@ -527,23 +526,27 @@ class PortalNavigationSyncDomainServiceTest {
             PortalNavigationStructure.ofTopNavbar(List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null)))
         );
 
-        @SuppressWarnings("unchecked")
-        var creates = (List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem>) verifyValidateAll();
-        assertThat(creates).isEmpty();
-        assertThat(verifyValidateAllUpdates()).hasSize(2);
+        var captured = verifyValidate();
+        assertThat(captured.creates()).isEmpty();
+        assertThat(captured.updates()).hasSize(2);
     }
 
-    private List<?> verifyValidateAll() {
-        var captor = org.mockito.ArgumentCaptor.forClass(List.class);
-        verify(validator).validateAll(captor.capture(), anyString());
-        return captor.getValue();
-    }
+    private record CapturedValidate(
+        List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem> creates,
+        List<PortalNavigationValidator.PendingUpdate> updates
+    ) {}
 
-    private List<PortalNavigationValidator.PendingUpdate> verifyValidateAllUpdates() {
+    private CapturedValidate verifyValidate() {
         @SuppressWarnings("unchecked")
-        var captor = org.mockito.ArgumentCaptor.forClass((Class<List<PortalNavigationValidator.PendingUpdate>>) (Class<?>) List.class);
-        verify(validator).validateAllUpdates(captor.capture());
-        return captor.getValue();
+        var createsCaptor = (org.mockito.ArgumentCaptor<
+            List<io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem>
+        >) (org.mockito.ArgumentCaptor<?>) org.mockito.ArgumentCaptor.forClass(List.class);
+        @SuppressWarnings("unchecked")
+        var updatesCaptor = (org.mockito.ArgumentCaptor<List<PortalNavigationValidator.PendingUpdate>>) (org.mockito.ArgumentCaptor<
+            ?
+        >) org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(validator).validate(createsCaptor.capture(), updatesCaptor.capture(), anyString());
+        return new CapturedValidate(createsCaptor.getValue(), updatesCaptor.getValue());
     }
 
     private Optional<PortalNavigationItem> findByPath(String path) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -85,7 +85,8 @@ class CreateOrUpdatePortalUseCaseTest {
             new PortalNavigationSyncDomainService(
                 navQueryService,
                 new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService, navQueryService),
-                new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService)
+                new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService),
+                mock(PortalNavigationItemValidatorService.class)
             ),
             pageContentQueryService,
             new PortalDocumentationSyncDomainService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -20,8 +20,10 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 
 import fixtures.core.model.PortalFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalListingCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -88,7 +90,13 @@ class DeletePortalUseCaseTest {
         var navSync = new PortalNavigationSyncDomainService(
             navQueryService,
             new AutomationManagedNavigationItemsQueryService(portalListingCrudService, pageContentQueryService, navQueryService),
-            new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService)
+            new NavigationSyncPlanExecutor(navCrudService, navQueryService, pageContentCrudService),
+            new PortalNavigationItemValidatorService(
+                navQueryService,
+                pageContentQueryService,
+                new ApiProductQueryServiceInMemory(),
+                new PortalNavigationItemSourceDomainServiceInMemory()
+            )
         );
         var scopeEnforcer = new PortalAutomationScopeDomainService(portalCrudService, () -> false);
         var themeQueryService = new ThemeQueryServiceInMemory(themeCrudService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -73,6 +73,7 @@ class PortalListingSyncDomainServiceTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
     private final ApiCrudServiceInMemory apiCrud = new ApiCrudServiceInMemory();
 
+    private PortalNavigationItemValidatorService validator;
     private PortalListingSyncDomainService syncService;
 
     @BeforeEach
@@ -89,6 +90,7 @@ class PortalListingSyncDomainServiceTest {
             mock(PortalNavigationItemValidatorService.class)
         );
         var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
+        validator = mock(PortalNavigationItemValidatorService.class);
         syncService = new PortalListingSyncDomainService(
             pageContentQuery,
             apiDocSync,
@@ -98,7 +100,8 @@ class PortalListingSyncDomainServiceTest {
                 apiCrud,
                 new NavigationSyncPlanExecutor(navItemCrud, navItemQuery, pageContentCrud),
                 automationManaged
-            )
+            ),
+            validator
         );
     }
 
@@ -215,6 +218,27 @@ class PortalListingSyncDomainServiceTest {
 
     private static PortalListing aListing(List<PortalListingApiEntry> apis) {
         return PortalListing.of(LISTING_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), PORTAL_ID, apis);
+    }
+
+    @Test
+    void validate_for_conflicts_produces_create_for_new_nav_api_and_no_updates() {
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+
+        syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, listing);
+
+        var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(validator).validateAll(createsCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
+        assertThat(createsCaptor.getValue()).hasSize(1);
+        var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(validator).validateAllUpdates(updatesCaptor.capture());
+        assertThat(updatesCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void validate_for_conflicts_is_a_noop_on_empty_listing() {
+        syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, aListing(List.of()));
+
+        org.mockito.Mockito.verifyNoInteractions(validator);
     }
 
     private static GraviteeMarkdownPageContent anApiDocPageContent(PortalPageContentId id, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
@@ -237,6 +238,35 @@ class PortalListingSyncDomainServiceTest {
     @Test
     void validate_for_conflicts_is_a_noop_on_empty_listing() {
         syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, aListing(List.of()));
+
+        org.mockito.Mockito.verifyNoInteractions(validator);
+    }
+
+    @Test
+    void validate_api_folder_conflicts_routes_desired_paths_through_the_shared_validator() {
+        // First materialize a nav-api row for this api so validateApiFolderConflictsForApi finds a target navApi
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
+        org.mockito.Mockito.reset(validator);
+
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var desired = List.of(new NavigationPath("/guides", "Guides"), new NavigationPath("/reference", "Reference"));
+
+        syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, desired);
+
+        var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(validator).validateAll(createsCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
+        assertThat(createsCaptor.getValue()).hasSize(2);
+        var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(validator).validateAllUpdates(updatesCaptor.capture());
+        assertThat(updatesCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void validate_api_folder_conflicts_is_a_noop_when_no_nav_api_row_exists_for_the_api() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+
+        syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, List.of(new NavigationPath("/guides", null)));
 
         org.mockito.Mockito.verifyNoInteractions(validator);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -27,6 +27,7 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
@@ -74,7 +75,7 @@ class PortalListingSyncDomainServiceTest {
     private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
     private final ApiCrudServiceInMemory apiCrud = new ApiCrudServiceInMemory();
 
-    private PortalNavigationItemValidatorService validator;
+    private PortalNavigationValidator validator;
     private PortalListingSyncDomainService syncService;
 
     @BeforeEach
@@ -91,7 +92,7 @@ class PortalListingSyncDomainServiceTest {
             mock(PortalNavigationItemValidatorService.class)
         );
         var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
-        validator = mock(PortalNavigationItemValidatorService.class);
+        validator = mock(PortalNavigationValidator.class);
         syncService = new PortalListingSyncDomainService(
             pageContentQuery,
             apiDocSync,
@@ -228,10 +229,13 @@ class PortalListingSyncDomainServiceTest {
         syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, listing);
 
         var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
-        org.mockito.Mockito.verify(validator).validateAll(createsCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
-        assertThat(createsCaptor.getValue()).hasSize(1);
         var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
-        org.mockito.Mockito.verify(validator).validateAllUpdates(updatesCaptor.capture());
+        org.mockito.Mockito.verify(validator).validate(
+            createsCaptor.capture(),
+            updatesCaptor.capture(),
+            org.mockito.ArgumentMatchers.anyString()
+        );
+        assertThat(createsCaptor.getValue()).hasSize(1);
         assertThat(updatesCaptor.getValue()).isEmpty();
     }
 
@@ -255,10 +259,52 @@ class PortalListingSyncDomainServiceTest {
         syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, desired);
 
         var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
-        org.mockito.Mockito.verify(validator).validateAll(createsCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
-        assertThat(createsCaptor.getValue()).hasSize(2);
         var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
-        org.mockito.Mockito.verify(validator).validateAllUpdates(updatesCaptor.capture());
+        org.mockito.Mockito.verify(validator).validate(
+            createsCaptor.capture(),
+            updatesCaptor.capture(),
+            org.mockito.ArgumentMatchers.anyString()
+        );
+        assertThat(createsCaptor.getValue()).hasSize(2);
+        assertThat(updatesCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void validate_for_conflicts_includes_folder_subtree_creates_for_new_nav_api_rows() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        apiCrud.initWith(
+            List.of(
+                io.gravitee.apim.core.api.model.Api.builder()
+                    .id(apiId)
+                    .name(API_HRID)
+                    .environmentId(AUDIT_INFO.environmentId())
+                    .portalNavigation(List.of(new NavigationPath("/reports", "Reports")))
+                    .build()
+            )
+        );
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+
+        syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, listing);
+
+        var expectedNavigationApiId = PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).listingApi(apiId).id()
+        );
+        var createsCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        var updatesCaptor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(validator).validate(
+            createsCaptor.capture(),
+            updatesCaptor.capture(),
+            org.mockito.ArgumentMatchers.anyString()
+        );
+        assertThat(createsCaptor.getValue())
+            .extracting("type", "parentId", "segment")
+            .contains(
+                org.assertj.core.groups.Tuple.tuple(
+                    io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.FOLDER,
+                    expectedNavigationApiId,
+                    "reports"
+                )
+            );
         assertThat(updatesCaptor.getValue()).isEmpty();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
@@ -58,7 +58,8 @@ class AncestorValidationTest {
         return new CreateValidationContext(
             List.of(),
             Map.of(),
-            Map.of(firstFolder.getId(), firstFolder, secondFolder.getId(), secondFolder)
+            Map.of(firstFolder.getId(), firstFolder, secondFolder.getId(), secondFolder),
+            List.of()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
@@ -89,7 +89,7 @@ class ApiProductItemCreateRuleTest {
     void should_reject_nested_product_in_pending_payload() {
         var parent = apiProductItem().toBuilder().id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000103")).build();
         var nested = apiProductItem().toBuilder().parentId(parent.getId()).build();
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(parent.getId(), parent));
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(parent.getId(), parent), List.of());
 
         assertThatThrownBy(() -> rule.validate(nested, ENVIRONMENT_ID, ctx)).isInstanceOf(InvalidPortalNavigationItemDataException.class);
     }
@@ -97,7 +97,7 @@ class ApiProductItemCreateRuleTest {
     @Test
     void should_reject_existing_product_reference() {
         var existing = PortalNavigationItemFixtures.anApiProduct("00000000-0000-0000-0000-000000000104", "Product", null, API_PRODUCT_ID);
-        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of());
+        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(apiProductItem(), ENVIRONMENT_ID, ctx)).isInstanceOf(
             ApiProductNavigationItemAlreadyExistsException.class
@@ -108,7 +108,12 @@ class ApiProductItemCreateRuleTest {
     void should_reject_existing_product_reference_before_validating_ancestors() {
         var existing = PortalNavigationItemFixtures.anApiProduct("00000000-0000-0000-0000-000000000104", "Product", null, API_PRODUCT_ID);
         var parent = apiProductItem().toBuilder().id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000105")).build();
-        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of(parent.getId(), parent));
+        var ctx = new CreateValidationContext(
+            List.of(existing),
+            Map.of(existing.getId(), existing),
+            Map.of(parent.getId(), parent),
+            List.of()
+        );
 
         assertThatThrownBy(() ->
             rule.validate(apiProductItem().toBuilder().parentId(parent.getId()).build(), ENVIRONMENT_ID, ctx)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
@@ -129,7 +129,7 @@ class ParentRuleTest {
     void create_uses_pending_parent_from_same_batch() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR);
         var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent));
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
 
         assertThatCode(() -> rule.validate(child, ENV_ID, ctx)).doesNotThrowAnyException();
     }
@@ -138,7 +138,7 @@ class ParentRuleTest {
     void create_pending_parent_area_mismatch_throws() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.HOMEPAGE);
         var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent));
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
 
         assertThatThrownBy(() -> rule.validate(child, ENV_ID, ctx)).isInstanceOf(ParentAreaMismatchException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
@@ -167,6 +167,35 @@ class ParentRuleTest {
         assertThatCode(() -> rule.validate(pageUpdate(MISSING_ID), existing, UpdateValidationContext.empty())).doesNotThrowAnyException();
     }
 
+    @Test
+    void update_uses_pending_parent_from_same_batch() {
+        var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR);
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+
+        assertThatCode(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void update_pending_parent_area_mismatch_throws() {
+        var pendingParent = folderCreate(FOLDER_ID, PortalArea.HOMEPAGE);
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+
+        assertThatThrownBy(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx)).isInstanceOf(ParentAreaMismatchException.class);
+    }
+
+    @Test
+    void update_pending_parent_public_under_private_throws() {
+        var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR).toBuilder().visibility(PortalVisibility.PRIVATE).build();
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+
+        assertThatThrownBy(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx))
+            .isInstanceOf(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("must be PUBLIC");
+    }
+
     private static CreatePortalNavigationItem pageCreate(PortalNavigationItemId parentId, PortalArea area, AutomationMetadata meta) {
         return CreatePortalNavigationItem.builder()
             .id(ITEM_ID)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
@@ -122,11 +122,23 @@ class SegmentConflictRuleTest {
 
     @Test
     void validate_throws_when_another_item_in_the_pending_batch_claims_same_parent_and_segment() {
-        var pending = item(OTHER_ID, "docs", PortalNavigationItemType.FOLDER, null);
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(OTHER_ID, pending));
+        var pendingClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of(pendingClaim));
         var item = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
 
         assertThatThrownBy(() -> rule.validate(item, ENV_ID, ctx))
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("/docs");
+    }
+
+    @Test
+    void validate_throws_when_a_pending_update_in_the_same_batch_targets_the_same_parent_and_segment() {
+        // A create at (PARENT_ID, "docs") collides with a pending update moving another item to the same slot.
+        var pendingUpdateClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of(pendingUpdateClaim));
+        var newItem = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
+
+        assertThatThrownBy(() -> rule.validate(newItem, ENV_ID, ctx))
             .isInstanceOf(PathConflictException.class)
             .hasMessageContaining("/docs");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal.exception.PathConflictException;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SegmentConflictRuleTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String ORG_ID = "org-1";
+    private static final PortalNavigationItemId PARENT_ID = PortalNavigationItemId.of("11111111-1111-1111-1111-111111111a11");
+    private static final PortalNavigationItemId ITEM_ID = PortalNavigationItemId.of("22222222-2222-2222-2222-2222222222a2");
+    private static final PortalNavigationItemId OTHER_ID = PortalNavigationItemId.of("33333333-3333-3333-3333-3333333333a3");
+
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private SegmentConflictRule rule;
+
+    @BeforeEach
+    void setUp() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        rule = new SegmentConflictRule(navigationItemsQueryService);
+    }
+
+    @Test
+    void appliesTo_returns_false_when_segment_or_id_is_null() {
+        assertThat(rule.appliesTo(item(null, "docs", PortalNavigationItemType.FOLDER, null))).isFalse();
+        assertThat(rule.appliesTo(item(ITEM_ID, null, PortalNavigationItemType.FOLDER, null))).isFalse();
+    }
+
+    @Test
+    void appliesTo_returns_false_for_page_type() {
+        assertThat(rule.appliesTo(item(ITEM_ID, "docs", PortalNavigationItemType.PAGE, null))).isFalse();
+    }
+
+    @Test
+    void appliesTo_returns_true_for_folder_link_api_and_api_product() {
+        assertThat(rule.appliesTo(item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, null))).isTrue();
+        assertThat(rule.appliesTo(item(ITEM_ID, "docs", PortalNavigationItemType.LINK, null))).isTrue();
+        assertThat(rule.appliesTo(item(ITEM_ID, "docs", PortalNavigationItemType.API, null))).isTrue();
+        assertThat(rule.appliesTo(item(ITEM_ID, "docs", PortalNavigationItemType.API_PRODUCT, null))).isTrue();
+    }
+
+    @Test
+    void validate_passes_when_no_sibling_holds_the_segment() {
+        assertThatCode(() ->
+            rule.validate(item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, null), ENV_ID, CreateValidationContext.empty())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_folder_throws_folder_path_message_when_persisted_sibling_collides() {
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "docs"));
+        var item = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
+
+        assertThatThrownBy(() -> rule.validate(item, ENV_ID, CreateValidationContext.empty()))
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("/docs")
+            .hasMessageContaining("not managed by the Automation API");
+    }
+
+    @Test
+    void validate_link_throws_link_kind_when_persisted_sibling_collides() {
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "help"));
+        var item = item(ITEM_ID, "help", PortalNavigationItemType.LINK, folderLocation("/help"));
+
+        assertThatThrownBy(() -> rule.validate(item, ENV_ID, CreateValidationContext.empty()))
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("Link entry at [/help]");
+    }
+
+    @Test
+    void validate_api_throws_listing_kind_when_persisted_sibling_collides() {
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "pets"));
+        var item = item(ITEM_ID, "pets", PortalNavigationItemType.API, folderLocation("/pets"));
+
+        assertThatThrownBy(() -> rule.validate(item, ENV_ID, CreateValidationContext.empty()))
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("Listing entry at [/pets]");
+    }
+
+    @Test
+    void validate_passes_when_sibling_at_same_segment_is_the_same_item() {
+        navigationItemsQueryService.storage().add(existingFolder(ITEM_ID, PARENT_ID, "docs"));
+
+        assertThatCode(() ->
+            rule.validate(item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, null), ENV_ID, CreateValidationContext.empty())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_throws_when_another_item_in_the_pending_batch_claims_same_parent_and_segment() {
+        var pending = item(OTHER_ID, "docs", PortalNavigationItemType.FOLDER, null);
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(OTHER_ID, pending));
+        var item = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
+
+        assertThatThrownBy(() -> rule.validate(item, ENV_ID, ctx))
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("/docs");
+    }
+
+    @Test
+    void validate_falls_back_to_segment_as_location_when_automation_metadata_absent() {
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "help"));
+
+        assertThatThrownBy(() ->
+            rule.validate(item(ITEM_ID, "help", PortalNavigationItemType.LINK, null), ENV_ID, CreateValidationContext.empty())
+        )
+            .isInstanceOf(PathConflictException.class)
+            .hasMessageContaining("Link entry at [help]");
+    }
+
+    private static CreatePortalNavigationItem item(
+        PortalNavigationItemId id,
+        String segment,
+        PortalNavigationItemType type,
+        AutomationMetadata meta
+    ) {
+        return CreatePortalNavigationItem.builder()
+            .id(id)
+            .title(segment != null ? segment : "n/a")
+            .segment(segment)
+            .type(type)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .parentId(PARENT_ID)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .automationMetadata(meta)
+            .build();
+    }
+
+    private static PortalNavigationFolder existingFolder(PortalNavigationItemId id, PortalNavigationItemId parentId, String segment) {
+        return PortalNavigationFolder.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title(segment)
+            .segment(segment)
+            .parentId(parentId)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+    }
+
+    private static AutomationMetadata folderLocation(String location) {
+        return new AutomationMetadata(AutomationMetadata.ReferenceType.PORTAL, "portal-id", null, Optional.of(location), Optional.empty());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-179

## Description

Preperation work for EXT-179 (visibility on automation-managed navigation): consolidates portal folder and listing validation into a single upfront pass through the shared rule collector, so any invalid plan is rejected before any DB write.

Previously, segment-conflict checks were duplicated across three ad-hoc call sites (folder executor, listing materializer, link sync) and fired mid-mutation - a failing item mid-plan could leave earlier items already committed.
  
Docs and links stay untouched - they already validate immediately before their single mutation, so they're atomic by construction.

##  Design note
  
New `PortalNavigationValidator` interface in `core.portal.domain_service.navigation`, implemented by the existing `PortalNavigationItemValidatorService`. This is standard dependency inversion - avoids a back-edge from `core.portal.domain_service` into `core.portal_page.domain_service`.

