### PR TITLE
feat(reporter-elasticsearch): let operators stop indexing captured log bodies

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/config/gravitee.yml
@@ -697,6 +697,10 @@ reporters:
 #      number_of_shards: 1
 #      number_of_replicas: 1
 #      refresh_interval: 5s
+#      index_body: true         # Index request, response and message bodies captured by the logging policy.
+                                # Set to false to stop indexing them: the Logs UI still displays them, but its
+                                # "search in payloads" filter no longer matches. Applies to indexes created
+                                # after the change, not to existing ones.
 #    pipeline:
 #      plugins:
 #        ingest: geoip, user_agent      # geoip and user_agent are enabled by default

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/README.adoc
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/README.adoc
@@ -54,6 +54,28 @@ Then you can activate the ILM feature by adding these settings in the gravitee.y
     index_mode: ilm         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
 ```
 
+=== Body indexing
+
+The logging policy can capture request, response and message bodies, and the reporter indexes them so the
+Logs UI can search inside payloads. That indexing is by far the heaviest work the reporter gives the cluster:
+with `logging.max_size` at 256KB a single v4 log document carries up to four analysed bodies. On a gateway
+running thousands of requests per minute it is the first thing to look at when Elasticsearch falls behind.
+
+Bodies are indexed for prefix search only — no positions, no norms — because that is all the Logs UI query
+needs. A cluster that still cannot keep up can stop indexing them altogether:
+
+```yaml
+  elasticsearch:
+    settings:
+      index_body: false # default: true
+```
+
+Bodies then stay in `_source`, so the Logs UI keeps displaying them in the log detail view, but its
+"search in payloads" filter no longer matches them.
+
+Both are mapping settings, so they only apply to indexes created after the change. Existing indexes keep the
+mapping they were created with until the next daily index or ILM rollover.
+
 == Testing
 
 By default, unit tests are run with a TestContainer version of ElasticSearch 8.5.2, but sometimes it can be useful to run them against other version of ElasticSearch.

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -52,6 +52,7 @@ public class ReporterConfiguration {
     public static final int DEFAULT_NUMBER_OF_SHARDS = 1;
     public static final int DEFAULT_NUMBER_OF_REPLICAS = 1;
     public static final String DEFAULT_REFRESH_INTERVAL = "5s";
+    public static final boolean DEFAULT_INDEX_BODY = true;
     public static final boolean DEFAULT_ENABLED = true;
     public static final String DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME = "index.lifecycle.name";
     public static final String DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME = "index.lifecycle.rollover_alias";
@@ -179,6 +180,17 @@ public class ReporterConfiguration {
      */
     @Value("${reporters.elasticsearch.settings.refresh_interval:" + DEFAULT_REFRESH_INTERVAL + "}")
     private String refreshInterval = DEFAULT_REFRESH_INTERVAL;
+
+    /**
+     * Settings: index the request, response and message bodies captured by the logging policy.
+     *
+     * <p>Indexing them is what makes the "search in payloads" filter of the Logs UI work, and it is also the
+     * heaviest thing the reporter asks Elasticsearch to do: a gateway capturing 256KB payloads hands the
+     * cluster up to four analysed bodies per request. Turning it off keeps the bodies in {@code _source}, so
+     * the Logs UI still displays them, but no longer matches them.
+     */
+    @Value("${reporters.elasticsearch.settings.index_body:" + DEFAULT_INDEX_BODY + "}")
+    private boolean indexBody = DEFAULT_INDEX_BODY;
 
     @Value("${reporters.elasticsearch.enabled:" + DEFAULT_ENABLED + "}")
     private boolean enabled = DEFAULT_ENABLED;
@@ -390,6 +402,14 @@ public class ReporterConfiguration {
 
     public void setRefreshInterval(String refreshInterval) {
         this.refreshInterval = refreshInterval;
+    }
+
+    public boolean isIndexBody() {
+        return indexBody;
+    }
+
+    public void setIndexBody(boolean indexBody) {
+        this.indexBody = indexBody;
     }
 
     public boolean isEnabled() {

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/mapping/AbstractIndexPreparer.java
@@ -105,6 +105,7 @@ public abstract class AbstractIndexPreparer implements IndexPreparer {
         data.put("numberOfShards", this.configuration.getNumberOfShards());
         data.put("numberOfReplicas", this.configuration.getNumberOfReplicas());
         data.put("refreshInterval", this.configuration.getRefreshInterval());
+        data.put("indexBody", this.configuration.isIndexBody());
         data.put("indexLifecyclePolicyPropertyName", this.configuration.getIndexLifecyclePolicyPropertyName());
         data.put("indexLifecycleRolloverAliasPropertyName", this.configuration.getIndexLifecycleRolloverAliasPropertyName());
         data.put("indexLifecyclePolicyHealth", this.configuration.getIndexLifecyclePolicyHealth());

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/common/mapping/log-body-field.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/common/mapping/log-body-field.ftl
@@ -1,0 +1,25 @@
+<#ftl output_format="JSON">
+<#--
+    Mapping of one captured request, response or message body.
+
+    Bodies are the heaviest thing the reporter asks Elasticsearch to index: with a 256KB logging limit a
+    single v4 log document carries up to four of them. The only query that ever reads these fields is the
+    "search in payloads" prefix query_string, which needs nothing beyond the term postings, so positions
+    and norms are left out.
+
+    When index_body is off the inverted index is dropped entirely: the body stays in _source and the Logs UI
+    still displays it, but payload search no longer matches it. Elasticsearch rejects analyzer, index_options
+    and norms on an unindexed field, hence the two exclusive branches.
+
+    The analyzer is passed in rather than fixed here because the template trees do not agree on one: es7x
+    maps v4 bodies with the Elasticsearch default while every other body uses gravitee_body_analyzer.
+-->
+<#macro mapping analyzer="">
+{
+    "type": "text"<#if indexBody><#if analyzer?has_content>,
+    "analyzer": "${analyzer?json_string}"</#if>,
+    "index_options": "docs",
+    "norms": false<#else>,
+    "index": false</#if>
+}
+</#macro>

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
@@ -36,10 +37,7 @@
                 "client-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -49,10 +47,7 @@
                 "client-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -62,10 +57,7 @@
                 "proxy-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -75,10 +67,7 @@
                 "proxy-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
@@ -41,9 +42,7 @@
             "entrypoint-request": {
                 "type": "object",
                 "properties": {
-                    "body":{
-                        "type": "text"
-                    },
+                    "body": <@bodyField.mapping/>,
                     "headers":  {
                        "enabled":  false,
                        "type": "object"
@@ -53,9 +52,7 @@
             "entrypoint-response": {
                 "type": "object",
                 "properties": {
-                    "body":{
-                        "type": "text"
-                    },
+                    "body": <@bodyField.mapping/>,
                     "headers":  {
                        "enabled":  false,
                        "type": "object"
@@ -65,9 +62,7 @@
             "endpoint-request": {
                 "type": "object",
                 "properties": {
-                    "body":{
-                        "type": "text"
-                    },
+                    "body": <@bodyField.mapping/>,
                     "headers":  {
                        "enabled":  false,
                        "type": "object"
@@ -77,9 +72,7 @@
             "endpoint-response": {
                 "type": "object",
                 "properties": {
-                    "body":{
-                        "type": "text"
-                    },
+                    "body": <@bodyField.mapping/>,
                     "headers": {
                         "enabled":  false,
                         "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
@@ -47,9 +48,7 @@
                     "id": {
                         "type": "keyword"
                     },
-                    "payload":{
-                        "type": "text"
-                    },
+                    "payload": <@bodyField.mapping/>,
                     "headers":{
                         "enabled": false,
                         "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -37,10 +38,7 @@
                 "client-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -50,10 +48,7 @@
                 "client-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -63,10 +58,7 @@
                 "proxy-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -76,10 +68,7 @@
                 "proxy-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -55,10 +56,7 @@
                 "entrypoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -68,10 +66,7 @@
                 "entrypoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -81,10 +76,7 @@
                 "endpoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -94,10 +86,7 @@
                 "endpoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -61,10 +62,7 @@
                         "id": {
                             "type": "keyword"
                         },
-                        "payload":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "payload": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":{
                             "enabled": false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -37,10 +38,7 @@
                 "client-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -50,10 +48,7 @@
                 "client-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -63,10 +58,7 @@
                 "proxy-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -76,10 +68,7 @@
                 "proxy-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -55,10 +56,7 @@
                 "entrypoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -68,10 +66,7 @@
                 "entrypoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -81,10 +76,7 @@
                 "endpoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -94,10 +86,7 @@
                 "endpoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -61,10 +62,7 @@
                         "id": {
                             "type": "keyword"
                         },
-                        "payload":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "payload": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":{
                             "enabled": false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -37,10 +38,7 @@
                 "client-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -50,10 +48,7 @@
                 "client-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -63,10 +58,7 @@
                 "proxy-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -76,10 +68,7 @@
                 "proxy-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -55,10 +56,7 @@
                 "entrypoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -68,10 +66,7 @@
                 "entrypoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -81,10 +76,7 @@
                 "endpoint-request": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":  {
                            "enabled":  false,
                            "type": "object"
@@ -94,10 +86,7 @@
                 "endpoint-response": {
                     "type": "object",
                     "properties": {
-                        "body":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "body": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers": {
                             "enabled":  false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
@@ -1,4 +1,5 @@
 <#ftl output_format="JSON">
+<#import "../../common/mapping/log-body-field.ftl" as bodyField>
 {
     "index_patterns": ["${indexName}*"],
     "template": {
@@ -61,10 +62,7 @@
                         "id": {
                             "type": "keyword"
                         },
-                        "payload":{
-                            "type": "text",
-                            "analyzer": "gravitee_body_analyzer"
-                        },
+                        "payload": <@bodyField.mapping analyzer="gravitee_body_analyzer"/>,
                         "headers":{
                             "enabled": false,
                             "type": "object"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/LogBodyIndexingIntegrationTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/LogBodyIndexingIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.reporter.elasticsearch.IntegrationTestConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Drives the v4 log template against a real Elasticsearch container, in both body-indexing modes, to prove
+ * what an operator actually gets: the cluster accepts the rendered mapping, the Logs UI payload search still
+ * matches when body indexing is on, and switching it off stops the matching without hiding the body itself.
+ *
+ * <p>That last point is the whole trade: turning payload search off is only an acceptable answer to an
+ * overloaded cluster if the Logs UI detail view keeps showing the payload, which it reads from
+ * {@code _source} rather than from the inverted index.
+ *
+ * <p>Scope: what the templates render is asserted by {@link LogBodyMappingTest}, which needs no container.
+ */
+@SpringJUnitConfig(IntegrationTestConfiguration.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LogBodyIndexingIntegrationTest {
+
+    private static final String NEEDLE = "gravitee-needle-42";
+
+    @Autowired
+    private Client client;
+
+    @Autowired
+    private ReporterConfiguration configuration;
+
+    @Autowired
+    private FreeMarkerComponent freeMarkerComponent;
+
+    @Autowired
+    private PipelineConfiguration pipelineConfiguration;
+
+    @Test
+    void should_match_the_payload_search_when_bodies_are_indexed() {
+        String index = prepareAndIndexOneLog("gravitee-body-indexed", true);
+
+        assertThat(payloadSearchHits(index, NEEDLE)).isOne();
+    }
+
+    @Test
+    void should_not_match_the_payload_search_when_body_indexing_is_off() {
+        String index = prepareAndIndexOneLog("gravitee-body-unindexed", false);
+
+        assertThat(payloadSearchHits(index, NEEDLE)).isZero();
+    }
+
+    @Test
+    void should_still_return_the_body_to_the_logs_ui_when_body_indexing_is_off() {
+        String index = prepareAndIndexOneLog("gravitee-body-unindexed-source", false);
+
+        var hits = searchAll(index);
+
+        assertThat(hits.getFirst().getSource().path("entrypoint-response").path("body").asText()).contains(NEEDLE);
+    }
+
+    /**
+     * Puts every index template through the reporter's own preparer, then indexes a single v4 log document
+     * into an index the {@code -v4-log} template pattern covers. The bulk is refreshed so the search that
+     * follows sees it without the test having to wait on {@code refresh_interval}.
+     */
+    private String prepareAndIndexOneLog(String indexName, boolean indexBody) {
+        configuration.setIndexName(indexName);
+        configuration.setIndexBody(indexBody);
+
+        new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client)
+            .prepare()
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete();
+
+        String index = indexName + "-v4-log-test";
+        // gravitee_body_analyzer splits on whitespace only, so the needle has to sit in a payload as its own
+        // whitespace-delimited word for the prefix query to reach it — exactly the constraint an operator
+        // hits when searching payloads today, and unrelated to how the field is indexed.
+        var document = JsonObject.of(
+            "@timestamp",
+            "2026-08-26T10:00:00.000Z",
+            "api-id",
+            "an-api",
+            "request-id",
+            "a-request",
+            "entrypoint-request",
+            JsonObject.of("body", "{\"note\":\"placed " + NEEDLE + " for review\"}"),
+            "entrypoint-response",
+            JsonObject.of("body", "{\"note\":\"accepted " + NEEDLE + " ok\"}")
+        );
+        var bulk = Buffer.buffer(JsonObject.of("index", JsonObject.of("_index", index)).encode() + "\n" + document.encode() + "\n");
+
+        var response = client.bulk(bulk, true).blockingGet();
+        assertThat(response.getErrors()).as("bulk indexing into %s reported errors: %s", index, response.getItems()).isFalse();
+
+        return index;
+    }
+
+    /**
+     * The query the Logs UI issues for "search in payloads" — see
+     * {@code SearchConnectionLogDetailQueryAdapter#addBodyTextFilter} in the Elasticsearch repository, which
+     * owns this shape. A prefix {@code query_string} over every {@code *.body} field, nothing more.
+     */
+    private long payloadSearchHits(String index, String bodyText) {
+        var query = JsonObject.of(
+            "query",
+            JsonObject.of(
+                "bool",
+                JsonObject.of("must", JsonArray.of(JsonObject.of("query_string", JsonObject.of("query", "\\*.body:" + bodyText + "*"))))
+            )
+        );
+
+        return client.search(index, null, query.encode()).blockingGet().getSearchHits().getTotal().getValue();
+    }
+
+    private List<SearchHit> searchAll(String index) {
+        return client
+            .search(index, null, JsonObject.of("query", JsonObject.of("match_all", JsonObject.of())).encode())
+            .blockingGet()
+            .getSearchHits()
+            .getHits();
+    }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/LogBodyMappingTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/LogBodyMappingTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.opensearch.OpenSearchIndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.utils.Type;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Asserts how the log templates map captured request/response bodies, across every template tree and every
+ * log type that carries a body.
+ *
+ * <p>Bodies are the most expensive thing the reporter indexes — a gateway capturing 256KB payloads hands
+ * Elasticsearch up to four analysed bodies per request — and the only query that ever reads them is a
+ * {@code query_string} prefix search. Positions and norms are therefore paid for and never used, which is
+ * what these tests pin down.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LogBodyMappingTest {
+
+    /**
+     * Where each log type keeps a captured payload, as a parent object property and the field under it.
+     */
+    private record BodyPath(String parent, String field) {}
+
+    static Stream<Arguments> trees_and_log_types() {
+        return Stream.of("es7x", "es8x", "es9x", "opensearch").flatMap(tree ->
+            Stream.of(Type.LOG, Type.V4_LOG, Type.V4_MESSAGE_LOG).map(type -> Arguments.of(tree, type))
+        );
+    }
+
+    /**
+     * The analyzer each tree already picked for a given log type, which this change must leave alone. es7x
+     * is the odd one out: it maps v4 bodies with the Elasticsearch default while every other body in every
+     * other tree goes through {@code gravitee_body_analyzer}.
+     */
+    private static String expectedAnalyzer(String tree, Type type) {
+        boolean elasticsearchDefault = "es7x".equals(tree) && type != Type.LOG;
+        return elasticsearchDefault ? null : "gravitee_body_analyzer";
+    }
+
+    @ParameterizedTest(name = "{0} {1} indexes bodies without positions or norms")
+    @MethodSource("trees_and_log_types")
+    void should_index_bodies_for_prefix_search_only(String tree, Type type) {
+        var bodyFields = bodyFieldsOf(render(tree, type, new ReporterConfiguration()), type);
+
+        assertThat(bodyFields).allSatisfy(body ->
+            assertThat(body).containsEntry("type", "text").containsEntry("index_options", "docs").containsEntry("norms", false)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} keeps indexing bodies searchable with the analyzer it already used")
+    @MethodSource("trees_and_log_types")
+    void should_keep_bodies_searchable_with_their_existing_analyzer(String tree, Type type) {
+        var bodyFields = bodyFieldsOf(render(tree, type, new ReporterConfiguration()), type);
+
+        assertThat(bodyFields).allSatisfy(body -> {
+            assertThat(body).doesNotContainKey("index");
+            if (expectedAnalyzer(tree, type) == null) {
+                assertThat(body).doesNotContainKey("analyzer");
+            } else {
+                assertThat(body).containsEntry("analyzer", expectedAnalyzer(tree, type));
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{0} {1} leaves bodies unindexed when body indexing is off")
+    @MethodSource("trees_and_log_types")
+    void should_not_index_bodies_at_all_when_disabled(String tree, Type type) {
+        var configuration = new ReporterConfiguration();
+        configuration.setIndexBody(false);
+
+        var bodyFields = bodyFieldsOf(render(tree, type, configuration), type);
+
+        // Elasticsearch rejects a mapping that sets analyzer, index_options or norms on an unindexed field,
+        // so turning indexing off has to drop all three rather than merely add "index": false next to them.
+        assertThat(bodyFields).allSatisfy(body ->
+            assertThat(body)
+                .containsEntry("type", "text")
+                .containsEntry("index", false)
+                .doesNotContainKey("analyzer")
+                .doesNotContainKey("index_options")
+                .doesNotContainKey("norms")
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} maps every captured payload")
+    @MethodSource("trees_and_log_types")
+    void should_map_every_captured_payload(String tree, Type type) {
+        assertThat(bodyFieldsOf(render(tree, type, new ReporterConfiguration()), type)).hasSameSizeAs(bodyPathsOf(type));
+    }
+
+    private static String render(String tree, Type type, ReporterConfiguration configuration) {
+        var freeMarkerComponent = FreeMarkerComponent.builder()
+            .classLoader(LogBodyMappingTest.class.getClassLoader())
+            .classLoaderTemplateBase("freemarker")
+            .build();
+        var pipelineConfiguration = new PipelineConfiguration(freeMarkerComponent);
+
+        // No client: generateIndexTemplate only renders, it never talks to the cluster.
+        AbstractIndexPreparer preparer = switch (tree) {
+            case "es7x" -> new ES7IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es8x" -> new ES8IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es9x" -> new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "opensearch" -> new OpenSearchIndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            default -> throw new IllegalArgumentException("Unknown template tree: " + tree);
+        };
+
+        return preparer.generateIndexTemplate(type);
+    }
+
+    /**
+     * Reads the body field mappings out of a rendered template. es7x puts {@code mappings} at the root while
+     * the composable-template trees nest it under {@code template}, so both shapes are accepted.
+     */
+    private static List<Map<String, Object>> bodyFieldsOf(String renderedTemplate, Type type) {
+        var root = new JsonObject(renderedTemplate);
+        var mappings = root.containsKey("mappings")
+            ? root.getJsonObject("mappings")
+            : root.getJsonObject("template").getJsonObject("mappings");
+        var properties = mappings.getJsonObject("properties");
+
+        return bodyPathsOf(type)
+            .stream()
+            .map(path -> properties.getJsonObject(path.parent()).getJsonObject("properties").getJsonObject(path.field()).getMap())
+            .toList();
+    }
+
+    private static List<BodyPath> bodyPathsOf(Type type) {
+        return switch (type) {
+            case LOG -> List.of(
+                new BodyPath("client-request", "body"),
+                new BodyPath("client-response", "body"),
+                new BodyPath("proxy-request", "body"),
+                new BodyPath("proxy-response", "body")
+            );
+            case V4_LOG -> List.of(
+                new BodyPath("entrypoint-request", "body"),
+                new BodyPath("entrypoint-response", "body"),
+                new BodyPath("endpoint-request", "body"),
+                new BodyPath("endpoint-response", "body")
+            );
+            case V4_MESSAGE_LOG -> List.of(new BodyPath("message", "payload"));
+            default -> throw new IllegalArgumentException("Type carries no body: " + type);
+        };
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/DatabaseHydrator.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/DatabaseHydrator.java
@@ -73,7 +73,8 @@ public class DatabaseHydrator {
                     Map.entry("numberOfShards", 5),
                     Map.entry("numberOfReplicas", 1),
                     Map.entry("refreshInterval", "1s"),
-                    Map.entry("indexName", indexName)
+                    Map.entry("indexName", indexName),
+                    Map.entry("indexBody", true)
                 );
                 String filename;
                 if (this.anatlyticsDatabase.getDatabaseType() == AnatlyticsDatabase.DatabaseType.ELASTICSEARCH) {


### PR DESCRIPTION
## Summary

The Elasticsearch reporter indexed every request, response and message body the logging policy captures as a full-text field. That is the heaviest work the reporter gives the cluster — `reporters.logging.max_size` is a limit **per captured body**, so a v4 log document at 256KB carries up to four of them — and on a gateway running thousands of requests per minute it is what puts log ingestion hours behind. Bodies are now indexed for prefix search only, and operators who need more can stop indexing them altogether while keeping them visible in the Logs UI.

Raised from [APIM-13313](https://gravitee.atlassian.net/browse/APIM-13313) / [TT-10329](https://gravitee.atlassian.net/browse/TT-10329), where the Platform team's conclusion was *"open a ticket on APIM team as the mapping is not performant and we have this issue on multiple customer"*, and Antoine Cordier's suggestion was to test disabling the body analyzer on that field.

## Changes

- **Bodies are indexed for prefix search only** — `index_options: docs` and `norms: false` on every body/payload field. Positions serve phrase queries and norms serve relevance scoring; the only query that ever reads these fields is the Logs UI prefix `query_string` over `*.body` ([`SearchConnectionLogDetailQueryAdapter#addBodyTextFilter`](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogDetailQueryAdapter.java#L87), [`ElasticLogRepository#getQuery`](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java#L158)), which needs neither.
- **New setting `reporters.elasticsearch.settings.index_body`** (default `true`). Set to `false` and the bodies' inverted index disappears: they stay in `_source`, so the Logs UI still displays them in the log detail view, but its "search in payloads" filter no longer matches them.
- The body mapping was repeated 36 times across the four template trees; it moves to a shared freemarker macro, `freemarker/common/mapping/log-body-field.ftl`.
- The macro reads `indexBody`, so every renderer of these templates has to supply it. The elasticsearch repository tests render them through their own `DatabaseHydrator` rather than through the reporter's `IndexPreparer`; it now passes the production default.
- Documented in the gateway `gravitee.yml` and in the reporter README.

