### PR TITLE
test: cover client abort during streaming and on http/2

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ClientAbortPropagationV4IntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ClientAbortPropagationV4IntegrationTest.java
@@ -28,6 +28,8 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -36,10 +38,12 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
 import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.io.InputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -48,19 +52,39 @@ import org.junit.jupiter.api.Test;
  * End-to-end coverage that a client abort releases the upstream connection-pool slot held (or awaited) by the aborted
  * request instead of burning it until the endpoint read timeout fires.
  *
- * The API under test uses a single-connection pool so one leaked slot is directly observable as latency on the next
+ * The APIs under test use a single-connection pool so one leaked slot is directly observable as latency on the next
  * request. Aborts are raw TCP socket closes, matching what the gateway sees when a real caller gives up.
  *
  * Without abort propagation, an aborted-while-queued request is still granted the connection once it frees up and
  * holds it idle until the read timeout (8s here) — the mechanism behind pool-collapse incidents where abandoned
  * requests shed no load and the collapse outlives the backend recovery.
+ *
+ * Each scenario runs against an HTTP/1.1 and an HTTP/2 endpoint. They are not the same test twice: an HTTP/1.1 slot is
+ * a whole connection released by closing it, while an HTTP/2 slot is one stream of a multiplexed connection released
+ * by an RST_STREAM, so the release path differs even though the observable contract does not. The HTTP/2 endpoint
+ * additionally caps multiplexing at one stream, without which the spare streams of the same connection would hide
+ * a leaked one.
+ *
+ * The three abort points cover the three owners of cancellation in the connector: while queued for the pool and while
+ * in flight before the response head, both guarded by {@code doOnDispose} on the connect chain, and during response
+ * streaming, guarded by {@code doOnCancel} on the response chunks.
+ *
+ * Five of the six combinations hold; the sixth is disabled and documents a gap on HTTP/2 — see
+ * should_release_pool_slot_when_queued_request_is_aborted_on_an_http2_endpoint.
  */
 @GatewayTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
 
+    private static final String HTTP_1_1_API = "/apis/v4/http/clientabort/api-client-abort-single-connection.json";
+    private static final String HTTP_2_API = "/apis/v4/http/clientabort/api-client-abort-single-connection-http2.json";
+
     private static final String BACKEND_PATH = "/endpoint";
     private static final long PROBE_LATENCY_BUDGET_MS = 2500;
+
+    /** Long enough that a slot held for the whole streamed response blows the probe budget several times over. */
+    private static final int STREAMED_BODY_DURATION_MS = 6000;
+    private static final int STREAMED_BODY_CHUNKS = 20;
 
     @Override
     public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
@@ -73,9 +97,67 @@ class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
     }
 
     @Test
