### PR TITLE
test(ci): regenerate the hotfix fixture master's generator had outgrown

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -833,6 +833,10 @@ jobs:
           command: yarn
           working_directory: ./release
       - run:
+          name: Run unit tests
+          command: yarn test
+          working_directory: ./release
+      - run:
           name: Open a PR to create release notes into docs repository
           command: yarn zx --quiet ci-steps/generate-changelog.mjs --version=4.2.0-hotfix.1
           working_directory: ./release


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-347

## Description

`master` is red: `ci/circleci: generate-config` fails on `be0a47f5f5`.

Two pull requests raced. [#19351](https://github.com/gravitee-io/gravitee-api-management/pull/19351) added `full-release/release-4-2-0-hotfix.yml`, generated from its own base. `6804d15807` had meanwhile added a *Run unit tests* step to the release job and regenerated the fixtures that existed at the time — this one did not yet. Each pull request was green on its own; together they are not.

This regenerates that fixture from `master`'s generator. It adds the four lines the step produces, and nothing else.

## Additional context

The four support branches are unaffected: their fixtures were generated from their own generators when the backports landed, and all four are green. Backporting this commit would break them, so it is deliberately `master`-only and carries no `apply-on-*` label.

**How to verify**: `npm ci && npx jest` in `.circleci/ci` — 179 tests, green with this commit and red without it.

Hardening the branch guard behind `hotfix/X.Y.Z`, which a review raised on the 4.10.x backport, comes in a separate pull request: that one *is* backportable, this one is not.