Both are **mapping** settings: they apply to indexes created after the change (next daily index or ILM rollover), not to existing ones.

## Test report

All numbers below come from real calls against Elasticsearch 9.2.1 (Lucene 10.3.1) in Docker — single node, 2 GiB heap, 1 shard, 0 replicas, `refresh_interval: 5s`. The corpus is seeded v4 log documents whose four captured bodies are ~64 KiB each (256 KiB of payload per request), compact JSON with human-text values, as a real API response would be.

### A. What the templates render — `LogBodyMappingTest`, 48 cases, no container

| # | Test | Expected | Observed | Result |
|---|---|---|---|---|
| A1 | Every body field, 4 template trees × 3 log types | `type: text`, `index_options: docs`, `norms: false` | as expected, 12/12 combinations | **PASS** |
| A2 | Same, with `index_body: false` | `type: text`, `index: false`, and no `analyzer` / `index_options` / `norms` (Elasticsearch rejects those on an unindexed field) | as expected, 12/12 | **PASS** |
| A3 | Existing analyzer per tree is untouched | `gravitee_body_analyzer` everywhere except es7x v4, which keeps the Elasticsearch default | as expected, 12/12 | **PASS** |
| A4 | Every captured payload still mapped | 4 bodies for `log` and `v4-log`, 1 payload for `v4-message-log` | as expected, 12/12 | **PASS** |

