### PR TITLE
fix(portal): default null visibility to PUBLIC when mapping legacy nav items

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemVisibilityIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalnavigationindex/PortalNavigationItemVisibilityIndexUpgrader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalnavigationindex;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalNavigationItemVisibilityIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_navigation_items")
+            .key("visibility", ascending())
+            .name("v1")
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultVisibilityMongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultVisibilityMongoUpgrader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills the {@code visibility} on portal navigation items that were persisted before this
+ * field was mandatory, so that Spring Data MongoDB can deserialize them into the now-{@code
+ * @Nonnull} core domain model, and so that DB-filtered queries (which exclude null-visibility
+ * documents) and Java-side viewer filtering (which defaults them to PUBLIC) no longer disagree
+ * about whether such an item is visible to anonymous portal viewers.
+ *
+ * Must run before {@code EnvironmentsDefaultPortalNavigationItemsUpgrader} (order 712), whose guard
+ * query fully deserializes existing items into the {@code @Nonnull}-annotated core domain model.
+ */
+@Component
+public class PortalNavigationItemDefaultVisibilityMongoUpgrader extends MongoUpgrader {
+
+    public static final int PORTAL_NAVIGATION_ITEM_DEFAULT_VISIBILITY_MONGO_UPGRADER_ORDER =
+        PortalNavigationItemDefaultReferenceMongoUpgrader.PORTAL_NAVIGATION_ITEM_DEFAULT_REFERENCE_MONGO_UPGRADER_ORDER + 1;
+
+    public static final String VISIBILITY = "visibility";
+    public static final String DEFAULT_VISIBILITY = "PUBLIC";
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var result = this.getCollection("portal_navigation_items").updateMany(
+            Filters.eq(VISIBILITY, null),
+            Updates.set(VISIBILITY, DEFAULT_VISIBILITY)
+        );
+        return result.wasAcknowledged();
+    }
+
+    @Override
+    public int getOrder() {
+        return PORTAL_NAVIGATION_ITEM_DEFAULT_VISIBILITY_MONGO_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultVisibilityMongoUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/portalnavigationitem/PortalNavigationItemDefaultVisibilityMongoUpgraderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem;
+
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem.PortalNavigationItemDefaultVisibilityMongoUpgrader.DEFAULT_VISIBILITY;
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem.PortalNavigationItemDefaultVisibilityMongoUpgrader.VISIBILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PortalNavigationItemDefaultVisibilityMongoUpgraderTest extends AbstractManagementRepositoryTest {
+
+    private static final String COLLECTION_NAME = "portal_navigation_items";
+
+    @Inject
+    private MongoTemplate mongoTemplate;
+
+    @Inject
+    private Environment environment;
+
+    private PortalNavigationItemDefaultVisibilityMongoUpgrader upgrader;
+    private String targetCollectionName;
+
+    @Override
+    protected String getTestCasesPath() {
+        // No fixtures: the upgrader manipulates the collection directly.
+        return null;
+    }
+
+    @BeforeEach
+    public void initUpgrader() {
+        upgrader = new PortalNavigationItemDefaultVisibilityMongoUpgrader();
+        upgrader.setMongoTemplate(mongoTemplate);
+        upgrader.setEnvironment(environment);
+        targetCollectionName = environment.getProperty("management.mongodb.prefix", "") + COLLECTION_NAME;
+        // deleteMany, not drop: drop() also removes the collection's indexes created once at context
+        // bootstrap, which would then make the notablescan-guarded updateMany fail with no index.
+        mongoTemplate.getCollection(targetCollectionName).deleteMany(new Document());
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        mongoTemplate.getCollection(targetCollectionName).deleteMany(new Document());
+    }
+
+    private Document findById(String id) {
+        return mongoTemplate.getCollection(targetCollectionName).find(new Document("_id", id)).first();
+    }
+
+    @Test
+    public void upgrade_should_backfill_visibility_when_field_is_missing() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-missing"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-missing").getString(VISIBILITY)).isEqualTo(DEFAULT_VISIBILITY);
+    }
+
+    @Test
+    public void upgrade_should_backfill_visibility_when_field_is_null() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-null").append(VISIBILITY, null));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-null").getString(VISIBILITY)).isEqualTo(DEFAULT_VISIBILITY);
+    }
+
+    @Test
+    public void upgrade_should_leave_existing_visibility_untouched() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-set").append(VISIBILITY, "PRIVATE"));
+
+        // When
+        boolean result = upgrader.upgrade();
+
+        // Then
+        assertThat(result).isTrue();
+        assertThat(findById("item-set").getString(VISIBILITY)).isEqualTo("PRIVATE");
+    }
+
+    @Test
+    public void upgrade_should_be_idempotent() throws Exception {
+        // Given
+        mongoTemplate.getCollection(targetCollectionName).insertOne(new Document("_id", "item-missing"));
+
+        // When
+        boolean first = upgrader.upgrade();
+        boolean second = upgrader.upgrade();
+
+        // Then
+        assertThat(first).isTrue();
+        assertThat(second).isTrue();
+        assertThat(findById("item-missing").getString(VISIBILITY)).isEqualTo(DEFAULT_VISIBILITY);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -71,7 +71,7 @@ public interface PortalNavigationItemAdapter {
 
     @Mapping(target = "url", expression = "java(parseUrl(portalNavigationItem.getConfiguration()))")
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
-    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -82,7 +82,7 @@ public interface PortalNavigationItemAdapter {
     );
 
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
-    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -93,7 +93,7 @@ public interface PortalNavigationItemAdapter {
     );
 
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
-    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -105,7 +105,7 @@ public interface PortalNavigationItemAdapter {
 
     @Mapping(target = "portalPageContentId", expression = "java(parsePortalPageContentId(portalNavigationItem.getConfiguration()))")
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
-    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
     @Mapping(target = "source", expression = "java(sourceFromRepository(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
@@ -356,22 +356,25 @@ public interface PortalNavigationItemAdapter {
         return PortalNavigationItemId.zero();
     }
 
-    @Named("repositoryVisibilityToDomain")
     default PortalVisibility repositoryVisibilityToDomain(
-        io.gravitee.repository.management.model.PortalNavigationItem.Visibility visibility
+        io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem
     ) {
+        var visibility = portalNavigationItem.getVisibility();
         if (visibility != null) {
             return switch (visibility) {
                 case PUBLIC -> PortalVisibility.PUBLIC;
                 case PRIVATE -> PortalVisibility.PRIVATE;
             };
         }
-        log.warn("Portal navigation item has null visibility; defaulting to PUBLIC.");
+        log.warn(
+            "Portal navigation item [{}] has null visibility; defaulting to PUBLIC. This is unexpected after visibility backfill.",
+            portalNavigationItem.getId()
+        );
         return PortalVisibility.PUBLIC;
     }
 
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
-    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
     @Mapping(target = "source", expression = "java(sourceFromRepository(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -71,6 +71,7 @@ public interface PortalNavigationItemAdapter {
 
     @Mapping(target = "url", expression = "java(parseUrl(portalNavigationItem.getConfiguration()))")
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -81,6 +82,7 @@ public interface PortalNavigationItemAdapter {
     );
 
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -91,6 +93,7 @@ public interface PortalNavigationItemAdapter {
     );
 
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
         target = "automationMetadata",
@@ -102,6 +105,7 @@ public interface PortalNavigationItemAdapter {
 
     @Mapping(target = "portalPageContentId", expression = "java(parsePortalPageContentId(portalNavigationItem.getConfiguration()))")
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
     @Mapping(target = "source", expression = "java(sourceFromRepository(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(
@@ -352,7 +356,22 @@ public interface PortalNavigationItemAdapter {
         return PortalNavigationItemId.zero();
     }
 
+    @Named("repositoryVisibilityToDomain")
+    default PortalVisibility repositoryVisibilityToDomain(
+        io.gravitee.repository.management.model.PortalNavigationItem.Visibility visibility
+    ) {
+        if (visibility != null) {
+            return switch (visibility) {
+                case PUBLIC -> PortalVisibility.PUBLIC;
+                case PRIVATE -> PortalVisibility.PRIVATE;
+            };
+        }
+        log.warn("Portal navigation item has null visibility; defaulting to PUBLIC.");
+        return PortalVisibility.PUBLIC;
+    }
+
     @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", source = "visibility", qualifiedByName = "repositoryVisibilityToDomain")
     @Mapping(target = "source", expression = "java(sourceFromRepository(portalNavigationItem))")
     @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
     @Mapping(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -191,6 +191,43 @@ class PortalNavigationItemAdapterTest {
             assertThat(((PortalNavigationFolder) entity).getRootId()).isEqualTo(PortalNavigationItemId.zero());
         }
 
+        /**
+         * Items persisted before visibility was mandatory (e.g. MongoDB, which has no NOT NULL
+         * constraint) can still have a null visibility. Defaulting to PUBLIC preserves the pre-existing
+         * behaviour where all items were visible.
+         */
+        @Test
+        void should_default_null_visibility_to_public_for_every_type() {
+            // Given
+            var folder = PortalNavigationItemsRepositoryFixtures.aFolder("550e8400-e29b-41d4-a716-446655440040", "My Folder", null);
+            folder.setVisibility(null);
+            var page = PortalNavigationItemsRepositoryFixtures.aPage(
+                "550e8400-e29b-41d4-a716-446655440041",
+                "My Page",
+                PortalPageContentId.random().toString(),
+                null
+            );
+            page.setVisibility(null);
+            var link = PortalNavigationItemsRepositoryFixtures.aLink("550e8400-e29b-41d4-a716-446655440042", "My Link", null, null);
+            link.setVisibility(null);
+            var api = PortalNavigationItemsRepositoryFixtures.anApi("550e8400-e29b-41d4-a716-446655440043", "My Api", "apiId", null);
+            api.setVisibility(null);
+            var apiProduct = PortalNavigationItemsRepositoryFixtures.anApiProduct(
+                "550e8400-e29b-41d4-a716-446655440044",
+                "My API Product",
+                "apiProductId",
+                null
+            );
+            apiProduct.setVisibility(null);
+
+            // Then
+            assertThat(adapter.toEntity(folder).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+            assertThat(adapter.toEntity(page).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+            assertThat(adapter.toEntity(link).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+            assertThat(adapter.toEntity(api).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+            assertThat(adapter.toEntity(apiProduct).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+        }
+
         @Test
         void should_throw_when_page_configuration_is_missing() {
             // Given

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -228,6 +228,43 @@ class PortalNavigationItemAdapterTest {
             assertThat(adapter.toEntity(apiProduct).getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
         }
 
+        /**
+         * The hand-written {@code Visibility} switch in {@code repositoryVisibilityToDomain} must map
+         * PRIVATE as faithfully as PUBLIC; a mis-mapped PRIVATE would leak private items to anonymous
+         * portal viewers without failing any null-visibility test.
+         */
+        @Test
+        void should_map_private_visibility_to_private_for_every_type() {
+            // Given
+            var folder = PortalNavigationItemsRepositoryFixtures.aFolder("550e8400-e29b-41d4-a716-446655440050", "My Folder", null);
+            folder.setVisibility(PortalNavigationItem.Visibility.PRIVATE);
+            var page = PortalNavigationItemsRepositoryFixtures.aPage(
+                "550e8400-e29b-41d4-a716-446655440051",
+                "My Page",
+                PortalPageContentId.random().toString(),
+                null
+            );
+            page.setVisibility(PortalNavigationItem.Visibility.PRIVATE);
+            var link = PortalNavigationItemsRepositoryFixtures.aLink("550e8400-e29b-41d4-a716-446655440052", "My Link", null, null);
+            link.setVisibility(PortalNavigationItem.Visibility.PRIVATE);
+            var api = PortalNavigationItemsRepositoryFixtures.anApi("550e8400-e29b-41d4-a716-446655440053", "My Api", "apiId", null);
+            api.setVisibility(PortalNavigationItem.Visibility.PRIVATE);
+            var apiProduct = PortalNavigationItemsRepositoryFixtures.anApiProduct(
+                "550e8400-e29b-41d4-a716-446655440054",
+                "My API Product",
+                "apiProductId",
+                null
+            );
+            apiProduct.setVisibility(PortalNavigationItem.Visibility.PRIVATE);
+
+            // Then
+            assertThat(adapter.toEntity(folder).getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            assertThat(adapter.toEntity(page).getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            assertThat(adapter.toEntity(link).getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            assertThat(adapter.toEntity(api).getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+            assertThat(adapter.toEntity(apiProduct).getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+        }
+
         @Test
         void should_throw_when_page_configuration_is_missing() {
             // Given


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-159

**Purpose**

Fix a NullPointerException that aborts `EnvironmentsDefaultPortalNavigationItemsUpgrader` when it reads a portal navigation item with a null `visibility`.

**Security-sensitive**

This change touches `visibility`, which gates portal exposure (`PortalNavigationItemViewerContext.shouldNotShow`) — i.e. whether an item is reachable by unauthenticated portal viewers.

**Summary of changes**

- `PortalNavigationItemAdapter` now maps `visibility` through a new `repositoryVisibilityToDomain` helper that defaults a null/missing value to `PUBLIC` (with a warning log identifying the item), instead of passing it straight into the `@Nonnull`-annotated domain model.
- Applied to all five `*FromRepository` mapping methods (Folder, Page, Link, Api, ApiProduct).
- Added a Mongo backfill upgrader (`PortalNavigationItemDefaultVisibilityMongoUpgrader`) that sets null/missing `visibility` to `PUBLIC` directly in MongoDB, following the same pattern as the existing `rootId`/`segment`/`reference` backfills. This closes a divergence where the DB-filtered `searchItems` path excluded null-visibility items for anonymous portal viewers while the Java-side `filterForViewer` path (which relies on the adapter's default) included them.
- Added a companion `PortalNavigationItemVisibilityIndexUpgrader` (the backfill query needs an index on `visibility` to run under Mongo's `notablescan` guard, same as `rootId`/`segment`).
- Added `should_default_null_visibility_to_public_for_every_type` and `should_map_private_visibility_to_private_for_every_type` tests, covering all five navigation item subtypes for both the null-default path and the existing PRIVATE mapping.

**Out of scope**

The same `@Nonnull`-from-nullable-Mongo issue on other fields (`order`, `area`, `title`) — these have always been present/non-null on every persisted item, unlike `visibility`, which was added to the schema between full releases, so this failure mode doesn't apply to them today.

**Testing**

Added unit tests reproducing the exact reported production error and covering the PRIVATE branch. Verified RED → GREEN manually: temporarily removed the `@Mapping` override for one type, confirmed the test throws the exact production `NullPointerException` (`visibility is marked non-null but is null`), then restored the fix and confirmed all 33 tests in `PortalNavigationItemAdapterTest` pass. Also added `PortalNavigationItemDefaultVisibilityMongoUpgraderTest`, covering missing/null/untouched/idempotent backfill cases against a real MongoDB (via `AbstractManagementRepositoryTest`).

**Additional context**

Production error this fixes:
```
io.gravitee.node.api.upgrader.UpgraderException: java.lang.NullPointerException: visibility is marked non-null but is null
	at io.gravitee.node.api.upgrader.Upgrader.wrapException(Upgrader.java:68)
```

No UI/endpoint involved — background upgrader/mapper fix, so no screenshot/Postman recording applies.
