### PR TITLE
feat(gamma-apim): support TCP Proxy in the scratch API creation wizard

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -42,6 +42,7 @@ import { ApiProductPlansPage } from '../features/api-products/pages/detail/plans
 import { ApiProductUserPermissionsPage } from '../features/api-products/pages/detail/user-permissions/ApiProductUserPermissionsPage';
 import { ApiDetailIndexRedirect, ApiDetailLayout } from '../features/apis/components/detail/ApiDetailLayout';
 import { ApisPage } from '../features/apis/pages/ApisPage';
+import { CreateApiGate } from '../features/apis/pages/CreateApiGate';
 import { CreateApiProxyPage } from '../features/apis/pages/CreateApiProxyPage';
 import { AlertFormPage } from '../features/apis/pages/detail/alerts/AlertFormPage';
 import { ApiAlertsPage } from '../features/apis/pages/detail/alerts/ApiAlertsPage';
@@ -204,7 +205,7 @@ export function AppRoutes() {
                         <Route path="quick-start" element={<QuickStartPage />} />
                         <Route path="apis">
                             <Route index element={<ApisPage />} />
-                            <Route path="new">
+                            <Route path="new" element={<CreateApiGate />}>
                                 <Route index element={<CreateApiProxyPage />} />
                                 <Route path="scratch" element={<ScratchWizardPage />} />
                                 <Route path="template/:id" element={<TemplateWizardPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
@@ -106,6 +106,7 @@ jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () =
 jest.mock('./ApiDetailSidebarNav', () => ({
     API_PROXY_NAV_GROUPS: [],
     ApiDetailSidebarNav: () => <div />,
+    withTcpRestrictions: (groups: unknown[]) => groups,
 }));
 
 import { ApiDetailIndexRedirect, ApiDetailLayout } from './ApiDetailLayout';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -40,13 +40,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useId, useState } from 'react';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav } from './ApiDetailSidebarNav';
+import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withTcpRestrictions } from './ApiDetailSidebarNav';
 import { useDetailBasePath } from '../../../../shared/hooks/useDetailBasePath';
 import { ApiDetailContext } from '../../context/ApiDetailContext';
 import { useApiDetail } from '../../hooks/useApiDetail';
 import { useApiPermissions } from '../../hooks/useApiPermissions';
 import { deployApi } from '../../services/apis';
 import type { ApiDetailDto } from '../../types';
+import { hasTcpListeners } from '../../utils/apiHttpProxy';
 import { apiDetailKeys } from '../../utils/queryKeys';
 
 /** Classic console caps the deployment label at 32 characters. */