### B. Behaviour on a real cluster — `LogBodyIndexingIntegrationTest`, Testcontainers ES 9.2.1

Each case runs the reporter's own `IndexPreparer.prepare()` (a real `PUT _index_template` for every type), then a real refreshed `_bulk`, then the query the Logs UI issues.

| # | Test | Expected | Observed | Result |
|---|---|---|---|---|
| B1 | Cluster accepts the rendered templates, both modes | `prepare()` completes with no error | completes in both modes | **PASS** |
| B2 | Payload search with body indexing on | 1 hit | 1 hit | **PASS** |
| B3 | Payload search with `index_body: false` | 0 hits | 0 hits | **PASS** |
| B4 | Log detail view with `index_body: false` | body still returned in `_source` | `entrypoint-response.body` returned intact | **PASS** |

### C. Payload search returns exactly the same thing — direct HTTP, same corpus indexed under both mappings

The query is the one the adapter builds: the Lucene-escaped term plus `*`, over `\*.body`.

| # | Search input | Expected | Observed (current → new) | Result |
|---|---|---|---|---|
| C1 | `order-4711` (whole token) | identical | 1 → 1 | **PASS** |
| C2 | `order` (token prefix) | identical | 1 → 1 | **PASS** |
| C3 | `ACME` | identical | 0 → 0 | **PASS** |
| C4 | `acme` (case folding) | identical | 0 → 0 | **PASS** |
| C5 | `SKU-1234` | identical | 0 → 0 | **PASS** |
| C6 | `{"status":"accepted"}` (raw JSON typed as a term) | identical | HTTP 400 → HTTP 400 | **PASS** |
| C7 | `ACME\ Corp` (multi-word, escaped as the adapter escapes it) | identical | 0 → 0 | **PASS** |
| C8 | `nothing-here` | identical | 0 → 0 | **PASS** |
| C9 | `42.5` | identical | 0 → 0 | **PASS** |
| C10 | `match_phrase` on a body — **not a query APIM issues** | breaks without positions | 0 hits → HTTP 400 *"field was indexed without position data"* | **known consequence** |

