### PR TITLE
feat: enable API key renewal for API product subscriptions

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.html
@@ -163,7 +163,22 @@
 
   <mat-card appearance="outlined" data-testid="product-subscription-credentials">
     <mat-card-header>
-      <mat-card-title class="next-gen-h4" i18n="@@apiProductSubscriptionCredentialsTitle">API access</mat-card-title>
+      <div class="credentials-header">
+        <mat-card-title class="next-gen-h4" i18n="@@apiProductSubscriptionCredentialsTitle">API access</mat-card-title>
+        @if (canRenewApiKey()) {
+          <button
+            mat-stroked-button
+            type="button"
+            matTooltip="Renew API Key"
+            i18n-matTooltip="@@apiKeyRenewTooltip"
+            [disabled]="isRenewingApiKey()"
+            data-testid="renew-api-key-button"
+            (click)="renewApiKey()"
+          >
+            <span class="next-gen-small-bold" i18n="@@apiKeyRenew">Renew API Key</span>
+          </button>
+        }
+      </div>
     </mat-card-header>
     <mat-card-content class="credentials">
       @if (displayedSubscription().status !== 'ACCEPTED') {
@@ -216,7 +231,7 @@
         } @else {
           @switch (productDetails.plan?.security) {
             @case ('API_KEY') {
-              <app-api-keys-list [apiKeys]="displayedSubscription().keys ?? []" [canManageApiKey]="false" />
+              <app-api-keys-list [apiKeys]="displayedSubscription().keys ?? []" [canManageApiKey]="false" [feedback]="apiKeyFeedback()" />
             }
             @case ('KEY_LESS') {
               <p i18n="@@apiProductSubscriptionKeyless">No credentials are required for this plan.</p>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.scss
@@ -67,6 +67,13 @@ p {
   padding-top: layout.$container-padding-horizontal;
 }
 
+.credentials-header {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .included-apis {
   display: flex;
   flex-direction: column;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.spec.ts
@@ -15,7 +15,9 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
@@ -26,16 +28,18 @@ import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/conf
 import { fakeApplication } from '../../../../entities/application/application.fixture';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import { PlanSecurityEnum } from '../../../../entities/plan/plan';
 import {
   fakeApiProductSubscriptionDetails,
   fakeSubscription,
   Subscription,
   SubscriptionConsumerStatusEnum,
+  SubscriptionStatusEnum,
 } from '../../../../entities/subscription';
 import { ApplicationService } from '../../../../services/application.service';
 import { PermissionsService } from '../../../../services/permissions.service';
 import { SubscriptionService } from '../../../../services/subscription.service';
-import { AppTestingModule } from '../../../../testing/app-testing.module';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../../testing/app-testing.module';
 
 describe('ApiProductSubscriptionDetailsComponent', () => {
   let fixture: ComponentFixture<ApiProductSubscriptionDetailsComponent>;
@@ -43,6 +47,7 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
   let applicationService: jest.Mocked<Pick<ApplicationService, 'get'>>;
   let permissionsService: jest.Mocked<Pick<PermissionsService, 'getApplicationPermissions'>>;
   let subscriptionService: jest.Mocked<Pick<SubscriptionService, 'changeConsumerStatus' | 'close' | 'get' | 'resumeConsumerStatus'>>;
+  let httpTestingController: HttpTestingController;
 
   const acceptedSubscription = (modifier: Partial<Subscription> = {}): Subscription =>
     fakeSubscription({
@@ -70,7 +75,7 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [ApiProductSubscriptionDetailsComponent, AppTestingModule],
+      imports: [ApiProductSubscriptionDetailsComponent, AppTestingModule, MatIconTestingModule],
       providers: [
         provideNoopAnimations(),
         provideRouter([]),
@@ -82,6 +87,11 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
 
     fixture = TestBed.createComponent(ApiProductSubscriptionDetailsComponent);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   async function init(
@@ -159,6 +169,90 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
     expect(await harness.getCredentialsText()).toContain('Client ID');
     expect(await harness.getCredentialsText()).toContain('Client Secret');
     expect(fixture.nativeElement.querySelectorAll('[data-testid="product-subscription-credentials"] app-copy-code')).toHaveLength(2);
+  });
+
+  it('should show Renew API Key for an accepted API Key subscription with application update permission', async () => {
+    const harness = await init(apiKeySubscription());
+
+    expect(await harness.hasRenewApiKeyButton()).toBeTruthy();
+  });
+
+  it('should hide Renew API Key without application update permission', async () => {
+    const harness = await init(apiKeySubscription(), fakeUserApplicationPermissions({ SUBSCRIPTION: ['R'] }));
+
+    expect(await harness.hasRenewApiKeyButton()).toBeFalsy();
+  });
+
+  it.each(['PENDING', 'PAUSED', 'REJECTED', 'CLOSED'] as SubscriptionStatusEnum[])(
+    'should hide Renew API Key for a %s subscription',
+    async status => {
+      const harness = await init(apiKeySubscription(status));
+
+      expect(await harness.hasRenewApiKeyButton()).toBeFalsy();
+    },
+  );
+
+  it.each(['KEY_LESS', 'OAUTH2', 'JWT'] as PlanSecurityEnum[])('should hide Renew API Key for a %s plan', async security => {
+    const harness = await init(apiKeySubscription('ACCEPTED', security));
+
+    expect(await harness.hasRenewApiKeyButton()).toBeFalsy();
+  });
+
+  it('should not renew the API key when confirmation is cancelled', async () => {
+    const harness = await init(apiKeySubscription());
+
+    await harness.clickRenewApiKey();
+    const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+    expect(await confirmDialog.getTitle()).toContain('Renew API Key?');
+    expect(await confirmDialog.getContent()).toContain('API Key renewal will eventually deprecate the current key');
+    await confirmDialog.cancel();
+
+    httpTestingController.expectNone(request => request.url.includes('/keys/_renew'));
+  });
+
+  it('should renew the API key and emit a refresh event after confirmation', async () => {
+    const subscription = apiKeySubscription();
+    const apiKeyRenewedSpy = jest.spyOn(fixture.componentInstance.apiKeyRenewed, 'emit');
+    const harness = await init(subscription);
+
+    await harness.clickRenewApiKey();
+    const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+    await confirmDialog.confirm();
+
+    const request = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions/${subscription.id}/keys/_renew`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toBeNull();
+    expect(await harness.isRenewApiKeyButtonDisabled()).toBeTruthy();
+    request.flush(null);
+    fixture.detectChanges();
+
+    expect(apiKeyRenewedSpy).toHaveBeenCalledTimes(1);
+    expect(await harness.getApiKeyFeedbackText()).toContain('API key renewed successfully');
+    expect(await harness.getApiKeyFeedbackAttribute('aria-live')).toBe('polite');
+    expect(await harness.getApiKeyFeedbackAttribute('role')).toBeNull();
+
+    fixture.componentRef.setInput('subscription', apiKeySubscription());
+    fixture.detectChanges();
+
+    expect(await harness.getApiKeyFeedbackText()).toBeNull();
+  });
+
+  it('should show an accessible error when API key renewal fails', async () => {
+    const subscription = apiKeySubscription();
+    const apiKeyRenewedSpy = jest.spyOn(fixture.componentInstance.apiKeyRenewed, 'emit');
+    const harness = await init(subscription);
+
+    await harness.clickRenewApiKey();
+    await (await rootLoader.getHarness(ConfirmDialogHarness)).confirm();
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/subscriptions/${subscription.id}/keys/_renew`)
+      .flush(null, { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(apiKeyRenewedSpy).not.toHaveBeenCalled();
+    expect(await harness.getApiKeyFeedbackText()).toContain('Failed to renew API key');
+    expect(await harness.getApiKeyFeedbackAttribute('role')).toBe('alert');
+    expect(await harness.isRenewApiKeyButtonDisabled()).toBeFalsy();
   });
 
   it('should distinguish a publisher-paused subscription from a consumer pause', async () => {
@@ -395,4 +489,13 @@ describe('ApiProductSubscriptionDetailsComponent', () => {
     expect(subscriptionService.changeConsumerStatus).toHaveBeenCalled();
     expect(await harness.getFeedbackText()).toContain('updated, but its latest details could not be loaded');
   });
+
+  function apiKeySubscription(status: SubscriptionStatusEnum = 'ACCEPTED', security: PlanSecurityEnum = 'API_KEY'): Subscription {
+    return acceptedSubscription({
+      status,
+      apiProduct: fakeApiProductSubscriptionDetails({
+        plan: { id: 'plan-id', name: 'Gold', security, mode: 'STANDARD' },
+      }),
+    });
+  }
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 import { DatePipe } from '@angular/common';
-import { Component, computed, DestroyRef, inject, input, linkedSignal, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, linkedSignal, output, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
-import { catchError, map, Observable, of, switchMap } from 'rxjs';
+import { catchError, filter, finalize, map, Observable, of, switchMap, tap } from 'rxjs';
 
 import { ApiProductSubscriptionApiAccessComponent } from './api-product-subscription-api-access/api-product-subscription-api-access.component';
-import { ApiKeysListComponent } from '../../../../components/api-access/api-keys-list/api-keys-list.component';
+import { ApiKeyFeedback, ApiKeysListComponent } from '../../../../components/api-access/api-keys-list/api-keys-list.component';
 import { BannerComponent } from '../../../../components/banner/banner.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { CopyCodeComponent } from '../../../../components/copy-code/copy-code.component';
@@ -34,6 +35,7 @@ import { CapitalizeFirstPipe } from '../../../../pipe/capitalize-first.pipe';
 import { ToPeriodTimeUnitLabelPipe } from '../../../../pipe/time-unit.pipe';
 import { ApplicationService } from '../../../../services/application.service';
 import { PermissionsService } from '../../../../services/permissions.service';
+import { SubscriptionKeysService } from '../../../../services/subscription-keys.service';
 import { SubscriptionService } from '../../../../services/subscription.service';
 
 type LifecycleAction = 'pause' | 'resume' | 'retry' | 'close';
@@ -55,6 +57,7 @@ interface ActionFeedback {
     LoaderComponent,
     MatButtonModule,
     MatCardModule,
+    MatTooltipModule,
     RouterLink,
     ToPeriodTimeUnitLabelPipe,
   ],
@@ -64,15 +67,23 @@ interface ActionFeedback {
 export class ApiProductSubscriptionDetailsComponent {
   private readonly applicationService = inject(ApplicationService);
   private readonly permissionsService = inject(PermissionsService);
+  private readonly subscriptionKeysService = inject(SubscriptionKeysService);
   private readonly subscriptionService = inject(SubscriptionService);
   private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly subscription = input.required<Subscription>();
+  readonly apiKeyRenewed = output<void>();
 
   protected readonly displayedSubscription = linkedSignal(() => this.subscription());
   protected readonly pendingAction = signal<LifecycleAction | null>(null);
   protected readonly actionFeedback = signal<ActionFeedback | null>(null);
+  protected readonly isRenewingApiKey = signal(false);
+  protected readonly apiKeyFeedback = linkedSignal<Subscription, ApiKeyFeedback | undefined>({
+    source: () => this.subscription(),
+    computation: () => undefined,
+  });
+  private readonly isRenewApiKeyDialogOpen = signal(false);
   protected readonly product = computed(() => this.displayedSubscription().apiProduct);
   protected readonly plan = computed(() => this.product()?.plan);
   protected readonly planSecurityLabel = computed(() => getPlanSecurityTypeLabel(this.plan()?.security));
@@ -104,6 +115,12 @@ export class ApiProductSubscriptionDetailsComponent {
     params: () => this.displayedSubscription().application,
     stream: ({ params }) => this.permissionsService.getApplicationPermissions(params),
   });
+  protected readonly canRenewApiKey = computed(
+    () =>
+      this.displayedSubscription().status === 'ACCEPTED' &&
+      this.plan()?.security === 'API_KEY' &&
+      !!this.permissionsResource.value()?.SUBSCRIPTION?.includes('U'),
+  );
   protected readonly clientId = computed(
     () => this.applicationResource.value()?.settings.oauth?.client_id ?? this.applicationResource.value()?.settings.app?.client_id,
   );
@@ -140,6 +157,34 @@ export class ApiProductSubscriptionDetailsComponent {
       (this.permissionsResource.value()?.SUBSCRIPTION?.includes('D') ?? false)
     );
   });
+
+  protected renewApiKey(): void {
+    if (!this.canRenewApiKey() || this.isRenewingApiKey() || this.isRenewApiKeyDialogOpen()) {
+      return;
+    }
+
+    const dialogData: ConfirmDialogData = {
+      title: $localize`:@@apiKeyRenewDialogTitle:Renew API Key?`,
+      content: $localize`:@@apiKeyRenewDialogContent:API Key renewal will eventually deprecate the current key`,
+      confirmLabel: $localize`:@@apiKeyRenewDialogConfirm:Yes, renew`,
+      cancelLabel: $localize`:@@apiKeyRenewDialogCancel:Cancel`,
+    };
+
+    this.isRenewApiKeyDialogOpen.set(true);
+    this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        id: 'confirmDialog',
+        data: dialogData,
+      })
+      .afterClosed()
+      .pipe(
+        tap(() => this.isRenewApiKeyDialogOpen.set(false)),
+        filter(confirmed => !!confirmed),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.executeApiKeyRenewal());
+  }
 
   protected pauseSubscription(): void {
     const subscriptionId = this.displayedSubscription().id;
@@ -210,6 +255,32 @@ export class ApiProductSubscriptionDetailsComponent {
         error: () => {
           this.pendingAction.set(null);
           this.actionFeedback.set({ type: 'error', message: this.getErrorMessage(action) });
+        },
+      });
+  }
+
+  private executeApiKeyRenewal(): void {
+    this.isRenewingApiKey.set(true);
+    this.apiKeyFeedback.set(undefined);
+    this.subscriptionKeysService
+      .renew(this.displayedSubscription().id)
+      .pipe(
+        finalize(() => this.isRenewingApiKey.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.apiKeyRenewed.emit();
+          this.apiKeyFeedback.set({
+            type: 'success',
+            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
+          });
+        },
+        error: () => {
+          this.apiKeyFeedback.set({
+            type: 'error',
+            message: $localize`:@@apiKeyRenewError:Failed to renew API key. Please try again.`,
+          });
         },
       });
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.harness.ts
@@ -28,6 +28,8 @@ export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
   private readonly retryButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="retry-subscription"]' }));
   private readonly closeButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="close-subscription"]' }));
   private readonly feedback = this.locatorForOptional('[data-testid="subscription-action-feedback"]');
+  private readonly renewApiKeyButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="renew-api-key-button"]' }));
+  private readonly apiKeyFeedback = this.locatorForOptional('[data-testid="api-key-feedback"]');
 
   async getSummaryText(): Promise<string> {
     return (await this.summary()).text();
@@ -67,5 +69,25 @@ export class ApiProductSubscriptionDetailsHarness extends ComponentHarness {
 
   async getFeedbackAttribute(attribute: string): Promise<string | null> {
     return (await this.feedback())?.getAttribute(attribute) ?? null;
+  }
+
+  async hasRenewApiKeyButton(): Promise<boolean> {
+    return !!(await this.renewApiKeyButton());
+  }
+
+  async clickRenewApiKey(): Promise<void> {
+    await (await this.renewApiKeyButton())?.click();
+  }
+
+  async isRenewApiKeyButtonDisabled(): Promise<boolean | null> {
+    return (await this.renewApiKeyButton())?.isDisabled() ?? null;
+  }
+
+  async getApiKeyFeedbackText(): Promise<string | null> {
+    return (await this.apiKeyFeedback())?.text() ?? null;
+  }
+
+  async getApiKeyFeedbackAttribute(attribute: string): Promise<string | null> {
+    return (await this.apiKeyFeedback())?.getAttribute(attribute) ?? null;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.html
@@ -23,7 +23,7 @@
   </div>
 } @else if (subscriptionResource.value(); as subscription) {
   @if (subscription.reference_type === 'API_PRODUCT') {
-    <app-api-product-subscription-details [subscription]="subscription" />
+    <app-api-product-subscription-details [subscription]="subscription" (apiKeyRenewed)="subscriptionResource.reload()" />
   } @else if (apiId(); as resolvedApiId) {
     <app-subscriptions-details [apiId]="resolvedApiId" [subscriptionId]="subscriptionId()" />
   } @else {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
@@ -15,8 +15,9 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
-import { Component, Input } from '@angular/core';
+import { Component, Input, output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
 
 import { ApiProductSubscriptionDetailsComponent } from './api-product-subscription-details/api-product-subscription-details.component';
@@ -47,6 +48,7 @@ class MockSubscriptionsDetailsComponent {
 })
 class MockApiProductSubscriptionDetailsComponent {
   @Input() subscription!: Subscription;
+  readonly apiKeyRenewed = output<void>();
 }
 
 describe('SubscriptionDetailsComponent', () => {
@@ -93,6 +95,30 @@ describe('SubscriptionDetailsComponent', () => {
 
     expect(await harness.hasApiProductSubscriptionDetails()).toBeTruthy();
     expect(await harness.hasSubscriptionsDetails()).toBeFalsy();
+  });
+
+  it('should reload API Product subscription details after API key renewal', async () => {
+    jest.mocked(subscriptionServiceMock.get!).mockReturnValue(
+      of(
+        fakeSubscription({
+          api: undefined,
+          reference_id: 'api-product-id',
+          reference_type: 'API_PRODUCT',
+          apiProduct: fakeApiProductSubscriptionDetails({ id: 'api-product-id' }),
+        }),
+      ),
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const apiProductDetails = fixture.debugElement.query(By.css('app-api-product-subscription-details'))
+      .componentInstance as MockApiProductSubscriptionDetailsComponent;
+    apiProductDetails.apiKeyRenewed.emit();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(subscriptionServiceMock.get).toHaveBeenCalledTimes(2);
   });
 
   it('should use the API reference ID when the legacy api field is absent', async () => {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import io.gravitee.apim.core.api_key.use_case.RevokeSubscriptionApiKeyUseCase;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -27,6 +28,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -36,6 +38,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import java.util.Objects;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -65,19 +68,37 @@ public class SubscriptionKeysResource extends AbstractResource {
     public Response renewKeySubscription(@PathParam("subscriptionId") String subscriptionId) {
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        if (
-            hasPermission(
-                executionContext,
-                RolePermission.APPLICATION_SUBSCRIPTION,
-                subscriptionEntity.getApplication(),
-                RolePermissionAction.UPDATE
-            ) ||
-            hasPermission(executionContext, RolePermission.API_SUBSCRIPTION, subscriptionEntity.getApi(), RolePermissionAction.UPDATE)
-        ) {
-            final Key createdKey = keyMapper.convert(apiKeyService.renew(executionContext, subscriptionEntity));
-            return Response.status(Response.Status.CREATED).entity(createdKey).build();
+        boolean apiProductSubscription = SubscriptionReferenceType.API_PRODUCT.name().equals(subscriptionEntity.getReferenceType());
+
+        if (apiProductSubscription && !Objects.equals(executionContext.getEnvironmentId(), subscriptionEntity.getEnvironmentId())) {
+            throw new SubscriptionNotFoundException(subscriptionId);
         }
-        throw new ForbiddenAccessException();
+        if (!hasUpdatePermission(executionContext, subscriptionEntity, apiProductSubscription)) {
+            throw new ForbiddenAccessException();
+        }
+
+        final Key createdKey = keyMapper.convert(apiKeyService.renew(executionContext, subscriptionEntity));
+        return Response.status(Response.Status.CREATED).entity(createdKey).build();
+    }
+
+    private boolean hasUpdatePermission(
+        ExecutionContext executionContext,
+        SubscriptionEntity subscriptionEntity,
+        boolean apiProductSubscription
+    ) {
+        boolean hasApplicationPermission = hasPermission(
+            executionContext,
+            RolePermission.APPLICATION_SUBSCRIPTION,
+            subscriptionEntity.getApplication(),
+            RolePermissionAction.UPDATE
+        );
+        if (apiProductSubscription) {
+            return hasApplicationPermission;
+        }
+        return (
+            hasApplicationPermission ||
+            hasPermission(executionContext, RolePermission.API_SUBSCRIPTION, subscriptionEntity.getApi(), RolePermissionAction.UPDATE)
+        );
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResourceTest.java
@@ -54,8 +54,10 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
     private static final String ANOTHER_SUBSCRIPTION = "my-other-ubscription";
     private static final String KEY = "my-key";
     private static final String API = "my-api";
+    private static final String API_PRODUCT = "my-api-product";
     private static final String APPLICATION = "my-application";
     private ApiKeyEntity apiKeyEntity;
+    private SubscriptionEntity subscriptionEntity;
 
     @Autowired
     private ApiKeyCrudServiceInMemory apiKeyCrudServiceInMemory;
@@ -88,11 +90,12 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
 
         doReturn(new Key().key(KEY)).when(keyMapper).convert(apiKeyEntity);
 
-        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity = new SubscriptionEntity();
         subscriptionEntity.setApi(API);
         subscriptionEntity.setReferenceId(API);
         subscriptionEntity.setReferenceType("API");
         subscriptionEntity.setApplication(APPLICATION);
+        subscriptionEntity.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         doReturn(subscriptionEntity).when(subscriptionService).findById(eq(SUBSCRIPTION));
         doReturn(true).when(permissionService).hasPermission(any(), any(), any(), any());
     }
@@ -111,6 +114,82 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
         Key key = response.readEntity(Key.class);
         assertNotNull(key);
         assertEquals(KEY, key.getKey());
+    }
+
+    @Test
+    public void should_renew_api_product_subscription_with_application_update_permission() {
+        subscriptionEntity.setApi(null);
+        subscriptionEntity.setReferenceId(API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        reset(permissionService);
+        doReturn(true)
+            .when(permissionService)
+            .hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.APPLICATION_SUBSCRIPTION,
+                APPLICATION,
+                RolePermissionAction.UPDATE
+            );
+
+        Response response = target(SUBSCRIPTION).path("keys/_renew").request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+        verify(apiKeyService).renew(GraviteeContext.getExecutionContext(), subscriptionEntity);
+        verify(permissionService, never()).hasPermission(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(RolePermission.API_SUBSCRIPTION),
+            any(),
+            eq(RolePermissionAction.UPDATE)
+        );
+    }
+
+    @Test
+    public void should_forbid_api_product_subscription_renewal_without_application_update_permission() {
+        subscriptionEntity.setApi(null);
+        subscriptionEntity.setReferenceId(API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        reset(permissionService);
+        doReturn(false)
+            .when(permissionService)
+            .hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.APPLICATION_SUBSCRIPTION,
+                APPLICATION,
+                RolePermissionAction.UPDATE
+            );
+        doReturn(true)
+            .when(permissionService)
+            .hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_SUBSCRIPTION,
+                API_PRODUCT,
+                RolePermissionAction.UPDATE
+            );
+
+        Response response = target(SUBSCRIPTION).path("keys/_renew").request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        verify(apiKeyService, never()).renew(any(), any(SubscriptionEntity.class));
+        verify(permissionService, never()).hasPermission(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(RolePermission.API_SUBSCRIPTION),
+            any(),
+            eq(RolePermissionAction.UPDATE)
+        );
+    }
+
+    @Test
+    public void should_not_renew_api_product_subscription_from_another_environment() {
+        subscriptionEntity.setApi(null);
+        subscriptionEntity.setReferenceId(API_PRODUCT);
+        subscriptionEntity.setReferenceType("API_PRODUCT");
+        subscriptionEntity.setEnvironmentId("another-environment");
+
+        Response response = target(SUBSCRIPTION).path("keys/_renew").request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(apiKeyService, never()).renew(any(), any(SubscriptionEntity.class));
+        verifyNoInteractions(permissionService);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-139

## Summary

This PR enables API key renewal for API Product subscriptions in Portal Next.

- Adds the **Renew API Key** action for accepted API Product subscriptions using an API Key plan.
- Displays the action only when the user has the required application subscription update permission.
- Reuses the existing confirmation dialog and API key renewal endpoint.
- Refreshes the subscription details after successful renewal.
- Provides accessible success and error feedback.
- Ensures API Product renewals use application-level permissions without falling back to API permissions.
- Prevents renewal of API Product subscriptions belonging to another environment.

No HTTP contract changes are introduced.