@@ -232,7 +233,7 @@ function ApiInfoHeader({ api, isLoading }: { api: ApiDetailDto | null; isLoading
             <div className="flex flex-wrap items-center gap-1">
                 {api.type ? (
                     <Badge variant="secondary" className="text-xs px-1.5 py-0 h-5">
-                        {api.type === 'PROXY' ? 'HTTP Proxy' : 'Event-driven'}
+                        {api.type === 'PROXY' ? (hasTcpListeners(api) ? 'TCP Proxy' : 'HTTP Proxy') : 'Event-driven'}
                     </Badge>
                 ) : null}
                 {api.apiVersion ? (
@@ -270,6 +271,7 @@ export function ApiDetailLayout() {
     });
 
     const showDeployBanner = !isError && api?.deploymentState === 'NEED_REDEPLOY' && canDeploy;
+    const navGroups = withTcpRestrictions(API_PROXY_NAV_GROUPS, hasTcpListeners(api));
 
     useLayoutConfig(
         {
@@ -277,7 +279,7 @@ export function ApiDetailLayout() {
             contextExpanded,
             contextSidebar: (
                 <ContextSidebar header={<ApiInfoHeader api={api ?? null} isLoading={isLoading} />}>
-                    <ApiDetailSidebarNav groups={API_PROXY_NAV_GROUPS} basePath={basePath} permissionsReady={permissionsReady} />
+                    <ApiDetailSidebarNav groups={navGroups} basePath={basePath} permissionsReady={permissionsReady} />
                 </ContextSidebar>
             ),
             leading: <ContextToggleButton expanded={contextExpanded} onToggle={() => setContextExpanded(v => !v)} />,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
@@ -16,7 +16,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav } from './ApiDetailSidebarNav';
+import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withTcpRestrictions } from './ApiDetailSidebarNav';
 
 const GROUPS = API_PROXY_NAV_GROUPS;
 const BASE = '/env/apis/abc-123';
@@ -79,11 +79,71 @@ describe('ApiDetailSidebarNav — flat links', () => {
         expect(screen.getByRole('link', { name: /^resources$/i })).toHaveAttribute('href', `${BASE}/resources`);
     });
 
-    it('hides "coming soon" items (API Score, Response Templates, Authorization)', () => {
+    it('renders "coming soon" items (API Score, Response Templates, Authorization) as disabled, non-navigable rows', () => {
         renderNav(`${BASE}/overview`);
-        expect(screen.queryByText('API Score')).not.toBeInTheDocument();
-        expect(screen.queryByText('Response Templates')).not.toBeInTheDocument();
-        expect(screen.queryByText('Authorization')).not.toBeInTheDocument();
+        for (const label of ['API Score', 'Response Templates', 'Authorization']) {
+            expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.queryByRole('link', { name: new RegExp(`^${label}$`, 'i') })).not.toBeInTheDocument();
+        }
+    });
+
+    it('makes "coming soon" rows reachable by keyboard, with their reason exposed for assistive tech', () => {
+        renderNav(`${BASE}/overview`);
+        const row = screen.getByText('API Score').closest('[tabindex]');
+        expect(row).not.toBeNull();
+        expect(row).toHaveAttribute('tabindex', '0');
+        expect(row).toHaveAttribute('aria-disabled', 'true');
+        expect(row).toHaveAttribute('title');
+    });
+});
+
+// ─── TCP restrictions ─────────────────────────────────────────────────────────
+
+describe('withTcpRestrictions', () => {
+    it('returns the groups unchanged when the API has no TCP listeners', () => {
+        expect(withTcpRestrictions(GROUPS, false)).toBe(GROUPS);
+    });
+
+    it('marks Policy Studio and CORS as comingSoon when the API has TCP listeners', () => {
+        const restricted = withTcpRestrictions(GROUPS, true);
+        const policyStudio = restricted.find(g => g.label === 'Design')!.items.find(i => i.path === 'policy-studio')!;
+        const cors = restricted.find(g => g.label === 'General')!.items.find(i => i.path === 'cors')!;
+
+        expect(policyStudio.comingSoon).toBe(true);
+        expect(policyStudio.comingSoonReason).toBe('Coming soon for V4 APIs');
+        expect(cors.comingSoon).toBe(true);
+        expect(cors.comingSoonReason).toBe('Coming soon for V4 APIs');
+    });
+
+    it('does not affect unrelated items', () => {
+        const restricted = withTcpRestrictions(GROUPS, true);
+        const plans = restricted.find(g => g.label === 'Consumer Access')!.items.find(i => i.path === 'plans')!;
+        expect(plans.comingSoon).toBeUndefined();
+    });
+
+    it('omits Failover and Health Check Dashboard from the Endpoints children for TCP APIs', () => {
+        const restricted = withTcpRestrictions(GROUPS, true);
+        const endpoints = restricted.find(g => g.label === 'Gateway')!.items.find(i => i.path === 'endpoints')!;
+        expect(endpoints.children!.map(c => c.path)).toEqual(['list']);
+    });
+
+    it('keeps Failover and Health Check Dashboard in the Endpoints children for non-TCP APIs', () => {
+        const endpoints = GROUPS.find(g => g.label === 'Gateway')!.items.find(i => i.path === 'endpoints')!;
+        expect(endpoints.children!.map(c => c.path)).toEqual(['list', 'failover', 'health-check-dashboard']);
+    });
+});
+
+describe('ApiDetailSidebarNav — TCP restrictions', () => {
+    it('renders Policy Studio as a disabled row instead of a link for a TCP API', () => {
+        const groups = withTcpRestrictions(GROUPS, true);
+        render(
+            <MemoryRouter initialEntries={[`${BASE}/overview`]}>
+                <ApiDetailSidebarNav groups={groups} basePath={BASE} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Policy Studio')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /^policy studio$/i })).not.toBeInTheDocument();
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { cn, Skeleton } from '@gravitee/graphene-core';
+import { cn, Skeleton, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@gravitee/graphene-core';
 import {
     ActivityIcon,
     BellIcon,
     ChevronDownIcon,
     ChevronRightIcon,
+    FlaskConicalIcon,
     GlobeIcon,
     LayoutDashboardIcon,
     ListIcon,
@@ -43,11 +44,15 @@ import { NavLink, useLocation } from 'react-router-dom';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+const DEFAULT_COMING_SOON_REASON = 'Coming soon';
+
 export interface DetailNavChild {
     path: string;
     label: string;
-    /** When true, renders as a non-navigable item with a lab icon and "Coming soon" tooltip. */
+    /** When true, renders as a non-navigable item with a lab icon and tooltip instead of a link. */
     comingSoon?: boolean;
+    /** Tooltip text for a `comingSoon` item. Defaults to "Coming soon". */
+    comingSoonReason?: string;
 }
 
 export interface DetailNavItem {
@@ -57,8 +62,10 @@ export interface DetailNavItem {
     /** When false, matches any sub-path (prefix match). Defaults to true (exact match). */
     end?: boolean;
     children?: DetailNavChild[];
-    /** When true, renders as a non-navigable item with a lab icon and "Coming soon" tooltip. */
+    /** When true, renders as a non-navigable item with a lab icon and tooltip instead of a link. */
     comingSoon?: boolean;
+    /** Tooltip text for a `comingSoon` item. Defaults to "Coming soon". */
+    comingSoonReason?: string;
 }
 
 export interface DetailNavGroup {
@@ -141,6 +148,61 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
     },
 ];
 
+/** Classic console parity (`api-v4-menu.service.ts`, `hasTcpListeners`) — TCP has no HTTP policy-chain semantics. */
+const TCP_UNSUPPORTED_PATHS = new Set(['policy-studio', 'cors']);
+const TCP_UNSUPPORTED_REASON = 'Coming soon for V4 APIs';
+
+/** Classic console never adds these menu entries for TCP APIs at all — omitted, not just disabled. */
+const TCP_OMITTED_CHILD_PATHS = new Set(['failover', 'health-check-dashboard']);
+
+/** Overlays `comingSoon` on the items TCP Proxy APIs don't support, and omits child routes that don't exist for TCP — matching classic console. */
+export function withTcpRestrictions(groups: DetailNavGroup[], apiHasTcpListeners: boolean): DetailNavGroup[] {
+    if (!apiHasTcpListeners) return groups;
+    return groups.map(group => ({
+        ...group,
+        items: group.items.map(item => {
+            const disabled = TCP_UNSUPPORTED_PATHS.has(item.path)
+                ? { ...item, comingSoon: true, comingSoonReason: TCP_UNSUPPORTED_REASON }
+                : item;
+            if (!disabled.children) return disabled;
+            return { ...disabled, children: disabled.children.filter(child => !TCP_OMITTED_CHILD_PATHS.has(child.path)) };
+        }),
+    }));
+}
+
+// ─── "Coming soon" row ────────────────────────────────────────────────────────
+
+interface ComingSoonRowProps {
+    icon?: ComponentType<{ className?: string }>;
+    label: string;
+    reason: string;
+    indented?: boolean;
+}
+
+function ComingSoonRow({ icon: Icon, label, reason, indented }: ComingSoonRowProps) {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <div
+                    className={cn(
+                        'flex w-full items-center gap-2.5 rounded-lg px-3 text-sm text-muted-foreground/50 cursor-default',
+                        indented ? 'py-1.5' : 'py-2',
+                    )}
+                    role="button"
+                    tabIndex={0}
+                    aria-disabled="true"
+                    title={reason}
+                >
+                    {Icon && <Icon className="size-4 shrink-0" aria-hidden />}
+                    <span className="flex-1 text-left">{label}</span>
+                    <FlaskConicalIcon className="size-3.5 shrink-0" aria-hidden />
+                </div>
+            </TooltipTrigger>
+            <TooltipContent side="right">{reason}</TooltipContent>
+        </Tooltip>
+    );
+}
+
 // ─── Collapsible item ─────────────────────────────────────────────────────────
 
 interface CollapsibleNavItemProps {
@@ -181,10 +243,15 @@ function CollapsibleNavItem({ item, basePath }: CollapsibleNavItemProps) {
             </button>
             {open && (
                 <div className="ml-4 border-l border-border pl-2 space-y-0.5">
-                    {/* "Coming soon" children are hidden until their feature ships. */}
-                    {item.children
-                        .filter(child => !child.comingSoon)
-                        .map(child => (
+                    {item.children.map(child =>
+                        child.comingSoon ? (
+                            <ComingSoonRow
+                                key={child.path}
+                                label={child.label}
+                                reason={child.comingSoonReason ?? DEFAULT_COMING_SOON_REASON}
+                                indented
+                            />
+                        ) : (
                             <NavLink
                                 end
                                 key={child.path}
@@ -198,7 +265,8 @@ function CollapsibleNavItem({ item, basePath }: CollapsibleNavItemProps) {
                             >
                                 {child.label}
                             </NavLink>
-                        ))}
+                        ),
+                    )}
                 </div>
             )}
         </div>
@@ -228,14 +296,22 @@ export function ApiDetailSidebarNav({ groups, basePath, permissionsReady = true 
     }
 
     return (
-        <div className="space-y-0.5 px-2 py-2">
-            {groups.map(group => (
-                <div key={group.label} className="pt-4 first:pt-0">
-                    <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
-                    {/* "Coming soon" items are hidden until their feature ships. */}
-                    {group.items
-                        .filter(item => !item.comingSoon)
-                        .map(item => {
+        <TooltipProvider delayDuration={200}>
+            <div className="space-y-0.5 px-2 py-2">
+                {groups.map(group => (
+                    <div key={group.label} className="pt-4 first:pt-0">
+                        <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
+                        {group.items.map(item => {
+                            if (item.comingSoon) {
+                                return (
+                                    <ComingSoonRow
+                                        key={item.path}
+                                        icon={item.icon}
+                                        label={item.label}
+                                        reason={item.comingSoonReason ?? DEFAULT_COMING_SOON_REASON}
+                                    />
+                                );
+                            }
                             if (item.children && item.children.length > 0) {
                                 return (
                                     <CollapsibleNavItem
@@ -265,8 +341,9 @@ export function ApiDetailSidebarNav({ groups, basePath, permissionsReady = true 
                                 </NavLink>
                             );
                         })}
-                </div>
-            ))}
-        </div>
+                    </div>
+                ))}
+            </div>
+        </TooltipProvider>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.spec.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('../../services/policyStudioService', () => ({
+    listEntrypointPlugins: jest.fn(),
+}));
+
+import { DetailsStep } from './DetailsStep';
+import { listEntrypointPlugins } from '../../services/policyStudioService';
+import { ApiCreationProvider, useApiCreation } from '../../store/apiCreationStore';
+import type { ConnectorPlugin } from '../../types/policyStudio';
+
+const mockListEntrypointPlugins = jest.mocked(listEntrypointPlugins);
+
+function plugin(id: string, overrides: Partial<ConnectorPlugin> = {}): ConnectorPlugin {
+    return { id, name: id, supportedModes: [], deployed: true, ...overrides };
+}
+
+function CurrentProtocol() {
+    const { state } = useApiCreation();
+    return <span data-testid="current-protocol">{state.form.protocol}</span>;
+}
+
+function renderStep() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <ApiCreationProvider>
+                <DetailsStep />
+                <CurrentProtocol />
+            </ApiCreationProvider>
+        </QueryClientProvider>,
+    );
+}
+
+describe('DetailsStep — proxy kind gating', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('keeps both options selectable when both plugins are deployed', async () => {
+        mockListEntrypointPlugins.mockResolvedValue([plugin('http-proxy'), plugin('tcp-proxy')]);
+        renderStep();
+
+        await waitFor(() => expect(mockListEntrypointPlugins).toHaveBeenCalled());
+
+        const tcpOption = await screen.findByRole('radio', { name: /tcp proxy/i });
+        expect(tcpOption).not.toBeDisabled();
+
+        fireEvent.click(tcpOption);
+        expect(screen.getByTestId('current-protocol')).toHaveTextContent('TCP');
+    });
+
+    it('keeps options selectable while the plugin list is still loading (fail open)', () => {
+        mockListEntrypointPlugins.mockReturnValue(new Promise(() => {}));
+        renderStep();
+
+        expect(screen.getByRole('radio', { name: /tcp proxy/i })).not.toBeDisabled();
+    });
+
+    it('disables the TCP Proxy option and shows why when the tcp-proxy plugin is not deployed', async () => {
+        mockListEntrypointPlugins.mockResolvedValue([plugin('http-proxy'), plugin('tcp-proxy', { deployed: false })]);
+        renderStep();
+
+        const tcpOption = await screen.findByRole('radio', { name: /tcp proxy/i });
+        await waitFor(() => expect(tcpOption).toBeDisabled());
+        expect(screen.getByText(/not available/i)).toBeInTheDocument();
+
+        fireEvent.click(tcpOption);
+        expect(screen.getByTestId('current-protocol')).toHaveTextContent('HTTP');
+    });
+
+    it('fails closed once loaded: disables an option whose plugin is missing from the response entirely', async () => {
+        // Only http-proxy comes back — tcp-proxy isn't in the list at all, not just deployed: false.
+        mockListEntrypointPlugins.mockResolvedValue([plugin('http-proxy')]);
+        renderStep();
+
+        const tcpOption = await screen.findByRole('radio', { name: /tcp proxy/i });
+        await waitFor(() => expect(tcpOption).toBeDisabled());
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.tsx
@@ -13,14 +13,63 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Input, Label, Textarea } from '@gravitee/graphene-core';
+import { cn, Input, Label, Textarea } from '@gravitee/graphene-core';
+import { CableIcon, CircleCheckIcon, GlobeIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
 import type { CSSProperties } from 'react';
 
+import { policyStudioKeys } from '../../hooks/usePolicyStudioData';
+import { listEntrypointPlugins } from '../../services/policyStudioService';
 import { useApiCreation } from '../../store/apiCreationStore';
+import type { ApiProtocol } from '../../types/apiCreation';
+
+interface ProxyKindOption {
+    id: ApiProtocol;
+    /** Entrypoint plugin id backing this option (classic console `ConnectorPlugin.id`), used to check `deployed`. */
+    pluginId: string;
+    label: string;
+    description: string;
+    Icon: LucideIcon;
+}
+
+const PROXY_KIND_OPTIONS: ProxyKindOption[] = [
+    {
+        id: 'HTTP',
+        pluginId: 'http-proxy',
+        label: 'HTTP Proxy',
+        description: 'Expose an HTTP backend through context paths or virtual hosts.',
+        Icon: GlobeIcon,
+    },
+    {
+        id: 'TCP',
+        pluginId: 'tcp-proxy',
+        label: 'TCP Proxy',
+        description: 'Expose a TCP backend through host-based listeners. Only a keyless plan is supported.',
+        Icon: CableIcon,
+    },
+];
 
 export function DetailsStep() {
     const { state, dispatch } = useApiCreation();
     const { form, validationErrors: errors } = state;
+
+    const { data: entrypointPlugins, isLoading: entrypointPluginsLoading } = useQuery({
+        queryKey: policyStudioKeys.entrypoints(),
+        queryFn: listEntrypointPlugins,
+        staleTime: 300_000,
+    });
+
+    /**
+     * Fails closed once the plugin list has loaded: a type is only selectable if its plugin
+     * is present AND deployed. While the query is still loading, every option stays enabled
+     * so HTTP (the default) isn't disabled during the initial fetch; a query error also fails
+     * closed since `entrypointPlugins` stays undefined but `isLoading` settles to false.
+     */
+    function isPluginUnavailable(pluginId: string): boolean {
+        if (entrypointPluginsLoading) return false;
+        return entrypointPlugins?.find(p => p.id === pluginId)?.deployed !== true;
+    }
 
     function update(patch: Partial<typeof form>) {
         dispatch({ type: 'UPDATE_FORM', patch });
@@ -76,6 +125,66 @@ export function DetailsStep() {
                         style={{ fieldSizing: 'fixed' } as unknown as CSSProperties}
                     />
                     <p className="text-xs text-muted-foreground text-right">{form.apiDescription.length}/250</p>
+                </div>
+
+                <div className="space-y-3">
+                    <div className="space-y-1">
+                        <p className="text-sm font-medium">Select API Type</p>
+                        <p className="text-xs text-muted-foreground">Choose how this proxy listens and forwards traffic.</p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="API type">
+                        {PROXY_KIND_OPTIONS.map(opt => {
+                            const Icon = opt.Icon;
+                            const selected = form.protocol === opt.id;
+                            const unavailable = isPluginUnavailable(opt.pluginId);
+                            return (
+                                <button
+                                    key={opt.id}
+                                    type="button"
+                                    role="radio"
+                                    aria-checked={selected}
+                                    disabled={unavailable}
+                                    onClick={() => !unavailable && update({ protocol: opt.id })}
+                                    className={cn(
+                                        'flex items-start gap-3 rounded-xl border-2 p-4 text-left transition-all',
+                                        unavailable
+                                            ? 'opacity-50 cursor-not-allowed border-border'
+                                            : selected
+                                              ? 'border-primary bg-primary/5 ring-2 ring-primary/30 ring-offset-1'
+                                              : 'border-border hover:border-foreground/20',
+                                    )}
+                                >
+                                    <div
+                                        className={cn(
+                                            'size-10 rounded-lg flex items-center justify-center shrink-0',
+                                            selected ? 'bg-primary/10' : 'bg-muted',
+                                        )}
+                                    >
+                                        <Icon className="size-5" aria-hidden />
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <span className="text-sm font-medium">{opt.label}</span>
+                                            {opt.id === 'HTTP' && !unavailable && (
+                                                <span className="rounded-full px-2 py-0.5 text-xs text-muted-foreground bg-muted">
+                                                    Default
+                                                </span>
+                                            )}
+                                            {unavailable && (
+                                                <span className="rounded-full px-2 py-0.5 text-xs text-muted-foreground bg-muted">
+                                                    Not available
+                                                </span>
+                                            )}
+                                        </div>
+                                        <p className="text-xs text-muted-foreground mt-1">{opt.description}</p>
+                                    </div>
+                                    {selected && !unavailable && (
+                                        <CircleCheckIcon className="size-5 text-primary shrink-0 mt-0.5" aria-hidden />
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
                 </div>
             </div>
         </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
@@ -18,10 +18,12 @@ import { PlusIcon, ServerIcon, Trash2Icon } from '@gravitee/graphene-core/icons'
 
 import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useVerifyContextPath } from '../../hooks/useVerifyContextPath';
+import { useVerifyTcpHosts } from '../../hooks/useVerifyTcpHosts';
 import { useApiCreation } from '../../store/apiCreationStore';
 import type { VirtualHostEntry } from '../../types/apiCreation';
+import { isTcpForm } from '../../utils/protocol';
 
-export function EntrypointsStep() {
+function HttpEntrypointsFields() {
     const { state, dispatch } = useApiCreation();
     const { form, validationErrors: errors } = state;
     const gatewayPrefix = useGatewayPrefix();
@@ -36,131 +38,245 @@ export function EntrypointsStep() {
     }
 
     return (
+        <>
+            <div className="space-y-4 rounded-xl border bg-muted/30 p-4">
+                <div className="flex items-center justify-between">
+                    <div>
+                        <p className="text-sm font-medium">Gateway path</p>
+                        <p className="text-xs text-muted-foreground">The path clients use to reach this API on the gateway.</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground">Virtual hosts</span>
+                        <Switch
+                            checked={form.virtualHostsEnabled}
+                            onCheckedChange={enabled => update({ virtualHostsEnabled: enabled })}
+                            size="sm"
+                            aria-label="Enable virtual hosts"
+                        />
+                    </div>
+                </div>
+
+                {form.virtualHostsEnabled ? (
+                    <div className="space-y-3">
+                        {form.virtualHosts.map((vh, index) => (
+                            <div key={vh.id} className="grid grid-cols-2 gap-3 items-end">
+                                <div className="space-y-1.5">
+                                    <Label htmlFor={`vh-host-${index}`} className="text-xs">
+                                        Host
+                                    </Label>
+                                    <Input
+                                        id={`vh-host-${index}`}
+                                        placeholder="e.g. api.example.com"
+                                        value={vh.host}
+                                        onChange={e => updateVirtualHost(index, { host: e.target.value })}
+                                    />
+                                </div>
+                                <div className="flex items-end gap-2">
+                                    <div className="flex-1 space-y-1.5">
+                                        <Label htmlFor={`vh-path-${index}`} className="text-xs">
+                                            Path
+                                        </Label>
+                                        <Input
+                                            id={`vh-path-${index}`}
+                                            placeholder="/"
+                                            value={vh.path}
+                                            onChange={e => updateVirtualHost(index, { path: e.target.value })}
+                                        />
+                                    </div>
+                                    {form.virtualHosts.length > 1 && (
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => dispatch({ type: 'REMOVE_VIRTUAL_HOST', index })}
+                                            aria-label="Remove virtual host"
+                                            className="shrink-0"
+                                        >
+                                            <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                        {errors['virtualHosts'] && <p className="text-xs text-destructive">{errors['virtualHosts']}</p>}
+                        <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'ADD_VIRTUAL_HOST' })} className="w-full">
+                            <PlusIcon className="size-4" aria-hidden />
+                            Add virtual host
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        <Label htmlFor="context-path">
+                            Context path <span className="text-destructive">*</span>
+                        </Label>
+                        <div
+                            className="flex items-stretch rounded-md border overflow-hidden"
+                            style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
+                        >
+                            <span
+                                className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
+                                aria-hidden
+                            >
+                                {gatewayPrefix}
+                            </span>
+                            <Input
+                                id="context-path"
+                                placeholder="/my-api"
+                                value={form.contextPath}
+                                onChange={e => update({ contextPath: e.target.value })}
+                                aria-invalid={Boolean(errors['contextPath'])}
+                                style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
+                            />
+                        </div>
+                        {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
+                        <p className="text-xs text-muted-foreground">Path prefix clients will use to access this API.</p>
+                    </div>
+                )}
+            </div>
+
+            <div className="space-y-2">
+                <Label htmlFor="target-url">
+                    Target URL <span className="text-destructive">*</span>
+                </Label>
+                <div className="relative">
+                    <ServerIcon
+                        className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                        aria-hidden
+                    />
+                    <Input
+                        id="target-url"
+                        placeholder="https://api.internal.example.com"
+                        value={form.targetUrl}
+                        onChange={e => update({ targetUrl: e.target.value })}
+                        aria-invalid={Boolean(errors['targetUrl'])}
+                        style={{ paddingLeft: '2.5rem' }}
+                    />
+                </div>
+                {errors['targetUrl'] && <p className="text-xs text-destructive">{errors['targetUrl']}</p>}
+                <p className="text-xs text-muted-foreground">The upstream backend the gateway will forward requests to.</p>
+            </div>
+        </>
+    );
+}
+
+function TcpEntrypointsFields() {
+    const { state, dispatch } = useApiCreation();
+    const { form, validationErrors: errors } = state;
+    useVerifyTcpHosts();
+
+    function update(patch: Partial<typeof form>) {
+        dispatch({ type: 'UPDATE_FORM', patch });
+    }
+
+    return (
+        <>
+            <div className="space-y-4 rounded-xl border bg-muted/30 p-4">
+                <div>
+                    <p className="text-sm font-medium">Gateway hosts</p>
+                    <p className="text-xs text-muted-foreground">Hostnames clients use to reach this TCP API on the gateway.</p>
+                </div>
+
+                <div className="space-y-3">
+                    {form.tcpHosts.map((row, index) => (
+                        <div key={row.id} className="flex items-end gap-2">
+                            <div className="flex-1 space-y-1.5">
+                                <Label htmlFor={`tcp-host-${index}`} className="text-xs">
+                                    Host {index === 0 ? <span className="text-destructive">*</span> : null}
+                                </Label>
+                                <Input
+                                    id={`tcp-host-${index}`}
+                                    placeholder="e.g. db.example.com"
+                                    value={row.host}
+                                    onChange={e => dispatch({ type: 'UPDATE_TCP_HOST', index, patch: { host: e.target.value } })}
+                                    aria-invalid={Boolean(errors['tcpHosts'])}
+                                />
+                            </div>
+                            {form.tcpHosts.length > 1 && (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => dispatch({ type: 'REMOVE_TCP_HOST', index })}
+                                    aria-label="Remove host"
+                                    className="shrink-0"
+                                >
+                                    <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                                </Button>
+                            )}
+                        </div>
+                    ))}
+                    {errors['tcpHosts'] && <p className="text-xs text-destructive">{errors['tcpHosts']}</p>}
+                    <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'ADD_TCP_HOST' })} className="w-full">
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add host
+                    </Button>
+                </div>
+            </div>
+
+            <div className="space-y-4">
+                <div>
+                    <p className="text-sm font-medium">Backend target</p>
+                    <p className="text-xs text-muted-foreground">The TCP host and port the gateway will connect to.</p>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="tcp-target-host">
+                            Host <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="tcp-target-host"
+                            placeholder="e.g. postgres.internal.example.com"
+                            value={form.tcpTargetHost}
+                            onChange={e => update({ tcpTargetHost: e.target.value })}
+                            aria-invalid={Boolean(errors['tcpTargetHost'])}
+                        />
+                        {errors['tcpTargetHost'] && <p className="text-xs text-destructive">{errors['tcpTargetHost']}</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="tcp-target-port">
+                            Port <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="tcp-target-port"
+                            placeholder="e.g. 5432"
+                            inputMode="numeric"
+                            value={form.tcpTargetPort}
+                            onChange={e => update({ tcpTargetPort: e.target.value })}
+                            aria-invalid={Boolean(errors['tcpTargetPort'])}
+                        />
+                        {errors['tcpTargetPort'] && <p className="text-xs text-destructive">{errors['tcpTargetPort']}</p>}
+                    </div>
+                </div>
+                <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                    <div>
+                        <p className="text-sm font-medium">Secured (TLS)</p>
+                        <p className="text-xs text-muted-foreground">Connect to the backend over TLS.</p>
+                    </div>
+                    <Switch
+                        checked={form.tcpTargetSecured}
+                        onCheckedChange={secured => update({ tcpTargetSecured: secured })}
+                        aria-label="Enable TLS to the backend"
+                    />
+                </div>
+            </div>
+        </>
+    );
+}
+
+export function EntrypointsStep() {
+    const { state } = useApiCreation();
+    const isTcp = isTcpForm(state.form);
+
+    return (
         <div className="space-y-6">
             <div className="space-y-1">
                 <h2 className="text-base font-semibold">Entrypoints & Backend</h2>
-                <p className="text-sm text-muted-foreground">Define how clients reach the gateway and where requests are forwarded.</p>
+                <p className="text-sm text-muted-foreground">
+                    {isTcp
+                        ? 'Define the gateway hosts and the TCP backend the proxy will connect to.'
+                        : 'Define how clients reach the gateway and where requests are forwarded.'}
+                </p>
             </div>
 
-            <div className="space-y-5">
-                {/* Context path / virtual hosts */}
-                <div className="space-y-4 rounded-xl border bg-muted/30 p-4">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <p className="text-sm font-medium">Gateway path</p>
-                            <p className="text-xs text-muted-foreground">The path clients use to reach this API on the gateway.</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground">Virtual hosts</span>
-                            <Switch
-                                checked={form.virtualHostsEnabled}
-                                onCheckedChange={enabled => update({ virtualHostsEnabled: enabled })}
-                                size="sm"
-                                aria-label="Enable virtual hosts"
-                            />
-                        </div>
-                    </div>
-
-                    {form.virtualHostsEnabled ? (
-                        <div className="space-y-3">
-                            {form.virtualHosts.map((vh, index) => (
-                                <div key={vh.id} className="grid grid-cols-2 gap-3 items-end">
-                                    <div className="space-y-1.5">
-                                        <Label htmlFor={`vh-host-${index}`} className="text-xs">
-                                            Host
-                                        </Label>
-                                        <Input
-                                            id={`vh-host-${index}`}
-                                            placeholder="e.g. api.example.com"
-                                            value={vh.host}
-                                            onChange={e => updateVirtualHost(index, { host: e.target.value })}
-                                        />
-                                    </div>
-                                    <div className="flex items-end gap-2">
-                                        <div className="flex-1 space-y-1.5">
-                                            <Label htmlFor={`vh-path-${index}`} className="text-xs">
-                                                Path
-                                            </Label>
-                                            <Input
-                                                id={`vh-path-${index}`}
-                                                placeholder="/"
-                                                value={vh.path}
-                                                onChange={e => updateVirtualHost(index, { path: e.target.value })}
-                                            />
-                                        </div>
-                                        {form.virtualHosts.length > 1 && (
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() => dispatch({ type: 'REMOVE_VIRTUAL_HOST', index })}
-                                                aria-label="Remove virtual host"
-                                                className="shrink-0"
-                                            >
-                                                <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
-                                            </Button>
-                                        )}
-                                    </div>
-                                </div>
-                            ))}
-                            {errors['virtualHosts'] && <p className="text-xs text-destructive">{errors['virtualHosts']}</p>}
-                            <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'ADD_VIRTUAL_HOST' })} className="w-full">
-                                <PlusIcon className="size-4" aria-hidden />
-                                Add virtual host
-                            </Button>
-                        </div>
-                    ) : (
-                        <div className="space-y-2">
-                            <Label htmlFor="context-path">
-                                Context path <span className="text-destructive">*</span>
-                            </Label>
-                            <div
-                                className="flex items-stretch rounded-md border overflow-hidden"
-                                style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
-                            >
-                                <span
-                                    className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
-                                    aria-hidden
-                                >
-                                    {gatewayPrefix}
-                                </span>
-                                <Input
-                                    id="context-path"
-                                    placeholder="/my-api"
-                                    value={form.contextPath}
-                                    onChange={e => update({ contextPath: e.target.value })}
-                                    aria-invalid={Boolean(errors['contextPath'])}
-                                    style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
-                                />
-                            </div>
-                            {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
-                            <p className="text-xs text-muted-foreground">Path prefix clients will use to access this API.</p>
-                        </div>
-                    )}
-                </div>
-
-                {/* Target URL */}
-                <div className="space-y-2">
-                    <Label htmlFor="target-url">
-                        Target URL <span className="text-destructive">*</span>
-                    </Label>
-                    <div className="relative">
-                        <ServerIcon
-                            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
-                            aria-hidden
-                        />
-                        <Input
-                            id="target-url"
-                            placeholder="https://api.internal.example.com"
-                            value={form.targetUrl}
-                            onChange={e => update({ targetUrl: e.target.value })}
-                            aria-invalid={Boolean(errors['targetUrl'])}
-                            style={{ paddingLeft: '2.5rem' }}
-                        />
-                    </div>
-                    {errors['targetUrl'] && <p className="text-xs text-destructive">{errors['targetUrl']}</p>}
-                    <p className="text-xs text-muted-foreground">The upstream backend the gateway will forward requests to.</p>
-                </div>
-            </div>
+            <div className="space-y-5">{isTcp ? <TcpEntrypointsFields /> : <HttpEntrypointsFields />}</div>
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
@@ -21,7 +21,8 @@ import { useState } from 'react';
 import { SecurityPlanFields } from './SecurityPlanFields';
 import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useApiCreation } from '../../store/apiCreationStore';
-import { buildPlanName, buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
+import { buildPlanName, buildPreviewGatewayUrl, buildPreviewUpstream } from '../../utils/apiProxyMapper';
+import { isTcpForm } from '../../utils/protocol';
 import { AUTH_LABEL } from '../../utils/securityFormatters';
 import { ReviewRow } from '../ReviewRow';
 
@@ -70,7 +71,9 @@ export function ReviewDeployStep() {
 
     const gatewayPrefix = useGatewayPrefix();
     const gatewayUrl = buildPreviewGatewayUrl(form, gatewayPrefix);
+    const upstream = buildPreviewUpstream(form);
     const planName = buildPlanName(form);
+    const isTcp = isTcpForm(form);
 
     // template: step 0 = Essentials (covers details + proxy + security)
     // scratch: step 0 = Details, step 1 = Entrypoints, step 2 = Security
@@ -94,9 +97,16 @@ export function ReviewDeployStep() {
                     {form.apiDescription && <ReviewRow label="Description" value={form.apiDescription} />}
                     <ReviewRow label="Protocol">
                         <Badge variant="secondary" className="text-xs">
-                            REST
+                            {isTcp ? 'TCP' : 'REST'}
                         </Badge>
                     </ReviewRow>
+                    {isTcp && (
+                        <ReviewRow label="Type">
+                            <Badge variant="secondary" className="text-xs">
+                                TCP Proxy
+                            </Badge>
+                        </ReviewRow>
+                    )}
                 </div>
 
                 {/* Proxy Configuration */}
@@ -105,7 +115,7 @@ export function ReviewDeployStep() {
                     <div className="flex items-start justify-between gap-4 px-4 py-2.5 border-b">
                         <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1.5">
                             <GlobeIcon className="size-3" aria-hidden />
-                            Gateway path
+                            {isTcp ? 'Gateway host' : 'Gateway path'}
                         </span>
                         <span
                             className="text-xs font-medium font-mono text-right"
@@ -123,7 +133,7 @@ export function ReviewDeployStep() {
                             className="text-xs font-medium font-mono text-right"
                             style={{ maxWidth: '60%', wordBreak: 'break-word', overflowWrap: 'break-word' }}
                         >
-                            {form.targetUrl || <span className="text-muted-foreground font-sans italic">Not set</span>}
+                            {upstream || <span className="text-muted-foreground font-sans italic">Not set</span>}
                         </span>
                     </div>
                 </div>
@@ -135,7 +145,7 @@ export function ReviewDeployStep() {
                         icon={<ShieldIcon className="size-3.5 text-primary" aria-hidden />}
                         onEdit={securityStep !== null ? () => goToStep(securityStep) : undefined}
                         trailing={
-                            isTemplate ? (
+                            isTemplate && !isTcp ? (
                                 <Button
                                     variant="ghost"
                                     size="sm"
@@ -159,7 +169,7 @@ export function ReviewDeployStep() {
                     </div>
                     <ReviewRow label="Plan name" value={planName} />
 
-                    {isTemplate && customizeSecurity && (
+                    {isTemplate && !isTcp && customizeSecurity && (
                         <div className="px-4 pb-4 pt-3 border-t">
                             <SecurityPlanFields showAuthSelector={true} />
                         </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityStep.tsx
@@ -14,16 +14,25 @@
  * limitations under the License.
  */
 import { SecurityPlanFields } from './SecurityPlanFields';
+import { useApiCreation } from '../../store/apiCreationStore';
+import { isTcpForm } from '../../utils/protocol';
 
 export function SecurityStep() {
+    const { state } = useApiCreation();
+    const isTcp = isTcpForm(state.form);
+
     return (
         <div className="space-y-6">
             <div className="space-y-1">
                 <h2 className="text-base font-semibold">Security & Plans</h2>
-                <p className="text-sm text-muted-foreground">Choose how consumers authenticate and configure the access plan.</p>
+                <p className="text-sm text-muted-foreground">
+                    {isTcp
+                        ? 'TCP proxies only support a Keyless plan. Consumers connect without HTTP authentication.'
+                        : 'Choose how consumers authenticate and configure the access plan.'}
+                </p>
             </div>
 
-            <SecurityPlanFields showAuthSelector />
+            <SecurityPlanFields showAuthSelector={!isTcp} />
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
@@ -17,7 +17,7 @@ import { cn } from '@gravitee/graphene-core';
 
 import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useApiCreation } from '../../store/apiCreationStore';
-import { buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
+import { buildPreviewGatewayUrl, buildPreviewUpstream } from '../../utils/apiProxyMapper';
 import { AUTH_LABEL } from '../../utils/securityFormatters';
 
 type NodeState = 'active' | 'muted' | 'complete';
@@ -126,7 +126,7 @@ export function ProxyFlowVisualization({ mode }: ProxyFlowVisualizationProps) {
 
     // Strip protocol prefix — URL is already clear from context
     const gatewayDisplay = buildPreviewGatewayUrl(form, gatewayPrefix).replace(/^https?:\/\//, '');
-    const upstreamDisplay = form.targetUrl.trim() || 'upstream:port';
+    const upstreamDisplay = buildPreviewUpstream(form);
     const securityLabel = AUTH_LABEL[form.authType];
     const caption = stepCaption(mode, step);
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
@@ -19,7 +19,7 @@ import { useParams } from 'react-router-dom';
 
 import { useApiDetailContext } from '../context/ApiDetailContext';
 import { getExposedEntrypoints, updateApiListeners } from '../services/entrypoints';
-import type { HttpListener } from '../types';
+import type { HttpListener, TcpListener } from '../types';
 import { apiDetailKeys, apiEntrypointKeys } from '../utils/queryKeys';
 
 export function useApiEntrypoints(showConfig: boolean) {
@@ -35,7 +35,7 @@ export function useApiEntrypoints(showConfig: boolean) {
     });
 
     const saveMutation = useMutation({
-        mutationFn: (listeners: HttpListener[]) => updateApiListeners(env!.id, apiId!, api!, listeners),
+        mutationFn: (listeners: (HttpListener | TcpListener)[]) => updateApiListeners(env!.id, apiId!, api!, listeners),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
             void queryClient.invalidateQueries({ queryKey: apiEntrypointKeys.exposed(env?.id ?? '', apiId ?? '') });

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useDebouncedUniquenessCheck.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useDebouncedUniquenessCheck.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useEffect, useRef } from 'react';
+
+import { useApiCreation } from '../store/apiCreationStore';
+
+const DEBOUNCE_MS = 500;
+
+interface VerificationResult {
+    ok: boolean;
+    reason?: string;
+}
+
+interface UseDebouncedUniquenessCheckOptions {
+    /** Effect dependency key — a string that changes whenever the value being checked changes. */
+    depsKey: string;
+    /** Skip verification entirely (e.g. local validation hasn't passed yet, or this field doesn't apply to the current mode/protocol). */
+    skip: boolean;
+    /** `validationErrors` key this check reports against. */
+    field: string;
+    /** Shown when the API rejects the value without a `reason`. */
+    fallbackMessage: string;
+    /** Dispatched once verification succeeds — use it to clear any stale error for `field` (e.g. `UPDATE_FORM` with the field's own current value). */
+    onVerified: () => void;
+    /** Performs the actual network call once the debounce delay has elapsed. */
+    verify: (environmentId: string) => Promise<VerificationResult>;
+}
+
+/**
+ * Shared skeleton behind the wizard's async "is this host/path already taken" checks
+ * (`useVerifyContextPath`, `useVerifyTcpHosts`): debounce, call `verify`, and write the
+ * result into store validation errors — extracted so the two near-identical hooks don't
+ * each carry their own copy of the debounce/dispatch bookkeeping.
+ */
+export function useDebouncedUniquenessCheck({
+    depsKey,
+    skip,
+    field,
+    fallbackMessage,
+    onVerified,
+    verify,
+}: UseDebouncedUniquenessCheckOptions) {
+    const { dispatch } = useApiCreation();
+    const env = useEnvironment();
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+
+        dispatch({ type: 'SET_PATH_VERIFYING', value: false });
+
+        if (!env || skip) return;
+
+        dispatch({ type: 'SET_PATH_VERIFYING', value: true });
+
+        timerRef.current = setTimeout(async () => {
+            try {
+                const result = await verify(env.id);
+                if (!result.ok) {
+                    dispatch({ type: 'SET_FIELD_ERROR', field, message: result.reason ?? fallbackMessage });
+                } else {
+                    onVerified();
+                }
+            } catch {
+                // Network/server error: don't block the user — backend enforces on submit.
+            } finally {
+                dispatch({ type: 'SET_PATH_VERIFYING', value: false });
+            }
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [depsKey, skip, env?.id]);
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.ts
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { useEffect, useRef } from 'react';
-
+import { useDebouncedUniquenessCheck } from './useDebouncedUniquenessCheck';
 import { verifyContextPath } from '../services/apiProxy';
 import { useApiCreation } from '../store/apiCreationStore';
 import { validateContextPath } from '../utils/apiCreationValidation';
-
-const DEBOUNCE_MS = 500;
 
 /**
  * Watches `form.contextPath` and, when virtual hosts are disabled, fires a
@@ -29,43 +25,14 @@ const DEBOUNCE_MS = 500;
  */
 export function useVerifyContextPath() {
     const { state, dispatch } = useApiCreation();
-    const env = useEnvironment();
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const { contextPath, virtualHostsEnabled } = state.form;
 
-    const contextPath = state.form.contextPath;
-    const virtualHostsEnabled = state.form.virtualHostsEnabled;
-
-    useEffect(() => {
-        if (timerRef.current) clearTimeout(timerRef.current);
-
-        dispatch({ type: 'SET_PATH_VERIFYING', value: false });
-
-        if (!env || virtualHostsEnabled || validateContextPath(contextPath) !== null) return;
-
-        dispatch({ type: 'SET_PATH_VERIFYING', value: true });
-
-        timerRef.current = setTimeout(async () => {
-            try {
-                const result = await verifyContextPath(env.id, [{ path: contextPath }]);
-                if (!result.ok) {
-                    dispatch({
-                        type: 'SET_FIELD_ERROR',
-                        field: 'contextPath',
-                        message: result.reason ?? 'This context path is already in use by another API.',
-                    });
-                } else {
-                    dispatch({ type: 'UPDATE_FORM', patch: { contextPath } });
-                }
-            } catch {
-                // Network/server error: don't block the user — backend enforces on submit.
-            } finally {
-                dispatch({ type: 'SET_PATH_VERIFYING', value: false });
-            }
-        }, DEBOUNCE_MS);
-
-        return () => {
-            if (timerRef.current) clearTimeout(timerRef.current);
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [contextPath, virtualHostsEnabled, env?.id]);
+    useDebouncedUniquenessCheck({
+        depsKey: contextPath,
+        skip: virtualHostsEnabled || validateContextPath(contextPath) !== null,
+        field: 'contextPath',
+        fallbackMessage: 'This context path is already in use by another API.',
+        onVerified: () => dispatch({ type: 'UPDATE_FORM', patch: { contextPath } }),
+        verify: environmentId => verifyContextPath(environmentId, [{ path: contextPath }]),
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyTcpHosts.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyTcpHosts.spec.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useVerifyTcpHosts } from './useVerifyTcpHosts';
+import { verifyApiHosts } from '../services/apiProxy';
+import { ApiCreationProvider, useApiCreation } from '../store/apiCreationStore';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    ...jest.requireActual<object>('@gravitee/gamma-modules-sdk'),
+    useEnvironment: jest.fn(),
+}));
+jest.mock('../services/apiProxy', () => ({ verifyApiHosts: jest.fn() }));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockVerifyApiHosts = jest.mocked(verifyApiHosts);
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <ApiCreationProvider>{children}</ApiCreationProvider>;
+}
+
+// Composite hook so we can drive the store and read its state in one renderHook call.
+function useHook() {
+    useVerifyTcpHosts();
+    return useApiCreation();
+}
+
+describe('useVerifyTcpHosts', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockUseEnvironment.mockReturnValue({ id: 'env-1', hrids: ['env-1'] });
+        mockVerifyApiHosts.mockResolvedValue({ ok: true });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it('does not call the API when protocol is HTTP', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyApiHosts).not.toHaveBeenCalled();
+    });
+
+    it('does not call the API when a host fails local validation', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'not a host!' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyApiHosts).not.toHaveBeenCalled();
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('calls the API with every host after the debounce delay once protocol is TCP', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 1, patch: { host: 'tcp2.example.com' } });
+        });
+
+        expect(mockVerifyApiHosts).not.toHaveBeenCalled();
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyApiHosts).toHaveBeenCalledTimes(1);
+        expect(mockVerifyApiHosts).toHaveBeenCalledWith('env-1', 'TCP', ['tcp.example.com', 'tcp2.example.com']);
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('still verifies once a first host is filled in, ignoring a blank row added via "Add host"', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+            // Row added but left blank — should not block validation or be sent to the API.
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyApiHosts).toHaveBeenCalledTimes(1);
+        expect(mockVerifyApiHosts).toHaveBeenCalledWith('env-1', 'TCP', ['tcp.example.com']);
+    });
+
+    it('sets a tcpHosts error when the API reports a host is already taken', async () => {
+        mockVerifyApiHosts.mockResolvedValue({ ok: false, reason: 'Host already in use.' });
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'taken.example.com' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.validationErrors['tcpHosts']).toBe('Host already in use.');
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('clears a stale tcpHosts error when verification later succeeds', async () => {
+        mockVerifyApiHosts.mockResolvedValueOnce({ ok: false, reason: 'Host already in use.' }).mockResolvedValueOnce({ ok: true });
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'taken.example.com' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        expect(result.current.state.validationErrors['tcpHosts']).toBe('Host already in use.');
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'free.example.com' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpHosts');
+    });
+
+    it('does not set an error and resets isPathVerifying on network failure', async () => {
+        mockVerifyApiHosts.mockRejectedValue(new Error('network error'));
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.isPathVerifying).toBe(false);
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpHosts');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyTcpHosts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyTcpHosts.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useDebouncedUniquenessCheck } from './useDebouncedUniquenessCheck';
+import { verifyApiHosts } from '../services/apiProxy';
+import { useApiCreation } from '../store/apiCreationStore';
+import { validateTcpHosts } from '../utils/apiCreationValidation';
+import { isTcpForm } from '../utils/protocol';
+
+/**
+ * Watches `form.tcpHosts` and, while protocol is TCP, fires a debounced uniqueness
+ * check against the gateway (matching legacy console webui's hostAsyncValidator).
+ * Writes the result directly into store validation errors.
+ */
+export function useVerifyTcpHosts() {
+    const { state, dispatch } = useApiCreation();
+    const { tcpHosts } = state.form;
+
+    useDebouncedUniquenessCheck({
+        depsKey: tcpHosts.map(h => h.host).join(','),
+        skip: !isTcpForm(state.form) || validateTcpHosts(tcpHosts) !== null,
+        field: 'tcpHosts',
+        fallbackMessage: 'One of these hosts is already in use by another API.',
+        onVerified: () => dispatch({ type: 'UPDATE_FORM', patch: { tcpHosts } }),
+        verify: environmentId => verifyApiHosts(environmentId, 'TCP', tcpHosts.map(h => h.host.trim()).filter(Boolean)),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiGate.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiGate.spec.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { CreateApiGate } from './CreateApiGate';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+
+function renderGate() {
+    return render(
+        <MemoryRouter initialEntries={['/apis/new/scratch']}>
+            <Routes>
+                <Route path="/apis/new" element={<CreateApiGate />}>
+                    <Route path="scratch" element={<div>Scratch wizard</div>} />
+                </Route>
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('CreateApiGate', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('checks the environment-api-c permission and renders the outlet when granted', () => {
+        mockUseHasPermission.mockReturnValue(true);
+        renderGate();
+
+        expect(mockUseHasPermission).toHaveBeenCalledWith(expect.objectContaining({ anyOf: ['environment-api-c'] }));
+        expect(screen.getByText('Scratch wizard')).toBeInTheDocument();
+    });
+
+    it('renders the fallback instead of the outlet when the permission is denied', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderGate();
+
+        expect(screen.getByText(/don.t have permission to create apis/i)).toBeInTheDocument();
+        expect(screen.queryByText('Scratch wizard')).not.toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiGate.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiGate.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { Outlet } from 'react-router-dom';
+
+function CreateApiForbidden() {
+    return (
+        <div className="flex items-center justify-center p-12">
+            <Card className="max-w-md">
+                <CardContent className="p-6 text-center space-y-2">
+                    <p className="text-sm font-medium">You don&apos;t have permission to create APIs</p>
+                    <p className="text-sm text-muted-foreground">Ask an administrator for the Create API permission on this environment.</p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+/**
+ * Route guard for `apis/new/*` — mirrors the `environment-api-c` check already used to gate
+ * the Create button on {@link ApisPage}. Uses `useHasPermission`, the same idiom every other
+ * permission check in this module uses, rather than the route-level `PermissionGate` component.
+ */
+export function CreateApiGate() {
+    const canCreate = useHasPermission({ anyOf: ['environment-api-c'] });
+
+    if (!canCreate) {
+        return <CreateApiForbidden />;
+    }
+
+    return <Outlet />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiProxyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/CreateApiProxyPage.tsx
@@ -261,8 +261,8 @@ export function CreateApiProxyPage() {
                         <div className="min-w-0 flex-1 space-y-1">
                             <p className="text-base font-semibold text-foreground">Start from scratch</p>
                             <p className="text-sm text-muted-foreground leading-relaxed">
-                                Full four-step wizard: details, entrypoints, security, and review. No preset plans — you choose everything
-                                explicitly.
+                                Full four-step wizard for an HTTP or TCP proxy: details, entrypoints, security, and review. No preset plans
+                                — you choose everything explicitly.
                             </p>
                         </div>
                         <ArrowRightIcon

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/ApiDetailOverviewPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/ApiDetailOverviewPage.tsx
@@ -20,6 +20,7 @@ import { ApiOverviewGatewayCards } from './overview/ApiOverviewGatewayCards';
 import { ApiOverviewTrafficCards } from './overview/ApiOverviewTrafficCards';
 import { useApiDetailContext } from '../../context/ApiDetailContext';
 import { useApiOverviewData } from '../../hooks/useApiOverviewData';
+import { formatEndpointTarget } from '../../utils/apiHttpProxy';
 
 export function ApiDetailOverviewPage() {
     const { apiId } = useParams<{ apiId: string }>();
@@ -37,7 +38,7 @@ export function ApiDetailOverviewPage() {
     } = useApiOverviewData(apiId);
 
     const gatewayUrl = exposedEntrypoints?.[0]?.value;
-    const upstreamUrl = api?.endpointGroups?.[0]?.endpoints?.[0]?.configuration?.target;
+    const upstreamUrl = formatEndpointTarget(api?.endpointGroups?.[0]?.endpoints?.[0]?.configuration?.target);
 
     return (
         <div className="space-y-6">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/ApiEndpointsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/ApiEndpointsPage.spec.tsx
@@ -230,6 +230,25 @@ const API_TWO_GROUPS = { ...HTTP_PROXY_API_BASE, endpointGroups: [GROUP_1, GROUP
 const API_NO_GROUPS = { ...HTTP_PROXY_API_BASE, endpointGroups: [] };
 const API_TWO_ENDPOINTS = { ...HTTP_PROXY_API_BASE, endpointGroups: [GROUP_TWO_ENDPOINTS] };
 
+// ─── TCP stub data ────────────────────────────────────────────────────────────
+
+const TCP_ENDPOINT = {
+    name: 'default-tcp',
+    type: 'tcp-proxy',
+    weight: 1,
+    configuration: { target: { host: 'backend.example.com', port: 9090, secured: false } },
+};
+
+const TCP_GROUP: EndpointGroupDto = {
+    name: 'tcp-group',
+    type: 'tcp-proxy',
+    loadBalancer: { type: 'ROUND_ROBIN' },
+    endpoints: [TCP_ENDPOINT],
+};
+
+const TCP_API_BASE = { id: 'api-2', type: 'PROXY' as const, listeners: [{ type: 'TCP' as const, hosts: ['tcp.example.com'] }] };
+const API_TCP = { ...TCP_API_BASE, endpointGroups: [TCP_GROUP] };
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockMutate = jest.fn();
@@ -463,6 +482,61 @@ describe('ApiEndpointsPage', () => {
             renderPage();
             fireEvent.click(screen.getByRole('button', { name: 'Edit endpoint ep-a' }));
             expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Edit endpoint');
+        });
+    });
+
+    // ── TCP endpoints ──────────────────────────────────────────────────────────
+
+    describe('tcp-proxy endpoint editing', () => {
+        it('shows Host/Port/Secured fields instead of Target URL when editing a tcp-proxy endpoint', () => {
+            mockUseApiDetailContext.mockReturnValue({ api: API_TCP, isLoading: false });
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit endpoint default-tcp' }));
+
+            expect(screen.getByLabelText(/^host/i)).toHaveValue('backend.example.com');
+            expect(screen.getByPlaceholderText('5432')).toHaveValue('9090');
+            expect(screen.queryByLabelText(/^target url/i)).not.toBeInTheDocument();
+        });
+
+        it('does not show the Configuration or Health-check steps for a tcp-proxy endpoint', () => {
+            mockUseApiDetailContext.mockReturnValue({ api: API_TCP, isLoading: false });
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit endpoint default-tcp' }));
+
+            expect(screen.queryByRole('button', { name: /^next$/i })).not.toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /save endpoint/i })).toBeInTheDocument();
+        });
+
+        it('saves a tcp-proxy endpoint with a {host, port, secured} configuration.target object', () => {
+            mockUseApiDetailContext.mockReturnValue({ api: API_TCP, isLoading: false });
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit endpoint default-tcp' }));
+            fireEvent.change(screen.getByLabelText(/^host/i), { target: { value: 'new-backend.example.com' } });
+            fireEvent.change(screen.getByPlaceholderText('5432'), { target: { value: '5432' } });
+            fireEvent.click(screen.getByRole('button', { name: /save endpoint/i }));
+
+            const savedGroups: EndpointGroupDto[] = mockMutate.mock.calls[0][0];
+            const savedEndpoint = savedGroups[0].endpoints?.[0];
+            expect(savedEndpoint?.configuration?.target).toEqual({ host: 'new-backend.example.com', port: 5432, secured: false });
+        });
+
+        it('defaults a newly-added endpoint in an existing tcp-proxy group to type tcp-proxy', () => {
+            mockUseApiDetailContext.mockReturnValue({ api: API_TCP, isLoading: false });
+            renderPage();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Add endpoint' }));
+            fireEvent.change(screen.getByPlaceholderText('my-endpoint'), { target: { value: 'second-tcp' } });
+            fireEvent.change(screen.getByLabelText(/^host/i), { target: { value: 'db2.example.com' } });
+            fireEvent.change(screen.getByPlaceholderText('5432'), { target: { value: '5433' } });
+            fireEvent.click(screen.getByRole('button', { name: /add endpoint/i }));
+
+            const savedGroups: EndpointGroupDto[] = mockMutate.mock.calls[0][0];
+            const newEndpoint = savedGroups[0].endpoints?.find(e => e.name === 'second-tcp');
+            expect(newEndpoint?.type).toBe('tcp-proxy');
+            expect(newEndpoint?.configuration?.target).toEqual({ host: 'db2.example.com', port: 5433, secured: false });
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/ApiEndpointsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/ApiEndpointsPage.tsx
@@ -29,8 +29,8 @@ import { buildDefaultEndpointForGroup, DEFAULT_GROUP_FORM, DEFAULT_SHARED_CONFIG
 import { notify } from '../../../../../shared/notify';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import { updateApiEndpointGroups } from '../../../services/apis';
-import type { EndpointGroupDto, EndpointGroupSharedConfiguration } from '../../../types';
-import { isHttpProxyApi } from '../../../utils/apiHttpProxy';
+import type { EndpointGroupDto, EndpointGroupSharedConfiguration, TcpTarget } from '../../../types';
+import { formatEndpointTarget, isHttpProxyApi } from '../../../utils/apiHttpProxy';
 import { serializeSharedConfiguration, serializeSharedConfigurationOverride } from '../../../utils/endpointSharedConfiguration';
 import {
     buildEndpointHealthCheckService,
@@ -42,6 +42,16 @@ import { apiDetailKeys } from '../../../utils/queryKeys';
 
 // ─── DTO ↔ form conversion ────────────────────────────────────────────────────
 
+/** tcp-proxy's `configuration.target` is `{host, port, secured}`; http-proxy's is a plain URL string. */
+function extractTcpTargetFields(target: string | TcpTarget | undefined): {
+    tcpTargetHost: string;
+    tcpTargetPort: string;
+    tcpTargetSecured: boolean;
+} {
+    if (!target || typeof target === 'string') return { tcpTargetHost: '', tcpTargetPort: '', tcpTargetSecured: false };
+    return { tcpTargetHost: target.host, tcpTargetPort: String(target.port), tcpTargetSecured: target.secured };
+}
+
 function dtoToFormState(group: EndpointGroupDto): EndpointGroupFormState {
     const groupHealth = group.services?.healthCheck;
     return {
@@ -52,7 +62,8 @@ function dtoToFormState(group: EndpointGroupDto): EndpointGroupFormState {
         endpoints: (group.endpoints ?? []).map(ep => ({
             _id: Math.random().toString(36).slice(2, 10),
             name: ep.name,
-            target: ep.configuration?.target ?? '',
+            target: formatEndpointTarget(ep.configuration?.target) ?? '',
+            ...extractTcpTargetFields(ep.configuration?.target),
             weight: ep.weight ?? 1,
             backup: ep.backup ?? false,
             inheritConfiguration: ep.inheritConfiguration ?? true,
@@ -119,7 +130,8 @@ function endpointDtoToFormState(groups: EndpointGroupDto[], groupIdx: number, ep
     return {
         _id: Math.random().toString(36).slice(2, 10),
         name: ep.name,
-        target: ep.configuration?.target ?? '',
+        target: formatEndpointTarget(ep.configuration?.target) ?? '',
+        ...extractTcpTargetFields(ep.configuration?.target),
         weight: ep.weight ?? 1,
         backup: ep.backup ?? false,
         inheritConfiguration: ep.inheritConfiguration ?? true,
@@ -296,14 +308,18 @@ export function ApiEndpointsPage() {
             if (gIdx !== endpointGroupIndex) return g;
             const endpoints = [...(g.endpoints ?? [])];
             const orig = ep._originalDto;
+            const isTcpGroup = g.type === 'tcp-proxy';
+            const target: string | TcpTarget = isTcpGroup
+                ? { host: ep.tcpTargetHost.trim(), port: Number(ep.tcpTargetPort.trim()), secured: ep.tcpTargetSecured }
+                : ep.target;
             const newEp = {
                 ...(orig ?? {}),
                 name: ep.name.trim(),
-                type: orig?.type ?? 'http-proxy',
+                type: orig?.type ?? g.type ?? 'http-proxy',
                 weight: ep.weight,
                 backup: ep.backup || undefined,
                 inheritConfiguration: ep.inheritConfiguration,
-                configuration: { ...(orig?.configuration ?? {}), target: ep.target },
+                configuration: { ...(orig?.configuration ?? {}), target },
                 tenants: ep.tenants.length > 0 ? ep.tenants : undefined,
                 sharedConfigurationOverride: ep.inheritConfiguration ? {} : serializeSharedConfigurationOverride(ep._configOverride),
                 ...(httpProxyApi
@@ -458,6 +474,7 @@ export function ApiEndpointsPage() {
                             initial={endpointInitialForm}
                             existingNames={endpointExistingNames}
                             showHealthCheck={httpProxyApi}
+                            isTcp={endpointGroupIndex !== null && groups[endpointGroupIndex]?.type === 'tcp-proxy'}
                             groupHealthCheck={endpointGroupIndex !== null ? groupInitialForm.healthCheck : undefined}
                             isReadOnly={isReadOnly}
                             isSaving={mutation.isPending}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/EndpointGroupList.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/EndpointGroupList.spec.tsx
@@ -136,6 +136,45 @@ describe('EndpointGroupList', () => {
         });
     });
 
+    // ── TCP groups ────────────────────────────────────────────────────────────
+
+    describe('tcp-proxy groups', () => {
+        const TCP_EP = {
+            name: 'default-tcp',
+            type: 'tcp-proxy',
+            weight: 1,
+            configuration: { target: { host: 'backend.example.com', port: 9090, secured: false } },
+        };
+        const TCP_GROUP: EndpointGroupDto = {
+            name: 'tcp-group',
+            type: 'tcp-proxy',
+            loadBalancer: { type: 'ROUND_ROBIN' },
+            endpoints: [TCP_EP],
+        };
+
+        it('shows the "TCP proxy" type label', () => {
+            render(<EndpointGroupList {...makeProps({ groups: [TCP_GROUP] })} />);
+            expect(screen.getByText('TCP proxy')).toBeInTheDocument();
+        });
+
+        it('does not render a Target URL column or value for tcp-proxy groups', () => {
+            render(<EndpointGroupList {...makeProps({ groups: [TCP_GROUP] })} />);
+            expect(screen.queryByText('Target URL')).not.toBeInTheDocument();
+            expect(screen.queryByText('backend.example.com:9090')).not.toBeInTheDocument();
+        });
+
+        it('still renders the endpoint name and weight for tcp-proxy groups', () => {
+            render(<EndpointGroupList {...makeProps({ groups: [TCP_GROUP] })} />);
+            expect(screen.getByText('default-tcp')).toBeInTheDocument();
+            expect(screen.getByText('1')).toBeInTheDocument();
+        });
+
+        it('still renders the Target URL column for http-proxy groups alongside a tcp-proxy group', () => {
+            render(<EndpointGroupList {...makeProps({ groups: [GROUP_1, TCP_GROUP] })} />);
+            expect(screen.getByText('Target URL')).toBeInTheDocument();
+        });
+    });
+
     // ── Read-only mode ────────────────────────────────────────────────────────
 
     describe('read-only mode', () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/EndpointGroupList.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/EndpointGroupList.tsx
@@ -33,6 +33,7 @@ import { ArrowDownIcon, ArrowUpIcon, PencilIcon, PlusIcon, Trash2Icon } from '@g
 import { useState } from 'react';
 
 import type { EndpointGroupDto } from '../../../types';
+import { formatEndpointTarget } from '../../../utils/apiHttpProxy';
 import { getEndpointHealthCheckBadge } from '../../../utils/healthCheckForm';
 
 const LB_LABELS: Record<string, string> = {
@@ -44,11 +45,16 @@ const LB_LABELS: Record<string, string> = {
 
 const TYPE_LABELS: Record<string, string> = {
     'http-proxy': 'HTTP Proxy',
+    'tcp-proxy': 'TCP proxy',
     grpc: 'gRPC',
     kafka: 'Kafka',
     mock: 'Mock',
     rabbitmq: 'RabbitMQ',
 };
+
+/** Classic console (`api-endpoint-groups-standard.adapter.ts`) has no "general info" formatter for tcp-proxy — no target column. */
+const GRID_WITH_TARGET = '56px 1fr 2fr 72px 56px';
+const GRID_WITHOUT_TARGET = '56px 1fr 72px 56px';
 
 function formatGroupType(type: string | undefined): string {
     if (!type) return 'Unknown';
@@ -113,6 +119,8 @@ export function EndpointGroupList({
                     const epCount = group.endpoints?.length ?? 0;
                     const canDeleteGroup = !isReadOnly && !isLastGroup;
                     const canDeleteEndpoint = !isReadOnly && epCount > 1;
+                    const showTarget = group.type !== 'tcp-proxy';
+                    const gridColumns = showTarget ? GRID_WITH_TARGET : GRID_WITHOUT_TARGET;
 
                     return (
                         <Card key={`${group.name}-${gIdx}`}>
@@ -185,13 +193,15 @@ export function EndpointGroupList({
                                         {/* Column headers */}
                                         <div
                                             className="grid items-center border-b bg-muted/40 px-3 py-2"
-                                            style={{ gridTemplateColumns: '56px 1fr 2fr 72px 56px', gap: '12px' }}
+                                            style={{ gridTemplateColumns: gridColumns, gap: '12px' }}
                                         >
                                             <span />
                                             <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Name</span>
-                                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                                                Target URL
-                                            </span>
+                                            {showTarget && (
+                                                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                                                    Target URL
+                                                </span>
+                                            )}
                                             <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                                                 Weight
                                             </span>
@@ -203,7 +213,7 @@ export function EndpointGroupList({
                                             <div
                                                 key={`${ep.name}-${eIdx}`}
                                                 className="grid items-center px-3 py-3 border-b last:border-0 hover:bg-muted/20 transition-colors"
-                                                style={{ gridTemplateColumns: '56px 1fr 2fr 72px 56px', gap: '12px' }}
+                                                style={{ gridTemplateColumns: gridColumns, gap: '12px' }}
                                             >
                                                 {/* Order buttons — left column */}
                                                 <div className="flex items-center gap-0.5 shrink-0">
@@ -261,9 +271,11 @@ export function EndpointGroupList({
                                                         );
                                                     })()}
                                                 </div>
-                                                <span className="text-xs text-muted-foreground truncate font-mono">
-                                                    {ep.configuration?.target ?? '—'}
-                                                </span>
+                                                {showTarget && (
+                                                    <span className="text-xs text-muted-foreground truncate font-mono">
+                                                        {formatEndpointTarget(ep.configuration?.target) ?? '—'}
+                                                    </span>
+                                                )}
                                                 <span className="text-sm text-muted-foreground">{ep.weight ?? 1}</span>
                                                 {/* Edit / delete — right column */}
                                                 <div className="flex items-center justify-end gap-0.5 shrink-0">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/endpoint-form/EndpointForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/endpoint-form/EndpointForm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { Button, Input, Label } from '@gravitee/graphene-core';
+import { Button, Input, Label, Switch } from '@gravitee/graphene-core';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 
@@ -22,6 +22,8 @@ import { TenantSelectInput } from './TenantSelectInput';
 import { WizardStepIndicator } from '../../../../components/WizardStepIndicator';
 import { getTenants } from '../../../../services/tenants';
 import type { Tenant } from '../../../../types';
+import { validateTcpPort } from '../../../../utils/apiCreationValidation';
+import { validateDuplicateHost } from '../../../../utils/duplicateDialogValidation';
 import { validateHttpProxyOptions } from '../../../../utils/endpointSharedConfiguration';
 import type { HealthCheckConfigFormState, HealthCheckFormState } from '../../../../utils/healthCheckForm';
 import { validateHealthCheckForm } from '../../../../utils/healthCheckForm';
@@ -46,10 +48,18 @@ interface GeneralStepProps {
     existingNames: string[];
     tenantsLoading: boolean;
     availableTenants: Tenant[];
+    isTcp?: boolean;
     onChange: <K extends keyof EndpointFormState>(key: K, value: EndpointFormState[K]) => void;
 }
 
-function EndpointGeneralStep({ form, existingNames, tenantsLoading, availableTenants, onChange }: Readonly<GeneralStepProps>) {
+function EndpointGeneralStep({
+    form,
+    existingNames,
+    tenantsLoading,
+    availableTenants,
+    isTcp = false,
+    onChange,
+}: Readonly<GeneralStepProps>) {
     const nameError = (() => {
         const base = validateEndpointName(form.name);
         if (base) return base;
@@ -63,6 +73,8 @@ function EndpointGeneralStep({ form, existingNames, tenantsLoading, availableTen
         : /\s/.test(form.target)
           ? 'Target URL must not contain whitespace.'
           : null;
+    const tcpHostError = validateDuplicateHost(form.tcpTargetHost);
+    const tcpPortError = validateTcpPort(form.tcpTargetPort);
     const weightError = form.weight < 1 ? 'Weight must be at least 1.' : null;
 
     return (
@@ -76,18 +88,61 @@ function EndpointGeneralStep({ form, existingNames, tenantsLoading, availableTen
                 <p className="text-xs text-muted-foreground">Must be unique in this group. Colons are not allowed.</p>
             </div>
 
-            <div className="space-y-2">
-                <Label htmlFor="ep-target" className="text-sm">
-                    Target URL <span className="text-destructive">*</span>
-                </Label>
-                <Input
-                    id="ep-target"
-                    value={form.target}
-                    onChange={e => onChange('target', e.target.value)}
-                    placeholder="https://backend.example.com"
-                />
-                {targetError && <p className="text-xs text-destructive">{targetError}</p>}
-            </div>
+            {isTcp ? (
+                <>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="ep-tcp-host" className="text-sm">
+                                Host <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="ep-tcp-host"
+                                value={form.tcpTargetHost}
+                                onChange={e => onChange('tcpTargetHost', e.target.value)}
+                                placeholder="postgres.internal.example.com"
+                            />
+                            {tcpHostError && <p className="text-xs text-destructive">{tcpHostError}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="ep-tcp-port" className="text-sm">
+                                Port <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="ep-tcp-port"
+                                inputMode="numeric"
+                                value={form.tcpTargetPort}
+                                onChange={e => onChange('tcpTargetPort', e.target.value)}
+                                placeholder="5432"
+                            />
+                            {tcpPortError && <p className="text-xs text-destructive">{tcpPortError}</p>}
+                        </div>
+                    </div>
+                    <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                        <div>
+                            <p className="text-sm font-medium">Secured (TLS)</p>
+                            <p className="text-xs text-muted-foreground">Connect to the backend over TLS.</p>
+                        </div>
+                        <Switch
+                            checked={form.tcpTargetSecured}
+                            onCheckedChange={v => onChange('tcpTargetSecured', v)}
+                            aria-label="Enable TLS to the backend"
+                        />
+                    </div>
+                </>
+            ) : (
+                <div className="space-y-2">
+                    <Label htmlFor="ep-target" className="text-sm">
+                        Target URL <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                        id="ep-target"
+                        value={form.target}
+                        onChange={e => onChange('target', e.target.value)}
+                        placeholder="https://backend.example.com"
+                    />
+                    {targetError && <p className="text-xs text-destructive">{targetError}</p>}
+                </div>
+            )}
 
             <div className="space-y-2">
                 <Label htmlFor="ep-weight" className="text-sm">
@@ -126,6 +181,8 @@ interface EndpointFormProps {
     initial?: EndpointFormState;
     existingNames: string[];
     showHealthCheck?: boolean;
+    /** tcp-proxy endpoints have no shared-configuration or health-check step — just General (host/port/secured). */
+    isTcp?: boolean;
     groupHealthCheck?: HealthCheckFormState;
     isReadOnly?: boolean;
     isSaving?: boolean;
@@ -138,6 +195,7 @@ export function EndpointForm({
     initial,
     existingNames,
     showHealthCheck = false,
+    isTcp = false,
     groupHealthCheck,
     isReadOnly = false,
     isSaving = false,
@@ -145,7 +203,10 @@ export function EndpointForm({
     onCancel,
 }: Readonly<EndpointFormProps>) {
     const env = useEnvironment();
-    const steps = useMemo(() => (showHealthCheck ? [...BASE_STEPS, HEALTH_CHECK_STEP] : [...BASE_STEPS]), [showHealthCheck]);
+    const steps = useMemo(
+        () => (isTcp ? [BASE_STEPS[0]] : showHealthCheck ? [...BASE_STEPS, HEALTH_CHECK_STEP] : [...BASE_STEPS]),
+        [isTcp, showHealthCheck],
+    );
 
     const [currentStep, setCurrentStep] = useState<StepId>('general');
     const [form, setForm] = useState<EndpointFormState>(initial ?? newEndpointRow(groupHealthCheck));
@@ -201,8 +262,13 @@ export function EndpointForm({
         return null;
     })();
 
-    const generalValid = !nameError && form.target.trim().length > 0 && !/\s/.test(form.target) && form.weight >= 1;
-    const configurationValid = form.inheritConfiguration || validateHttpProxyOptions(configOverride.proxy) === null;
+    const generalValid = isTcp
+        ? !nameError &&
+          validateDuplicateHost(form.tcpTargetHost) === null &&
+          validateTcpPort(form.tcpTargetPort) === null &&
+          form.weight >= 1
+        : !nameError && form.target.trim().length > 0 && !/\s/.test(form.target) && form.weight >= 1;
+    const configurationValid = isTcp || form.inheritConfiguration || validateHttpProxyOptions(configOverride.proxy) === null;
     const healthCheckValid = !showHealthCheck || Object.keys(validateHealthCheckForm(form.healthCheck)).length === 0;
 
     const currentStepIndex = steps.findIndex(s => s.id === currentStep);
@@ -270,6 +336,7 @@ export function EndpointForm({
                         existingNames={existingNames}
                         tenantsLoading={tenantsLoading}
                         availableTenants={availableTenants}
+                        isTcp={isTcp}
                         onChange={setField}
                     />
                 )}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/endpoints/types.ts
@@ -23,7 +23,12 @@ export interface EndpointFormState {
     /** Local row id for React key management — not sent to backend. */
     _id: string;
     name: string;
+    /** http-proxy (and other string-target types) upstream URL. Unused for tcp-proxy. */
     target: string;
+    /** tcp-proxy target host/port/secured — unused for http-proxy. */
+    tcpTargetHost: string;
+    tcpTargetPort: string;
+    tcpTargetSecured: boolean;
     weight: number;
     backup: boolean;
     inheritConfiguration: boolean;
@@ -213,6 +218,9 @@ export function newEndpointRow(groupHealthCheck?: HealthCheckFormState): Endpoin
         _id: Math.random().toString(36).slice(2, 10),
         name: '',
         target: '',
+        tcpTargetHost: '',
+        tcpTargetPort: '',
+        tcpTargetSecured: false,
         weight: 1,
         backup: false,
         inheritConfiguration: true,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.spec.tsx
@@ -193,6 +193,18 @@ const API_WITH_VIRTUAL_HOSTS = {
     ],
 };
 
+const API_TCP = {
+    id: 'api-2',
+    name: 'TCP API',
+    listeners: [
+        {
+            type: 'TCP' as const,
+            hosts: ['tcp.example.com'],
+            entrypoints: [{ type: 'tcp-proxy' }],
+        },
+    ],
+};
+
 function makeClient() {
     return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
 }
@@ -331,6 +343,52 @@ describe('ApiEntrypointsPage', () => {
         fireEvent.click(screen.getByRole('button', { name: /switch/i }));
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         expect(screen.getByText(/entrypoint context-paths/i)).toBeInTheDocument();
+    });
+
+    // ── TCP entrypoints ────────────────────────────────────────────────────────
+
+    describe('tcp-proxy entrypoints', () => {
+        beforeEach(() => {
+            mockUseApiDetailContext.mockReturnValue({ api: API_TCP, isLoading: false, permissionsReady: true });
+            mockUpdateApiListeners.mockResolvedValue(API_TCP);
+        });
+
+        it('shows the TCP hosts card instead of context paths / virtual hosts', () => {
+            renderPage('api-2');
+            expect(screen.getByText(/entrypoint hosts/i)).toBeInTheDocument();
+            expect(screen.queryByText(/entrypoint context-paths/i)).not.toBeInTheDocument();
+            expect(screen.queryByText(/why configure entrypoints/i)).not.toBeInTheDocument();
+        });
+
+        it('seeds the host input from the existing TCP listener', () => {
+            renderPage('api-2');
+            expect(screen.getByRole('textbox', { name: /^host$/i })).toHaveValue('tcp.example.com');
+        });
+
+        it('adds a new empty host row when "Add host" is clicked', () => {
+            renderPage('api-2');
+            fireEvent.click(screen.getByRole('button', { name: /add host/i }));
+            expect(screen.getAllByRole('textbox', { name: /^host$/i })).toHaveLength(2);
+        });
+
+        it('disables the delete button when only one host remains', () => {
+            renderPage('api-2');
+            expect(screen.getByRole('button', { name: /delete host/i })).toBeDisabled();
+        });
+
+        it('saves an updated TCP listener with the edited hosts on Save', async () => {
+            renderPage('api-2');
+
+            fireEvent.change(screen.getByRole('textbox', { name: /^host$/i }), { target: { value: 'new-tcp.example.com' } });
+            fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+            await waitFor(() => expect(mockUpdateApiListeners).toHaveBeenCalledTimes(1));
+
+            const [, , , listeners] = mockUpdateApiListeners.mock.calls[0];
+            expect(listeners).toEqual([
+                expect.objectContaining({ type: 'TCP', hosts: ['new-tcp.example.com'], entrypoints: [{ type: 'tcp-proxy' }] }),
+            ]);
+        });
     });
 
     // ── permission guard tests ──────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
@@ -22,12 +22,16 @@ import { ContextPathsCard } from './ContextPathsCard';
 import { EntrypointsLanding } from './EntrypointsLanding';
 import { ExposedEntrypointsCard } from './ExposedEntrypointsCard';
 import { SwitchModeDialog } from './SwitchModeDialog';
+import { TcpHostsCard } from './TcpHostsCard';
 import type { ContextPathRow, VirtualHostRow } from './types';
 import { validatePath } from './types';
 import { VirtualHostsCard } from './VirtualHostsCard';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import { useApiEntrypoints } from '../../../hooks/useApiEntrypoints';
-import type { ApiDetailDto, HttpListener } from '../../../types';
+import type { ApiDetailDto, HttpListener, TcpListener } from '../../../types';
+import type { TcpHostEntry } from '../../../types/apiCreation';
+import { validateTcpHosts } from '../../../utils/apiCreationValidation';
+import { hasTcpListeners } from '../../../utils/apiHttpProxy';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -36,7 +40,11 @@ function newId(): string {
 }
 
 function getHttpListener(api: ApiDetailDto | null): HttpListener | undefined {
-    return api?.listeners?.find(l => l.type === 'HTTP');
+    return api?.listeners?.find(l => l.type === 'HTTP') as HttpListener | undefined;
+}
+
+function getTcpListener(api: ApiDetailDto | null): TcpListener | undefined {
+    return api?.listeners?.find(l => l.type === 'TCP') as TcpListener | undefined;
 }
 
 function isVirtualHostMode(listener: HttpListener | undefined): boolean {
@@ -56,6 +64,7 @@ function hasDuplicates(rows: ContextPathRow[]): boolean {
 
 export function ApiEntrypointsPage() {
     const { api, isLoading: apiLoading, permissionsReady } = useApiDetailContext();
+    const isTcp = hasTcpListeners(api);
 
     // ── permission guard (mirrors legacy api-entrypoints.component.ts) ──
     // Requires both api-definition-u AND api-gateway_definition-u.
@@ -69,15 +78,26 @@ export function ApiEntrypointsPage() {
     const [virtualHostMode, setVirtualHostMode] = useState(false);
     const [contextPaths, setContextPaths] = useState<ContextPathRow[]>([{ id: newId(), path: '/' }]);
     const [virtualHosts, setVirtualHosts] = useState<VirtualHostRow[]>([{ id: newId(), host: '', path: '/', overrideAccess: false }]);
+    const [tcpHosts, setTcpHosts] = useState<TcpHostEntry[]>([{ id: newId(), host: '' }]);
     const [isDirty, setIsDirty] = useState(false);
     const [switchModeDialogOpen, setSwitchModeDialogOpen] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
 
-    const { exposedQuery, saveMutation } = useApiEntrypoints(showConfig);
+    const { exposedQuery, saveMutation } = useApiEntrypoints(showConfig && !isTcp);
 
     const initFromApi = useCallback(
         (apiData: ApiDetailDto | null) => {
             if (!apiData) return;
+
+            if (hasTcpListeners(apiData)) {
+                const tcpListener = getTcpListener(apiData);
+                const hosts = tcpListener?.hosts ?? [];
+                setTcpHosts(hosts.length > 0 ? hosts.map(host => ({ id: newId(), host })) : [{ id: newId(), host: '' }]);
+                setIsDirty(false);
+                setSaveError(null);
+                return;
+            }
+
             const listener = getHttpListener(apiData);
 
             if (isVirtualHostMode(listener)) {
@@ -120,7 +140,8 @@ export function ApiEntrypointsPage() {
 
     const isContextPathValid = contextPathErrors.every(e => e === null) && !contextPathHasDupes;
     const isVirtualHostValid = virtualHostErrors.every(e => e === null);
-    const isFormValid = virtualHostMode ? isVirtualHostValid : isContextPathValid;
+    const isTcpHostsValid = validateTcpHosts(tcpHosts) === null;
+    const isFormValid = isTcp ? isTcpHostsValid : virtualHostMode ? isVirtualHostValid : isContextPathValid;
     const canSave = isDirty && isFormValid && !saveMutation.isPending;
 
     // ── form mutations ──
@@ -160,6 +181,22 @@ export function ApiEntrypointsPage() {
         markDirty();
     }
 
+    function addTcpHost() {
+        setTcpHosts(prev => [...prev, { id: newId(), host: '' }]);
+        markDirty();
+    }
+
+    function deleteTcpHost(id: string) {
+        if (tcpHosts.length <= 1) return;
+        setTcpHosts(prev => prev.filter(r => r.id !== id));
+        markDirty();
+    }
+
+    function updateTcpHost(id: string, host: string) {
+        setTcpHosts(prev => prev.map(r => (r.id === id ? { ...r, host } : r)));
+        markDirty();
+    }
+
     function handleEnableVirtualHosts() {
         setVirtualHostMode(true);
         if (virtualHosts.length === 0) {
@@ -196,16 +233,23 @@ export function ApiEntrypointsPage() {
     function handleSave() {
         if (!api || !isFormValid) return;
 
-        const existingListener = getHttpListener(api);
-        const updatedListener: HttpListener = {
-            ...(existingListener ?? { type: 'HTTP' }),
-            paths: virtualHostMode ? (existingListener?.paths ?? []) : contextPaths.map(r => ({ path: r.path })),
-            hosts: virtualHostMode ? virtualHosts.map(r => ({ host: r.host, path: r.path, overrideAccess: r.overrideAccess })) : [],
-        };
-
-        // Keep all listeners, replace/add the HTTP one
-        const otherListeners = (api.listeners ?? []).filter(l => l.type !== 'HTTP');
-        const updatedListeners: HttpListener[] = [...otherListeners, updatedListener];
+        const updatedListeners: (HttpListener | TcpListener)[] = isTcp
+            ? [
+                  ...(api.listeners ?? []).filter(l => l.type !== 'TCP'),
+                  { ...(getTcpListener(api) ?? { type: 'TCP' as const }), hosts: tcpHosts.map(r => r.host.trim()) },
+              ]
+            : (() => {
+                  const existingListener = getHttpListener(api);
+                  const updatedListener: HttpListener = {
+                      ...(existingListener ?? { type: 'HTTP' }),
+                      paths: virtualHostMode ? (existingListener?.paths ?? []) : contextPaths.map(r => ({ path: r.path })),
+                      hosts: virtualHostMode
+                          ? virtualHosts.map(r => ({ host: r.host, path: r.path, overrideAccess: r.overrideAccess }))
+                          : [],
+                  };
+                  // Keep all listeners, replace/add the HTTP one
+                  return [...(api.listeners ?? []).filter(l => l.type !== 'HTTP'), updatedListener];
+              })();
 
         saveMutation.mutate(updatedListeners, {
             onSuccess: () => {
@@ -231,6 +275,53 @@ export function ApiEntrypointsPage() {
                     <Skeleton className="h-9 w-28 rounded-md" />
                 </div>
                 <Skeleton className="h-48 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    if (isTcp) {
+        return (
+            <div className="space-y-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                        <h1 className="text-2xl font-semibold tracking-tight">Entrypoints</h1>
+                        <p className="text-sm text-muted-foreground">Configure the gateway hosts this TCP API listens on.</p>
+                    </div>
+
+                    <div className="flex items-center gap-2 shrink-0">
+                        {isDirty && !isReadOnly && (
+                            <Button size="sm" variant="outline" onClick={handleDiscard} aria-label="Discard changes">
+                                Discard
+                            </Button>
+                        )}
+                        {!isReadOnly && (
+                            <Button size="sm" onClick={handleSave} disabled={!canSave} className="gap-1.5" aria-label="Save changes">
+                                <CheckIcon className="size-3.5" />
+                                Save changes
+                            </Button>
+                        )}
+                    </div>
+                </div>
+
+                {saveError && (
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+                        <p className="text-sm text-destructive">{saveError}</p>
+                    </div>
+                )}
+
+                {saveMutation.isSuccess && !isDirty && (
+                    <div className="rounded-lg border border-success/30 bg-success/5 px-4 py-3">
+                        <p className="text-sm text-success">Configuration successfully saved!</p>
+                    </div>
+                )}
+
+                <TcpHostsCard
+                    rows={tcpHosts}
+                    onAdd={addTcpHost}
+                    onDelete={deleteTcpHost}
+                    onHostChange={updateTcpHost}
+                    isReadOnly={isReadOnly}
+                />
             </div>
         );
     }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/TcpHostsCard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/TcpHostsCard.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { TcpHostsCard } from './TcpHostsCard';
+import type { TcpHostEntry } from '../../../types/apiCreation';
+
+function rows(...hosts: string[]): TcpHostEntry[] {
+    return hosts.map((host, i) => ({ id: `row-${i}`, host }));
+}
+
+const noop = () => {};
+
+describe('TcpHostsCard row validation', () => {
+    it('shows no error for a single valid host', () => {
+        render(<TcpHostsCard rows={rows('db.example.com')} onAdd={noop} onDelete={noop} onHostChange={noop} isReadOnly={false} />);
+        expect(screen.queryByText(/Duplicated hosts not allowed/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Host is not valid/)).not.toBeInTheDocument();
+    });
+
+    it('shows a format error for an invalid hostname', () => {
+        render(<TcpHostsCard rows={rows('not a valid host!')} onAdd={noop} onDelete={noop} onHostChange={noop} isReadOnly={false} />);
+        expect(screen.getByText('Host is not valid')).toBeInTheDocument();
+    });
+
+    it('shows a duplicate error on every row sharing the same host', () => {
+        render(
+            <TcpHostsCard
+                rows={rows('db.example.com', 'db.example.com')}
+                onAdd={noop}
+                onDelete={noop}
+                onHostChange={noop}
+                isReadOnly={false}
+            />,
+        );
+        expect(screen.getAllByText('Duplicated hosts not allowed')).toHaveLength(2);
+    });
+
+    it('treats hosts as duplicate after trimming surrounding whitespace', () => {
+        render(
+            <TcpHostsCard
+                rows={rows('db.example.com', ' db.example.com ')}
+                onAdd={noop}
+                onDelete={noop}
+                onHostChange={noop}
+                isReadOnly={false}
+            />,
+        );
+        expect(screen.getAllByText('Duplicated hosts not allowed')).toHaveLength(2);
+    });
+
+    it('does not flag distinct hosts as duplicates', () => {
+        render(
+            <TcpHostsCard
+                rows={rows('db.example.com', 'cache.example.com')}
+                onAdd={noop}
+                onDelete={noop}
+                onHostChange={noop}
+                isReadOnly={false}
+            />,
+        );
+        expect(screen.queryByText(/Duplicated hosts not allowed/)).not.toBeInTheDocument();
+    });
+
+    it('shows a required error for a blank host row', () => {
+        render(<TcpHostsCard rows={rows('')} onAdd={noop} onDelete={noop} onHostChange={noop} isReadOnly={false} />);
+        expect(screen.getByText('Host is required.')).toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/TcpHostsCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/TcpHostsCard.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, Input, Label, cn } from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { InfoTooltip } from './InfoTooltip';
+import type { TcpHostEntry } from '../../../types/apiCreation';
+import { validateDuplicateHost } from '../../../utils/duplicateDialogValidation';
+
+function findRowError(rows: TcpHostEntry[], row: TcpHostEntry): string | null {
+    const formatError = validateDuplicateHost(row.host);
+    if (formatError) return formatError;
+    const isDuplicate = rows.filter(r => r.host.trim() === row.host.trim()).length > 1;
+    return isDuplicate ? 'Duplicated hosts not allowed' : null;
+}
+
+interface TcpHostsCardProps {
+    rows: TcpHostEntry[];
+    onAdd: () => void;
+    onDelete: (id: string) => void;
+    onHostChange: (id: string, host: string) => void;
+    isReadOnly: boolean;
+}
+
+export function TcpHostsCard({ rows, onAdd, onDelete, onHostChange, isReadOnly }: Readonly<TcpHostsCardProps>) {
+    const canDelete = rows.length > 1;
+
+    return (
+        <Card>
+            <CardContent className="p-5 space-y-4">
+                <div>
+                    <div className="text-sm font-semibold text-foreground flex items-center">
+                        Entrypoint hosts
+                        <InfoTooltip text="Hostnames clients use to reach this TCP API on the gateway's TCP port. Matched against SNI." />
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                        Each row is a hostname the gateway matches for this API. Add or remove hosts as needed.
+                    </p>
+                </div>
+
+                <div>
+                    <Label className="text-xs font-medium text-muted-foreground">Host</Label>
+                </div>
+
+                <div className="space-y-2">
+                    {rows.map(row => {
+                        const error = findRowError(rows, row);
+                        return (
+                            <div key={row.id} className="flex items-start gap-2">
+                                <div className="flex-1 space-y-1">
+                                    <Input
+                                        value={row.host}
+                                        onChange={e => onHostChange(row.id, e.target.value)}
+                                        placeholder="db.example.com"
+                                        disabled={isReadOnly}
+                                        aria-invalid={error !== null}
+                                        aria-label="Host"
+                                    />
+                                    {error && <p className="text-xs text-destructive">{error}</p>}
+                                </div>
+                                {!isReadOnly && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onDelete(row.id)}
+                                        disabled={!canDelete}
+                                        aria-label="Delete host"
+                                        className={cn(
+                                            'mt-1 p-1.5 rounded-md transition-colors',
+                                            canDelete
+                                                ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/10'
+                                                : 'text-muted-foreground/30 cursor-not-allowed',
+                                        )}
+                                    >
+                                        <Trash2Icon className="size-4" />
+                                    </button>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {!isReadOnly && (
+                    <Button variant="outline" size="sm" onClick={onAdd} className="gap-1.5">
+                        <PlusIcon className="size-3.5" />
+                        Add host
+                    </Button>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/ApiPlansPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/ApiPlansPage.tsx
@@ -17,14 +17,26 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { useParams } from 'react-router-dom';
 
 import { PlansPage } from './PlansPage';
+import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import type { PlanContext } from '../../../types/plan';
+import { hasTcpListeners } from '../../../utils/apiHttpProxy';
 
 export function ApiPlansPage() {
     const { apiId } = useParams<{ apiId: string }>();
+    const { api } = useApiDetailContext();
     const ctx: PlanContext = { type: 'api', entityId: apiId ?? '' };
     const canRead = useHasPermission({ anyOf: ['api-plan-r'] });
     const canCreate = useHasPermission({ anyOf: ['api-plan-c'] });
     const canUpdate = useHasPermission({ anyOf: ['api-plan-u'] });
     const canDelete = useHasPermission({ anyOf: ['api-plan-d'] });
-    return <PlansPage ctx={ctx} canRead={canRead} canCreate={canCreate} canUpdate={canUpdate} canDelete={canDelete} />;
+    return (
+        <PlansPage
+            ctx={ctx}
+            canRead={canRead}
+            canCreate={canCreate}
+            canUpdate={canUpdate}
+            canDelete={canDelete}
+            isTcpApi={hasTcpListeners(api)}
+        />
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/CreatePlanDropdown.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/CreatePlanDropdown.spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('@gravitee/graphene-core', () => ({
+    Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+    DropdownMenu: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+        <button role="menuitem" onClick={onClick}>
+            {children}
+        </button>
+    ),
+}));
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+import { CreatePlanDropdown } from './CreatePlanDropdown';
+import type { PlanContext } from '../../../types/plan';
+
+const CTX: PlanContext = { type: 'api', entityId: 'api-1' };
+
+function renderDropdown(restrictToKeyless?: boolean) {
+    return render(
+        <MemoryRouter>
+            <CreatePlanDropdown ctx={CTX} restrictToKeyless={restrictToKeyless} />
+        </MemoryRouter>,
+    );
+}
+
+describe('CreatePlanDropdown', () => {
+    it('lists every plan security type for a regular (non-TCP) API', () => {
+        renderDropdown(false);
+
+        expect(screen.getByRole('menuitem', { name: /api key/i })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: /oauth2/i })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: /keyless/i })).toBeInTheDocument();
+    });
+
+    it('restricts the menu to Keyless only when restrictToKeyless is set (TCP Proxy parity)', () => {
+        renderDropdown(true);
+
+        expect(screen.getAllByRole('menuitem')).toHaveLength(1);
+        expect(screen.getByRole('menuitem', { name: /keyless/i })).toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/CreatePlanDropdown.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/CreatePlanDropdown.tsx
@@ -22,11 +22,13 @@ import { PLAN_SECURITY_LABELS, PLAN_TYPES_BY_CTX } from '../../../types/plan';
 
 interface CreatePlanDropdownProps {
     ctx: PlanContext;
+    /** TCP Proxy APIs have no HTTP-level auth — only a Keyless plan makes sense (classic console parity). */
+    restrictToKeyless?: boolean;
 }
 
-export function CreatePlanDropdown({ ctx }: Readonly<CreatePlanDropdownProps>) {
+export function CreatePlanDropdown({ ctx, restrictToKeyless = false }: Readonly<CreatePlanDropdownProps>) {
     const navigate = useNavigate();
-    const types: PlanSecurityType[] = PLAN_TYPES_BY_CTX[ctx.type];
+    const types: PlanSecurityType[] = restrictToKeyless ? ['KEY_LESS'] : PLAN_TYPES_BY_CTX[ctx.type];
 
     return (
         <DropdownMenu>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/PlansPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/plans/PlansPage.tsx
@@ -35,6 +35,7 @@ interface PlansPageProps {
     canCreate: boolean;
     canUpdate: boolean;
     canDelete: boolean;
+    isTcpApi?: boolean;
 }
 
 function AllowMultiSubscriptionsToggle({ apiId, canUpdate }: { apiId: string; canUpdate: boolean }) {
@@ -98,7 +99,7 @@ function AllowMultiSubscriptionsToggle({ apiId, canUpdate }: { apiId: string; ca
     );
 }
 
-export function PlansPage({ ctx, canRead, canCreate, canUpdate }: Readonly<PlansPageProps>) {
+export function PlansPage({ ctx, canRead, canCreate, canUpdate, isTcpApi = false }: Readonly<PlansPageProps>) {
     const counts = usePlanStatusCounts(ctx);
 
     if (!canRead) {
@@ -117,7 +118,7 @@ export function PlansPage({ ctx, canRead, canCreate, canUpdate }: Readonly<Plans
                     <h1 className="text-2xl font-semibold tracking-tight">Plans</h1>
                     <p className="text-sm text-muted-foreground">Manage subscription plans and their lifecycle.</p>
                 </div>
-                {canCreate && <CreatePlanDropdown ctx={ctx} />}
+                {canCreate && <CreatePlanDropdown ctx={ctx} restrictToKeyless={isTcpApi} />}
             </div>
 
             {/* Allow multi JWT/OAuth2 subscriptions — API only */}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/policy-studio/PolicyStudioPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/policy-studio/PolicyStudioPage.spec.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { PolicyStudioPage } from './PolicyStudioPage';
+import { usePolicyStudioData } from '../../hooks/usePolicyStudioData';
+import type { PolicyStudioData } from '../../hooks/usePolicyStudioData';
+import type { PolicyStudioApiDetail } from '../../types/policyStudio';
+
+jest.mock('@gravitee/graphene-core', () => ({ useLayoutConfig: jest.fn() }));
+jest.mock('@gravitee/graphene-policy-studio', () => ({ PolicyStudio: () => <div data-testid="policy-studio-editor" /> }), {
+    virtual: true,
+});
+jest.mock('../../hooks/usePolicyStudioData');
+jest.mock('../../hooks/usePolicyStudioSave', () => ({ usePolicyStudioSave: jest.fn(() => jest.fn()) }));
+
+const mockUsePolicyStudioData = jest.mocked(usePolicyStudioData);
+
+function baseData(overrides: Partial<PolicyStudioData> = {}): PolicyStudioData {
+    return {
+        apiType: 'PROXY',
+        policies: [],
+        sharedPolicyGroups: [],
+        plans: [],
+        commonFlows: [],
+        entrypointsInfo: [],
+        endpointsInfo: [],
+        flowExecution: { mode: 'DEFAULT', matchRequired: false },
+        isLoading: false,
+        isError: false,
+        apiDetail: undefined,
+        isV2: false,
+        ...overrides,
+    };
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/apis/api-1/policy-studio']}>
+            <Routes>
+                <Route path="/apis/:apiId/policy-studio" element={<PolicyStudioPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('PolicyStudioPage', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('shows an error message when the studio data failed to load', () => {
+        mockUsePolicyStudioData.mockReturnValue(baseData({ isError: true }));
+        renderPage();
+        expect(screen.getByText(/failed to load policy studio data/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('policy-studio-editor')).not.toBeInTheDocument();
+    });
+
+    it('shows a "not available" message instead of the editor for a TCP Proxy API', () => {
+        mockUsePolicyStudioData.mockReturnValue(baseData({ apiDetail: { listeners: [{ type: 'TCP' }] } as PolicyStudioApiDetail }));
+        renderPage();
+        expect(screen.getByText(/policy studio is not available for tcp proxy apis/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('policy-studio-editor')).not.toBeInTheDocument();
+    });
+
+    it('renders the policy editor for a non-TCP API', () => {
+        mockUsePolicyStudioData.mockReturnValue(baseData({ apiDetail: { listeners: [{ type: 'HTTP' }] } as PolicyStudioApiDetail }));
+        renderPage();
+        expect(screen.getByTestId('policy-studio-editor')).toBeInTheDocument();
+    });
+
+    it('renders the policy editor while the API detail is still loading (no false-positive TCP block)', () => {
+        mockUsePolicyStudioData.mockReturnValue(baseData({ isLoading: true, apiDetail: undefined }));
+        renderPage();
+        expect(screen.getByTestId('policy-studio-editor')).toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/policy-studio/PolicyStudioPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/policy-studio/PolicyStudioPage.tsx
@@ -23,6 +23,7 @@ import { usePolicyStudioData } from '../../hooks/usePolicyStudioData';
 import { usePolicyStudioSave } from '../../hooks/usePolicyStudioSave';
 import { getPolicyDocumentation, getPolicySchema } from '../../services/policyStudioService';
 import { getApiProtocolType } from '../../types/policyStudio';
+import { hasTcpListeners } from '../../utils/apiHttpProxy';
 
 export function PolicyStudioPage() {
     const { apiId } = useParams<{ apiId: string }>();
@@ -54,6 +55,17 @@ export function PolicyStudioPage() {
         return (
             <div className="flex items-center justify-center p-8">
                 <p className="text-sm text-destructive">Failed to load Policy Studio data. Please try again.</p>
+            </div>
+        );
+    }
+
+    if (hasTcpListeners(studioData.apiDetail)) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <div className="text-center space-y-2">
+                    <p className="text-sm font-medium">Policy Studio is not available for TCP Proxy APIs</p>
+                    <p className="text-sm text-muted-foreground">TCP Proxy APIs forward raw traffic and do not support policy flows.</p>
+                </div>
             </div>
         );
     }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.spec.ts
@@ -32,7 +32,7 @@ describe('searchApis', () => {
         await searchApis('DEFAULT', { query: 'my-api' }, 1, 10);
 
         expect(tracker.callCount).toBe(1);
-        expect(tracker.lastCall?.body).toEqual({ query: 'my-api', apiTypes: ['V4_HTTP_PROXY'] });
+        expect(tracker.lastCall?.body).toEqual({ query: 'my-api', apiTypes: ['V4_HTTP_PROXY', 'V4_TCP_PROXY'] });
     });
 
     it('overrides any caller-supplied apiTypes so the filter cannot be widened', async () => {
@@ -40,7 +40,7 @@ describe('searchApis', () => {
 
         await searchApis('DEFAULT', { apiTypes: ['V4_KAFKA', 'V2'] }, 1, 10);
 
-        expect(tracker.lastCall?.body).toEqual({ apiTypes: ['V4_HTTP_PROXY'] });
+        expect(tracker.lastCall?.body).toEqual({ apiTypes: ['V4_HTTP_PROXY', 'V4_TCP_PROXY'] });
     });
 
     it('passes pagination and sort as query params', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.ts
@@ -19,11 +19,11 @@ import type { ApiListResponse, ApiSearchQuery } from '../types';
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 /**
- * The gamma APIM module only manages V4 HTTP proxy APIs. This filter is enforced server-side
- * on every search — overriding any caller-supplied `apiTypes` — so neither the list nor any
- * count derived from it can be widened to other API types from the client.
+ * The gamma APIM module manages V4 proxy APIs (HTTP and TCP). This filter is enforced
+ * server-side on every search — overriding any caller-supplied `apiTypes` — so neither the
+ * list nor any count derived from it can be widened to other API types from the client.
  */
-const V4_HTTP_PROXY_API_TYPES = ['V4_HTTP_PROXY'];
+const V4_PROXY_API_TYPES = ['V4_HTTP_PROXY', 'V4_TCP_PROXY'];
 
 export async function searchApis(
     environmentId: string,
@@ -34,7 +34,7 @@ export async function searchApis(
 ): Promise<ApiListResponse> {
     const params = new URLSearchParams({ page: String(page), perPage: String(perPage), expands: 'deploymentState' });
     if (sortBy) params.set('sortBy', sortBy);
-    const body: ApiSearchQuery = { ...query, apiTypes: [...V4_HTTP_PROXY_API_TYPES] };
+    const body: ApiSearchQuery = { ...query, apiTypes: [...V4_PROXY_API_TYPES] };
     return apimFetchJsonV2<ApiListResponse>(environmentId, `/apis/_search?${params}`, {
         method: 'POST',
         headers: JSON_HEADERS,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/entrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/entrypoints.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { ApiDetailDto, ExposedEntrypoint, HttpListener } from '../types';
+import type { ApiDetailDto, ExposedEntrypoint, HttpListener, TcpListener } from '../types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -26,7 +26,7 @@ export async function updateApiListeners(
     environmentId: string,
     apiId: string,
     current: ApiDetailDto,
-    listeners: HttpListener[],
+    listeners: (HttpListener | TcpListener)[],
 ): Promise<ApiDetailDto> {
     return apimFetchJsonV2<ApiDetailDto>(environmentId, `/apis/${encodeURIComponent(apiId)}`, {
         method: 'PUT',

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.spec.tsx
@@ -68,6 +68,7 @@ describe('ApiCreationProvider — initial state', () => {
         expect(state.creationMode).toBe('picker');
         expect(state.step).toBe(0);
         expect(state.form.apiName).toBe('');
+        expect(state.form.protocol).toBe('HTTP');
         expect(state.form.authType).toBe('keyless');
         expect(state.form.deployImmediately).toBe(true);
         expect(state.validationErrors).toEqual({});
@@ -104,6 +105,19 @@ describe('ApiCreationProvider — reducer actions', () => {
         expect(result.current.state.form.authType).toBe('api-key');
         expect(result.current.state.form.apiKeyPlanName).toBe('Template API Key Plan');
         expect(result.current.state.step).toBe(0);
+    });
+
+    it('SELECT_TEMPLATE resets protocol to HTTP even if TCP was previously selected', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'SELECT_TEMPLATE', template: MOCK_TEMPLATE });
+        });
+
+        expect(result.current.state.form.protocol).toBe('HTTP');
     });
 
     it('SELECT_SCRATCH resets to scratch mode and clears the template', () => {
@@ -221,6 +235,183 @@ describe('ApiCreationProvider — reducer actions', () => {
 
         expect(result.current.state.form.virtualHosts[0]!.host).toBe('api.example.com');
         expect(result.current.state.form.virtualHosts[1]!.host).toBe('');
+    });
+
+    it('UPDATE_FORM with protocol clears HTTP and TCP field errors but keeps others', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({
+                type: 'SET_VALIDATION_ERRORS',
+                errors: {
+                    targetUrl: 'Required',
+                    contextPath: 'Required',
+                    tcpHosts: 'Required',
+                    tcpTargetHost: 'Required',
+                    apiName: 'Required',
+                },
+            });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('targetUrl');
+        expect(result.current.state.validationErrors).not.toHaveProperty('contextPath');
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpHosts');
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpTargetHost');
+        expect(result.current.state.validationErrors).toHaveProperty('apiName');
+    });
+
+    it('UPDATE_FORM with protocol: TCP forces authType to keyless, even if patched together with another authType', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { authType: 'jwt' } });
+        });
+        expect(result.current.state.form.authType).toBe('jwt');
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+        });
+
+        expect(result.current.state.form.protocol).toBe('TCP');
+        expect(result.current.state.form.authType).toBe('keyless');
+    });
+
+    it('UPDATE_FORM with protocol: HTTP does not force authType', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { authType: 'jwt' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'HTTP' } });
+        });
+
+        expect(result.current.state.form.authType).toBe('jwt');
+    });
+
+    it('switching HTTP → TCP resets stale HTTP field values back to their defaults', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({
+                type: 'UPDATE_FORM',
+                patch: { targetUrl: 'https://old-http-target.example.com', contextPath: '/old-path' },
+            });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+        });
+
+        expect(result.current.state.form.targetUrl).toBe('');
+        expect(result.current.state.form.contextPath).toBe('/');
+    });
+
+    it('switching TCP → HTTP resets stale TCP field values back to their defaults', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'old-tcp-host.example.com' } });
+            result.current.dispatch({
+                type: 'UPDATE_FORM',
+                patch: { tcpTargetHost: 'old-target.internal', tcpTargetPort: '5432', tcpTargetSecured: true },
+            });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'HTTP' } });
+        });
+
+        expect(result.current.state.form.tcpHosts).toEqual([{ id: expect.any(String), host: '' }]);
+        expect(result.current.state.form.tcpTargetHost).toBe('');
+        expect(result.current.state.form.tcpTargetPort).toBe('');
+        expect(result.current.state.form.tcpTargetSecured).toBe(false);
+    });
+
+    it('an explicit value in the same UPDATE_FORM patch wins over the protocol-switch reset', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { protocol: 'TCP', tcpTargetHost: 'db.internal.example.com' } });
+        });
+
+        expect(result.current.state.form.tcpTargetHost).toBe('db.internal.example.com');
+    });
+
+    it('ADD_TCP_HOST appends a blank row', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+        const initialCount = result.current.state.form.tcpHosts.length;
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+        });
+
+        expect(result.current.state.form.tcpHosts).toHaveLength(initialCount + 1);
+        expect(result.current.state.form.tcpHosts[initialCount]!.host).toBe('');
+    });
+
+    it('REMOVE_TCP_HOST removes the row at the given index but never the last one', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+        });
+        const countBefore = result.current.state.form.tcpHosts.length;
+
+        act(() => {
+            result.current.dispatch({ type: 'REMOVE_TCP_HOST', index: 0 });
+        });
+        expect(result.current.state.form.tcpHosts).toHaveLength(countBefore - 1);
+
+        act(() => {
+            result.current.dispatch({ type: 'REMOVE_TCP_HOST', index: 0 });
+        });
+        expect(result.current.state.form.tcpHosts).toHaveLength(1);
+    });
+
+    it('REMOVE_TCP_HOST clears a tcpHosts validation error', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+            result.current.dispatch({ type: 'SET_VALIDATION_ERRORS', errors: { tcpHosts: 'Duplicated hosts not allowed' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'REMOVE_TCP_HOST', index: 0 });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpHosts');
+    });
+
+    it('UPDATE_TCP_HOST patches only the row at the given index', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_TCP_HOST' });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+        });
+
+        expect(result.current.state.form.tcpHosts[0]!.host).toBe('tcp.example.com');
+        expect(result.current.state.form.tcpHosts[1]!.host).toBe('');
+    });
+
+    it('UPDATE_TCP_HOST clears a tcpHosts validation error', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_VALIDATION_ERRORS', errors: { tcpHosts: 'Host is not valid' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_TCP_HOST', index: 0, patch: { host: 'tcp.example.com' } });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('tcpHosts');
     });
 
     it('SET_MODE switches creation mode and resets step to 0', () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
@@ -21,6 +21,7 @@ import type {
     ApiCreationState,
     ApiProxyDraft,
     ProxyTemplate,
+    TcpHostEntry,
     ValidationErrors,
     VirtualHostEntry,
 } from '../types/apiCreation';
@@ -31,10 +32,15 @@ const INITIAL_FORM: ApiProxyDraft = {
     apiName: '',
     apiVersion: '1.0.0',
     apiDescription: '',
+    protocol: 'HTTP',
     contextPath: '/',
     virtualHostsEnabled: false,
     virtualHosts: [{ id: crypto.randomUUID(), host: '', path: '/', overrideAccess: false }],
     targetUrl: '',
+    tcpHosts: [{ id: crypto.randomUUID(), host: '' }],
+    tcpTargetHost: '',
+    tcpTargetPort: '',
+    tcpTargetSecured: false,
     authType: 'keyless',
     apiKeyPlanName: 'Default API Key plan',
     jwtPlanName: 'Default JWT plan',
@@ -71,6 +77,9 @@ type ApiCreationAction =
     | { type: 'ADD_VIRTUAL_HOST' }
     | { type: 'REMOVE_VIRTUAL_HOST'; index: number }
     | { type: 'UPDATE_VIRTUAL_HOST'; index: number; patch: Omit<Partial<VirtualHostEntry>, 'id'> }
+    | { type: 'ADD_TCP_HOST' }
+    | { type: 'REMOVE_TCP_HOST'; index: number }
+    | { type: 'UPDATE_TCP_HOST'; index: number; patch: Omit<Partial<TcpHostEntry>, 'id'> }
     | { type: 'SET_VALIDATION_ERRORS'; errors: ValidationErrors }
     | { type: 'CLEAR_VALIDATION_ERRORS' }
     | { type: 'SET_PATH_VERIFYING'; value: boolean }
@@ -108,6 +117,7 @@ function apiCreationReducer(state: ApiCreationState, action: ApiCreationAction):
                     ...(d.oauth2ResourceType !== undefined && { oauth2ResourceType: d.oauth2ResourceType }),
                     ...(d.mtlsPlanName !== undefined && { mtlsPlanName: d.mtlsPlanName }),
                     virtualHostsEnabled: false,
+                    protocol: 'HTTP',
                 },
             };
         }
@@ -122,13 +132,45 @@ function apiCreationReducer(state: ApiCreationState, action: ApiCreationAction):
                 delete remaining['virtualHosts'];
                 delete remaining['contextPath'];
             }
+            if ('protocol' in action.patch) {
+                delete remaining['targetUrl'];
+                delete remaining['contextPath'];
+                delete remaining['virtualHosts'];
+                delete remaining['tcpHosts'];
+                delete remaining['tcpTargetHost'];
+                delete remaining['tcpTargetPort'];
+            }
             if ('authType' in action.patch) {
                 delete remaining['apiKeyPlanName'];
                 delete remaining['jwtPlanName'];
                 delete remaining['oauth2PlanName'];
                 delete remaining['mtlsPlanName'];
             }
-            return { ...state, form: { ...state.form, ...action.patch }, validationErrors: remaining };
+            // Switching protocol also resets the *other* protocol's fields back to their
+            // defaults — otherwise stale HTTP values linger under a TCP form (or vice versa)
+            // after a HTTP→TCP→HTTP round trip. Harmless today since apiProxyMapper branches
+            // cleanly on protocol, but a latent trap for any future direct form read.
+            let protocolReset: Partial<ApiProxyDraft> = {};
+            if (action.patch.protocol === 'TCP') {
+                protocolReset = {
+                    contextPath: INITIAL_FORM.contextPath,
+                    virtualHostsEnabled: INITIAL_FORM.virtualHostsEnabled,
+                    virtualHosts: [{ id: crypto.randomUUID(), host: '', path: '/', overrideAccess: false }],
+                    targetUrl: INITIAL_FORM.targetUrl,
+                };
+            } else if (action.patch.protocol === 'HTTP') {
+                protocolReset = {
+                    tcpHosts: [{ id: crypto.randomUUID(), host: '' }],
+                    tcpTargetHost: INITIAL_FORM.tcpTargetHost,
+                    tcpTargetPort: INITIAL_FORM.tcpTargetPort,
+                    tcpTargetSecured: INITIAL_FORM.tcpTargetSecured,
+                };
+            }
+            const patch =
+                action.patch.protocol === 'TCP'
+                    ? { ...protocolReset, ...action.patch, authType: 'keyless' as const }
+                    : { ...protocolReset, ...action.patch };
+            return { ...state, form: { ...state.form, ...patch }, validationErrors: remaining };
         }
 
         case 'ADD_VIRTUAL_HOST':
@@ -160,6 +202,39 @@ function apiCreationReducer(state: ApiCreationState, action: ApiCreationAction):
                     virtualHosts: state.form.virtualHosts.map((row, i) => (i === action.index ? { ...row, ...action.patch } : row)),
                 },
             };
+
+        case 'ADD_TCP_HOST':
+            return {
+                ...state,
+                form: { ...state.form, tcpHosts: [...state.form.tcpHosts, { id: crypto.randomUUID(), host: '' }] },
+            };
+
+        case 'REMOVE_TCP_HOST': {
+            const remaining = { ...state.validationErrors };
+            delete remaining['tcpHosts'];
+            return {
+                ...state,
+                validationErrors: remaining,
+                form: {
+                    ...state.form,
+                    tcpHosts:
+                        state.form.tcpHosts.length === 1 ? state.form.tcpHosts : state.form.tcpHosts.filter((_, i) => i !== action.index),
+                },
+            };
+        }
+
+        case 'UPDATE_TCP_HOST': {
+            const remaining = { ...state.validationErrors };
+            delete remaining['tcpHosts'];
+            return {
+                ...state,
+                validationErrors: remaining,
+                form: {
+                    ...state.form,
+                    tcpHosts: state.form.tcpHosts.map((row, i) => (i === action.index ? { ...row, ...action.patch } : row)),
+                },
+            };
+        }
 
         case 'SET_VALIDATION_ERRORS':
             return { ...state, validationErrors: action.errors };

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -78,6 +78,33 @@ export interface HttpEndpointGroup {
     endpoints: HttpEndpoint[];
 }
 
+export interface TcpListener {
+    type: 'TCP';
+    hosts: string[];
+    entrypoints?: { type: string }[];
+}
+
+export interface TcpTarget {
+    host: string;
+    port: number;
+    secured: boolean;
+}
+
+export interface TcpEndpoint {
+    name: string;
+    type: 'tcp-proxy';
+    weight: number;
+    inheritConfiguration: boolean;
+    configuration: { target: TcpTarget };
+}
+
+export interface TcpEndpointGroup {
+    name: string;
+    type: 'tcp-proxy';
+    sharedConfiguration: Record<string, unknown>;
+    endpoints: TcpEndpoint[];
+}
+
 export interface CreateApiProxyRequest {
     name: string;
     apiVersion: string;
@@ -86,8 +113,8 @@ export interface CreateApiProxyRequest {
     definitionVersion: 'V4';
     visibility: ApiVisibility;
     allowedInApiProducts: boolean;
-    listeners: HttpListener[];
-    endpointGroups: HttpEndpointGroup[];
+    listeners: (HttpListener | TcpListener)[];
+    endpointGroups: (HttpEndpointGroup | TcpEndpointGroup)[];
 }
 
 export interface ApiProxyCreated {
@@ -177,7 +204,7 @@ export interface ApiSearchQuery {
 export interface ApiHttpEndpoint {
     name: string;
     type: string;
-    configuration?: { target?: string };
+    configuration?: { target?: string | TcpTarget };
 }
 
 export interface ApiEndpointGroup {
@@ -276,7 +303,7 @@ export interface EndpointDto {
     weight?: number;
     backup?: boolean;
     inheritConfiguration?: boolean;
-    configuration?: { target?: string; [key: string]: unknown };
+    configuration?: { target?: string | TcpTarget; [key: string]: unknown };
     tenants?: string[];
     sharedConfigurationOverride?: Record<string, unknown>;
     services?: EndpointServices;
@@ -341,7 +368,7 @@ export interface ApiDetailDto {
 
     services?: { dynamicProperty?: DynamicPropertyConfig };
     analytics?: Analytics;
-    listeners?: HttpListener[];
+    listeners?: (HttpListener | TcpListener)[];
     endpointGroups?: EndpointGroupDto[];
     failover?: Failover;
     allowMultiJwtOauth2Subscriptions?: boolean;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/apiCreation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/apiCreation.ts
@@ -17,12 +17,18 @@ import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
 export type AuthType = 'keyless' | 'api-key' | 'jwt' | 'oauth2' | 'mtls';
 export type ApiCreationMode = 'picker' | 'template' | 'scratch';
+export type ApiProtocol = 'HTTP' | 'TCP';
 
 export interface VirtualHostEntry {
     id: string;
     host: string;
     path: string;
     overrideAccess: boolean;
+}
+
+export interface TcpHostEntry {
+    id: string;
+    host: string;
 }
 
 export interface ProxyTemplateDefaults {
@@ -56,10 +62,15 @@ export interface ApiProxyDraft {
     apiName: string;
     apiVersion: string;
     apiDescription: string;
+    protocol: ApiProtocol;
     contextPath: string;
     virtualHostsEnabled: boolean;
     virtualHosts: VirtualHostEntry[];
     targetUrl: string;
+    tcpHosts: TcpHostEntry[];
+    tcpTargetHost: string;
+    tcpTargetPort: string;
+    tcpTargetSecured: boolean;
     authType: AuthType;
     apiKeyPlanName: string;
     jwtPlanName: string;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/policyStudio.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/policyStudio.ts
@@ -33,6 +33,9 @@ export interface ConnectorPlugin {
     name: string;
     icon?: string;
     supportedModes: string[];
+    /** Whether the plugin is installed/licensed in this environment (classic console `ConnectorPlugin.deployed`). */
+    deployed?: boolean;
+    supportedApiType?: string;
 }
 
 export interface SharedPolicyGroupPlugin {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.spec.ts
@@ -13,17 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { validateContextPath, validateDetails, validateEntrypoints, validateEssentials, validateSecurity } from './apiCreationValidation';
+import {
+    validateContextPath,
+    validateDetails,
+    validateEntrypoints,
+    validateEssentials,
+    validateSecurity,
+    validateTcpHosts,
+    validateTcpPort,
+} from './apiCreationValidation';
 import type { ApiProxyDraft } from '../types/apiCreation';
 
 const BASE: ApiProxyDraft = {
     apiName: 'My API',
     apiVersion: '1.0.0',
     apiDescription: '',
+    protocol: 'HTTP',
     contextPath: '/my-api',
     virtualHostsEnabled: false,
     virtualHosts: [{ id: '1', host: 'api.example.com', path: '/v1', overrideAccess: false }],
     targetUrl: 'https://backend.example.com',
+    tcpHosts: [{ id: '1', host: 'tcp.example.com' }],
+    tcpTargetHost: 'backend.example.com',
+    tcpTargetPort: '9090',
+    tcpTargetSecured: false,
     authType: 'keyless',
     apiKeyPlanName: 'Default API Key plan',
     jwtPlanName: 'Default JWT plan',
@@ -112,6 +125,95 @@ describe('validateEntrypoints', () => {
                 }),
             ),
         ).toEqual({});
+    });
+});
+
+describe('validateTcpHosts', () => {
+    it('rejects an empty or invalid host value', () => {
+        expect(validateTcpHosts([{ id: '1', host: '' }])).toBe('Host is required.');
+        expect(validateTcpHosts([{ id: '1', host: 'not a host!' }])).toBe('Host is not valid');
+    });
+
+    it('rejects duplicated hosts across the list', () => {
+        expect(
+            validateTcpHosts([
+                { id: '1', host: 'tcp.example.com' },
+                { id: '2', host: 'tcp.example.com' },
+            ]),
+        ).toBe('Duplicated hosts not allowed');
+    });
+
+    it('returns null when all hosts are valid and unique', () => {
+        expect(
+            validateTcpHosts([
+                { id: '1', host: 'tcp.example.com' },
+                { id: '2', host: 'localhost' },
+            ]),
+        ).toBeNull();
+    });
+
+    it('ignores a blank extra row added via "Add host" as long as another row is filled in', () => {
+        expect(
+            validateTcpHosts([
+                { id: '1', host: 'tcp.example.com' },
+                { id: '2', host: '' },
+            ]),
+        ).toBeNull();
+    });
+
+    it('still requires at least one non-blank host when every row is blank', () => {
+        expect(
+            validateTcpHosts([
+                { id: '1', host: '' },
+                { id: '2', host: '  ' },
+            ]),
+        ).toBe('Host is required.');
+    });
+
+    it('validates format only on non-blank rows, ignoring blank ones', () => {
+        expect(
+            validateTcpHosts([
+                { id: '1', host: 'tcp.example.com' },
+                { id: '2', host: '' },
+                { id: '3', host: 'not a host!' },
+            ]),
+        ).toBe('Host is not valid');
+    });
+});
+
+describe('validateTcpPort', () => {
+    it('requires a port value', () => {
+        expect(validateTcpPort('')).toBe('Port is required.');
+    });
+
+    it('rejects out-of-range or non-integer ports', () => {
+        expect(validateTcpPort('70000')).toContain('between 0 and 65535');
+        expect(validateTcpPort('-1')).toContain('between 0 and 65535');
+        expect(validateTcpPort('abc')).toContain('between 0 and 65535');
+        expect(validateTcpPort('8080.5')).toContain('between 0 and 65535');
+    });
+
+    it('accepts a valid port, including 0', () => {
+        expect(validateTcpPort('8080')).toBeNull();
+        expect(validateTcpPort('0')).toBeNull();
+        expect(validateTcpPort('65535')).toBeNull();
+    });
+});
+
+describe('validateEntrypoints — TCP protocol', () => {
+    it('validates TCP hosts, target host, and target port instead of HTTP fields', () => {
+        const errors = validateEntrypoints(
+            form({ protocol: 'TCP', tcpHosts: [{ id: '1', host: '' }], tcpTargetHost: '', tcpTargetPort: '' }),
+        );
+        expect(errors).toHaveProperty('tcpHosts');
+        expect(errors).toHaveProperty('tcpTargetHost');
+        expect(errors).toHaveProperty('tcpTargetPort');
+        expect(errors).not.toHaveProperty('targetUrl');
+        expect(errors).not.toHaveProperty('contextPath');
+    });
+
+    it('returns no errors for a fully configured TCP entrypoint', () => {
+        expect(validateEntrypoints(form({ protocol: 'TCP' }))).toEqual({});
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApiProxyDraft, ValidationErrors } from '../types/apiCreation';
+import { validateDuplicateHost } from './duplicateDialogValidation';
+import { isTcpForm } from './protocol';
+import type { ApiProxyDraft, TcpHostEntry, ValidationErrors } from '../types/apiCreation';
 
 const CONTEXT_PATH_PATTERN = /^\/[/.a-zA-Z0-9\-_]*$/;
 
@@ -44,7 +46,44 @@ export function validateDetails(form: ApiProxyDraft): ValidationErrors {
     return errors;
 }
 
+export function validateTcpHosts(hosts: TcpHostEntry[]): string | null {
+    // Extra rows added via "Add host" are allowed to sit blank until filled in — only rows
+    // the user has actually typed into are validated as hostnames. At least one non-blank
+    // host is still required overall.
+    const nonEmptyHosts = hosts.filter(h => h.host.trim() !== '');
+    if (nonEmptyHosts.length === 0) return 'Host is required.';
+
+    const firstError = nonEmptyHosts.map(h => validateDuplicateHost(h.host)).find(message => message !== null);
+    if (firstError) return firstError;
+
+    const hostValues = nonEmptyHosts.map(h => h.host.trim());
+    if (new Set(hostValues).size !== hostValues.length) return 'Duplicated hosts not allowed';
+    return null;
+}
+
+export function validateTcpPort(value: string): string | null {
+    const trimmed = value.trim();
+    if (!trimmed) return 'Port is required.';
+    if (!/^\d+$/.test(trimmed)) return 'Port must be a number between 0 and 65535.';
+    const port = Number(trimmed);
+    if (port < 0 || port > 65535) return 'Port must be a number between 0 and 65535.';
+    return null;
+}
+
+function validateTcpEntrypoint(form: ApiProxyDraft): ValidationErrors {
+    const errors: ValidationErrors = {};
+    const hostsError = validateTcpHosts(form.tcpHosts);
+    if (hostsError) errors['tcpHosts'] = hostsError;
+    const targetHostError = validateDuplicateHost(form.tcpTargetHost);
+    if (targetHostError) errors['tcpTargetHost'] = targetHostError;
+    const portError = validateTcpPort(form.tcpTargetPort);
+    if (portError) errors['tcpTargetPort'] = portError;
+    return errors;
+}
+
 export function validateEntrypoints(form: ApiProxyDraft): ValidationErrors {
+    if (isTcpForm(form)) return validateTcpEntrypoint(form);
+
     const errors: ValidationErrors = {};
     const urlError = validateTargetUrl(form.targetUrl);
     if (urlError) errors['targetUrl'] = urlError;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiHttpProxy.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiHttpProxy.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatEndpointTarget, hasTcpListeners, isHttpProxyApi } from './apiHttpProxy';
+import type { ApiDetailDto } from '../types';
+
+describe('hasTcpListeners', () => {
+    it('returns false when api is null, undefined, or has no listeners', () => {
+        expect(hasTcpListeners(null)).toBe(false);
+        expect(hasTcpListeners(undefined)).toBe(false);
+        expect(hasTcpListeners({})).toBe(false);
+    });
+
+    it('returns false when no listener is TCP', () => {
+        expect(hasTcpListeners({ listeners: [{ type: 'HTTP' }] })).toBe(false);
+    });
+
+    it('returns true when any listener is TCP', () => {
+        expect(hasTcpListeners({ listeners: [{ type: 'HTTP' }, { type: 'TCP' }] })).toBe(true);
+    });
+});
+
+describe('isHttpProxyApi', () => {
+    it('returns false when api is null or undefined', () => {
+        expect(isHttpProxyApi(null)).toBe(false);
+        expect(isHttpProxyApi(undefined)).toBe(false);
+    });
+
+    it('returns false when the api is not a PROXY type', () => {
+        expect(isHttpProxyApi({ id: '1', name: 'a', type: 'MESSAGE' } as ApiDetailDto)).toBe(false);
+    });
+
+    it('returns false when the api has a TCP listener', () => {
+        const api = { id: '1', name: 'a', type: 'PROXY', listeners: [{ type: 'TCP' }] } as unknown as ApiDetailDto;
+        expect(isHttpProxyApi(api)).toBe(false);
+    });
+
+    it('returns true for a PROXY api without TCP listeners', () => {
+        const api = { id: '1', name: 'a', type: 'PROXY', listeners: [{ type: 'HTTP' }] } as ApiDetailDto;
+        expect(isHttpProxyApi(api)).toBe(true);
+    });
+});
+
+describe('formatEndpointTarget', () => {
+    it('returns undefined when the target is undefined', () => {
+        expect(formatEndpointTarget(undefined)).toBeUndefined();
+    });
+
+    it('returns the string target unchanged for HTTP endpoints', () => {
+        expect(formatEndpointTarget('https://backend.example.com')).toBe('https://backend.example.com');
+    });
+
+    it('formats a TCP target as host:port', () => {
+        expect(formatEndpointTarget({ host: 'backend.example.com', port: 9090, secured: false })).toBe('backend.example.com:9090');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiHttpProxy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiHttpProxy.ts
@@ -13,11 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApiDetailDto } from '../types';
+import type { ApiDetailDto, TcpTarget } from '../types';
+
+/** Structural — matches both `ApiDetailDto` and the narrower `PolicyStudioApiDetail`. */
+interface ApiWithListeners {
+    listeners?: { type?: string }[];
+}
+
+export function hasTcpListeners(api: ApiWithListeners | null | undefined): boolean {
+    return Boolean(api?.listeners?.some(l => l.type === 'TCP'));
+}
 
 /** HTTP PROXY API without TCP listeners — health-check is available (legacy console rule). */
 export function isHttpProxyApi(api: ApiDetailDto | null | undefined): boolean {
     if (!api) return false;
     if (api.type !== 'PROXY') return false;
-    return !api.listeners?.some(l => (l as { type?: string }).type === 'TCP');
+    return !hasTcpListeners(api);
+}
+
+/** An endpoint's `configuration.target` is a plain URL for http-proxy, or a {host,port,secured} object for tcp-proxy. */
+export function formatEndpointTarget(target: string | TcpTarget | undefined): string | undefined {
+    if (target === undefined) return undefined;
+    if (typeof target === 'string') return target;
+    return `${target.host}:${target.port}`;
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
@@ -17,10 +17,12 @@ import {
     buildApiResources,
     buildPlanName,
     buildPreviewGatewayUrl,
+    buildPreviewUpstream,
     GATEWAY_URL_PLACEHOLDER,
     mapFormToCreateRequest,
     mapFormToPlanRequest,
     OAUTH2_RESOURCE_NAME,
+    TCP_HOST_PLACEHOLDER,
 } from './apiProxyMapper';
 import type { ApiProxyDraft } from '../types/apiCreation';
 
@@ -28,10 +30,15 @@ const BASE: ApiProxyDraft = {
     apiName: 'My API',
     apiVersion: '1.0.0',
     apiDescription: 'A test API',
+    protocol: 'HTTP',
     contextPath: '/my-api',
     virtualHostsEnabled: false,
     virtualHosts: [{ id: '1', host: 'api.example.com', path: '/v1', overrideAccess: false }],
     targetUrl: 'https://backend.example.com',
+    tcpHosts: [{ id: '1', host: 'tcp.example.com' }],
+    tcpTargetHost: 'backend.example.com',
+    tcpTargetPort: '9090',
+    tcpTargetSecured: false,
     authType: 'keyless',
     apiKeyPlanName: 'API Key Plan',
     jwtPlanName: 'JWT Plan',
@@ -76,6 +83,36 @@ describe('buildPreviewGatewayUrl', () => {
     it('falls back to "/your-api" placeholder when contextPath is empty and virtual hosts are disabled', () => {
         expect(buildPreviewGatewayUrl(form({ contextPath: '' }))).toBe(`${GATEWAY_URL_PLACEHOLDER}/your-api`);
     });
+
+    it('returns the first TCP host when protocol is TCP', () => {
+        expect(buildPreviewGatewayUrl(form({ protocol: 'TCP' }))).toBe('tcp.example.com');
+    });
+
+    it('falls back to the TCP host placeholder when no TCP host is set', () => {
+        expect(buildPreviewGatewayUrl(form({ protocol: 'TCP', tcpHosts: [{ id: '1', host: '' }] }))).toBe(TCP_HOST_PLACEHOLDER);
+    });
+});
+
+describe('buildPreviewUpstream', () => {
+    it('returns the target URL for HTTP', () => {
+        expect(buildPreviewUpstream(form())).toBe('https://backend.example.com');
+    });
+
+    it('falls back to the "upstream:port" placeholder when the HTTP target URL is empty', () => {
+        expect(buildPreviewUpstream(form({ targetUrl: '' }))).toBe('upstream:port');
+    });
+
+    it('returns host:port for TCP', () => {
+        expect(buildPreviewUpstream(form({ protocol: 'TCP' }))).toBe('backend.example.com:9090');
+    });
+
+    it('falls back to the "port" placeholder when no TCP port is set', () => {
+        expect(buildPreviewUpstream(form({ protocol: 'TCP', tcpTargetPort: '' }))).toBe('backend.example.com:port');
+    });
+
+    it('falls back to the "upstream" placeholder when no TCP target host is set', () => {
+        expect(buildPreviewUpstream(form({ protocol: 'TCP', tcpTargetHost: '' }))).toBe('upstream:9090');
+    });
 });
 
 describe('mapFormToCreateRequest', () => {
@@ -104,6 +141,49 @@ describe('mapFormToCreateRequest', () => {
     it('defaults visibility to PRIVATE so the classic console can read the created API', () => {
         expect(mapFormToCreateRequest(form()).visibility).toBe('PRIVATE');
     });
+
+    it('produces a TCP listener and tcp-proxy endpoint group when protocol is TCP', () => {
+        const req = mapFormToCreateRequest(form({ protocol: 'TCP', tcpTargetSecured: true }));
+
+        expect(req.listeners[0]).toEqual({ type: 'TCP', hosts: ['tcp.example.com'], entrypoints: [{ type: 'tcp-proxy' }] });
+        expect(req.endpointGroups[0]).toEqual({
+            name: 'Default TCP Proxy group',
+            type: 'tcp-proxy',
+            sharedConfiguration: {},
+            endpoints: [
+                {
+                    name: 'Default TCP Proxy',
+                    type: 'tcp-proxy',
+                    weight: 1,
+                    inheritConfiguration: false,
+                    configuration: { target: { host: 'backend.example.com', port: 9090, secured: true } },
+                },
+            ],
+        });
+    });
+
+    it('sends every TCP host, mapped to trimmed plain hostnames with blanks filtered out', () => {
+        const req = mapFormToCreateRequest(
+            form({
+                protocol: 'TCP',
+                tcpHosts: [
+                    { id: '1', host: ' a.example.com ' },
+                    { id: '2', host: '' },
+                    { id: '3', host: 'b.example.com' },
+                ],
+            }),
+        );
+        expect(req.listeners[0]).toMatchObject({ hosts: ['a.example.com', 'b.example.com'] });
+    });
+
+    it('trims the TCP target host and parses the port as a number', () => {
+        const req = mapFormToCreateRequest(form({ protocol: 'TCP', tcpTargetHost: ' backend.example.com ', tcpTargetPort: ' 9090 ' }));
+        expect(req.endpointGroups[0].endpoints[0].configuration.target).toEqual({
+            host: 'backend.example.com',
+            port: 9090,
+            secured: false,
+        });
+    });
 });
 
 describe('mapFormToPlanRequest', () => {
@@ -123,6 +203,10 @@ describe('mapFormToPlanRequest', () => {
         const oauth2Security = mapFormToPlanRequest(form({ authType: 'oauth2' })).security;
         expect(oauth2Security.type).toBe('OAUTH2');
         expect(oauth2Security.configuration).toMatchObject({ oauthResource: OAUTH2_RESOURCE_NAME });
+    });
+
+    it('always maps TCP APIs to KEY_LESS security, even if authType somehow differs', () => {
+        expect(mapFormToPlanRequest(form({ protocol: 'TCP', authType: 'jwt' })).security).toEqual({ type: 'KEY_LESS' });
     });
 });
 
@@ -147,6 +231,10 @@ describe('buildApiResources', () => {
     it('returns no resources when no OAuth2 provider has been selected', () => {
         expect(buildApiResources(form({ authType: 'oauth2', oauth2ResourceType: '' }))).toEqual([]);
     });
+
+    it('returns no resources for TCP APIs even if oauth2 fields are somehow set', () => {
+        expect(buildApiResources(form({ protocol: 'TCP', authType: 'oauth2' }))).toEqual([]);
+    });
 });
 
 describe('buildPlanName', () => {
@@ -156,5 +244,9 @@ describe('buildPlanName', () => {
         expect(buildPlanName(form({ authType: 'jwt' }))).toBe('JWT Plan');
         expect(buildPlanName(form({ authType: 'oauth2' }))).toBe('OAuth2 Plan');
         expect(buildPlanName(form({ authType: 'mtls' }))).toBe('mTLS Plan');
+    });
+
+    it('flags TCP APIs as unsecured regardless of auth type', () => {
+        expect(buildPlanName(form({ protocol: 'TCP' }))).toBe('Default Keyless (UNSECURED)');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
@@ -13,16 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isTcpForm } from './protocol';
 import { DEFAULT_OAUTH2_CONFIG } from '../pages/detail/plans/plan-form/security/oauth2Config';
-import type { CreateApiPlanRequest, CreateApiProxyRequest, HttpListener, PlanSecurity } from '../types';
+import type {
+    CreateApiPlanRequest,
+    CreateApiProxyRequest,
+    HttpEndpointGroup,
+    HttpListener,
+    PlanSecurity,
+    TcpEndpointGroup,
+    TcpListener,
+} from '../types';
 import type { ApiProxyDraft } from '../types/apiCreation';
 import type { ApiResource } from '../types/resource';
 
 export const GATEWAY_URL_PLACEHOLDER = 'https://gateway.company.com';
+export const TCP_HOST_PLACEHOLDER = 'host.example.com';
 
 export const OAUTH2_RESOURCE_NAME = 'OAuth2 Authorization Server';
 
 export function buildPreviewGatewayUrl(form: ApiProxyDraft, gatewayPrefix = GATEWAY_URL_PLACEHOLDER): string {
+    if (isTcpForm(form)) {
+        return form.tcpHosts.find(h => h.host.trim())?.host.trim() || TCP_HOST_PLACEHOLDER;
+    }
     if (form.virtualHostsEnabled && form.virtualHosts.length > 0) {
         const first = form.virtualHosts[0];
         const host = first.host || gatewayPrefix;
@@ -33,7 +46,25 @@ export function buildPreviewGatewayUrl(form: ApiProxyDraft, gatewayPrefix = GATE
     return `${gatewayPrefix}${path}`;
 }
 
-function buildListener(form: ApiProxyDraft): HttpListener {
+/** Upstream target display, shared by the review step and the flow visualization. */
+export function buildPreviewUpstream(form: ApiProxyDraft): string {
+    if (isTcpForm(form)) {
+        const host = form.tcpTargetHost.trim() || 'upstream';
+        const port = form.tcpTargetPort.trim() || 'port';
+        return `${host}:${port}`;
+    }
+    return form.targetUrl.trim() || 'upstream:port';
+}
+
+function buildTcpListener(form: ApiProxyDraft): TcpListener {
+    return {
+        type: 'TCP',
+        hosts: form.tcpHosts.map(h => h.host.trim()).filter(Boolean),
+        entrypoints: [{ type: 'tcp-proxy' }],
+    };
+}
+
+function buildHttpListener(form: ApiProxyDraft): HttpListener {
     if (form.virtualHostsEnabled && form.virtualHosts.length > 0) {
         return {
             type: 'HTTP',
@@ -48,7 +79,70 @@ function buildListener(form: ApiProxyDraft): HttpListener {
     return { type: 'HTTP', paths: [{ path: form.contextPath }], entrypoints: [{ type: 'http-proxy' }] };
 }
 
+const LISTENER_BUILDERS: Record<ApiProxyDraft['protocol'], (form: ApiProxyDraft) => HttpListener | TcpListener> = {
+    HTTP: buildHttpListener,
+    TCP: buildTcpListener,
+};
+
+function buildListener(form: ApiProxyDraft): HttpListener | TcpListener {
+    return LISTENER_BUILDERS[form.protocol](form);
+}
+
+function buildTcpEndpointGroups(form: ApiProxyDraft): TcpEndpointGroup[] {
+    return [
+        {
+            name: 'Default TCP Proxy group',
+            type: 'tcp-proxy',
+            sharedConfiguration: {},
+            endpoints: [
+                {
+                    name: 'Default TCP Proxy',
+                    type: 'tcp-proxy',
+                    weight: 1,
+                    inheritConfiguration: false,
+                    configuration: {
+                        target: {
+                            host: form.tcpTargetHost.trim(),
+                            port: Number(form.tcpTargetPort.trim()),
+                            secured: form.tcpTargetSecured,
+                        },
+                    },
+                },
+            ],
+        },
+    ];
+}
+
+function buildHttpEndpointGroups(form: ApiProxyDraft): HttpEndpointGroup[] {
+    return [
+        {
+            name: 'Default endpoint group',
+            type: 'http-proxy',
+            sharedConfiguration: {},
+            endpoints: [
+                {
+                    name: 'Default endpoint',
+                    type: 'http-proxy',
+                    weight: 1,
+                    inheritConfiguration: false,
+                    configuration: { target: form.targetUrl },
+                },
+            ],
+        },
+    ];
+}
+
+const ENDPOINT_GROUP_BUILDERS: Record<ApiProxyDraft['protocol'], (form: ApiProxyDraft) => (HttpEndpointGroup | TcpEndpointGroup)[]> = {
+    HTTP: buildHttpEndpointGroups,
+    TCP: buildTcpEndpointGroups,
+};
+
+function buildEndpointGroups(form: ApiProxyDraft): (HttpEndpointGroup | TcpEndpointGroup)[] {
+    return ENDPOINT_GROUP_BUILDERS[form.protocol](form);
+}
+
 function buildPlanSecurity(form: ApiProxyDraft): PlanSecurity {
+    if (isTcpForm(form)) return { type: 'KEY_LESS' };
     switch (form.authType) {
         case 'keyless':
             return { type: 'KEY_LESS' };
@@ -71,6 +165,7 @@ function buildPlanSecurity(form: ApiProxyDraft): PlanSecurity {
 }
 
 export function buildPlanName(form: ApiProxyDraft): string {
+    if (isTcpForm(form)) return 'Default Keyless (UNSECURED)';
     switch (form.authType) {
         case 'keyless':
             return 'Default keyless plan';
@@ -95,27 +190,12 @@ export function mapFormToCreateRequest(form: ApiProxyDraft): CreateApiProxyReque
         visibility: 'PRIVATE',
         listeners: [buildListener(form)],
         allowedInApiProducts: false,
-        endpointGroups: [
-            {
-                name: 'Default endpoint group',
-                type: 'http-proxy',
-                sharedConfiguration: {},
-                endpoints: [
-                    {
-                        name: 'Default endpoint',
-                        type: 'http-proxy',
-                        weight: 1,
-                        inheritConfiguration: false,
-                        configuration: { target: form.targetUrl },
-                    },
-                ],
-            },
-        ],
+        endpointGroups: buildEndpointGroups(form),
     };
 }
 
 export function buildApiResources(form: ApiProxyDraft): ApiResource[] {
-    if (form.authType !== 'oauth2' || !form.oauth2ResourceType) return [];
+    if (isTcpForm(form) || form.authType !== 'oauth2' || !form.oauth2ResourceType) return [];
     return [
         {
             name: OAUTH2_RESOURCE_NAME,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/protocol.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/protocol.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiProxyDraft } from '../types/apiCreation';
+
+/**
+ * Single source of truth for "is this creation-wizard draft a TCP proxy" — was previously
+ * re-derived as `form.protocol === 'TCP'` independently in half a dozen files. For the
+ * post-creation API detail side, the equivalent predicate is `hasTcpListeners()` in
+ * `apiHttpProxy.ts` (a different data shape — `ApiDetailDto`, not a wizard draft).
+ */
+export function isTcpForm(form: Pick<ApiProxyDraft, 'protocol'>): boolean {
+    return form.protocol === 'TCP';
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14670

## Description

## Summary

Adds **TCP Proxy** as a second selectable API type in Gamma's "Start from scratch" wizard, alongside the existing HTTP proxy flow — bringing TCP proxy creation to Gamma for the first time (previously only possible via legacy Console).

## What changed

- **API Details step** — API type now chosen via HTTP Proxy / TCP Proxy cards, gated on the entrypoint plugin's deployment status
- **Configure Proxy step** — TCP swaps HTTP path/vhost fields for TCP-specific ones: gateway hosts, backend target host/port, optional TLS
- **Host validation** — reuses existing hostname-regex validation and the async host-uniqueness-check service (previously only used by the duplicate-API dialog)
- **Secure step** — Keyless-only for TCP (no auth-type selector), matching classic console's rule that TCP listeners can't carry HTTP-level auth
- **Review & Deploy** — builds a TCP listener + `tcp-proxy` endpoint group matching the plugin's config schema
- **Detail pages** — Entrypoints, Endpoints, and the endpoint form all gained TCP-aware variants (TCP hosts, `host:port` display, hidden HTTP-only options like health checks)
- **Sidebar nav** — locks/hides HTTP-only sections (CORS, Response Templates, Policy Studio, API Score) for TCP APIs
- **Access control** — new `CreateApiGate` guards `apis/new*` routes behind `environment-api-c` permission
- **Reused, not rebuilt** — extends the existing wizard/step/store scaffolding rather than a parallel TCP flow

## New files

- `useVerifyTcpHosts.ts` — async TCP host uniqueness validation hook
- `TcpHostsCard.tsx` — TCP entrypoints display card
- `CreateApiGate.tsx` — permission gate for create-API routes
- Specs for the above, plus expanded coverage on `ApiDetailSidebarNav`, `ApiEndpointsPage`, `ApiEntrypointsPage`, `EndpointGroupList`, `CreatePlanDropdown`


https://github.com/user-attachments/assets/4e073d98-0bb4-4f34-b8fa-d4e4cc8d1872

[tcp_proxy_test_scenarios.md](https://github.com/user-attachments/files/31776539/tcp_proxy_test_scenarios.md)

