### PR TITLE
fix(api-import): store the fetched spec, not the url, when importing from a url

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
@@ -97,9 +97,12 @@ public class OAIDomainServiceImpl implements OAIDomainService {
             var importWithEndpointGroupsSharedConfiguration = addEndpointGroupSharedConfiguration(importDefinition);
             var importWithGroups = replaceGroupNamesWithIds(environmentId, importWithEndpointGroupsSharedConfiguration);
             var importWithTags = replaceTagsNamesWithIds(organizationId, importWithGroups);
-            var importWithDocumentation = addOAIDocumentation(withDocumentation, payload, importWithTags);
+            // Both consumers below store their argument as an OpenAPI document, so a URL payload has to be
+            // resolved first. Skip the work when neither of them is going to keep it.
+            var specContent = (withDocumentation || withOASValidationPolicy) ? resolveSpecContent(payload, descriptor) : payload;
+            var importWithDocumentation = addOAIDocumentation(withDocumentation, specContent, importWithTags);
             boolean deferResponseValidation = shouldDeferResponseValidation(importSwaggerDescriptor);
-            return addOASValidationPolicy(withOASValidationPolicy, payload, importWithDocumentation, deferResponseValidation);
+            return addOASValidationPolicy(withOASValidationPolicy, specContent, importWithDocumentation, deferResponseValidation);
         }
 
         return null;
@@ -215,7 +218,26 @@ public class OAIDomainServiceImpl implements OAIDomainService {
             .build();
     }
 
