### PR TITLE
chore(master): bump gamma-module-esm to 1.5.0-alpha.6 and reactor-native-kafka to 7.1.0-alpha.13

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -240,7 +240,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.1.0-alpha.11</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.1.0-alpha.13</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.3.1</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>4.2.0-alpha.6</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>
@@ -276,7 +276,7 @@
     <gravitee-gamma-module-aim.version>4.3.0-alpha.2</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>1.3.0</gravitee-gamma-module-edge.version>
-    <gravitee-gamma-module-esm.version>1.4.2</gravitee-gamma-module-esm.version>
+    <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>
 
     <!-- Authz plugins -->
     <gravitee-service-authz-pdp.version>2.1.1</gravitee-service-authz-pdp.version>


### PR DESCRIPTION
## Summary

Bumps two plugin versions in `gravitee-apim-distribution/pom.xml`:

| Plugin | From | To |
| --- | --- | --- |
| [gravitee-gamma-module-esm](https://github.com/gravitee-io/gravitee-gamma-module-esm) | `1.4.2` | `1.5.0-alpha.6` |
| [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka) | `7.1.0-alpha.11` | `7.1.0-alpha.13` |

## Changelog

See the releases pages of [gravitee-gamma-module-esm](https://github.com/gravitee-io/gravitee-gamma-module-esm/releases) and [gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases).