### PR TITLE
feat(gateway): expose the subscribable plans of an Edge API

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApi.java
@@ -16,9 +16,11 @@
 package io.gravitee.gateway.reactive.handlers.api.v4;
 
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.AbstractPlan;
 import io.gravitee.gateway.reactor.AbstractReactableApi;
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class EdgeApi extends AbstractReactableApi<io.gravitee.definition.model.v4.edge.EdgeApi> {
 
@@ -57,9 +59,15 @@ public class EdgeApi extends AbstractReactableApi<io.gravitee.definition.model.v
 
     @Override
     public Set<String> getSubscribablePlans() {
-        return Collections.emptySet();
+        return definition.getPlans() != null
+            ? definition.getPlans().stream().filter(AbstractPlan::isSubscribable).map(AbstractPlan::getId).collect(Collectors.toSet())
+            : Set.of();
     }
 
+    /**
+     * An Edge API cannot carry an api-key plan: the daemon authenticates with a client certificate, and the
+     * subscription is resolved from its thumbprint, never from a key.
+     */
     @Override
     public Set<String> getApiKeyPlans() {
         return Collections.emptySet();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApiTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApiTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EdgeApiTest {
+
+    private static EdgeApi edgeApi(List<Plan> plans) {
+        return new EdgeApi(io.gravitee.definition.model.v4.edge.EdgeApi.builder().id("edge-api").plans(plans).build());
+    }
+
+    private static Plan plan(String id, String securityType) {
+        return Plan.builder().id(id).security(PlanSecurity.builder().type(securityType).build()).build();
+    }
+
+    @Nested
+    class Subscribable_plans {
+
+        @Test
+        void should_return_the_ids_of_the_subscribable_plans() {
+            // Given
+            EdgeApi api = edgeApi(List.of(plan("mtls-plan", "MTLS"), plan("keyless-plan", "KEY_LESS")));
+
+            // When / Then
+            assertThat(api.getSubscribablePlans()).containsExactly("mtls-plan");
+        }
+
+        @Test
+        void should_return_an_empty_set_when_the_definition_has_no_plan() {
+            // Given
+            EdgeApi api = edgeApi(null);
+
+            // When / Then
+            assertThat(api.getSubscribablePlans()).isEmpty();
+        }
+
+        @Test
+        void should_return_an_empty_set_when_every_plan_is_keyless() {
+            // Given
+            EdgeApi api = edgeApi(List.of(plan("keyless-plan", "KEY_LESS")));
+
+            // When / Then
+            assertThat(api.getSubscribablePlans()).isEmpty();
+        }
+    }
+
+    @Nested
+    class Api_key_plans {
+
+        @Test
+        void should_always_be_empty_since_an_edge_api_cannot_carry_an_api_key_plan() {
+            // Given
+            EdgeApi api = edgeApi(List.of(plan("apikey-plan", "API_KEY")));
+
+            // When / Then
+            assertThat(api.getApiKeyPlans()).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EDGE-107

## Description

`io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi.getSubscribablePlans()` returned `Collections.emptySet()`, so `ApiReactorDeployable` contributed no plan id and `SubscriptionAppender.collectApiPlans` had nothing to pass to `loadSubscriptions`. As a result **no subscription was ever fetched for an Edge API**, and the reactor could not resolve one.

This implements it, mirroring `v4/Api.java`, with a null guard because the `plans` field of the Edge definition has no `@Builder.Default`:

```java
return definition.getPlans() != null
    ? definition.getPlans().stream().filter(AbstractPlan::isSubscribable).map(AbstractPlan::getId).collect(Collectors.toSet())
    : Set.of();
```

`isSubscribable()` excludes `KEY_LESS`, so the permanent keyless plan of an Edge API does not pollute the subscription query — only the mTLS plan is looked up.

`getApiKeyPlans()` deliberately stays empty: an Edge API cannot carry an api-key plan, the daemon authenticates with a client certificate and the subscription is resolved from its thumbprint.

Covered by a new `EdgeApiTest` (4 tests): subscribable plan ids, keyless exclusion, no-plan and null-plans cases, and api-key plans staying empty.

## Additional context

Prerequisite for EDGE-107, which puts the Edge Reactor endpoints behind an APIM mTLS plan. The reactor-side work lives in `gravitee-reactor-edge` and depends on this: without it the mTLS subscription never reaches `SubscriptionCacheService`.

Note that `EdgeApi.dependencies(Policy.class)` still returns an empty set. The Edge plan security policies are resolved plugin-side for now, so this PR stays limited to the subscription path.