-    @DeployApi("/apis/v4/http/clientabort/api-client-abort-single-connection.json")
+    @DeployApi(HTTP_1_1_API)
     void should_release_pool_slot_when_queued_request_is_aborted(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway)
         throws Exception {
+        assertQueuedAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    /**
+     * Reports a gap the APIM-14605 fix does not cover rather than asserting the defect: on an HTTP/2 endpoint the
+     * release path does run for an abort that happens while the request is queued — the stream granted after the
+     * abort is reset, and the connector logs it — but the multiplexing permit it consumed is never returned. The
+     * pooled connection is then permanently short one stream: with the single stream this endpoint allows, every
+     * later request answers 504 at the 8s readTimeout without ever reaching the backend, and the endpoint only
+     * recovers when the 30s idleTimeout evicts the connection. HTTP/1.1 releases the very same slot correctly, and
+     * an HTTP/2 abort after the request has been sent does too — it is the reset of a not-yet-sent stream that
+     * leaks. Enable once the permit is released.
+     */
+    @Test
+    @Disabled("Gap in APIM-14605 on HTTP/2 endpoints: an abort while queued leaks the stream's multiplexing permit")
+    @DeployApi(HTTP_2_API)
+    void should_release_pool_slot_when_queued_request_is_aborted_on_an_http2_endpoint(
+        HttpClient httpClient,
+        GatewayDynamicConfig.HttpConfig gateway
+    ) throws Exception {
+        assertQueuedAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    @Test
+    @DeployApi(HTTP_1_1_API)
+    void should_release_pool_slot_when_in_flight_request_is_aborted(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway)
+        throws Exception {
+        assertInFlightAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    @Test
+    @DeployApi(HTTP_2_API)
+    void should_release_pool_slot_when_in_flight_request_is_aborted_on_an_http2_endpoint(
+        HttpClient httpClient,
+        GatewayDynamicConfig.HttpConfig gateway
+    ) throws Exception {
+        assertInFlightAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    @Test
+    @DeployApi(HTTP_1_1_API)
+    void should_release_pool_slot_when_request_is_aborted_during_response_streaming(
+        HttpClient httpClient,
+        GatewayDynamicConfig.HttpConfig gateway
+    ) throws Exception {
+        assertStreamingAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    @Test
+    @DeployApi(HTTP_2_API)
+    void should_release_pool_slot_when_request_is_aborted_during_response_streaming_on_an_http2_endpoint(
+        HttpClient httpClient,
+        GatewayDynamicConfig.HttpConfig gateway
+    ) throws Exception {
+        assertStreamingAbortReleasesPoolSlot(httpClient, gateway);
+    }
+
+    private void assertQueuedAbortReleasesPoolSlot(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway) throws Exception {
         // First backend call is slow (3s) to keep the single connection busy; every later call answers immediately, so
         // any latency observed on the probe is pool-acquisition wait, not backend time.
         stubSlowThenFastBackend(3000);
@@ -102,10 +184,7 @@ class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
         wiremock.verify(2, getRequestedFor(urlPathEqualTo(BACKEND_PATH)));
     }
 
-    @Test
-    @DeployApi("/apis/v4/http/clientabort/api-client-abort-single-connection.json")
-    void should_release_pool_slot_when_in_flight_request_is_aborted(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway)
-        throws Exception {
+    private void assertInFlightAbortReleasesPoolSlot(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway) throws Exception {
         stubSlowThenFastBackend(6000);
 
         // Dispatched to the backend (single connection acquired), then aborted while the backend is still answering.
@@ -116,6 +195,21 @@ class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
         assertProbeAcquiresSlotWithin(httpClient, PROBE_LATENCY_BUDGET_MS);
     }
 
+    private void assertStreamingAbortReleasesPoolSlot(HttpClient httpClient, GatewayDynamicConfig.HttpConfig gateway) throws Exception {
+        stubStreamedThenFastBackend();
+
+        // Aborted after the response head has been received, so the slot is held by a response being streamed. From
+        // that point the connect chain is complete and only the response chunks' cancellation can release the slot.
+        abortClientRequestOnceResponseIsStreaming(gateway.httpPort());
+
+        // Without that release the slot stays busy for the rest of the 6s stream — the client it was being streamed to
+        // having already gone.
+        assertProbeAcquiresSlotWithin(httpClient, PROBE_LATENCY_BUDGET_MS);
+
+        // The aborted request did reach the backend here, unlike the queued case: streamed response + probe.
+        wiremock.verify(2, getRequestedFor(urlPathEqualTo(BACKEND_PATH)));
+    }
+
     private void stubSlowThenFastBackend(int slowDelayMillis) {
         wiremock.stubFor(
             get(BACKEND_PATH)
@@ -124,6 +218,33 @@ class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
                 .willReturn(ok("slow").withFixedDelay(slowDelayMillis))
                 .willSetStateTo("fast")
         );
+        stubFastBackend();
+    }
+
+    /**
+     * First call answers its head immediately then dribbles the body over {@link #STREAMED_BODY_DURATION_MS}, which is
+     * what puts the exchange in the response-streaming phase long enough to be aborted there.
+     * <p>
+     * The content type is what makes the response stream at all: the gateway only streams a body downstream for the
+     * content types {@code RequestUtils.hasStreamingContentType} recognises, and aggregates every other response,
+     * releasing it in one piece once the backend is done — which would leave no streaming window to abort in.
+     */
+    private void stubStreamedThenFastBackend() {
+        wiremock.stubFor(
+            get(BACKEND_PATH)
+                .inScenario("single-slot")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(
+                    ok("x".repeat(STREAMED_BODY_CHUNKS * 64))
+                        .withHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.TEXT_EVENT_STREAM)
+                        .withChunkedDribbleDelay(STREAMED_BODY_CHUNKS, STREAMED_BODY_DURATION_MS)
+                )
+                .willSetStateTo("fast")
+        );
+        stubFastBackend();
+    }
+
+    private void stubFastBackend() {
         wiremock.stubFor(get(BACKEND_PATH).inScenario("single-slot").whenScenarioStateIs("fast").willReturn(ok("fast")));
     }
 
@@ -133,11 +254,45 @@ class ClientAbortPropagationV4IntegrationTest extends AbstractGatewayTest {
      */
     private void abortClientRequest(int gatewayPort, long holdMillis) throws Exception {
         try (Socket socket = new Socket("localhost", gatewayPort)) {
-            socket.getOutputStream().write("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.UTF_8));
-            socket.getOutputStream().flush();
+            writeRequest(socket);
             Thread.sleep(holdMillis);
         }
-        // Leaves the gateway a beat to observe the close before the test moves on.
+        awaitCloseObservedByGateway();
+    }
+
+    /**
+     * Same abort, but held until the response head plus a first body byte have come back, so the exchange is provably
+     * past the response head and streaming its body. Sleeping a guessed duration instead would silently degrade into
+     * the in-flight case whenever the machine is slow, and pass for the wrong reason.
+     */
+    private void abortClientRequestOnceResponseIsStreaming(int gatewayPort) throws Exception {
+        try (Socket socket = new Socket("localhost", gatewayPort)) {
+            socket.setSoTimeout(5000);
+            writeRequest(socket);
+            readResponseHead(socket);
+            assertThat(socket.getInputStream().read()).as("first streamed body byte").isNotEqualTo(-1);
+        }
+        awaitCloseObservedByGateway();
+    }
+
+    private void writeRequest(Socket socket) throws Exception {
+        socket.getOutputStream().write("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+        socket.getOutputStream().flush();
+    }
+
+    /** Reads up to and including the CRLFCRLF that ends the response head. */
+    private void readResponseHead(Socket socket) throws Exception {
+        final InputStream in = socket.getInputStream();
+        int[] last = new int[4];
+        while (!(last[0] == '\r' && last[1] == '\n' && last[2] == '\r' && last[3] == '\n')) {
+            final int read = in.read();
+            assertThat(read).as("response head must be received before the abort").isNotEqualTo(-1);
+            last = new int[] { last[1], last[2], last[3], read };
+        }
+    }
+
+    /** Leaves the gateway a beat to observe the close before the test moves on. */
+    private void awaitCloseObservedByGateway() throws Exception {
         Thread.sleep(200);
     }
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/http/clientabort/api-client-abort-single-connection-http2.json
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/http/clientabort/api-client-abort-single-connection-http2.json
@@ -1,0 +1,68 @@
+{
+  "id": "my-api-v4-client-abort-http2",
+  "name": "my-api-v4-client-abort-http2",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 8000,
+              "idleTimeout": 30000,
+              "version": "HTTP_2",
+              "clearTextUpgrade": false,
+              "maxConcurrentConnections": 1,
+              "http2MultiplexingLimit": 1
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/P1ACT-466

## Description

Post-P1 action for P1ACT-464 (Marex 18000), part 2. Adds the two client-abort cases the existing coverage misses, extending `ClientAbortPropagationV4IntegrationTest` from 2 to 6 tests.

**1. Abort during response streaming.** The APIM-14605 fix guards the window between pool acquisition and the response head via `doOnDispose` in `HttpConnector.connect()`. From the response head onward cancellation is owned by a different branch — `doOnCancel` on the response chunks in `getEndpointResponseChunks()` — which had no slot-release assertion.

**2. Abort on an HTTP/2 endpoint.** All three abort points, against an h2c endpoint where a pool slot is one stream of a multiplexed connection.

The two existing test bodies moved unchanged into three shared scenario helpers so each abort point runs against both endpoint protocols without triplicating the setup. Assertions remain on observable slot availability (probe latency + backend request count).

New API definition `api-client-abort-single-connection-http2.json` caps **both** `maxConcurrentConnections: 1` and `http2MultiplexingLimit: 1` — with the default multiplexing limit the spare streams on the connection hide a leaked one and the test gives a false pass.

## Additional context

### Mutation evidence

Each test fails on the branch it guards, and on the probe-latency assertion:

| Test | fix removed (`doOnDispose`) | `doOnCancel` reset removed | master |
|---|---|---|---|
| queued HTTP/1.1 | FAIL | pass | pass |
| in-flight HTTP/1.1 | FAIL | pass | pass |
| in-flight HTTP/2 | FAIL | pass | pass |
| streaming HTTP/1.1 | pass | **FAIL** | pass |
| streaming HTTP/2 | pass | **FAIL** | pass |
| queued HTTP/2 | FAIL | FAIL | **FAIL — see below** |

### Gap found: HTTP/2 queued abort leaks the stream's multiplexing permit

On an HTTP/2 endpoint, a client abort **while the request is queued** for a pool slot leaves the endpoint unusable. The APIM-14605 release path does run — the stream granted after the abort is reset and the connector logs `Downstream request has been disposed, releasing upstream request to [...]` — but the multiplexing permit it consumed is never returned.

Measured with `maxConcurrentConnections: 1`, `http2MultiplexingLimit: 1`, `readTimeout: 8000`, `idleTimeout: 30000`:

- three consecutive probes → 504 after ~8s each, backend request count frozen at 1 (they never reach the backend);
- after a 35s idle wait → 200 in 16ms, i.e. recovery only once `idleTimeout` evicts the poisoned connection.

It is specifically the **reset of a not-yet-sent H2 stream** that leaks: HTTP/1.1 releases the same slot correctly, and an HTTP/2 abort after the request has been sent (in-flight, streaming) does too. A control run without the abort confirms the configuration is sound — the queued request waits ~2.9s and gets a 200.

Per the ticket's acceptance criteria the gap is reported rather than the assertion relaxed: that test is `@Disabled` with the full characterisation in its javadoc, ready to enable once the permit is released. A Jira bug for it is not filed yet.

### Note on the streaming stub

The streamed response uses `Content-Type: text/event-stream`. The gateway only streams a body downstream for the content types `RequestUtils.hasStreamingContentType` recognises and aggregates every other response, releasing it in one piece once the backend is done — which would leave no streaming window to abort in. Unrelated observation, not addressed here: `application/octet-stream` is listed in that method but did not stream in practice, whereas `text/event-stream` did.

### Verification

`ClientAbortPropagationV4IntegrationTest` — 6 tests, 5 pass, 1 skipped, 8.2s, with the prettier format gate enabled. Run against the working-tree engine (`-Pengine-snapshot`); without that profile the distribution assembles the pinned 4.12.14 engine instead.

Test-only change: no production code, no compatibility-sensitive surface touched.