C10 is the one thing `index_options: docs` takes away. Nothing in APIM issues a phrase query on a body field: the only `match_phrase` in the Elasticsearch repository is on `additional-metrics.string_*` in the message-metrics index, which this change does not touch. Note that on the current mapping the phrase query returns 0 hits anyway, because `gravitee_body_analyzer` splits on whitespace only and never produces the tokens a phrase query looks for.

C3/C5 returning 0 on both mappings is pre-existing behaviour, not a regression: with a whitespace tokenizer a compact JSON body is one single token, so a prefix search only reaches a term that starts a whitespace-delimited word.

### D. The transition window — old and new mappings behind one index pattern

A mapping change only applies to new indexes, so for a while the Logs UI searches a wildcard spanning both. If Elasticsearch refused a `query_string` over a pattern where one index has the field unindexed, the Logs UI would break for every operator flipping the flag.

| # | Index pattern searched | Expected | Observed | Result |
|---|---|---|---|---|
| D1 | current mapping only | 1 hit | 1 hit | **PASS** |
| D2 | new mapping only | 1 hit | 1 hit | **PASS** |
| D3 | `index_body: false` only | 0 hits, no error | 0 hits | **PASS** |
| D4 | current + new | 2 hits | 2 hits | **PASS** |
| D5 | current + unindexed | 1 hit, no error | 1 hit | **PASS** |
| D6 | wildcard over all three | 2 hits, no error | 2 hits | **PASS** |

