### PR TITLE
refactor: allow callers to set api ids

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -353,6 +353,9 @@ public interface ApiMapper {
     @Mapping(target = "services", expression = "java(mapApiV4Services(api))")
     ApiExport toApiExport(ApiV4 api);
 
+    // The Console wire model carries no id: the platform generates one. Only id-deterministic
+    // callers (the Automation API) supply it, through the builder.
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "listeners", qualifiedByName = "toHttpListeners")
     NewHttpApi mapToNewHttpApi(CreateApiV4 api);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
@@ -38,6 +38,12 @@ import lombok.experimental.SuperBuilder;
 @Setter(lombok.AccessLevel.NONE)
 public class NewHttpApi extends AbstractNewApi {
 
+    /**
+     * Optional caller-supplied API id; null lets the platform generate one. Lets id-deterministic callers — the
+     * Automation API derives ids from HRIDs — create the API under the id they will resolve it by.
+     */
+    private String id;
+
     private List<Listener> listeners;
 
     private List<EndpointGroup> endpointGroups;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -46,7 +46,7 @@ public class ApiModelFactory {
     private ApiModelFactory() {}
 
     public static Api fromNewHttpApi(NewHttpApi newHttpApi, String environmentId) {
-        var id = UuidString.generateRandom();
+        var id = newHttpApi.getId() != null ? newHttpApi.getId() : UuidString.generateRandom();
         var now = TimeProvider.now();
         return newHttpApi
             .toApiBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api.use_case;
 import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.oneShotIndexation;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
@@ -33,6 +34,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import java.util.List;
 import java.util.Set;
 import org.jspecify.annotations.NonNull;
@@ -52,15 +54,18 @@ public class CreateHttpApiUseCase {
     private final ValidateApiDomainService validateApiDomainService;
     private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
     private final CreateApiDomainService createApiDomainService;
+    private final ApiCrudService apiCrudService;
 
     public CreateHttpApiUseCase(
         ValidateApiDomainService validateApiDomainService,
         ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
-        CreateApiDomainService createApiDomainService
+        CreateApiDomainService createApiDomainService,
+        ApiCrudService apiCrudService
     ) {
         this.validateApiDomainService = validateApiDomainService;
         this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
         this.createApiDomainService = createApiDomainService;
+        this.apiCrudService = apiCrudService;
     }
 
     public record Input(NewHttpApi newHttpApi, AuditInfo auditInfo) {
@@ -75,6 +80,7 @@ public class CreateHttpApiUseCase {
 
     public Output execute(Input input) {
         var auditInfo = input.auditInfo;
+        ensureSuppliedIdIsFree(input.newHttpApi.getId());
 
         var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(
             auditInfo.organizationId(),
@@ -102,6 +108,13 @@ public class CreateHttpApiUseCase {
         );
 
         return new Output(created);
+    }
+
+    /** A caller-supplied id is created verbatim, so it must be free; a generated id (null here) cannot collide. */
+    private void ensureSuppliedIdIsFree(String suppliedId) {
+        if (suppliedId != null && apiCrudService.existsById(suppliedId)) {
+            throw new ApiAlreadyExistsException(suppliedId);
+        }
     }
 
     private static @NonNull List<Flow> defaultFlowsLlmProxy() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api.model.factory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.NewApiFixtures;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
@@ -40,6 +41,27 @@ import org.junit.jupiter.api.Test;
 class ApiModelFactoryTest {
 
     private static final String ENVIRONMENT_ID = "environment-id";
+
+    @Test
+    void fromNewHttpApi_should_generate_an_id_when_none_is_supplied() {
+        var newHttpApi = NewApiFixtures.aProxyApiV4();
+        assertThat(newHttpApi.getId()).isNull();
+
+        Api api = ApiModelFactory.fromNewHttpApi(newHttpApi, ENVIRONMENT_ID);
+
+        assertThat(api.getId()).isNotBlank();
+        assertThat(api.getApiDefinitionHttpV4().getId()).isEqualTo(api.getId());
+    }
+
+    @Test
+    void fromNewHttpApi_should_use_the_supplied_id_on_the_api_and_its_definition() {
+        var newHttpApi = NewApiFixtures.aProxyApiV4().toBuilder().id("supplied-id").build();
+
+        Api api = ApiModelFactory.fromNewHttpApi(newHttpApi, ENVIRONMENT_ID);
+
+        assertThat(api.getId()).isEqualTo("supplied-id");
+        assertThat(api.getApiDefinitionHttpV4().getId()).isEqualTo("supplied-id");
+    }
 
     @Test
     void fromApiExport_should_leave_allowedInApiProducts_null_for_v4_http_proxy_export_when_flag_missing() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.NewApiFixtures;
 import inmemory.ApiCategoryQueryServiceInMemory;
@@ -84,6 +85,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.MetadataService;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.impl.NotifierServiceImpl;
 import java.time.Clock;
 import java.time.Instant;
@@ -186,7 +188,7 @@ class CreateHttpApiUseCaseTest {
             workflowCrudService,
             createCategoryApiDomainService
         );
-        useCase = new CreateHttpApiUseCase(validateApiDomainService, apiPrimaryOwnerFactory, createApiDomainService);
+        useCase = new CreateHttpApiUseCase(validateApiDomainService, apiPrimaryOwnerFactory, createApiDomainService, apiCrudService);
 
         when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any())).thenAnswer(invocation ->
             invocation.getArgument(0)
@@ -419,6 +421,37 @@ class CreateHttpApiUseCaseTest {
                     )
                 );
         });
+    }
+
+    @Test
+    void should_create_the_api_with_the_supplied_id() {
+        // Given
+        var newApi = NewApiFixtures.aProxyApiV4().toBuilder().id("supplied-id").build();
+
+        // When
+        var output = useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(output.api().getId()).isEqualTo("supplied-id");
+            soft.assertThat(output.api().getApiDefinitionHttpV4().getId()).isEqualTo("supplied-id");
+            soft.assertThat(apiCrudService.storage()).extracting(Api::getId).containsExactly("supplied-id");
+            soft.assertThat(auditCrudService.storage()).isNotEmpty().extracting(AuditEntity::getReferenceId).containsOnly("supplied-id");
+        });
+    }
+
+    @Test
+    void should_reject_a_supplied_id_an_api_already_uses() {
+        // Given
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV4().toBuilder().id("existing-id").build()));
+        var newApi = NewApiFixtures.aProxyApiV4().toBuilder().id("existing-id").build();
+
+        // When
+        var throwable = catchThrowable(() -> useCase.execute(new Input(newApi, AUDIT_INFO)));
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiAlreadyExistsException.class);
+        assertThat(apiCrudService.storage()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
this is required by the automation usecase, where the id is infered from an HRID.

see https://gravitee.atlassian.net/browse/AIAM-233
