### PR TITLE
fix(management-api): keep response template status when promoting a v4 API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5941,9 +5941,11 @@ components:
         ResponseTemplate:
             type: object
             properties:
-                #                TODO: How to specify that json output is "status"?
+                # The definition model writes this field as "status" (@JsonProperty). A promoted API
+                # definition is serialized from that model, so it must be readable under both names.
                 statusCode:
                     type: integer
+                    x-field-extra-annotation: '@com.fasterxml.jackson.annotation.JsonAlias("status")'
                 headers:
                     type: object
                     additionalProperties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
@@ -19,14 +19,17 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.ListenerModelFixtures;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
 import io.gravitee.rest.api.management.v2.rest.model.PrimaryOwner;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
@@ -161,5 +164,30 @@ public class ImportExportApiMapperTest extends AbstractMapperTest {
         assertThat(importDefinition.getApiExport()).isNotNull();
         // The metadata Map in GenericApi (expand field) must be null — not an empty map
         assertThat(api.getMetadata()).isNull();
+    }
+
+    @Test
+    void shouldKeepResponseTemplateStatusWhenParsingAPromotedApiDefinition() throws Exception {
+        var definitionResponseTemplate = new ResponseTemplate();
+        definitionResponseTemplate.setStatusCode(418);
+        definitionResponseTemplate.setBody("I am a teapot");
+        // A promoted API definition is serialized from the definition model, which writes the
+        // status under "status" while this REST model names the property "statusCode".
+        var promotedDefinition = new ObjectMapper()
+            .writeValueAsString(
+                Map.of(
+                    "api",
+                    Map.of(
+                        "definitionVersion",
+                        "V4",
+                        "responseTemplates",
+                        Map.of("DEFAULT", Map.of("*/*", definitionResponseTemplate))
+                    )
+                )
+            );
+
+        var exportApiV4 = importExportApiMapper.definitionToExportApiV4(promotedDefinition);
+
+        assertThat(exportApiV4.getApi().getResponseTemplates().get("DEFAULT").get("*/*").getStatusCode()).isEqualTo(418);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ImportExportApiMapperTest.java
@@ -173,18 +173,12 @@ public class ImportExportApiMapperTest extends AbstractMapperTest {
         definitionResponseTemplate.setBody("I am a teapot");
         // A promoted API definition is serialized from the definition model, which writes the
         // status under "status" while this REST model names the property "statusCode".
-        var promotedDefinition = new ObjectMapper()
-            .writeValueAsString(
-                Map.of(
-                    "api",
-                    Map.of(
-                        "definitionVersion",
-                        "V4",
-                        "responseTemplates",
-                        Map.of("DEFAULT", Map.of("*/*", definitionResponseTemplate))
-                    )
-                )
-            );
+        var promotedDefinition = new ObjectMapper().writeValueAsString(
+            Map.of(
+                "api",
+                Map.of("definitionVersion", "V4", "responseTemplates", Map.of("DEFAULT", Map.of("*/*", definitionResponseTemplate)))
+            )
+        );
 
         var exportApiV4 = importExportApiMapper.definitionToExportApiV4(promotedDefinition);
 


### PR DESCRIPTION
## Problem

Promoting a v4 API resets every Response Template's status code to `0` in the target
environment. The body and headers survive; only the status is lost, which produces
invalid HTTP responses at the gateway.

## Root cause

The promotion payload crosses a model boundary where the two sides disagree on the JSON key:

| Side | Model | Wire key |
| --- | --- | --- |
| Source — `CreatePromotionUseCase` → `ApiExportDomainService` → `GraviteeDefinitionSerializer` | `io.gravitee.definition.model.ResponseTemplate` (`@JsonProperty("status")`) | `status` |
| Target — `PromotionsResource:71` → `ImportExportApiMapper.definitionToExportApiV4` | generated management-v2 `ExportApiV4` | `statusCode` |

`status` is ignored on read, so the status never reaches the target and is persisted as `0`.
The OpenAPI spec already carried a `TODO: How to specify that json output is "status"?`
on that property.

## Fix

Declare a read-only alias on the generated model:

```yaml
statusCode:
    type: integer
    x-field-extra-annotation: '@com.fasterxml.jackson.annotation.JsonAlias("status")'
```

The REST model still **writes** `statusCode`, so the Console contract and every existing
export/import payload are unchanged; it now also **reads** `status`, which is what the
promotion payload carries.

## Verification

Reproduced live against a running Management API before the fix: creating a v4 API with a
response template of status `418`, then feeding the target-side import the payload shape the
promotion actually serializes (`"status": 418`), persisted `statusCode: 0` with the body intact —
the reported symptom.

RED → GREEN on `ImportExportApiMapperTest.shouldKeepResponseTemplateStatusWhenParsingAPromotedApiDefinition`.
The test builds its JSON from the real `io.gravitee.definition.model.ResponseTemplate`, so the
`status` key comes from the production annotation rather than a hand-written string, and calls
the same mapper method `PromotionsResource` uses. Without the fix it fails (status absent); with
it, it passes.

Full module suite: 1380 tests, 1 failure — `ApiLogsResourceTest$GetApiLogErrorKeys.should_return_empty_list_when_no_error_keys`,
which fails identically on the untouched baseline in a full-suite run and passes in isolation on
both. Pre-existing and order-dependent, unrelated to this change.

## Backports

Verified per branch rather than assumed:

- **master, 4.12.x, 4.10.x** — affected. Both halves present: the v2 `PromotionsResource` calls
  `definitionToExportApiV4`, and the spec carries the un-aliased `statusCode`.
- **4.9.x** — **not** affected by this defect and deliberately excluded. It has no v4 promotion
  path at all (no `CreatePromotionUseCase`, no management-v2 `PromotionsResource`); promotion
  there still runs through the v1 `ApiExportService`, which fails outright on a v4 API rather
  than losing the status.

Note for the master backport: master moved the spec to
`gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-apis.yaml`,
so the cherry-pick will conflict on the path and needs to be applied by hand.

Closes APIM-14624
