### PR TITLE
fix(idp): reject disabled org identity providers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -75,11 +75,8 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
             Stream<IdentityProviderEntity> identityProviderEntityStream = identityProviderService
                 .findAll(executionContext)
                 .stream()
-                .filter(idp -> allIdpByTarget.contains(idp.getId()));
-
-            if (target.getReferenceType() == IdentityProviderActivationReferenceType.ENVIRONMENT) {
-                identityProviderEntityStream = identityProviderEntityStream.filter(IdentityProviderEntity::isEnabled);
-            }
+                .filter(idp -> allIdpByTarget.contains(idp.getId()))
+                .filter(IdentityProviderEntity::isEnabled);
 
             return identityProviderEntityStream
                 .sorted((idp1, idp2) -> String.CASE_INSENSITIVE_ORDER.compare(idp1.getName(), idp2.getName()))
@@ -108,7 +105,7 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
 
             IdentityProviderEntity identityProvider = identityProviderService.findById(id);
 
-            if (target.getReferenceType() == IdentityProviderActivationReferenceType.ENVIRONMENT && !identityProvider.isEnabled()) {
+            if (!identityProvider.isEnabled()) {
                 throw new IdentityProviderNotFoundException(identityProvider.getId());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.identity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderActivationReferenceType;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderType;
+import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService.ActivationTarget;
+import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SocialIdentityProviderImplTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("DEFAULT", "DEFAULT");
+    private static final ActivationTarget ORGANIZATION_TARGET = new ActivationTarget(
+        "DEFAULT",
+        IdentityProviderActivationReferenceType.ORGANIZATION
+    );
+    private static final ActivationTarget ENVIRONMENT_TARGET = new ActivationTarget(
+        "DEFAULT",
+        IdentityProviderActivationReferenceType.ENVIRONMENT
+    );
+
+    @InjectMocks
+    private SocialIdentityProviderImpl socialIdentityProvider = new SocialIdentityProviderImpl();
+
+    @Mock
+    private IdentityProviderService identityProviderService;
+
+    @Mock
+    private IdentityProviderActivationService identityProviderActivationService;
+
+    @Test
+    public void find_all_should_exclude_disabled_idp_for_organization_target() {
+        givenActivatedIdps(ORGANIZATION_TARGET, googleIdp("enabled-idp", "Enabled", true), googleIdp("disabled-idp", "Disabled", false));
+
+        Set<String> ids = socialIdentityProvider
+            .findAll(EXECUTION_CONTEXT, ORGANIZATION_TARGET)
+            .stream()
+            .map(SocialIdentityProviderEntity::getId)
+            .collect(Collectors.toSet());
+
+        assertEquals(Set.of("enabled-idp"), ids);
+    }
+
+    @Test
+    public void find_all_should_exclude_disabled_idp_for_environment_target() {
+        givenActivatedIdps(ENVIRONMENT_TARGET, googleIdp("enabled-idp", "Enabled", true), googleIdp("disabled-idp", "Disabled", false));
+
+        Set<String> ids = socialIdentityProvider
+            .findAll(EXECUTION_CONTEXT, ENVIRONMENT_TARGET)
+            .stream()
+            .map(SocialIdentityProviderEntity::getId)
+            .collect(Collectors.toSet());
+
+        assertEquals(Set.of("enabled-idp"), ids);
+    }
+
+    @Test
+    public void find_by_id_should_return_enabled_idp_for_organization_target() {
+        IdentityProviderEntity enabled = googleIdp("enabled-idp", "Enabled", true);
+        givenActivatedIdp(ORGANIZATION_TARGET, enabled);
+
+        SocialIdentityProviderEntity result = socialIdentityProvider.findById("enabled-idp", ORGANIZATION_TARGET);
+
+        assertEquals("enabled-idp", result.getId());
+    }
+
+    @Test(expected = IdentityProviderNotFoundException.class)
+    public void find_by_id_should_reject_disabled_idp_for_organization_target() {
+        givenActivatedIdp(ORGANIZATION_TARGET, googleIdp("disabled-idp", "Disabled", false));
+
+        socialIdentityProvider.findById("disabled-idp", ORGANIZATION_TARGET);
+    }
+
+    @Test(expected = IdentityProviderNotFoundException.class)
+    public void find_by_id_should_reject_disabled_idp_for_environment_target() {
+        givenActivatedIdp(ENVIRONMENT_TARGET, googleIdp("disabled-idp", "Disabled", false));
+
+        socialIdentityProvider.findById("disabled-idp", ENVIRONMENT_TARGET);
+    }
+
+    @Test(expected = IdentityProviderNotFoundException.class)
+    public void find_by_id_should_reject_idp_not_activated_on_target() {
+        when(identityProviderActivationService.findAllByTarget(ORGANIZATION_TARGET)).thenReturn(Set.of());
+
+        socialIdentityProvider.findById("missing-idp", ORGANIZATION_TARGET);
+    }
+
+    @Test
+    public void find_all_should_include_enabled_idp_for_organization_target() {
+        givenActivatedIdps(ORGANIZATION_TARGET, googleIdp("enabled-idp", "Enabled", true));
+
+        Set<SocialIdentityProviderEntity> result = socialIdentityProvider.findAll(EXECUTION_CONTEXT, ORGANIZATION_TARGET);
+
+        assertEquals(1, result.size());
+        assertTrue(result.stream().anyMatch(idp -> "enabled-idp".equals(idp.getId())));
+    }
+
+    private void givenActivatedIdps(ActivationTarget target, IdentityProviderEntity... identityProviders) {
+        Set<IdentityProviderActivationEntity> activations = Set.of(identityProviders)
+            .stream()
+            .map(idp -> activation(idp.getId()))
+            .collect(Collectors.toSet());
+        when(identityProviderActivationService.findAllByTarget(target)).thenReturn(activations);
+        when(identityProviderService.findAll(EXECUTION_CONTEXT)).thenReturn(Set.of(identityProviders));
+    }
+
+    private void givenActivatedIdp(ActivationTarget target, IdentityProviderEntity identityProvider) {
+        when(identityProviderActivationService.findAllByTarget(target)).thenReturn(Set.of(activation(identityProvider.getId())));
+        when(identityProviderService.findById(identityProvider.getId())).thenReturn(identityProvider);
+    }
+
+    private static IdentityProviderActivationEntity activation(String identityProviderId) {
+        IdentityProviderActivationEntity activation = new IdentityProviderActivationEntity();
+        activation.setIdentityProvider(identityProviderId);
+        return activation;
+    }
+
+    private static IdentityProviderEntity googleIdp(String id, String name, boolean enabled) {
+        IdentityProviderEntity identityProvider = new IdentityProviderEntity();
+        identityProvider.setId(id);
+        identityProvider.setName(name);
+        identityProvider.setType(IdentityProviderType.GOOGLE);
+        identityProvider.setEnabled(enabled);
+        identityProvider.setConfiguration(Map.of("clientId", "client-id", "clientSecret", "client-secret"));
+        return identityProvider;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14900

## Description

- Disabling an organization Identity Provider only hid it from the Portal login list. Console (organization-scoped) login still resolved and accepted the IdP.
- `enabled` is a kill-switch on the IdP definition. Honor it for every activation target (organization Console and environment Portal), not only `ENVIRONMENT`.
- Authentication against a disabled IdP now fails with `IdentityProviderNotFoundException` (404), matching the Portal path.

## Additional context

- `SocialIdentityProviderImpl.findAll()` / `findById()` filtered `isEnabled()` only when `target.referenceType == ENVIRONMENT`. Management Console login uses `ORGANIZATION`, so a disabled IdP stayed fully usable via mAPI.
- Activation (which surfaces expose the IdP) is unchanged. Org settings still list disabled IdPs via `IdentityProviderService` so an admin can re-enable them.