-    private ImportDefinition addOAIDocumentation(boolean withDocumentation, String payload, ImportDefinition importWithTags) {
+    /**
+     * Returns the OpenAPI document to persist for the imported API.
+     *
+     * <p>For an inline import the payload already is the document and is kept verbatim, preserving the
+     * user's original formatting. For a URL import the payload is only a locator, so the document parsed
+     * from it is serialized instead. Note that the parse above runs with {@code resolveFully}, so a
+     * URL-imported document is stored with its {@code $ref}s inlined.
+     */
+    private String resolveSpecContent(String payload, OAIDescriptor descriptor) {
+        if (!UrlSanitizerUtils.isUrl(payload)) {
+            return payload;
+        }
+        try {
+            return descriptor.toJson();
+        } catch (JsonProcessingException e) {
+            throw new TechnicalManagementException("Error while serializing the OpenAPI specification fetched from " + payload, e);
+        }
+    }
+
+    private ImportDefinition addOAIDocumentation(boolean withDocumentation, String specContent, ImportDefinition importWithTags) {
         if (!withDocumentation) {
             return importWithTags;
         }
@@ -223,7 +245,7 @@ public class OAIDomainServiceImpl implements OAIDomainService {
             .name(DEFAULT_IMPORT_PAGE_NAME)
             .type(io.gravitee.apim.core.documentation.model.Page.Type.SWAGGER)
             .homepage(false)
-            .content(payload)
+            .content(specContent)
             .referenceType(io.gravitee.apim.core.documentation.model.Page.ReferenceType.API)
             .published(true)
             .visibility(Page.Visibility.PUBLIC)
@@ -234,7 +256,7 @@ public class OAIDomainServiceImpl implements OAIDomainService {
 
     private ImportDefinition addOASValidationPolicy(
         boolean withOASValidationPolicy,
-        String payload,
+        String specContent,
         ImportDefinition importDefinition,
         boolean deferResponseValidation
     ) {
@@ -251,7 +273,7 @@ public class OAIDomainServiceImpl implements OAIDomainService {
             Resource resource = Resource.builder()
                 .name("OpenAPI Specification")
                 .type("content-provider-inline-resource")
-                .configuration(new ObjectMapper().writeValueAsString(new LinkedHashMap<>(Map.of("content", payload))))
+                .configuration(new ObjectMapper().writeValueAsString(new LinkedHashMap<>(Map.of("content", specContent))))
                 .build();
             importDefinition.getApiExport().setResources(List.of(resource));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
@@ -15,15 +15,21 @@
  */
 package io.gravitee.apim.infra.domain_service.api;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.PolicyPluginCrudServiceInMemory;
 import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.definition.model.v4.flow.Flow;
@@ -200,6 +206,108 @@ class OAIDomainServiceImplTest {
             assertThat(oasFlows).hasSize(1);
             assertThat(oasFlows.getFirst().getRequest()).hasSize(1);
             assertThat(oasFlows.getFirst().getResponse()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @WireMockTest
+    class RemoteUrlPayload {
+
+        private static final String REMOTE_SPEC = """
+            {
+              "openapi": "3.0.3",
+              "info": { "title": "Remote", "version": "1.0.0" },
+              "servers": [ { "url": "https://api.example.com/remote" } ],
+              "paths": {
+                "/pets": {
+                  "get": {
+                    "operationId": "listPets",
+                    "responses": {
+                      "200": {
+                        "description": "ok",
+                        "content": {
+                          "application/json": {
+                            "schema": { "$ref": "#/components/schemas/Pet" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "components": {
+                "schemas": {
+                  "Pet": { "type": "object", "properties": { "name": { "type": "string" } } }
+                }
+              }
+            }
+            """;
+
+        private OAIDomainServiceImpl service;
+
+        @BeforeEach
+        void setUp() {
+            var importConfig = mock(ImportConfiguration.class);
+            when(importConfig.getImportWhitelist()).thenReturn(List.of());
+            // the stub server listens on localhost, which is a private address
+            when(importConfig.isAllowImportFromPrivate()).thenReturn(true);
+
+            var policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+            policyPluginCrudService.initWith(List.of(PolicyPlugin.builder().id("oas-validation").name("OAS Validation").build()));
+            var endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+            when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn("{}");
+
+            service = new OAIDomainServiceImpl(
+                new PolicyOperationVisitorManagerImpl(),
+                new GroupQueryServiceInMemory(),
+                new TagQueryServiceInMemory(),
+                endpointConnectorPluginService,
+                policyPluginCrudService,
+                importConfig
+            );
+        }
+
+        private String stubSpecUrl(WireMockRuntimeInfo wm) {
+            wm.getWireMock().register(get(urlEqualTo("/openapi.json")).willReturn(aResponse().withStatus(200).withBody(REMOTE_SPEC)));
+            return wm.getHttpBaseUrl() + "/openapi.json";
+        }
+
+        @Test
+        void should_store_the_fetched_specification_as_documentation_rather_than_the_url(WireMockRuntimeInfo wm) {
+            var url = stubSpecUrl(wm);
+            var descriptor = ImportSwaggerDescriptorEntity.builder().payload(url).build();
+
+            var result = service.convert(ORGANIZATION_ID, ENVIRONMENT_ID, descriptor, true, false);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getPages()).hasSize(1);
+            var page = result.getPages().getFirst();
+            assertThat(page.getType()).isEqualTo(Page.Type.SWAGGER);
+            assertThat(page.getContent()).isNotEqualTo(url).contains("\"openapi\"").contains("listPets");
+        }
+
+        @Test
+        void should_give_the_oas_validation_policy_the_fetched_specification_rather_than_the_url(WireMockRuntimeInfo wm) {
+            var url = stubSpecUrl(wm);
+            var descriptor = ImportSwaggerDescriptorEntity.builder().payload(url).build();
+
+            var result = service.convert(ORGANIZATION_ID, ENVIRONMENT_ID, descriptor, false, true);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getApiExport().getResources()).hasSize(1);
+            var configuration = result.getApiExport().getResources().getFirst().getConfiguration();
+            assertThat(configuration).isNotNull();
+            assertThat(configuration.toString()).doesNotContain(url).contains("listPets");
+        }
+
+        @Test
+        void should_keep_an_inline_payload_verbatim(WireMockRuntimeInfo wm) {
+            var descriptor = ImportSwaggerDescriptorEntity.builder().payload(REMOTE_SPEC).build();
+
+            var result = service.convert(ORGANIZATION_ID, ENVIRONMENT_ID, descriptor, true, false);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getPages().getFirst().getContent()).isEqualTo(REMOTE_SPEC);
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-989

## Problem

Importing an API from an OpenAPI **URL** stores the URL string itself as the imported specification, instead of the document fetched from it.

`OAIDomainServiceImpl.convert()` fetches and parses the URL via `toOAIDescriptor(payload)`, but then passes the raw `payload` on to the two places that persist it. Both end up holding `https://example.com/openapi.json` where an OpenAPI document is expected:

- `addOAIDocumentation` → the generated `SWAGGER` documentation page's `content` (no `PageSource` is attached, so nothing resolves it later)
- `addOASValidationPolicy` → the `content-provider-inline-resource` backing the OAS validation policy

Anything that later parses that content fails. Reported via the AI Management "create a tool from an API" flow, which surfaces the swagger-parser message ``attribute  is not of type `object` `` — swagger-parser reads a bare URL as a valid YAML *scalar* rather than a mapping. The OAS validation policy variant is quieter: the policy validates against a URL string at runtime rather than failing loudly.

## Fix

Resolve the payload once and hand the resolved document to both consumers. An inline payload is kept verbatim, so the existing path is byte-for-byte unchanged; only URL imports change behaviour. Resolution is skipped entirely when neither consumer is going to store anything.

The document is serialized from the descriptor already parsed in `convert()`, so there is no extra network fetch.

## Verification

Reproduced and verified end-to-end against a local 4.12.x instance with the AI Management module:

| Import method | Stored spec content | MCP tool generation |
| --- | --- | --- |
| By URL, before | 48 chars — the URL string | 0 tools, `invalidSpec` |
| By URL, after | the fetched document | **19 tools**, no errors |
| Inline, after | byte-for-byte identical to input | unchanged |

Also verified: Swagger 2.0 URL imports (converted to OAS 3 by the parser) now generate tools; a URL import with both flags off does no serialization; and recursive-schema specs serialize without blowing up (swagger-parser keeps cycles as `$ref`).

Three tests added in `OAIDomainServiceImplTest.RemoteUrlPayload`, using the WireMock convention already used in this module. The two fix-specific tests fail without the production change; the third is a regression guard for the inline path and passes either way.

## Reviewer note — worth a look

For URL imports the parse runs with `resolveFully`, so the stored document has its `$ref`s inlined: **18KB → 102KB** for the Petstore spec (5.6x). Storage is `nclob` on both columns so nothing breaks, but the OAS-validation resource lives in the API definition that ships to the gateway, so this does grow the deploy payload for APIs imported by URL with that option on. It buys correctness — that policy was validating against a URL before — but if the inflation is unwelcome, the alternative is fetching the URL's raw bytes and storing the original text verbatim, at the cost of one extra HTTP GET on import. Happy to switch.

Relatedly, a v2 document imported by URL is now stored as the converted OAS 3 document rather than the URL.

Ref: GMA-989, GMA-951
