### PR TITLE
fix(ci): accept only a hotfix version on a hotfix branch

### DIFF
--- a/.circleci/ci/src/pipelines/pipeline-release.ts
+++ b/.circleci/ci/src/pipelines/pipeline-release.ts
@@ -26,13 +26,15 @@ const HOTFIX_QUALIFIER = /-hotfix\.\d+$/;
  * brings them together: the published version comes from the poms of whichever branch runs, while
  * the tag comes from the version. A mismatch therefore tags one version and publishes another,
  * without failing. A hotfix is where the two diverge most easily, since `hotfix/4.12.17` and
- * `4.12.17-hotfix.1` name the same release twice.
+ * `4.12.17-hotfix.1` name the same release twice. A hotfix branch releases hotfix versions of the
+ * tag it was cut from, and nothing else: any other qualifier on it would tag a version its poms do
+ * not carry.
  */
 function assertVersionMatchesBranch(version: string, branch: string): void {
   if (isHotfixBranch(branch)) {
     const releasedVersion = branch.substring('hotfix/'.length);
-    if (!version.startsWith(`${releasedVersion}-`)) {
-      throw new Error(`${branch} releases ${releasedVersion} with a qualifier, not ${version}`);
+    if (!HOTFIX_QUALIFIER.test(version) || version.replace(HOTFIX_QUALIFIER, '') !== releasedVersion) {
+      throw new Error(`${branch} releases ${releasedVersion}-hotfix.N, not ${version}`);
     }
   } else if (HOTFIX_QUALIFIER.test(version)) {
     throw new Error(`${version} is only released from hotfix/${version.replace(HOTFIX_QUALIFIER, '')}, not from ${branch}`);

--- a/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
@@ -83,10 +83,13 @@ describe('Release tests', () => {
   });
 
   it.each`
-    graviteeioVersion   | branch            | expectedError
-    ${'4.2.0'}          | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0 with a qualifier, not 4.2.0'}
-    ${'4.2.1-hotfix.1'} | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0 with a qualifier, not 4.2.1-hotfix.1'}
-    ${'4.2.0-hotfix.1'} | ${'4.2.x'}        | ${'4.2.0-hotfix.1 is only released from hotfix/4.2.0, not from 4.2.x'}
+    graviteeioVersion      | branch            | expectedError
+    ${'4.2.0'}             | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0-hotfix.N, not 4.2.0'}
+    ${'4.2.1-hotfix.1'}    | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0-hotfix.N, not 4.2.1-hotfix.1'}
+    ${'4.2.0-alpha.1'}     | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0-hotfix.N, not 4.2.0-alpha.1'}
+    ${'4.2.0-milestone.3'} | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0-hotfix.N, not 4.2.0-milestone.3'}
+    ${'4.2.0-hotfix'}      | ${'hotfix/4.2.0'} | ${'hotfix/4.2.0 releases 4.2.0-hotfix.N, not 4.2.0-hotfix'}
+    ${'4.2.0-hotfix.1'}    | ${'4.2.x'}        | ${'4.2.0-hotfix.1 is only released from hotfix/4.2.0, not from 4.2.x'}
   `('should throw for version $graviteeioVersion on branch $branch', ({ graviteeioVersion, branch, expectedError }) => {
     expect(() =>
       generateReleaseConfig({


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-347

## Description

The guard added in [#19351](https://github.com/gravitee-io/gravitee-api-management/pull/19351) checks that the version and the branch agree before a release runs. On a hotfix branch it only tested the `<tag>-` prefix, so **any** qualifier passed. Probed against the generator on `master`:

```
4.2.0-alpha.1       on hotfix/4.2.0   →  accepted
4.2.0-milestone.3   on hotfix/4.2.0   →  accepted
4.2.0-hotfix        on hotfix/4.2.0   →  accepted
```

Releasing `4.2.0-alpha.1` from `hotfix/4.2.0` would tag `4.2.0-alpha.1` while the branch's poms carry `4.2.0-hotfix.1` — the tag says one thing, the artefacts another. That is the exact mismatch the guard exists to prevent, and it survived on the one branch the guard was written for.

Reachable through `yarn release --version=4.2.0-alpha.1 --branch=hotfix/4.2.0`: the client-side check does not object either, since the version carries no hotfix qualifier.

The condition now requires the version to carry a hotfix qualifier *and* its base to equal the branch's released version, rather than testing the prefix alone. The error message names the shape it expects.

## Additional context

Raised by a review comment on the 4.10.x backport ([#19389](https://github.com/gravitee-io/gravitee-api-management/pull/19389)). It was not fixed there on purpose: a backport has to stay a faithful copy of what merged into `master`, or the support branches drift apart. This is the `master` fix, and it is backportable — unlike [#19393](https://github.com/gravitee-io/gravitee-api-management/pull/19393), which regenerated a fixture that only `master` needed.

**How to verify**: `npm ci && npx jest` in `.circleci/ci` — 182 tests. Five cases were added to the throw table; restoring the old condition turns three of them red, which are the three the change is about. The other two only assert the new message.

**Security-sensitive**: this changes CI/CD configuration. It publishes nothing on its own; it makes an existing release guard stricter.
