### PR TITLE
chore(deps): bump gravitee-service-authz-pdp to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
     <gravitee-gamma-module-esm.version>1.0.0</gravitee-gamma-module-esm.version>
 
     <!-- Authz plugins -->
-    <gravitee-service-authz-pdp.version>1.0.1</gravitee-service-authz-pdp.version>
+    <gravitee-service-authz-pdp.version>1.0.2</gravitee-service-authz-pdp.version>
     <gravitee-policy-authz-pep.version>1.1.0</gravitee-policy-authz-pep.version>
     <gravitee-policy-authz-pdp-authzen.version>1.0.0</gravitee-policy-authz-pdp-authzen.version>
   </properties>


### PR DESCRIPTION
Bumps the bundled Authz PDP service plugin from 1.0.1 to 1.0.2 on the 4.12.x line.

## What 1.0.2 contains

A maintenance release of the 1.0.x line carrying the namespaced-action fix backported from 2.1.1 (gravitee-io/gravitee-service-authz-pdp#23).

Before it, a policy targeting a namespaced action such as `ds::Action::"drive"` could not be matched by any request. The action entity type was hardcoded to `Action`, so every request produced `Action::"drive"` regardless of namespace, and action matching is plain `EntityUID` equality. Spelling the full UID in the request did not help either: the whole string went in as an opaque id under the default type.

1.0.2 lets a request name a namespaced action explicitly, either as a canonical UID (`ds::Action::"drive"`, quoted or not) or as a bare name plus `action.properties.type`. It also fixes a defect found in review of the backport, where a declared `action.properties.type` swallowed the whole action name as the id, which emptied every `search-action` request that carried it.

Deliberately unchanged: a bare action name is still not resolved through the schema. That is AUTHZ-97, and doing it here would silently move existing bare actions into a namespace.

## Why 1.0.x rather than the 2.x line

Neither released 2.x artifact can run on a 4.12.x gateway:

- **2.1.0+** builds on `gravitee-parent` 25.1.0 and emits class file 69, while 4.12.x runs Temurin 21, so the plugin cannot load at all.
- **2.0.0** (and the identically built 1.1.0) reports decisions through `AuthzEventMetrics`, which needs `gravitee-reporter-api` 2.7.0. This line pins 2.5.0 up to 4.12.14 and only reaches 2.8.0 at 4.12.15, so below that the plugin boots and then throws `NoClassDefFoundError` on the first evaluation.

1.0.2 carries neither: class file 65, and no `decision/` package in the jar.

## Verification

Verified end to end on a plain docker stack of `graviteeio/apim-management-api:4.12.11` and `graviteeio/apim-gateway:4.12.11` with mongo, policies seeded through the gamma authz REST API and evaluated on the AuthZEN endpoint. The published artifact was pulled from download.gravitee.io, its sha512 checked against the bucket, and dropped into `plugins/` alongside the bundled 1.0.1 — the gateway logged `service-authz-pdp [1.0.2] has been loaded`, confirming the version wins as expected.

| | bundled 1.0.1 | published 1.0.2 |
|---|---|---|
| `action.name = "ns::Action::\"read\""` | DENY | PERMIT |
| `action.name = "read"` + `properties.type` | DENY | PERMIT |
| `action.name = "read"` (bare) | DENY | DENY, unchanged |
| ReBAC through `ns::Group`, ABAC on attributes | DENY | PERMIT |
| batch evaluation | `[false, false]` | `[true, true]` |
| `search/subject`, `search/resource`, `search/action` | all empty | all populated |

With namespaced action policies, the bundled 1.0.1 fails across all four AuthZEN surfaces, not only evaluation, because search works by evaluating candidates.

Non-namespaced setups are unaffected: every spelling that resolves today keeps resolving to the same UID.

## Upgrade warning — please read before merging

This bump changes authorization decisions in both directions on any deployment that already uses `::Action::` in policy text. AUTHZ-93 requires a release note for it; the generated 1.0.2 changelog does not carry one. Both effects were reproduced live on 4.12.11, bundled 1.0.1 versus published 1.0.2.

**Grants appear.** Every policy targeting a namespaced action has been inert until now and starts granting on upgrade, with no review gate. Action groups are included, and a group is directly nameable by an untrusted caller: `action in ds::Action::"admin_group"` is satisfied by sending the group name as the action, because `in` is reflexive. Observed: sending the group name alone returned PERMIT.

**Grants disappear.** Action ids that literally start with `Action::` or contain `::Action::` are read as canonical UIDs from this build on. `Action::foo` used to be the id `Action::"Action::foo"` and becomes `Action::"foo"`. Observed on the same policy and request: PERMIT on 1.0.1, DENY on 1.0.2. Fail-closed, but a real loss of access.

Inventory query, verified against a live `gravitee` database, so an operator can look before upgrading:

```js
// A) policies targeting a namespaced action — these start granting
db.authz_policies.find({ policyText: /::Action::/ }, { name: 1, _id: 0 })

// B) policies using an action group — the group is nameable by the caller
db.authz_policies.find({ policyText: /action\s+in\s/ }, { name: 1, _id: 0 })

// C) policies whose action id itself contains "Action::" — these stop matching
db.authz_policies.find({ policyText: /Action::"[^"]*Action::/ }, { name: 1, _id: 0 })
```

A deployment with no hits on any of the three is unaffected: every action spelling that resolves today keeps resolving to the same UID.