### E. What it costs the cluster

**E1 — body index structures**, measured field by field with `_disk_usage?run_expensive_tasks=true`, 400 documents:

| Mapping | Bodies' inverted index | `_source` | Result |
|---|---|---|---|
| current master | 26.8 MiB | 39.4 MiB | baseline |
| this PR, default | **20.2 MiB (−25%)** | 39.4 MiB | **PASS** |
| this PR, `index_body: false` | **0.0 MiB (−100%)** | 39.4 MiB | **PASS** |

**E2 — indexing and store**, 1200 documents (316 MiB of JSON), one throwaway container per mapping, two runs each:

| Mapping | Shard indexing time | Merge time | Store after force-merge |
|---|---|---|---|
| current master | 8045 / 7931 ms | 4595 / 5277 ms | 198.4 MiB |
| this PR, default | 7652 / 7709 ms (−4%) | 4213 / 4453 ms (−12%) | 165.7 / 178.7 MiB |
| this PR, `index_body: false` | **3170 / 2876 ms (−62%)** | **562 / 466 ms (−89%)** | **118.4 MiB (−40%)** |

Read honestly: **the default change is a disk and merge win, not an indexing-time win.** Analysis dominates shard indexing time and the analyzer is unchanged, so the −4% sits inside run-to-run noise and should not be quoted as a speedup. The lever for a cluster that cannot keep up is `index_body: false`.

