### PR TITLE
chore(deps): bump gravitee-reactor-native-kafka to 7.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.7</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.0.8</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.6</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.8</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-142

## Description

Bumps `gravitee-reactor-native-kafka` from **7.0.7** to **7.0.8** on `4.12.x`.

The release carries two virtual cluster fixes. Both are the same defect in different places: a response the gateway hands back describes a broker in the *backend's* terms rather than the virtual cluster's, and so disagrees with what `Metadata` advertises for that same broker.

**1. `DescribeCluster` served from the merged cache leaked the backends' real addresses.** The merged snapshot deliberately stores virtual broker ids against the backends' real host and port — virtualizing the address is the serving path's job, and it was skipped there while the `Metadata` path did it. `AdminClient.describeCluster()` therefore received addresses that are either unreachable from outside the mesh or reachable while **bypassing the gateway and the policies it enforces**. Systematic, on every call.

**2. KIP-951 steering hints carried the backends' real broker ids.** When a broker steers a client elsewhere (`NOT_LEADER_OR_FOLLOWER`, `FENCED_LEADER_EPOCH`), `Produce`/`Fetch`/`ShareFetch`/`ShareAcknowledge` may attach the new leader's identity. The gateway rewrote the address but not the id, while `Metadata` advertises virtual ids. The client does not discard the mismatch — it merges the hint into its node table — and since two backends typically both own a broker `1`, that one client-side id resolved to whichever backend last sent a hint, steering partitions to the wrong backend. Narrower than the first: only on a leader change, and it self-corrects on the next metadata refresh.

## Additional context

- Release: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/7.0.8
- Source PR: https://github.com/gravitee-io/gravitee-reactor-native-kafka/pull/402 (approved, merged to `main`)
- Follow-ups filed from that review, **not** in this release: [ESM-149](https://gravitee.atlassian.net/browse/ESM-149), [ESM-150](https://gravitee.atlassian.net/browse/ESM-150)

Both fixes are confined to the virtual cluster (MESH) path. The single-cluster path is unchanged — the id remap is gated on the broker-connect attributes, which a non-mesh connection never carries, and the frame it produces is byte-for-byte identical to 7.0.7's.

The same changes are being merged into `alpha` separately, for the 7.1.0 line.


[ESM-149]: https://gravitee.atlassian.net/browse/ESM-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