An earlier version of this benchmark ran all three mappings against one container and produced incoherent numbers (the unindexed mapping came out *larger* than the baseline) because background merges and pre-merge segment files leaked across mappings. The figures above come from one container per mapping, with the store read only after the shard settles to a single segment of stable size.

### F. Regression

| # | Test | Expected | Observed | Result |
|---|---|---|---|---|
| F1 | `mvn -pl gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch test` | all green | **144 tests, 0 failures, 0 errors** | **PASS** |

Includes the pre-existing `IndexTemplateTest` (50), `IndexPreparerIntegrationTest` against a real OpenSearch container (3), and `ElasticsearchReporterTest` against a real Elasticsearch container (6).

## Answers to the questions on the ticket

**"They currently have `gravitee_reporters_logging_max_size` set to 256KB. Should we suggest a smaller value?"**
It helps, but it is the wrong lever to reach for first, and it is bigger than it looks: the limit is applied **per captured body**, so 256KB means up to 1 MB of payload per request document. Lowering it trades away log content for indexing cost. `index_body: false` removes almost all of that indexing cost while keeping every byte of the payload visible in the Logs UI.

**"Are there any other parameters we can work with?"**
Before this PR, no — nothing exposed the body mapping. Now, in order of impact:
1. `reporters.elasticsearch.settings.index_body: false` — the measured −62% / −40% above. Costs payload search.
2. `reporters.logging.excluded_response_types` — already exists, already defaults to excluding video, audio, images, octet-stream and PDF. Worth confirming it is not overridden.
3. `reporters.logging.max_size` — remember it is per body.
4. `reporters.elasticsearch.bulk.actions` / `flush_interval` and `settings.refresh_interval` — these shape how the reporter talks to the cluster, not how much work the cluster does per document.

**Antoine's suggestion — "disable the body_analyser indexer on that field, worth testing on our side, to check how the logs UI reacts"** — tested, sections B, C and D. The Logs UI keeps rendering payloads in the log detail view (they come from `_source`); only the "search in payloads" filter goes quiet, and it goes quiet without an error, including while old and new indexes coexist.

**Scope note:** this addresses the Elasticsearch side that APIM owns. The Logstash saturation described in TT-10329 is a separate, Platform-owned bottleneck; less data reaching it will help, but this PR does not remove it.

## Reviewer notes

- The interesting file is `freemarker/common/mapping/log-body-field.ftl` — everything else in the template trees is a call into it.
- The analyzer is a macro parameter rather than a constant because **es7x maps v4 bodies without `gravitee_body_analyzer`** while every other tree uses it. That inconsistency predates this PR and is deliberately left alone: aligning it would change what payload search matches on existing ES 7 deployments. Worth a separate ticket.
- **Security-sensitive:** touches a configuration key and deployment configuration (`gravitee.yml`). No change to authentication, authorization, input parsing or logging redaction. `index_body: false` reduces what is derivable from the index but does not remove payloads from `_source`; it is not a data-protection control.
- **Compatibility-sensitive:** new configuration key `reporters.elasticsearch.settings.index_body`, and a change to the shipped index templates. Existing indexes are untouched; the new mapping applies from the next daily index or ILM rollover.

## Test plan

- [ ] `mvn -pl gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch test` is green (needs Docker for the Testcontainers cases).
- [ ] On a gateway with an Elasticsearch reporter and a v4 API with payload logging on, let a new daily index roll, then `GET gravitee-v4-log-*/_mapping` and confirm the body fields carry `index_options: docs` and `norms: false`.
- [ ] In the Console Logs view, search a term inside a payload and confirm the results are what they were before this change.
- [ ] Set `reporters.elasticsearch.settings.index_body: false`, restart, let a new index roll. Confirm: the log detail view still shows request and response payloads; the "search in payloads" filter returns nothing rather than an error; a search spanning the day before and the day after returns the older matches without erroring.
- [ ] Confirm existing indexes created before the upgrade still answer payload searches normally.


[APIM-13313]: https://gravitee.atlassian.net/browse/APIM-13313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-10329]: https://gravitee.atlassian.net/browse/TT-10329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
