### PR TITLE
fix(gamma): improve env level filter in sidenav

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -22,6 +22,7 @@ import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEn
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { ApimApiError } from '../shared/api/apimClient';
 import { useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
+import { markNavItemDenied, resetDeniedNavItemsForEnvironment } from '../shared/nav/deniedNavItems';
 
 jest.mock('./PlatformToaster', () => ({
     PlatformToaster: () => <div data-testid="platform-toaster" />,
@@ -49,6 +50,8 @@ const mockPermissionListeners = new Set<() => void>();
 let mockPermissionStoreVersion = 0;
 
 const mockUseEnvironmentPermissionGrant = jest.fn<boolean | undefined, [string[]]>();
+
+let deniedNavItemResetCount = 0;
 
 function emitPermissionChange() {
     mockPermissionStoreVersion += 1;
@@ -79,6 +82,7 @@ jest.mock('../shared/hooks/useEnvironmentPermissions', () => ({
 }));
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: () => ({ id: 'env-1' }),
     useHasPermission: (options: unknown) => mockUseHasPermission(options),
     useHasFeature: (feature: unknown) => mockUseHasFeature(feature),
     permissionService: {
@@ -320,6 +324,8 @@ describe('AppRoutes', () => {
         mockUseEnvironmentPermissionsReady.mockReturnValue(true);
         mockPermissionListeners.clear();
         mockPermissionStoreVersion = 0;
+        // The denial store is module state; a switch to an unused environment id clears it.
+        resetDeniedNavItemsForEnvironment(`reset-${(deniedNavItemResetCount += 1)}`);
         mockUseEnvironmentDictionaries.mockReturnValue({
             data: [],
             isLoading: false,
@@ -706,6 +712,17 @@ describe('AppRoutes', () => {
 
         expect(screen.queryByTestId('alerts-page')).toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    // The audit pages answer an unlicensed visit with an upsell dialog whose dismiss leaves the page.
+    // Landing on one makes it undismissable: every exit resolves back to the landing key.
+    it('does not land on an audit page when the Audit Trail is unlicensed', () => {
+        mockUseHasFeature.mockImplementation((feature: string) => feature !== 'apim-audit-trail');
+        grantOnlyPermissions('organization-settings-u', 'organization-audit-r');
+
+        renderPlatform('/');
+
+        expect(screen.queryByTestId('org-audit-logs-page')).toBeNull();
     });
 
     it('hides the Alerts nav item when the user lacks environment-alert-r', () => {
@@ -1178,6 +1195,22 @@ describe('AppRoutes', () => {
 
         expect(screen.queryByTestId('alerts-page')).toBeNull();
         expect(screen.getByTestId('platform-no-access-page')).not.toBeNull();
+    });
+
+    // Tenants is granted by the organization scope, which the 403 strip cannot rewrite. Without the
+    // denial it stays visible and stays the landing key, so the redirect out of it lands back on it.
+    it('drops an org-scoped item from the sidebar and the landing key once a 403 denies it', () => {
+        grantOnlyPermissions('organization-settings-r', 'organization-tenant-r');
+        renderPlatform('/');
+
+        expect(visibleNavKeys()).toContain('tenants');
+        expect(screen.getByTestId('tenants-page')).not.toBeNull();
+
+        act(() => markNavItemDenied('tenants'));
+
+        expect(visibleNavKeys()).not.toContain('tenants');
+        expect(screen.queryByTestId('tenants-page')).toBeNull();
+        expect(screen.getByTestId('management-and-schedulers-page')).not.toBeNull();
     });
 
     it('does not reserve a context sidebar when no Platform menus are visible', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type { ComponentType } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -21,6 +21,7 @@ import { AppRoutes } from './AppRoutes';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { ApimApiError } from '../shared/api/apimClient';
+import { useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
 
 jest.mock('./PlatformToaster', () => ({
     PlatformToaster: () => <div data-testid="platform-toaster" />,
@@ -37,13 +38,29 @@ jest.mock('@gravitee/gamma-modules-sdk/routing', () => ({
 }));
 
 const mockUseLayoutConfig = jest.fn();
+const mockUseHasPermission = jest.fn().mockReturnValue(true);
+const mockUseHasFeature = jest.fn().mockReturnValue(true);
+const mockUseHasEnvironmentPermission = jest.fn().mockReturnValue(true);
+
+// The permission store is an external store, not React state: nav visibility only stays correct if it
+// re-reads on every version bump. A stub with a no-op `subscribe` and a constant `getSnapshot` makes a
+// frozen memo indistinguishable from a reactive one, so the fake keeps real listeners and a real version.
+const mockPermissionListeners = new Set<() => void>();
+let mockPermissionStoreVersion = 0;
+
+const mockUseEnvironmentPermissionGrant = jest.fn<boolean | undefined, [string[]]>();
+
+function emitPermissionChange() {
+    mockPermissionStoreVersion += 1;
+    mockPermissionListeners.forEach(listener => listener());
+}
 
 jest.mock('@gravitee/graphene-core', () => {
     const actual = jest.requireActual('@gravitee/graphene-core') as object;
     return {
         ...actual,
         useLayoutConfig: (config: unknown, deps: unknown) => mockUseLayoutConfig(config, deps),
-        ContextSidebar: () => null,
+        ContextSidebar: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
         ContextToggleButton: () => null,
         SidebarNavigation: () => null,
         buildLinearBreadcrumbs: () => [],
@@ -54,25 +71,24 @@ jest.mock('../shared/console-settings', () => ({
     ConsoleSettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-const mockUseHasEnvironmentPermission = jest.fn().mockReturnValue(true);
-
 jest.mock('../shared/hooks/useEnvironmentPermissions', () => ({
     useEnvironmentPermissions: jest.fn(),
     useEnvironmentPermissionsReady: jest.fn().mockReturnValue(true),
     useHasEnvironmentPermission: (anyOf: string[]) => mockUseHasEnvironmentPermission(anyOf),
-}));
-
-const mockUseHasPermission = jest.fn().mockReturnValue(true);
-const mockUseHasFeature = jest.fn().mockReturnValue(true);
-
-jest.mock('../shared/gamma-modules-sdk', () => ({
-    useHasPermission: (options: unknown) => mockUseHasPermission(options),
-    useHasFeature: (feature: unknown) => mockUseHasFeature(feature),
+    useEnvironmentPermissionGrant: (anyOf: string[]) => mockUseEnvironmentPermissionGrant(anyOf),
 }));
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: (options: unknown) => mockUseHasPermission(options),
     useHasFeature: (feature: unknown) => mockUseHasFeature(feature),
+    permissionService: {
+        hasAnyOf: (required?: string[]) => mockUseHasPermission({ anyOf: required ?? [] }),
+        subscribe: (listener: () => void) => {
+            mockPermissionListeners.add(listener);
+            return () => mockPermissionListeners.delete(listener);
+        },
+        getSnapshot: () => mockPermissionStoreVersion,
+    },
 }));
 
 jest.mock('../features/dictionaries/hooks/useEnvironmentDictionaries');
@@ -80,6 +96,16 @@ jest.mock('../features/metadata/hooks/useEnvironmentMetadata');
 
 const mockUseEnvironmentDictionaries = jest.mocked(useEnvironmentDictionaries);
 const mockUseEnvironmentMetadata = jest.mocked(useEnvironmentMetadata);
+const mockUseEnvironmentPermissionsReady = jest.mocked(useEnvironmentPermissionsReady);
+
+function denyPermissions(...denied: string[]) {
+    mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.some(permission => denied.includes(permission)));
+}
+
+/** Grants exactly `allowed` and nothing else, to pin the landing item down to a single nav entry. */
+function grantOnlyPermissions(...allowed: string[]) {
+    mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.some(permission => allowed.includes(permission)));
+}
 
 jest.mock('../pages/ApplicationsPage', () => ({
     ApplicationsPage: () => <div data-testid="applications-page" />,
@@ -172,6 +198,22 @@ jest.mock('../pages/NotificationTemplateDetailPage', () => ({
     NotificationTemplateDetailPage: () => <div data-testid="notification-template-detail-page" />,
 }));
 
+jest.mock('../pages/PlatformNoAccessPage', () => ({
+    PlatformNoAccessPage: () => <div data-testid="platform-no-access-page" />,
+}));
+
+jest.mock('../pages/EntrypointsAndShardingTagsPage', () => ({
+    EntrypointsAndShardingTagsPage: () => <div data-testid="entrypoints-page" />,
+}));
+
+jest.mock('../features/security-plan-types/SecurityPlanTypesPage', () => ({
+    SecurityPlanTypesPage: () => <div data-testid="security-plan-types-page" />,
+}));
+
+jest.mock('../pages/GatewayInstancesPage', () => ({
+    GatewayInstancesPage: () => <div data-testid="gateways-page" />,
+}));
+
 jest.mock('../features/applications/components/detail', () => ({
     ApplicationDetailLayout: () => <div data-testid="application-detail-layout" />,
     ApplicationDetailIndexRedirect: () => null,
@@ -220,7 +262,13 @@ type LayoutConfig = {
             children?: { props?: { groups?: NavGroupProps[]; onItemSelect?: (key: string) => void } };
         };
     };
+    viewMode?: 'global' | 'context';
+    breadcrumbs?: unknown;
 };
+
+function sectionLayout(): LayoutConfig | undefined {
+    return layoutConfigs().findLast(config => 'breadcrumbs' in config);
+}
 
 function layoutConfigs(): LayoutConfig[] {
     return mockUseLayoutConfig.mock.calls.map(call => call[0] as LayoutConfig);
@@ -268,6 +316,10 @@ describe('AppRoutes', () => {
         mockUseHasPermission.mockReset().mockReturnValue(true);
         mockUseHasFeature.mockReset().mockReturnValue(true);
         mockUseHasEnvironmentPermission.mockReset().mockReturnValue(true);
+        mockUseEnvironmentPermissionGrant.mockReset().mockReturnValue(true);
+        mockUseEnvironmentPermissionsReady.mockReturnValue(true);
+        mockPermissionListeners.clear();
+        mockPermissionStoreVersion = 0;
         mockUseEnvironmentDictionaries.mockReturnValue({
             data: [],
             isLoading: false,
@@ -473,9 +525,7 @@ describe('AppRoutes', () => {
     });
 
     it('redirects away from Shared Policy Groups when the user lacks environment-shared_policy_group-r', () => {
-        // The route guard reads this module's own live permission query, not the SDK's useHasPermission —
-        // see useEnvironmentPermissions.ts.
-        mockUseHasEnvironmentPermission.mockImplementation((anyOf: string[]) => !anyOf.includes('environment-shared_policy_group-r'));
+        mockUseEnvironmentPermissionGrant.mockImplementation((anyOf: string[]) => !anyOf.includes('environment-shared_policy_group-r'));
 
         render(
             <MemoryRouter initialEntries={['/shared-policy-groups']}>
@@ -483,6 +533,7 @@ describe('AppRoutes', () => {
             </MemoryRouter>,
         );
 
+        expect(screen.queryByTestId('shared-policy-groups-page')).toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 
@@ -492,8 +543,35 @@ describe('AppRoutes', () => {
         expect(visibleNavKeys()).toContain('shared-policy-groups');
     });
 
+    // permissionService is an external store: a 403 patch or a host reload bumps it without changing any
+    // React state the sidebar memo depends on, so the memo has to track the store's version explicitly.
+    it('recomputes the sidebar when the permission store changes after the first render', () => {
+        renderPlatform('/applications');
+        expect(visibleNavKeys()).toContain('gateways');
+
+        denyPermissions('environment-instance-r');
+        act(() => {
+            emitPermissionChange();
+        });
+
+        expect(visibleNavKeys()).not.toContain('gateways');
+    });
+
+    it('re-adds a nav item when the permission store grants it after the first render', () => {
+        denyPermissions('environment-instance-r');
+        renderPlatform('/applications');
+        expect(visibleNavKeys()).not.toContain('gateways');
+
+        mockUseHasPermission.mockReturnValue(true);
+        act(() => {
+            emitPermissionChange();
+        });
+
+        expect(visibleNavKeys()).toContain('gateways');
+    });
+
     it('hides the Shared Policy Groups nav item when the user lacks environment-shared_policy_group-r', () => {
-        mockUseHasEnvironmentPermission.mockImplementation((anyOf: string[]) => !anyOf.includes('environment-shared_policy_group-r'));
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-shared_policy_group-r'));
 
         renderPlatform();
 
@@ -636,6 +714,35 @@ describe('AppRoutes', () => {
         renderPlatform();
 
         expect(visibleNavKeys()).not.toContain('alerts');
+    });
+
+    // Alerts stays in the sidebar as a locked item, so it must not also be the landing target: the
+    // license redirect would bounce to applications, whose guard would bounce back to the landing key.
+    it('does not land on Alerts when Alert Engine is unlicensed, so the license redirect cannot loop', () => {
+        mockUseHasFeature.mockImplementation((feature: string) => feature !== 'alert-engine');
+        grantOnlyPermissions('environment-alert-r');
+
+        expect(() => renderPlatform('/')).not.toThrow();
+
+        expect(screen.queryByTestId('alerts-page')).toBeNull();
+        expect(screen.getByTestId('platform-no-access-page')).not.toBeNull();
+    });
+
+    it('does not loop when the permission store grants Shared Policy Groups but the module cache denies it', () => {
+        grantOnlyPermissions('environment-shared_policy_group-r');
+        mockUseEnvironmentPermissionGrant.mockReturnValue(false);
+
+        expect(() => renderPlatform('/')).not.toThrow();
+
+        expect(screen.queryByTestId('shared-policy-groups-page')).toBeNull();
+    });
+
+    it('defers to the permission store when the module permission cache has no data', () => {
+        mockUseEnvironmentPermissionGrant.mockReturnValue(undefined);
+
+        renderPlatform('/shared-policy-groups');
+
+        expect(screen.getByTestId('shared-policy-groups-page')).not.toBeNull();
     });
 
     it('routes to the Tenants page under the platform module', () => {
@@ -909,7 +1016,7 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 
-    it('shows Management & Schedulers, CORS, and SMTP when the user can read org settings', () => {
+    it('shows Management & Schedulers, CORS, SMTP, and Templates when the user can read org settings', () => {
         mockUseModuleRouting.mockReturnValue({
             activeNavKey: 'management-and-schedulers',
             navigateToKey: jest.fn(),
@@ -918,23 +1025,40 @@ describe('AppRoutes', () => {
         renderPlatform('/management-and-schedulers');
 
         expect(visibleNavKeys()).toEqual(
-            expect.arrayContaining(['access-management', 'authentication', 'management-and-schedulers', 'cors', 'smtp', 'templates']),
+            expect.arrayContaining(['authentication', 'management-and-schedulers', 'cors', 'smtp', 'templates']),
         );
+        expect(visibleNavKeys()).not.toContain('access-management');
     });
 
     it('hides organization console settings nav items without organization-settings-r', () => {
         mockUseModuleRouting.mockReturnValue({
-            activeNavKey: 'access-management',
+            activeNavKey: 'management-and-schedulers',
             navigateToKey: jest.fn(),
             rootPath: '/platform',
         });
-        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('organization-settings-r'));
+        denyPermissions('organization-settings-r', 'organization-settings-u');
+        renderPlatform('/applications');
+
+        expect(visibleNavKeys()).not.toContain('management-and-schedulers');
+        expect(visibleNavKeys()).not.toContain('cors');
+        expect(visibleNavKeys()).not.toContain('smtp');
+        expect(visibleNavKeys()).not.toContain('templates');
+        expect(visibleNavKeys()).toContain('access-management');
+        expect(visibleNavKeys()).not.toContain('tenants');
+        expect(visibleNavKeys()).not.toContain('users');
+        expect(visibleNavKeys()).not.toContain('policy-studio');
+    });
+
+    it('hides Management, CORS, and SMTP when the user has organization-settings-u without -r', () => {
+        denyPermissions('organization-settings-r');
         renderPlatform('/access-management');
 
         expect(visibleNavKeys()).not.toContain('management-and-schedulers');
         expect(visibleNavKeys()).not.toContain('cors');
         expect(visibleNavKeys()).not.toContain('smtp');
-        expect(visibleNavKeys()).toContain('access-management');
+        renderPlatform('/cors');
+        expect(screen.queryByTestId('cors-settings-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
     });
 
     it('routes to Authentication and Create Identity Provider', () => {
@@ -974,5 +1098,146 @@ describe('AppRoutes', () => {
         renderPlatform('/authentication/google-idp');
         expect(screen.queryByTestId('edit-identity-provider-page')).toBeNull();
         expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('hides Applications without environment-application-r', () => {
+        denyPermissions('environment-application-r');
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('applications');
+    });
+
+    it('does not render Applications for a pasted URL without environment-application-r', () => {
+        denyPermissions('environment-application-r');
+        renderPlatform('/applications');
+
+        expect(screen.queryByTestId('applications-page')).toBeNull();
+        expect(screen.getByTestId('tenants-page')).not.toBeNull();
+    });
+
+    it('does not render Alerts for a pasted URL without environment-alert-r', () => {
+        denyPermissions('environment-alert-r');
+        renderPlatform('/alerts');
+
+        expect(screen.queryByTestId('alerts-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('does not render Gateways for a pasted URL without environment-instance-r', () => {
+        denyPermissions('environment-instance-r');
+        renderPlatform('/gateways');
+
+        expect(screen.queryByTestId('gateways-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('does not render Security Plan Types for a pasted URL without environment-settings-r', () => {
+        denyPermissions('environment-settings-r');
+        renderPlatform('/security-plan-types');
+
+        expect(screen.queryByTestId('security-plan-types-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('hides Security Plan Types without environment-settings-r', () => {
+        denyPermissions('environment-settings-r');
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('security-plan-types');
+    });
+
+    it('renders Access Management from a pasted URL without organization-settings', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'access-management',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        denyPermissions('organization-settings-r', 'organization-settings-u');
+        renderPlatform('/access-management');
+
+        expect(screen.getByTestId('access-management-page')).not.toBeNull();
+        expect(visibleNavKeys()).toContain('access-management');
+    });
+
+    it('does not render Access Management without environment-am_configuration-r', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'access-management',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        denyPermissions('environment-am_configuration-r');
+        renderPlatform('/access-management');
+
+        expect(screen.queryByTestId('access-management-page')).toBeNull();
+        expect(visibleNavKeys()).not.toContain('access-management');
+    });
+
+    it('shows a no-access page when the user has no Platform menus', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPlatform('/alerts');
+
+        expect(screen.queryByTestId('alerts-page')).toBeNull();
+        expect(screen.getByTestId('platform-no-access-page')).not.toBeNull();
+    });
+
+    it('does not reserve a context sidebar when no Platform menus are visible', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPlatform('/no-access');
+
+        expect(sectionLayout()?.contextSidebar).toBeUndefined();
+        expect(sectionLayout()?.viewMode).toBeUndefined();
+    });
+
+    it('keeps no-access when that URL is opened and nothing is visible', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPlatform('/no-access');
+
+        expect(screen.getByTestId('platform-no-access-page')).not.toBeNull();
+    });
+
+    it('leaves a leftover no-access URL when the user has Applications', () => {
+        renderPlatform('/no-access');
+
+        expect(screen.queryByTestId('platform-no-access-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('opens Applications from the platform index when the user can read them', () => {
+        renderPlatform('/');
+
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('hides all nav items until environment permissions are ready', () => {
+        mockUseEnvironmentPermissionsReady.mockReturnValue(false);
+        renderPlatform();
+
+        expect(visibleNavKeys()).toEqual([]);
+        expect(primaryNavKeys()).toEqual([]);
+    });
+
+    it('keeps a stable empty groups list for the section layout while nothing is visible', () => {
+        mockUseEnvironmentPermissionsReady.mockReturnValue(false);
+        const view = render(
+            <MemoryRouter initialEntries={['/applications']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        const groupsAfterFirst = mockUseLayoutConfig.mock.calls
+            .filter(call => call[0] !== undefined && typeof call[0] === 'object' && call[0] !== null && 'breadcrumbs' in call[0])
+            .at(-1)?.[1] as unknown[];
+
+        view.rerender(
+            <MemoryRouter initialEntries={['/applications']}>
+                <AppRoutes />
+            </MemoryRouter>,
+        );
+
+        const groupsAfterRerender = mockUseLayoutConfig.mock.calls
+            .filter(call => call[0] !== undefined && typeof call[0] === 'object' && call[0] !== null && 'breadcrumbs' in call[0])
+            .at(-1)?.[1] as unknown[];
+
+        expect(groupsAfterFirst?.[3]).toBe(groupsAfterRerender?.[3]);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { permissionService, useHasFeature, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { permissionService, useEnvironment, useHasFeature, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import {
     buildLinearBreadcrumbs,
@@ -30,7 +30,7 @@ import {
     useLayoutConfig,
 } from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createContext, type ReactElement, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, type ReactElement, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { PlatformToaster } from './PlatformToaster';
@@ -52,6 +52,7 @@ import { AlertFormPage } from '../features/alerts/pages/AlertFormPage';
 import { AlertsActivityPage } from '../features/alerts/pages/AlertsActivityPage';
 import { ALERT_ENGINE_FEATURE } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { APIM_AUDIT_TRAIL_FEATURE } from '../features/audit-logs/license/auditTrailLicense';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { GatewayInstanceDetailLayout } from '../features/gateway-instances/components/GatewayInstanceDetailLayout';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
@@ -98,6 +99,7 @@ import {
     useEnvironmentPermissions,
     useEnvironmentPermissionsReady,
 } from '../shared/hooks/useEnvironmentPermissions';
+import { resetDeniedNavItemsForEnvironment, useDeniedNavItemKeys } from '../shared/nav/deniedNavItems';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
 const queryClient = new QueryClient({
@@ -109,8 +111,8 @@ const queryClient = new QueryClient({
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 const EMPTY_NAV_GROUPS: NavGroup[] = [];
-const NO_LOCKED_NAV_ITEMS: readonly string[] = [];
-const ALERT_ENGINE_LOCKED_NAV_ITEMS: readonly string[] = ['alerts'];
+const ALERT_ENGINE_NAV_ITEMS: readonly string[] = ['alerts'];
+const AUDIT_TRAIL_NAV_ITEMS: readonly string[] = ['organization-audit', 'environment-audit'];
 
 function resolveRequiredPermissions(permission?: string, anyOf?: readonly string[]): readonly string[] {
     if (anyOf) {
@@ -181,6 +183,12 @@ function NavPermissionGuard({
     children,
 }: Readonly<{ itemKey: string; unauthorizedTo?: string; children: ReactElement }>) {
     const { anyOf, alsoAnyOf } = pageGuardForNavItem(itemKey);
+    const deniedNavItemKeys = useDeniedNavItemKeys();
+    // A live 403 outranks the permission map, which can still grant the item from a scope this module
+    // does not own. Without this the page renders, 403s, and redirects on every visit.
+    if (deniedNavItemKeys.has(itemKey)) {
+        return <UnauthorizedRedirect />;
+    }
     return (
         <PermissionPageGuard anyOf={anyOf} alsoAnyOf={alsoAnyOf} unauthorizedTo={unauthorizedTo}>
             {children}
@@ -255,6 +263,12 @@ function usePlatformNavContext(): PlatformNavContextValue {
 function ModuleLayout() {
     useEnvironmentPermissions();
     const permissionVersion = usePermissionServiceSnapshot();
+    const env = useEnvironment();
+    const deniedNavItemKeys = useDeniedNavItemKeys();
+
+    useEffect(() => {
+        resetDeniedNavItemsForEnvironment(env?.id);
+    }, [env?.id]);
 
     const permissionsReady = useEnvironmentPermissionsReady();
     const [contextExpanded, setContextExpanded] = useState(true);
@@ -273,6 +287,14 @@ function ModuleLayout() {
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
     const hasAlertEngine = useHasFeature(ALERT_ENGINE_FEATURE);
+    const hasAuditTrail = useHasFeature(APIM_AUDIT_TRAIL_FEATURE);
+
+    // Unlicensed pages redirect away or open an upsell dialog, so landing on one bounces the user
+    // straight back out. Alerts redirects; the audit pages show the dialog and cannot be dismissed.
+    const lockedItemKeys = useMemo(
+        () => [...(hasAlertEngine ? [] : ALERT_ENGINE_NAV_ITEMS), ...(hasAuditTrail ? [] : AUDIT_TRAIL_NAV_ITEMS)],
+        [hasAlertEngine, hasAuditTrail],
+    );
 
     // permissionService is an external store, so re-reading it has to be keyed on its version:
     // a 403 patch or a host reload changes the answers without changing any React state below.
@@ -284,9 +306,10 @@ function ModuleLayout() {
             has: hasPermission,
             metadataForbidden,
             dictionariesForbidden,
-            lockedItemKeys: hasAlertEngine ? NO_LOCKED_NAV_ITEMS : ALERT_ENGINE_LOCKED_NAV_ITEMS,
+            lockedItemKeys,
+            deniedItemKeys: deniedNavItemKeys,
         }),
-        [dictionariesForbidden, hasAlertEngine, hasPermission, metadataForbidden, permissionsReady],
+        [deniedNavItemKeys, dictionariesForbidden, hasPermission, lockedItemKeys, metadataForbidden, permissionsReady],
     );
 
     const visibleNavSections = useMemo(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useHasFeature, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { permissionService, useHasFeature, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import {
     buildLinearBreadcrumbs,
     ContextSidebar,
     ContextToggleButton,
+    type NavGroup,
     type NavItem,
     SidebarGroup,
     SidebarGroupContent,
@@ -30,7 +31,7 @@ import {
 } from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, type ReactElement, useCallback, useContext, useMemo, useState } from 'react';
-import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
 import { PlatformToaster } from './PlatformToaster';
 import { APPLICATION_NAV_GROUPS, flattenApplicationDetailNavItems } from '../config/applicationDetailNavigation';
@@ -44,23 +45,20 @@ import {
     platformPrimaryNavItems,
     type PlatformNavSection,
 } from '../config/navigation';
+import { isNavItemVisible, landingNavItemKey, modulePathFor, NO_ACCESS_ROUTE_KEY, pageGuardForNavItem } from '../config/navVisibility';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { AlertsLayout } from '../features/alerts/components/AlertsLayout';
 import { AlertFormPage } from '../features/alerts/pages/AlertFormPage';
 import { AlertsActivityPage } from '../features/alerts/pages/AlertsActivityPage';
-import { ALERT_ENGINE_FEATURE, ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
+import { ALERT_ENGINE_FEATURE } from '../features/alerts/utils/alertPermissions';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
-import { ENVIRONMENT_AUDIT_READ_PERMISSIONS, ORGANIZATION_AUDIT_READ_PERMISSIONS } from '../features/audit-logs/utils/auditPermissions';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { GatewayInstanceDetailLayout } from '../features/gateway-instances/components/GatewayInstanceDetailLayout';
-import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
-import { ORGANIZATION_NOTIFICATION_TEMPLATES_READ } from '../features/notification-templates/utils/permissions';
-import { ORGANIZATION_POLICIES_ACCESS_PERMISSIONS } from '../features/platform-policies/utils/platformPolicyPermissions';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { usePermissionServiceSnapshot } from '../features/shared/hooks/usePermissionServiceSnapshot';
 import { SharedPolicyGroupDetailLayout } from '../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout';
 import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
-import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { AlertsPage } from '../pages/AlertsPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
@@ -84,6 +82,7 @@ import { NotificationTemplateDetailPage } from '../pages/NotificationTemplateDet
 import { NotificationTemplatesPage } from '../pages/NotificationTemplatesPage';
 import { OrganizationPolicyStudioPage } from '../pages/OrganizationPolicyStudioPage';
 import { OrgAuditLogsPage } from '../pages/OrgAuditLogsPage';
+import { PlatformNoAccessPage } from '../pages/PlatformNoAccessPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
 import { SharedPolicyGroupHistoryPage } from '../pages/SharedPolicyGroupHistoryPage';
 import { SharedPolicyGroupsPage } from '../pages/SharedPolicyGroupsPage';
@@ -95,9 +94,9 @@ import { UsersPage } from '../pages/UsersPage';
 import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
 import {
+    useEnvironmentPermissionGrant,
     useEnvironmentPermissions,
     useEnvironmentPermissionsReady,
-    useHasEnvironmentPermission,
 } from '../shared/hooks/useEnvironmentPermissions';
 import { isForbiddenApiError } from '../shared/utils/apiErrors';
 
@@ -109,6 +108,9 @@ const queryClient = new QueryClient({
 });
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
+const EMPTY_NAV_GROUPS: NavGroup[] = [];
+const NO_LOCKED_NAV_ITEMS: readonly string[] = [];
+const ALERT_ENGINE_LOCKED_NAV_ITEMS: readonly string[] = ['alerts'];
 
 function resolveRequiredPermissions(permission?: string, anyOf?: readonly string[]): readonly string[] {
     if (anyOf) {
@@ -123,129 +125,81 @@ function resolveRequiredPermissions(permission?: string, anyOf?: readonly string
 function PermissionPageGuard({
     permission,
     anyOf,
-    unauthorizedTo = 'applications',
+    alsoAnyOf,
+    unauthorizedTo,
     children,
-}: Readonly<{ permission?: string; anyOf?: readonly string[]; unauthorizedTo?: string; children: ReactElement }>) {
+}: Readonly<{
+    permission?: string;
+    anyOf?: readonly string[];
+    alsoAnyOf?: readonly string[];
+    unauthorizedTo?: string;
+    children: ReactElement;
+}>) {
     const required = resolveRequiredPermissions(permission, anyOf);
+    const extraAnyOf = alsoAnyOf ?? [];
     const permissionsReady = useEnvironmentPermissionsReady();
-    const canAccess = useHasPermission({ anyOf: [...required] });
+    const canAccessPrimary = useHasPermission({ anyOf: [...required] });
+    const canAccessExtra = useHasPermission({ anyOf: [...extraAnyOf] });
     if (!permissionsReady) return null;
-    if (!canAccess) return <Navigate to={unauthorizedTo} replace />;
+    if (required.length === 0 && extraAnyOf.length === 0) {
+        if (unauthorizedTo) return <Navigate to={unauthorizedTo} replace />;
+        return <UnauthorizedRedirect />;
+    }
+    if (!canAccessPrimary || (extraAnyOf.length > 0 && !canAccessExtra)) {
+        if (unauthorizedTo) return <Navigate to={unauthorizedTo} replace />;
+        return <UnauthorizedRedirect />;
+    }
     return children;
 }
 
+// Redirects out of a locked page go through UnauthorizedRedirect rather than a hardcoded
+// "../applications": applications is itself guarded now, so a fixed target can bounce the user
+// straight back here. UnauthorizedRedirect resolves the landing key, which excludes locked items.
 function RequireAlertEngineLicense({ children }: { readonly children: ReactElement }) {
     const hasFeature = useHasFeature(ALERT_ENGINE_FEATURE);
     if (!hasFeature) {
-        return <Navigate to="../applications" replace />;
+        return <UnauthorizedRedirect />;
     }
     return children;
 }
 
-// Shared Policy Groups gates on useHasEnvironmentPermission (this module's own live permission
-// fetch) rather than PermissionPageGuard's SDK-backed useHasPermission, so a permission revoked
-// mid-session is reflected here the same way it already is in the nav link — see
-// useEnvironmentPermissions.ts.
-function SharedPolicyGroupPageGuard({ unauthorizedTo, children }: Readonly<{ unauthorizedTo: string; children: ReactElement }>) {
+// Shared Policy Groups narrows on this module's own permission cache, so a permission revoked
+// mid-session closes the page the same way it already disappears from the nav link. It only narrows
+// when the cache actually holds an answer; "no answer" defers to the store-backed NavPermissionGuard
+// wrapping this route, which is the same source the sidebar and landing key read.
+function SharedPolicyGroupPageGuard({ children }: Readonly<{ children: ReactElement }>) {
     const permissionsReady = useEnvironmentPermissionsReady();
-    const canAccess = useHasEnvironmentPermission([ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION]);
+    const grant = useEnvironmentPermissionGrant([ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION]);
     if (!permissionsReady) return null;
-    if (!canAccess) return <Navigate to={unauthorizedTo} replace />;
+    if (grant === false) return <UnauthorizedRedirect />;
     return children;
 }
 
-interface PlatformNavVisibility {
-    readonly permissionsReady: boolean;
-    readonly canReadMetadata: boolean;
-    readonly canReadDictionaries: boolean;
-    readonly canAccessUsers: boolean;
-    readonly canReadGateways: boolean;
-    readonly canReadEntrypoints: boolean;
-    readonly canReadGroups: boolean;
-    readonly canReadSharedPolicyGroups: boolean;
-    readonly canReadAlerts: boolean;
-    readonly canReadTenants: boolean;
-    readonly canAccessPlatformPolicies: boolean;
-    readonly canReadOrgAudit: boolean;
-    readonly canReadEnvAudit: boolean;
-    readonly canReadOrgSettings: boolean;
-    readonly canReadIdentityProviders: boolean;
-    readonly canReadNotificationTemplates: boolean;
+function NavPermissionGuard({
+    itemKey,
+    unauthorizedTo,
+    children,
+}: Readonly<{ itemKey: string; unauthorizedTo?: string; children: ReactElement }>) {
+    const { anyOf, alsoAnyOf } = pageGuardForNavItem(itemKey);
+    return (
+        <PermissionPageGuard anyOf={anyOf} alsoAnyOf={alsoAnyOf} unauthorizedTo={unauthorizedTo}>
+            {children}
+        </PermissionPageGuard>
+    );
 }
 
-function isNavItemVisible(itemKey: string, visibility: PlatformNavVisibility): boolean {
-    const {
-        permissionsReady,
-        canReadMetadata,
-        canReadDictionaries,
-        canAccessUsers,
-        canReadGateways,
-        canReadEntrypoints,
-        canReadGroups,
-        canReadSharedPolicyGroups,
-        canReadAlerts,
-        canReadTenants,
-        canAccessPlatformPolicies,
-        canReadOrgAudit,
-        canReadEnvAudit,
-        canReadOrgSettings,
-        canReadIdentityProviders,
-        canReadNotificationTemplates,
-    } = visibility;
-    if (itemKey === 'users') {
-        return !permissionsReady || canAccessUsers;
-    }
-    if (itemKey === 'groups') {
-        return !permissionsReady || canReadGroups;
-    }
-    if (itemKey === 'metadata') {
-        return !permissionsReady || canReadMetadata;
-    }
-    if (itemKey === 'dictionaries') {
-        return !permissionsReady || canReadDictionaries;
-    }
-    if (itemKey === 'shared-policy-groups') {
-        return !permissionsReady || canReadSharedPolicyGroups;
-    }
-    if (itemKey === 'gateways') {
-        return !permissionsReady || canReadGateways;
-    }
-    if (itemKey === 'entrypoints-and-sharding-tags') {
-        return !permissionsReady || canReadEntrypoints;
-    }
-    if (itemKey === 'alerts') {
-        return !permissionsReady || canReadAlerts;
-    }
-    if (itemKey === 'tenants') {
-        return !permissionsReady || canReadTenants;
-    }
-    if (itemKey === 'policy-studio') {
-        return !permissionsReady || canAccessPlatformPolicies;
-    }
-    if (itemKey === 'organization-audit') {
-        return !permissionsReady || canReadOrgAudit;
-    }
-    if (itemKey === 'environment-audit') {
-        return !permissionsReady || canReadEnvAudit;
-    }
-    if (itemKey === 'management-and-schedulers' || itemKey === 'cors' || itemKey === 'smtp') {
-        return !permissionsReady || canReadOrgSettings;
-    }
-    if (itemKey === 'templates') {
-        return !permissionsReady || canReadNotificationTemplates;
-    }
-    if (itemKey === 'authentication') {
-        return !permissionsReady || canReadIdentityProviders;
-    }
-    return true;
+function UnauthorizedRedirect() {
+    const location = useLocation();
+    const { landingNavKey } = usePlatformNavContext();
+    return <Navigate to={modulePathFor(location.pathname, landingNavKey ?? NO_ACCESS_ROUTE_KEY)} replace />;
 }
 
-function EntrypointsGuard() {
-    const permissionsReady = useEnvironmentPermissionsReady();
-    const canRead = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
+function PlatformLandingOrNoAccess() {
+    const location = useLocation();
+    const { landingNavKey, permissionsReady } = usePlatformNavContext();
     if (!permissionsReady) return null;
-    if (!canRead) return <Navigate to="applications" replace />;
-    return <EntrypointsAndShardingTagsPage />;
+    if (!landingNavKey) return <PlatformNoAccessPage />;
+    return <Navigate to={modulePathFor(location.pathname, landingNavKey)} replace />;
 }
 
 function PlatformPrimaryNavigation({
@@ -284,6 +238,8 @@ interface PlatformNavContextValue {
     readonly navigateToKey: (key: string) => void;
     readonly contextExpanded: boolean;
     readonly toggleContext: () => void;
+    readonly permissionsReady: boolean;
+    readonly landingNavKey: string | undefined;
 }
 
 const PlatformNavContext = createContext<PlatformNavContextValue | null>(null);
@@ -298,6 +254,7 @@ function usePlatformNavContext(): PlatformNavContextValue {
 
 function ModuleLayout() {
     useEnvironmentPermissions();
+    const permissionVersion = usePermissionServiceSnapshot();
 
     const permissionsReady = useEnvironmentPermissionsReady();
     const [contextExpanded, setContextExpanded] = useState(true);
@@ -308,75 +265,40 @@ function ModuleLayout() {
     // page for every user, including those who already correctly lack access.
     const canReadMetadataPermission = useHasPermission({ anyOf: ['environment-metadata-r'] });
     const metadataQuery = useEnvironmentMetadata({ enabled: canReadMetadataPermission });
-    const canReadMetadata = canReadMetadataPermission && !isForbiddenApiError(metadataQuery.isError, metadataQuery.error);
+    const metadataForbidden = isForbiddenApiError(metadataQuery.isError, metadataQuery.error);
 
     const canReadDictionariesPermission = useHasPermission({ anyOf: ['environment-dictionary-r'] });
     const dictionariesQuery = useEnvironmentDictionaries({ enabled: canReadDictionariesPermission });
-    const canReadDictionaries = canReadDictionariesPermission && !isForbiddenApiError(dictionariesQuery.isError, dictionariesQuery.error);
-
-    const canAccessUsers = useHasPermission({ anyOf: [...ORGANIZATION_USER_ACCESS_PERMISSIONS] });
-    const canReadGateways = useHasPermission({ anyOf: ['environment-instance-r'] });
-    const canReadEntrypoints = useHasPermission({ anyOf: ['environment-entrypoint-r', 'organization-entrypoint-r'] });
-    const canReadGroups = useHasPermission({ anyOf: [ENVIRONMENT_GROUP_READ_PERMISSION] });
-    const canReadSharedPolicyGroups = useHasEnvironmentPermission([ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION]);
-    const canReadAlerts = useHasPermission({ anyOf: [ENVIRONMENT_ALERT_READ_PERMISSION] });
-    const hasAlertEngine = useHasFeature(ALERT_ENGINE_FEATURE);
-    const canReadTenants = useHasPermission({ anyOf: ['organization-tenant-r', 'environment-tenant-r'] });
-    const canAccessPlatformPolicies = useHasPermission({ anyOf: [...ORGANIZATION_POLICIES_ACCESS_PERMISSIONS] });
-    const canReadOrgAudit = useHasPermission({ anyOf: [...ORGANIZATION_AUDIT_READ_PERMISSIONS] });
-    const canReadEnvAudit = useHasPermission({ anyOf: [...ENVIRONMENT_AUDIT_READ_PERMISSIONS] });
-    const canReadOrgSettings = useHasPermission({ anyOf: ['organization-settings-r'] });
-    const canReadIdentityProviders = useHasPermission({ anyOf: ['organization-identity_provider-r'] });
-    const canReadNotificationTemplates = useHasPermission({ anyOf: [ORGANIZATION_NOTIFICATION_TEMPLATES_READ] });
+    const dictionariesForbidden = isForbiddenApiError(dictionariesQuery.isError, dictionariesQuery.error);
 
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
+    const hasAlertEngine = useHasFeature(ALERT_ENGINE_FEATURE);
+
+    // permissionService is an external store, so re-reading it has to be keyed on its version:
+    // a 403 patch or a host reload changes the answers without changing any React state below.
+    const hasPermission = useCallback((permission: string): boolean => permissionService.hasAnyOf([permission]), [permissionVersion]);
+
+    const navVisibility = useMemo(
+        () => ({
+            permissionsReady,
+            has: hasPermission,
+            metadataForbidden,
+            dictionariesForbidden,
+            lockedItemKeys: hasAlertEngine ? NO_LOCKED_NAV_ITEMS : ALERT_ENGINE_LOCKED_NAV_ITEMS,
+        }),
+        [dictionariesForbidden, hasAlertEngine, hasPermission, metadataForbidden, permissionsReady],
+    );
 
     const visibleNavSections = useMemo(
         () =>
             lockNavItem(
-                filterNavSections(NAV_SECTIONS, itemKey =>
-                    isNavItemVisible(itemKey, {
-                        permissionsReady,
-                        canReadMetadata,
-                        canReadDictionaries,
-                        canAccessUsers,
-                        canReadGateways,
-                        canReadEntrypoints,
-                        canReadGroups,
-                        canReadSharedPolicyGroups,
-                        canReadAlerts,
-                        canReadTenants,
-                        canAccessPlatformPolicies,
-                        canReadOrgAudit,
-                        canReadEnvAudit,
-                        canReadOrgSettings,
-                        canReadIdentityProviders,
-                        canReadNotificationTemplates,
-                    }),
-                ),
+                filterNavSections(NAV_SECTIONS, itemKey => isNavItemVisible(itemKey, navVisibility)),
                 'alerts',
                 !hasAlertEngine,
             ),
-        [
-            permissionsReady,
-            canReadMetadata,
-            canReadDictionaries,
-            canAccessUsers,
-            canReadGateways,
-            canReadEntrypoints,
-            canReadGroups,
-            canReadSharedPolicyGroups,
-            canReadAlerts,
-            canReadTenants,
-            canAccessPlatformPolicies,
-            canReadOrgAudit,
-            canReadEnvAudit,
-            canReadOrgSettings,
-            canReadIdentityProviders,
-            canReadNotificationTemplates,
-            hasAlertEngine,
-        ],
+        [hasAlertEngine, navVisibility],
     );
+    const landingNavKey = landingNavItemKey(navVisibility);
 
     const activeSectionKey = findNavSectionKey(visibleNavSections, activeNavKey) ?? visibleNavSections[0]?.key;
     const activeSection = visibleNavSections.find(section => section.key === activeSectionKey);
@@ -415,8 +337,16 @@ function ModuleLayout() {
     );
 
     const navContext = useMemo(
-        () => ({ activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext }),
-        [activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext],
+        () => ({
+            activeNavKey,
+            activeSection,
+            navigateToKey,
+            contextExpanded,
+            toggleContext,
+            permissionsReady,
+            landingNavKey,
+        }),
+        [activeNavKey, activeSection, contextExpanded, landingNavKey, navigateToKey, permissionsReady, toggleContext],
     );
 
     return (
@@ -429,25 +359,31 @@ function ModuleLayout() {
 function PlatformSectionLayout() {
     const { activeNavKey, activeSection, navigateToKey, contextExpanded, toggleContext } = usePlatformNavContext();
     const navigate = useNavigate();
-    const groups = activeSection?.groups ?? [];
+    const groups = activeSection?.groups ?? EMPTY_NAV_GROUPS;
     const breadcrumbs = useMemo(
-        () => buildLinearBreadcrumbs(navigate, [{ label: PLATFORM_ROUTE_CONFIG.routes[activeNavKey].label }]),
+        () => buildLinearBreadcrumbs(navigate, [{ label: PLATFORM_ROUTE_CONFIG.routes[activeNavKey]?.label ?? activeNavKey }]),
         [activeNavKey, navigate],
     );
 
+    const hasContextNav = Boolean(activeSection?.groups.some(group => group.items.length > 0));
+
     useLayoutConfig(
         {
-            viewMode: 'context',
-            contextExpanded,
-            contextSidebar: (
-                <ContextSidebar>
-                    <SidebarNavigation groups={groups} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />
-                </ContextSidebar>
-            ),
-            leading: <ContextToggleButton expanded={contextExpanded} onToggle={toggleContext} />,
             breadcrumbs,
+            ...(hasContextNav && activeSection
+                ? {
+                      viewMode: 'context' as const,
+                      contextExpanded,
+                      contextSidebar: (
+                          <ContextSidebar>
+                              <SidebarNavigation groups={groups} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />
+                          </ContextSidebar>
+                      ),
+                      leading: <ContextToggleButton expanded={contextExpanded} onToggle={toggleContext} />,
+                  }
+                : {}),
         },
-        [activeNavKey, breadcrumbs, contextExpanded, groups, navigateToKey, toggleContext],
+        [activeNavKey, breadcrumbs, contextExpanded, groups, hasContextNav, navigateToKey, toggleContext],
     );
 
     return <Outlet />;
@@ -462,16 +398,37 @@ export function AppRoutes() {
                 <Routes>
                     <Route element={<ModuleLayout />}>
                         <Route element={<PlatformSectionLayout />}>
-                            <Route index element={<Navigate to="applications" replace />} />
-                            <Route path="applications" element={<ApplicationsPage />} />
-                            <Route path="applications/new" element={<RegisterApplicationPage />} />
-                            <Route path="access-management" element={<AccessManagementPage />} />
+                            <Route index element={<PlatformLandingOrNoAccess />} />
+                            <Route
+                                path="applications"
+                                element={
+                                    <NavPermissionGuard itemKey="applications">
+                                        <ApplicationsPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
+                            <Route
+                                path="applications/new"
+                                element={
+                                    <PermissionPageGuard permission="environment-application-c">
+                                        <RegisterApplicationPage />
+                                    </PermissionPageGuard>
+                                }
+                            />
+                            <Route
+                                path="access-management"
+                                element={
+                                    <NavPermissionGuard itemKey="access-management">
+                                        <AccessManagementPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
                             <Route
                                 path="authentication"
                                 element={
-                                    <PermissionPageGuard permission="organization-identity_provider-r" unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="authentication">
                                         <Outlet />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             >
                                 <Route index element={<AuthenticationPage />} />
@@ -488,66 +445,53 @@ export function AppRoutes() {
                             <Route
                                 path="management-and-schedulers"
                                 element={
-                                    <PermissionPageGuard permission="organization-settings-r" unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="management-and-schedulers">
                                         <ManagementAndSchedulersPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
                             <Route
                                 path="cors"
                                 element={
-                                    <PermissionPageGuard permission="organization-settings-r" unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="cors">
                                         <CorsSettingsPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
                             <Route
                                 path="smtp"
                                 element={
-                                    <PermissionPageGuard permission="organization-settings-r" unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="smtp">
                                         <SmtpSettingsPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
-                            <Route path="templates">
-                                <Route
-                                    index
-                                    element={
-                                        <PermissionPageGuard
-                                            permission={ORGANIZATION_NOTIFICATION_TEMPLATES_READ}
-                                            unauthorizedTo="../applications"
-                                        >
-                                            <NotificationTemplatesPage />
-                                        </PermissionPageGuard>
-                                    }
-                                />
-                                <Route
-                                    path=":scope/:hook"
-                                    element={
-                                        <PermissionPageGuard
-                                            permission={ORGANIZATION_NOTIFICATION_TEMPLATES_READ}
-                                            unauthorizedTo="../../applications"
-                                        >
-                                            <NotificationTemplateDetailPage />
-                                        </PermissionPageGuard>
-                                    }
-                                />
+                            <Route
+                                path="templates"
+                                element={
+                                    <NavPermissionGuard itemKey="templates">
+                                        <Outlet />
+                                    </NavPermissionGuard>
+                                }
+                            >
+                                <Route index element={<NotificationTemplatesPage />} />
+                                <Route path=":scope/:hook" element={<NotificationTemplateDetailPage />} />
                             </Route>
                             <Route path="users">
                                 <Route
                                     index
                                     element={
-                                        <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                        <NavPermissionGuard itemKey="users">
                                             <UsersPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                                 <Route
                                     path=":userId"
                                     element={
-                                        <PermissionPageGuard anyOf={ORGANIZATION_USER_ACCESS_PERMISSIONS}>
+                                        <NavPermissionGuard itemKey="users">
                                             <UserDetailPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                             </Route>
@@ -555,41 +499,35 @@ export function AppRoutes() {
                                 <Route
                                     index
                                     element={
-                                        <PermissionPageGuard
-                                            permission={ENVIRONMENT_GROUP_READ_PERMISSION}
-                                            unauthorizedTo="../applications"
-                                        >
+                                        <NavPermissionGuard itemKey="groups">
                                             <GroupsPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                                 <Route
                                     path=":groupId"
                                     element={
-                                        <PermissionPageGuard
-                                            permission={ENVIRONMENT_GROUP_READ_PERMISSION}
-                                            unauthorizedTo="../../applications"
-                                        >
+                                        <NavPermissionGuard itemKey="groups">
                                             <GroupDetailPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                             </Route>
                             <Route
                                 path="metadata"
                                 element={
-                                    <PermissionPageGuard permission="environment-metadata-r">
+                                    <NavPermissionGuard itemKey="metadata">
                                         <MetadataPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
                             <Route path="dictionaries">
                                 <Route
                                     index
                                     element={
-                                        <PermissionPageGuard permission="environment-dictionary-r" unauthorizedTo="../applications">
+                                        <NavPermissionGuard itemKey="dictionaries">
                                             <DictionariesPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                                 <Route
@@ -602,18 +540,24 @@ export function AppRoutes() {
                                                 'environment-dictionary-u',
                                                 'environment-dictionary-d',
                                             ]}
-                                            unauthorizedTo="../../applications"
                                         >
                                             <DictionaryDetailPage />
                                         </PermissionPageGuard>
                                     }
                                 />
                             </Route>
-                            <Route path="shared-policy-groups">
+                            <Route
+                                path="shared-policy-groups"
+                                element={
+                                    <NavPermissionGuard itemKey="shared-policy-groups">
+                                        <Outlet />
+                                    </NavPermissionGuard>
+                                }
+                            >
                                 <Route
                                     index
                                     element={
-                                        <SharedPolicyGroupPageGuard unauthorizedTo="../applications">
+                                        <SharedPolicyGroupPageGuard>
                                             <SharedPolicyGroupsPage />
                                         </SharedPolicyGroupPageGuard>
                                     }
@@ -621,7 +565,7 @@ export function AppRoutes() {
                                 <Route
                                     path=":sharedPolicyGroupId"
                                     element={
-                                        <SharedPolicyGroupPageGuard unauthorizedTo="../../applications">
+                                        <SharedPolicyGroupPageGuard>
                                             <SharedPolicyGroupDetailLayout />
                                         </SharedPolicyGroupPageGuard>
                                     }
@@ -636,17 +580,17 @@ export function AppRoutes() {
                                 <Route
                                     index
                                     element={
-                                        <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../applications">
+                                        <NavPermissionGuard itemKey="gateways">
                                             <GatewayInstancesPage />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 />
                                 <Route
                                     path=":instanceId"
                                     element={
-                                        <PermissionPageGuard permission="environment-instance-r" unauthorizedTo="../../applications">
+                                        <NavPermissionGuard itemKey="gateways">
                                             <GatewayInstanceDetailLayout />
-                                        </PermissionPageGuard>
+                                        </NavPermissionGuard>
                                     }
                                 >
                                     <Route index element={<Navigate to="environment" replace />} />
@@ -657,32 +601,43 @@ export function AppRoutes() {
                             <Route
                                 path="tenants"
                                 element={
-                                    <PermissionPageGuard
-                                        anyOf={['organization-tenant-r', 'environment-tenant-r']}
-                                        unauthorizedTo="../applications"
-                                    >
+                                    <NavPermissionGuard itemKey="tenants">
                                         <TenantsPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
-                            <Route path="entrypoints-and-sharding-tags" element={<EntrypointsGuard />} />
+                            <Route
+                                path="entrypoints-and-sharding-tags"
+                                element={
+                                    <NavPermissionGuard itemKey="entrypoints-and-sharding-tags">
+                                        <EntrypointsAndShardingTagsPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
                             <Route
                                 path="policy-studio"
                                 element={
-                                    <PermissionPageGuard anyOf={ORGANIZATION_POLICIES_ACCESS_PERMISSIONS} unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="policy-studio">
                                         <OrganizationPolicyStudioPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
-                            <Route path="security-plan-types" element={<SecurityPlanTypesPage />} />
+                            <Route
+                                path="security-plan-types"
+                                element={
+                                    <NavPermissionGuard itemKey="security-plan-types">
+                                        <SecurityPlanTypesPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
                             <Route
                                 path="alerts"
                                 element={
-                                    <PermissionPageGuard permission={ENVIRONMENT_ALERT_READ_PERMISSION} unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="alerts">
                                         <RequireAlertEngineLicense>
                                             <Outlet />
                                         </RequireAlertEngineLicense>
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             >
                                 <Route element={<AlertsLayout />}>
@@ -695,21 +650,29 @@ export function AppRoutes() {
                             <Route
                                 path="organization-audit"
                                 element={
-                                    <PermissionPageGuard anyOf={[...ORGANIZATION_AUDIT_READ_PERMISSIONS]} unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="organization-audit">
                                         <OrgAuditLogsPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
                             <Route
                                 path="environment-audit"
                                 element={
-                                    <PermissionPageGuard anyOf={[...ENVIRONMENT_AUDIT_READ_PERMISSIONS]} unauthorizedTo="../applications">
+                                    <NavPermissionGuard itemKey="environment-audit">
                                         <EnvAuditLogsPage />
-                                    </PermissionPageGuard>
+                                    </NavPermissionGuard>
                                 }
                             />
+                            <Route path={NO_ACCESS_ROUTE_KEY} element={<PlatformLandingOrNoAccess />} />
                         </Route>
-                        <Route path="applications/:applicationId" element={<ApplicationDetailLayout />}>
+                        <Route
+                            path="applications/:applicationId"
+                            element={
+                                <NavPermissionGuard itemKey="applications">
+                                    <ApplicationDetailLayout />
+                                </NavPermissionGuard>
+                            }
+                        >
                             <Route index element={<ApplicationDetailIndexRedirect />} />
                             {APPLICATION_DETAIL_TABS.map(tab => (
                                 <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -161,6 +161,15 @@ describe('platform nav visibility', () => {
         expect(landingNavItemKey(visibility(['environment-alert-r']))).toBe('alerts');
     });
 
+    // A 403 on an organization-scoped page strips nothing from the environment permissions, so without
+    // the denial the item stays visible and stays the landing key the page keeps redirecting back to.
+    it('hides a denied item and lands elsewhere, even while its permission is still granted', () => {
+        const denied = visibility([...ORGANIZATION_ADMIN], { deniedItemKeys: new Set(['tenants']) });
+        expect(visibleNavItemKeys(denied)).not.toContain('tenants');
+        expect(landingNavItemKey(denied)).not.toBe('tenants');
+        expect(landingNavItemKey(visibility([...ORGANIZATION_ADMIN]))).toBe('tenants');
+    });
+
     it('skips a locked item and lands on the next visible one', () => {
         const input = visibility(['environment-alert-r', 'environment-group-r'], { lockedItemKeys: ['alerts'] });
         expect(landingNavItemKey(input)).toBe('groups');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NAV_SECTIONS } from './navigation';
+import {
+    firstVisibleNavItemKey,
+    isNavItemVisible,
+    landingNavItemKey,
+    modulePathFor,
+    NAV_ITEM_PERMISSIONS,
+    pageGuardForNavItem,
+    requiresOrganizationSettingsGate,
+    visibleNavItemKeys,
+    type NavVisibilityInput,
+} from './navVisibility';
+
+const ORGANIZATION_USER = [
+    'organization-environment-r',
+    'organization-role-r',
+    'organization-tag-r',
+    'organization-tenant-r',
+    'organization-entrypoint-r',
+] as const;
+
+const ENVIRONMENT_USER = [
+    'environment-api-r',
+    'environment-application-c',
+    'environment-application-r',
+    'environment-application-u',
+    'environment-application-d',
+    'environment-group-r',
+    'environment-documentation-r',
+    'environment-integration-r',
+    'environment-api_product-r',
+    'environment-shared_policy_group-r',
+] as const;
+
+const FEDERATION_AGENT = [
+    'environment-integration-c',
+    'environment-integration-r',
+    'environment-integration-u',
+    'environment-integration-d',
+] as const;
+
+const GAMMA_IDENTITY_ADMIN = [
+    'environment-am_configuration-c',
+    'environment-am_configuration-r',
+    'environment-am_configuration-u',
+    'environment-agent_identity-c',
+    'environment-agent_identity-r',
+    'environment-agent_identity-u',
+    'environment-agent_identity-d',
+] as const;
+
+const ENVIRONMENT_ADMIN = [
+    ...ENVIRONMENT_USER,
+    'environment-metadata-r',
+    'environment-dictionary-r',
+    'environment-instance-r',
+    'environment-alert-r',
+    'environment-settings-r',
+    'environment-audit-r',
+    'environment-am_configuration-r',
+] as const;
+
+const ORGANIZATION_ADMIN = [
+    ...ORGANIZATION_USER,
+    'organization-settings-r',
+    'organization-settings-u',
+    'organization-identity_provider-r',
+    'organization-audit-r',
+    'organization-policies-r',
+    'organization-policies-c',
+    'organization-policies-d',
+    'organization-policies-u',
+    'organization-user-c',
+    'organization-user-r',
+    'organization-user-u',
+    'organization-user-d',
+    'organization-notification_templates-r',
+] as const;
+
+function hasOf(granted: readonly string[]): (permission: string) => boolean {
+    const set = new Set(granted);
+    return permission => set.has(permission);
+}
+
+function visibility(granted: readonly string[], extra: Partial<NavVisibilityInput> = {}): NavVisibilityInput {
+    return {
+        permissionsReady: true,
+        has: hasOf(granted),
+        ...extra,
+    };
+}
+
+describe('platform nav visibility', () => {
+    it('declares a permission map for every nav item and none for organization-groups', () => {
+        const keys = NAV_SECTIONS.flatMap(section => section.groups.flatMap(group => group.items.map(item => item.key)));
+        expect(keys).not.toContain('organization-groups');
+        expect(Object.keys(NAV_ITEM_PERMISSIONS).sort()).toEqual([...keys].sort());
+        expect(Object.keys(NAV_ITEM_PERMISSIONS)).toEqual(expect.arrayContaining(['groups']));
+        expect(Object.keys(NAV_ITEM_PERMISSIONS)).not.toContain('user-groups');
+    });
+
+    it('hides every item until environment permissions are ready', () => {
+        const admin = visibility([...ORGANIZATION_ADMIN, ...ENVIRONMENT_ADMIN], { permissionsReady: false });
+        expect(visibleNavItemKeys(admin)).toEqual([]);
+    });
+
+    it('hides unknown keys', () => {
+        expect(isNavItemVisible('organization-groups', visibility([...ORGANIZATION_ADMIN, ...ENVIRONMENT_ADMIN]))).toBe(false);
+        expect(isNavItemVisible('missing', visibility(['environment-application-r']))).toBe(false);
+    });
+
+    it('shows Applications, Shared Policy Groups, and Groups for ENVIRONMENT:USER with org USER', () => {
+        const keys = visibleNavItemKeys(visibility([...ORGANIZATION_USER, ...ENVIRONMENT_USER]));
+        expect(keys.sort()).toEqual(['applications', 'groups', 'shared-policy-groups']);
+        expect(
+            firstVisibleNavItemKey(NAV_SECTIONS, itemKey =>
+                isNavItemVisible(itemKey, visibility([...ORGANIZATION_USER, ...ENVIRONMENT_USER])),
+            ),
+        ).toBe('applications');
+    });
+
+    it('shows no Platform items for FEDERATION_AGENT with org USER', () => {
+        const input = visibility([...ORGANIZATION_USER, ...FEDERATION_AGENT]);
+        expect(visibleNavItemKeys(input)).toEqual([]);
+        expect(firstVisibleNavItemKey(NAV_SECTIONS, itemKey => isNavItemVisible(itemKey, input))).toBeUndefined();
+        expect(landingNavItemKey(input)).toBeUndefined();
+    });
+
+    it('lands on Applications when that item is visible, even if Organization is first in the nav', () => {
+        expect(landingNavItemKey(visibility([...ORGANIZATION_ADMIN, ...ENVIRONMENT_ADMIN]))).toBe('applications');
+        expect(landingNavItemKey(visibility([...ORGANIZATION_USER, ...ENVIRONMENT_USER]))).toBe('applications');
+    });
+
+    it('lands on the first remaining item when Applications is not visible', () => {
+        expect(landingNavItemKey(visibility([...ORGANIZATION_ADMIN]))).toBe('tenants');
+        expect(landingNavItemKey(visibility(['environment-group-r']))).toBe('groups');
+        expect(landingNavItemKey(visibility([]))).toBeUndefined();
+    });
+
+    // A locked item stays in the sidebar but its route redirects away, so landing on it would bounce
+    // straight back out. It must never be chosen as the landing target.
+    it('never lands on a locked item, even when it is the only visible one', () => {
+        const alertsOnly = visibility(['environment-alert-r'], { lockedItemKeys: ['alerts'] });
+        expect(visibleNavItemKeys(alertsOnly)).toEqual(['alerts']);
+        expect(landingNavItemKey(alertsOnly)).toBeUndefined();
+        expect(landingNavItemKey(visibility(['environment-alert-r']))).toBe('alerts');
+    });
+
+    it('skips a locked item and lands on the next visible one', () => {
+        const input = visibility(['environment-alert-r', 'environment-group-r'], { lockedItemKeys: ['alerts'] });
+        expect(landingNavItemKey(input)).toBe('groups');
+    });
+
+    it('hides Organization and Users for ENVIRONMENT:ADMIN who is still org USER', () => {
+        const keys = visibleNavItemKeys(visibility([...ORGANIZATION_USER, ...ENVIRONMENT_ADMIN]));
+        expect(keys).toEqual(
+            expect.arrayContaining([
+                'applications',
+                'metadata',
+                'dictionaries',
+                'shared-policy-groups',
+                'gateways',
+                'alerts',
+                'security-plan-types',
+                'environment-audit',
+                'access-management',
+                'groups',
+            ]),
+        );
+        expect(keys).not.toContain('tenants');
+        expect(keys).not.toContain('users');
+        expect(keys).not.toContain('cors');
+        expect(keys).not.toContain('policy-studio');
+    });
+
+    it('shows Access Management for GAMMA_IDENTITY_ADMIN or env ADMIN without org settings', () => {
+        expect(requiresOrganizationSettingsGate('access-management')).toBe(false);
+        expect(pageGuardForNavItem('access-management')).toEqual({ anyOf: ['environment-am_configuration-r'] });
+        expect(visibleNavItemKeys(visibility([...ORGANIZATION_USER, ...GAMMA_IDENTITY_ADMIN]))).toEqual(['access-management']);
+        expect(isNavItemVisible('access-management', visibility(['environment-am_configuration-r']))).toBe(true);
+        expect(isNavItemVisible('access-management', visibility([...ORGANIZATION_USER, ...ENVIRONMENT_USER]))).toBe(false);
+        expect(isNavItemVisible('access-management', visibility([...ORGANIZATION_USER, ...FEDERATION_AGENT]))).toBe(false);
+    });
+
+    it('hides Management, CORS, and SMTP when the user has organization-settings-u without -r', () => {
+        const onlyUpdate = visibility(['organization-settings-u']);
+        expect(isNavItemVisible('management-and-schedulers', onlyUpdate)).toBe(false);
+        expect(isNavItemVisible('cors', onlyUpdate)).toBe(false);
+        expect(isNavItemVisible('smtp', onlyUpdate)).toBe(false);
+        expect(isNavItemVisible('users', visibility(['organization-settings-u', 'organization-user-r']))).toBe(true);
+    });
+
+    it('shows Management, CORS, and SMTP when the user has organization-settings-r', () => {
+        const canRead = visibility(['organization-settings-r']);
+        expect(isNavItemVisible('management-and-schedulers', canRead)).toBe(true);
+        expect(isNavItemVisible('cors', canRead)).toBe(true);
+        expect(isNavItemVisible('smtp', canRead)).toBe(true);
+        expect(isNavItemVisible('templates', canRead)).toBe(false);
+    });
+
+    it('gates Templates on organization-notification_templates-r after the org settings gate', () => {
+        expect(requiresOrganizationSettingsGate('templates')).toBe(true);
+        expect(isNavItemVisible('templates', visibility(['organization-settings-r']))).toBe(false);
+        expect(isNavItemVisible('templates', visibility(['organization-notification_templates-r']))).toBe(false);
+        expect(isNavItemVisible('templates', visibility(['organization-settings-r', 'organization-notification_templates-r']))).toBe(true);
+    });
+
+    it('shows Organization items for org ADMIN after the outer gate plus item-level -r', () => {
+        const keys = visibleNavItemKeys(visibility([...ORGANIZATION_ADMIN, ...ENVIRONMENT_ADMIN]));
+        expect(keys).toEqual(
+            expect.arrayContaining([
+                'tenants',
+                'entrypoints-and-sharding-tags',
+                'policy-studio',
+                'access-management',
+                'authentication',
+                'management-and-schedulers',
+                'cors',
+                'smtp',
+                'templates',
+                'organization-audit',
+                'users',
+            ]),
+        );
+    });
+
+    it('gates Policy Studio on organization-policies read/create/delete/update after the org settings gate', () => {
+        expect(requiresOrganizationSettingsGate('policy-studio')).toBe(true);
+        expect(isNavItemVisible('policy-studio', visibility(['organization-settings-r', 'organization-policies-r']))).toBe(true);
+        expect(isNavItemVisible('policy-studio', visibility(['organization-policies-u']))).toBe(false);
+        expect(isNavItemVisible('policy-studio', visibility(['organization-settings-r', 'organization-policies-u']))).toBe(true);
+        expect(isNavItemVisible('policy-studio', visibility(['organization-settings-r']))).toBe(false);
+    });
+
+    it('does not show Tenants without organization-tenant-r even with the org settings gate', () => {
+        expect(isNavItemVisible('tenants', visibility(['organization-settings-r', 'organization-tag-r']))).toBe(false);
+        expect(isNavItemVisible('tenants', visibility(['organization-settings-r', 'environment-tenant-r']))).toBe(false);
+        expect(isNavItemVisible('tenants', visibility(['organization-settings-r', 'organization-tenant-r']))).toBe(true);
+    });
+
+    it('gates Entrypoints on organization-tag-r after the org settings gate', () => {
+        expect(
+            isNavItemVisible('entrypoints-and-sharding-tags', visibility(['organization-settings-r', 'organization-entrypoint-r'])),
+        ).toBe(false);
+        expect(isNavItemVisible('entrypoints-and-sharding-tags', visibility(['organization-settings-r', 'organization-tag-r']))).toBe(true);
+    });
+
+    it('requires the org settings gate for Users even when the user has organization-user-r', () => {
+        expect(requiresOrganizationSettingsGate('users')).toBe(true);
+        expect(isNavItemVisible('users', visibility(['organization-user-r']))).toBe(false);
+        expect(isNavItemVisible('users', visibility(['organization-settings-r', 'organization-user-r']))).toBe(true);
+    });
+
+    it('builds page guards from the same map as nav visibility', () => {
+        expect(pageGuardForNavItem('applications')).toEqual({ anyOf: ['environment-application-r'] });
+        expect(pageGuardForNavItem('access-management')).toEqual({ anyOf: ['environment-am_configuration-r'] });
+        expect(pageGuardForNavItem('cors')).toEqual({
+            anyOf: ['organization-settings-r'],
+            alsoAnyOf: ['organization-settings-r', 'organization-settings-u'],
+        });
+        expect(pageGuardForNavItem('tenants')).toEqual({
+            anyOf: ['organization-tenant-r'],
+            alsoAnyOf: ['organization-settings-r', 'organization-settings-u'],
+        });
+    });
+
+    it('does not require the org settings gate for env Groups', () => {
+        expect(requiresOrganizationSettingsGate('groups')).toBe(false);
+        expect(isNavItemVisible('groups', visibility(['environment-group-r']))).toBe(true);
+    });
+
+    it('fails closed for an unmapped page-guard key', () => {
+        expect(pageGuardForNavItem('user-groups')).toEqual({ anyOf: [] });
+        expect(pageGuardForNavItem('missing')).toEqual({ anyOf: [] });
+    });
+
+    it('hides metadata and dictionaries when the list API 403s', () => {
+        const granted = visibility(['environment-metadata-r', 'environment-dictionary-r'], {
+            metadataForbidden: true,
+            dictionariesForbidden: true,
+        });
+        expect(isNavItemVisible('metadata', granted)).toBe(false);
+        expect(isNavItemVisible('dictionaries', granted)).toBe(false);
+    });
+
+    it('rewrites a pasted module URL onto another leaf without dropping the host prefix', () => {
+        expect(modulePathFor('/alerts', 'applications')).toBe('/applications');
+        expect(modulePathFor('/environments/dev/platform/alerts', 'applications')).toBe('/environments/dev/platform/applications');
+        expect(modulePathFor('/groups/group-1', 'applications')).toBe('/applications');
+        expect(modulePathFor('/environments/dev/platform/applications/app-1/subscriptions/sub-1', 'groups')).toBe(
+            '/environments/dev/platform/groups',
+        );
+        expect(modulePathFor('/environments/dev/platform', 'no-access')).toBe('/environments/dev/platform/no-access');
+        expect(modulePathFor('/', 'no-access')).toBe('/no-access');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
@@ -91,6 +91,8 @@ export interface NavVisibilityInput {
     readonly dictionariesForbidden?: boolean;
     /** Items shown but not enterable (missing license). Visible in the sidebar, never a landing target. */
     readonly lockedItemKeys?: readonly string[];
+    /** Items a live 403 denied at runtime, whichever permission scope still grants them. */
+    readonly deniedItemKeys?: ReadonlySet<string>;
 }
 
 export function requiresOrganizationSettingsGate(itemKey: string): boolean {
@@ -124,6 +126,9 @@ export function isNavItemVisible(itemKey: string, visibility: NavVisibilityInput
     }
     const itemPermissions = NAV_ITEM_PERMISSIONS[itemKey];
     if (!itemPermissions) {
+        return false;
+    }
+    if (visibility.deniedItemKeys?.has(itemKey)) {
         return false;
     }
     if (requiresOrganizationSettingsGate(itemKey) && !hasAny(visibility.has, ORGANIZATION_SETTINGS_GATE_PERMISSIONS)) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filterNavSections, firstNavItemKey, NAV_SECTIONS, type PlatformNavSection } from './navigation';
+import { DEFAULT_ROUTE_KEY, ROUTE_KEYS } from './routes';
+import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
+import { ENVIRONMENT_AUDIT_READ_PERMISSION, ORGANIZATION_AUDIT_READ_PERMISSION } from '../features/audit-logs/utils/auditPermissions';
+import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
+import { ORGANIZATION_NOTIFICATION_TEMPLATES_READ } from '../features/notification-templates/utils/permissions';
+import { ORGANIZATION_POLICIES_ACCESS_PERMISSIONS } from '../features/platform-policies/utils/platformPolicyPermissions';
+import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
+import { ORGANIZATION_USER_ACCESS_PERMISSIONS } from '../features/users/utils/userPermissions';
+
+export const ORGANIZATION_SETTINGS_READ_PERMISSION = 'organization-settings-r' as const;
+export const ORGANIZATION_SETTINGS_GATE_PERMISSIONS = [ORGANIZATION_SETTINGS_READ_PERMISSION, 'organization-settings-u'] as const;
+
+export const ENVIRONMENT_APPLICATION_READ_PERMISSION = 'environment-application-r' as const;
+export const ENVIRONMENT_AM_CONFIGURATION_READ_PERMISSION = 'environment-am_configuration-r' as const;
+export const ENVIRONMENT_SETTINGS_READ_PERMISSION = 'environment-settings-r' as const;
+export const ORGANIZATION_TAG_READ_PERMISSION = 'organization-tag-r' as const;
+export const ORGANIZATION_TENANT_READ_PERMISSION = 'organization-tenant-r' as const;
+export const ORGANIZATION_IDENTITY_PROVIDER_READ_PERMISSION = 'organization-identity_provider-r' as const;
+
+export const NO_ACCESS_ROUTE_KEY = 'no-access' as const;
+
+const ORGANIZATION_SETTINGS_GATED_ITEMS: ReadonlySet<string> = new Set([
+    'tenants',
+    'entrypoints-and-sharding-tags',
+    'policy-studio',
+    'authentication',
+    'management-and-schedulers',
+    'cors',
+    'smtp',
+    'templates',
+    'organization-audit',
+    'users',
+]);
+
+/**
+ * Item-level anyOf permissions. Classic org nav is the reference for Classic-equivalent
+ * items: Tenants and Entrypoints use `organization-tenant-r` / `organization-tag-r`
+ * after the org-settings outer gate (organization-navigation.service.ts). Gamma does
+ * not also accept environment-tenant-r or environment-entrypoint-r for those items.
+ *
+ * Two deliberate divergences: Classic filters its org Audit item on license only, while
+ * Gamma also requires `organization-audit-r`; and Access Management is environment-scoped
+ * here, outside the org-settings gate, because it is Gamma-only.
+ */
+export const NAV_ITEM_PERMISSIONS: Readonly<Record<string, readonly string[]>> = {
+    tenants: [ORGANIZATION_TENANT_READ_PERMISSION],
+    'entrypoints-and-sharding-tags': [ORGANIZATION_TAG_READ_PERMISSION],
+    'policy-studio': ORGANIZATION_POLICIES_ACCESS_PERMISSIONS,
+    'access-management': [ENVIRONMENT_AM_CONFIGURATION_READ_PERMISSION],
+    authentication: [ORGANIZATION_IDENTITY_PROVIDER_READ_PERMISSION],
+    'management-and-schedulers': [ORGANIZATION_SETTINGS_READ_PERMISSION],
+    cors: [ORGANIZATION_SETTINGS_READ_PERMISSION],
+    smtp: [ORGANIZATION_SETTINGS_READ_PERMISSION],
+    templates: [ORGANIZATION_NOTIFICATION_TEMPLATES_READ],
+    'organization-audit': [ORGANIZATION_AUDIT_READ_PERMISSION],
+    applications: [ENVIRONMENT_APPLICATION_READ_PERMISSION],
+    metadata: ['environment-metadata-r'],
+    dictionaries: ['environment-dictionary-r'],
+    'shared-policy-groups': [ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION],
+    gateways: ['environment-instance-r'],
+    alerts: [ENVIRONMENT_ALERT_READ_PERMISSION],
+    'security-plan-types': [ENVIRONMENT_SETTINGS_READ_PERMISSION],
+    'environment-audit': [ENVIRONMENT_AUDIT_READ_PERMISSION],
+    users: ORGANIZATION_USER_ACCESS_PERMISSIONS,
+    groups: [ENVIRONMENT_GROUP_READ_PERMISSION],
+};
+
+const MODULE_LEAF_KEYS: ReadonlySet<string> = new Set(ROUTE_KEYS);
+
+export interface NavVisibilityInput {
+    readonly permissionsReady: boolean;
+    readonly has: (permission: string) => boolean;
+    readonly metadataForbidden?: boolean;
+    readonly dictionariesForbidden?: boolean;
+    /** Items shown but not enterable (missing license). Visible in the sidebar, never a landing target. */
+    readonly lockedItemKeys?: readonly string[];
+}
+
+export function requiresOrganizationSettingsGate(itemKey: string): boolean {
+    return ORGANIZATION_SETTINGS_GATED_ITEMS.has(itemKey);
+}
+
+export function pageGuardForNavItem(itemKey: string): {
+    readonly anyOf: readonly string[];
+    readonly alsoAnyOf?: readonly string[];
+} {
+    const itemPermissions = NAV_ITEM_PERMISSIONS[itemKey];
+    if (itemPermissions === undefined) {
+        return { anyOf: [] };
+    }
+    if (!requiresOrganizationSettingsGate(itemKey)) {
+        return { anyOf: itemPermissions };
+    }
+    if (itemPermissions.length === 0) {
+        return { anyOf: ORGANIZATION_SETTINGS_GATE_PERMISSIONS };
+    }
+    return { anyOf: itemPermissions, alsoAnyOf: ORGANIZATION_SETTINGS_GATE_PERMISSIONS };
+}
+
+function hasAny(has: (permission: string) => boolean, permissions: readonly string[]): boolean {
+    return permissions.some(permission => has(permission));
+}
+
+export function isNavItemVisible(itemKey: string, visibility: NavVisibilityInput): boolean {
+    if (!visibility.permissionsReady) {
+        return false;
+    }
+    const itemPermissions = NAV_ITEM_PERMISSIONS[itemKey];
+    if (!itemPermissions) {
+        return false;
+    }
+    if (requiresOrganizationSettingsGate(itemKey) && !hasAny(visibility.has, ORGANIZATION_SETTINGS_GATE_PERMISSIONS)) {
+        return false;
+    }
+    if (itemPermissions.length > 0 && !hasAny(visibility.has, itemPermissions)) {
+        return false;
+    }
+    if (itemKey === 'metadata' && visibility.metadataForbidden) {
+        return false;
+    }
+    if (itemKey === 'dictionaries' && visibility.dictionariesForbidden) {
+        return false;
+    }
+    return true;
+}
+
+export function firstVisibleNavItemKey(
+    sections: readonly PlatformNavSection[],
+    isVisible: (itemKey: string) => boolean,
+): string | undefined {
+    const firstSection = filterNavSections(sections, isVisible)[0];
+    return firstSection ? firstNavItemKey(firstSection) : undefined;
+}
+
+export function visibleNavItemKeys(visibility: NavVisibilityInput): string[] {
+    return NAV_SECTIONS.flatMap(section => section.groups.flatMap(group => group.items.map(item => item.key))).filter(itemKey =>
+        isNavItemVisible(itemKey, visibility),
+    );
+}
+
+/**
+ * Prefer Applications when visible; otherwise the first remaining nav item.
+ *
+ * Locked items are excluded: their route redirects away, and every redirect out of a page lands back
+ * here, so choosing one as the landing target would bounce between the two forever.
+ */
+export function landingNavItemKey(visibility: NavVisibilityInput): string | undefined {
+    const locked = new Set(visibility.lockedItemKeys ?? []);
+    const keys = visibleNavItemKeys(visibility).filter(itemKey => !locked.has(itemKey));
+    if (keys.includes(DEFAULT_ROUTE_KEY)) {
+        return DEFAULT_ROUTE_KEY;
+    }
+    return keys[0];
+}
+
+/** Replace the module leaf (a platform route key) with `itemKey`, keeping host prefixes. */
+export function modulePathFor(pathname: string, itemKey: string): string {
+    const segments = pathname.split('/').filter(Boolean);
+    let leafIndex = -1;
+    for (let index = segments.length - 1; index >= 0; index--) {
+        if (MODULE_LEAF_KEYS.has(segments[index]!)) {
+            leafIndex = index;
+            break;
+        }
+    }
+    const prefix = leafIndex >= 0 ? segments.slice(0, leafIndex) : segments;
+    return `/${[...prefix, itemKey].join('/')}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -45,9 +45,8 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Organization', 'Design')).toEqual(['policy-studio']);
     });
 
-    it('places Access Management, Management & Schedulers, CORS, SMTP, Templates, then Audit under Organization / System & Security', () => {
+    it('places Authentication, Management & Schedulers, CORS, SMTP, Templates, then Audit under Organization / System & Security', () => {
         expect(sectionKeys('Organization', 'System & Security')).toEqual([
-            'access-management',
             'authentication',
             'management-and-schedulers',
             'cors',
@@ -55,6 +54,7 @@ describe('platform navigation config', () => {
             'templates',
             'organization-audit',
         ]);
+        expect(sectionKeys('Organization', 'System & Security')).not.toContain('access-management');
         const systemItems =
             NAV_SECTIONS.find(section => section.key === 'organization')?.groups.find(group => group.label === 'System & Security')
                 ?.items ?? [];
@@ -66,8 +66,14 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries', 'shared-policy-groups']);
     });
 
-    it('places Gateways, Alerts, Security Plan Types, and Audit under Environment / System & Security', () => {
-        expect(sectionKeys('Environment', 'System & Security')).toEqual(['gateways', 'alerts', 'security-plan-types', 'environment-audit']);
+    it('places Access Management, Gateways, Alerts, Security Plan Types, and Audit under Environment / System & Security', () => {
+        expect(sectionKeys('Environment', 'System & Security')).toEqual([
+            'access-management',
+            'gateways',
+            'alerts',
+            'security-plan-types',
+            'environment-audit',
+        ]);
     });
 
     it('places Users and Groups under Team', () => {
@@ -89,8 +95,9 @@ describe('platform navigation config', () => {
     it('resolves the section that owns a nav item', () => {
         expect(findNavSectionKey(NAV_SECTIONS, 'applications')).toBe('environment');
         expect(findNavSectionKey(NAV_SECTIONS, 'users')).toBe('team');
-        expect(findNavSectionKey(NAV_SECTIONS, 'access-management')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'access-management')).toBe('environment');
         expect(findNavSectionKey(NAV_SECTIONS, 'tenants')).toBe('organization');
+        expect(findNavSectionKey(NAV_SECTIONS, 'policy-studio')).toBe('organization');
         expect(findNavSectionKey(NAV_SECTIONS, 'authentication')).toBe('organization');
         expect(findNavSectionKey(NAV_SECTIONS, 'organization-audit')).toBe('organization');
         expect(findNavSectionKey(NAV_SECTIONS, 'environment-audit')).toBe('environment');
@@ -170,5 +177,12 @@ describe('platform navigation config', () => {
     it('declares the authentication route in platform routing config', () => {
         expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('authentication');
         expect(ROUTES.authentication).toEqual({ path: 'authentication', label: 'Authentication' });
+    });
+
+    it('does not expose no-access as a sidebar item', () => {
+        expect(sectionKeys('Organization', 'System & Security')).not.toContain('no-access');
+        expect(sectionKeys('Environment', 'System & Security')).not.toContain('no-access');
+        expect(sectionKeys('Team', 'Team')).not.toContain('no-access');
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('no-access');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -77,7 +77,6 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
             {
                 label: 'System & Security',
                 items: [
-                    { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
                     { key: 'authentication', title: ROUTES.authentication.label, icon: FingerprintIcon },
                     { key: 'management-and-schedulers', title: ROUTES['management-and-schedulers'].label, icon: SettingsIcon },
                     { key: 'cors', title: ROUTES.cors.label, icon: GlobeIcon },
@@ -105,6 +104,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
             {
                 label: 'System & Security',
                 items: [
+                    { key: 'access-management', title: ROUTES['access-management'].label, icon: ShieldIcon },
                     { key: 'gateways', title: ROUTES.gateways.label, icon: ServerIcon },
                     { key: 'alerts', title: ROUTES.alerts.label, icon: BellIcon },
                     { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -36,10 +36,11 @@ export const ROUTE_KEYS: readonly string[] = [
     'cors',
     'smtp',
     'templates',
+    'no-access',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
-const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
+export const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
@@ -62,6 +63,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     cors: { path: 'cors', label: 'CORS' },
     smtp: { path: 'smtp', label: 'SMTP' },
     templates: { path: 'templates', label: 'Templates' },
+    'no-access': { path: 'no-access', label: 'No access' },
 };
 
 export const PLATFORM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceDetailLayout.spec.tsx
@@ -33,6 +33,7 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useEnvironment: jest.fn(),
+    permissionService: { load: jest.fn() },
 }));
 
 jest.mock('../hooks/useGatewayInstanceDetail');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/gateway-instances/components/GatewayInstanceDetailLayout.tsx
@@ -39,6 +39,7 @@ export function GatewayInstanceDetailLayout() {
     const isForbidden = isForbiddenApiError(isError, error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'gateways',
         permissionPrefix: 'environment-instance-',
         redirectTo: '../../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.spec.tsx
@@ -185,6 +185,7 @@ describe('SharedPolicyGroupDetailLayout', () => {
 
         expect(mockUseForbiddenResourceRedirect).toHaveBeenCalledWith({
             isForbidden: true,
+            navItemKey: 'shared-policy-groups',
             permissionPrefix: 'environment-shared_policy_group-',
             redirectTo: '../../applications',
         });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
@@ -95,6 +95,7 @@ export function SharedPolicyGroupDetailLayout() {
 
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'shared-policy-groups',
         permissionPrefix: ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
         redirectTo: '../../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.spec.tsx
@@ -47,6 +47,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
     useEnvironment: () => ({ id: 'env-1' }),
+    permissionService: { load: jest.fn() },
 }));
 jest.mock('../features/authentication/hooks/useAuthenticationPage');
 jest.mock('../features/authentication/hooks/useIdentityProviderMutations');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/AuthenticationPage.tsx
@@ -73,6 +73,7 @@ export function AuthenticationPage() {
     const isForbidden = isForbiddenApiError(providersQuery.isError, providersQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'authentication',
         permissionPrefix: 'organization-identity_provider-',
         redirectTo: '../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useEnvironment: jest.fn(),
+    permissionService: { load: jest.fn() },
 }));
 
 jest.mock('../features/dictionaries/hooks/useDictionaryPermissions');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/DictionariesPage.tsx
@@ -48,7 +48,12 @@ export function DictionariesPage() {
     const deleteMutation = useDeleteDictionary();
 
     const isForbidden = isForbiddenApiError(isError, error);
-    useForbiddenResourceRedirect({ isForbidden, permissionPrefix: 'environment-dictionary-', redirectTo: '../applications' });
+    useForbiddenResourceRedirect({
+        isForbidden,
+        navItemKey: 'dictionaries',
+        permissionPrefix: 'environment-dictionary-',
+        redirectTo: '../applications',
+    });
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
     const editDictionaryId = sheet.type === 'edit' ? sheet.dictionaryId : undefined;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EditIdentityProviderPage.tsx
@@ -50,6 +50,7 @@ export function EditIdentityProviderPage() {
     const isForbidden = isForbiddenApiError(providerQuery.isError, providerQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'authentication',
         permissionPrefix: 'organization-identity_provider-',
         redirectTo: '..',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasFeature: jest.fn(),
     useEnvironment: jest.fn(),
+    permissionService: { load: jest.fn() },
 }));
 
 jest.mock('../features/audit-logs/hooks/useAuditLogs');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvAuditLogsPage.tsx
@@ -50,6 +50,7 @@ export function EnvAuditLogsPage() {
     const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'environment-audit',
         permissionPrefix: 'environment-audit-',
         redirectTo: '../applications',
     });
@@ -60,7 +61,8 @@ export function EnvAuditLogsPage() {
     );
 
     if (!hasLicense) {
-        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('../applications')} />;
+        // The module index, not a fixed page: Applications is permission-guarded and can bounce back here.
+        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('..')} />;
     }
 
     if (isForbidden) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.spec.tsx
@@ -26,6 +26,7 @@ import { ApimApiError } from '../shared/api/apimClient';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useEnvironment: jest.fn(),
+    permissionService: { load: jest.fn() },
 }));
 
 const mockUseEnvironment = jest.mocked(useEnvironment);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/GatewayInstancesPage.tsx
@@ -39,6 +39,7 @@ export function GatewayInstancesPage() {
     const isForbidden = isForbiddenApiError(isError, error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'gateways',
         permissionPrefix: 'environment-instance-',
         redirectTo: '../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.spec.tsx
@@ -35,6 +35,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
     useEnvironment: () => ({ id: 'env-1' }),
+    permissionService: { load: jest.fn() },
 }));
 jest.mock('../features/metadata/hooks/useEnvironmentMetadata');
 jest.mock('../features/metadata/hooks/useMetadataMutations');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/MetadataPage.tsx
@@ -42,7 +42,12 @@ export function MetadataPage() {
     const deleteMutation = useDeleteMetadata();
 
     const isForbidden = isForbiddenApiError(isError, error);
-    useForbiddenResourceRedirect({ isForbidden, permissionPrefix: 'environment-metadata-', redirectTo: '../applications' });
+    useForbiddenResourceRedirect({
+        isForbidden,
+        navItemKey: 'metadata',
+        permissionPrefix: 'environment-metadata-',
+        redirectTo: '../applications',
+    });
 
     const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
@@ -200,4 +200,16 @@ describe('OrgAuditLogsPage', () => {
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
         expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-audit-r']);
     });
+
+    // Applications is permission-guarded, so dismissing onto it can bounce the user back here and make
+    // the dialog undismissable. The module index resolves to whatever the user can actually open.
+    it('dismisses the unlicensed dialog to the module index rather than a guarded page', async () => {
+        mockUseHasFeature.mockReturnValue(false);
+
+        renderPage();
+
+        fireEvent.click(screen.getAllByRole('button', { name: /close/i })[0]);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('..'));
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.spec.tsx
@@ -42,6 +42,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasFeature: jest.fn(),
     useEnvironment: () => ({ id: 'env-1' }),
+    permissionService: { load: jest.fn() },
 }));
 
 jest.mock('../features/audit-logs/hooks/useAuditLogs');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/OrgAuditLogsPage.tsx
@@ -51,6 +51,7 @@ export function OrgAuditLogsPage() {
     const isForbidden = isForbiddenApiError(Boolean(logsQuery.isError), logsQuery.error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'organization-audit',
         permissionPrefix: 'organization-audit-',
         redirectTo: '../applications',
     });
@@ -61,7 +62,8 @@ export function OrgAuditLogsPage() {
     );
 
     if (!hasLicense) {
-        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('../applications')} />;
+        // The module index, not a fixed page: Applications is permission-guarded and can bounce back here.
+        return <AuditTrailLicenseDialog open onOpenChange={open => !open && navigate('..')} />;
     }
 
     if (isForbidden) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/PlatformNoAccessPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/PlatformNoAccessPage.spec.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { PlatformNoAccessPage } from './PlatformNoAccessPage';
+
+describe('PlatformNoAccessPage', () => {
+    it('tells the user they do not have access and to contact an administrator', () => {
+        render(<PlatformNoAccessPage />);
+
+        expect(screen.getByRole('heading', { name: "You don't have access here" })).not.toBeNull();
+        expect(screen.getByText(/assign an environment or organization role/i)).not.toBeNull();
+    });
+
+    it('explains what environment and organization roles unlock', () => {
+        render(<PlatformNoAccessPage />);
+
+        expect(screen.getByText('Why these menus are empty')).not.toBeNull();
+        expect(screen.getByText('Without an environment or organization role')).not.toBeNull();
+        expect(screen.getByText('With an environment or organization role')).not.toBeNull();
+        expect(screen.getByText('No menus')).not.toBeNull();
+        expect(screen.getByText('Menus appear')).not.toBeNull();
+        expect(screen.getByText('Ask your administrator')).not.toBeNull();
+        expect(screen.getByText('Typical USER access')).not.toBeNull();
+        expect(screen.getByText('Typical ADMIN access')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/PlatformNoAccessPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/PlatformNoAccessPage.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import {
+    AppWindowIcon,
+    ArrowRightIcon,
+    CircleCheckIcon,
+    CircleXIcon,
+    LockIcon,
+    ShieldIcon,
+    UsersIcon,
+} from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+import { FeatureTile } from '../features/shared/components';
+
+const WITHOUT_ACCESS = [
+    'These menus stay empty in this environment',
+    'Applications, groups, and organization settings stay out of reach',
+    'Pasting a URL cannot open a page you are not allowed to see',
+] as const;
+
+const WITH_ACCESS = [
+    'An administrator assigns an environment or organization role',
+    'Matching menus appear in the sidebar',
+    'You can open the pages your role actually grants',
+] as const;
+
+const FEATURE_TILES: { readonly Icon: LucideIcon; readonly title: string; readonly description: string }[] = [
+    {
+        Icon: UsersIcon,
+        title: 'Ask your administrator',
+        description: 'Tell them which environment you need (for example Dev or Test) and what you are trying to do.',
+    },
+    {
+        Icon: AppWindowIcon,
+        title: 'Typical USER access',
+        description: 'ENVIRONMENT:USER opens Applications, Shared Policy Groups, and Groups.',
+    },
+    {
+        Icon: ShieldIcon,
+        title: 'Typical ADMIN access',
+        description: 'ENVIRONMENT:ADMIN adds gateways, alerts, and settings. ORGANIZATION:ADMIN opens organization configuration.',
+    },
+];
+
+function FlowNode({ Icon, label }: { readonly Icon: LucideIcon; readonly label: string }) {
+    return (
+        <div className="flex flex-col items-center text-center">
+            <div className="rounded-lg bg-muted p-2">
+                <Icon className="size-4 text-muted-foreground" aria-hidden />
+            </div>
+            <p className="text-xs font-medium mt-1">{label}</p>
+        </div>
+    );
+}
+
+function ComparisonLine({ label, variant }: { readonly label: string; readonly variant: 'positive' | 'negative' }) {
+    return (
+        <li className="flex items-center gap-1 text-xs text-muted-foreground">
+            {variant === 'positive' ? (
+                <CircleCheckIcon className="size-3 shrink-0 text-success" aria-hidden />
+            ) : (
+                <CircleXIcon className="size-3 shrink-0 text-destructive" aria-hidden />
+            )}
+            {label}
+        </li>
+    );
+}
+
+export function PlatformNoAccessPage() {
+    return (
+        <div className="space-y-6" data-testid="platform-no-access-page">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">{"You don't have access here"}</h1>
+                <p className="text-sm text-muted-foreground">Ask your administrator to assign an environment or organization role.</p>
+            </div>
+
+            <Card>
+                <CardContent className="pt-6 space-y-6">
+                    <div>
+                        <h2 className="text-base font-semibold">Why these menus are empty</h2>
+                        <p className="text-xs text-muted-foreground mt-1">
+                            Platform Management uses environment and organization roles. Your current role does not unlock any of those
+                            menus, so there is nothing to open here.
+                        </p>
+                    </div>
+
+                    <div className="flex flex-col gap-4 items-stretch md:flex-row">
+                        <div className="flex-1 rounded-xl border p-4 space-y-3">
+                            <p className="text-xs font-semibold text-muted-foreground">Without an environment or organization role</p>
+                            <div className="flex items-center justify-center gap-2">
+                                <FlowNode Icon={LockIcon} label="Your account" />
+                                <ArrowRightIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                                <FlowNode Icon={AppWindowIcon} label="No menus" />
+                            </div>
+                            <ul className="space-y-1">
+                                {WITHOUT_ACCESS.map(label => (
+                                    <ComparisonLine key={label} label={label} variant="negative" />
+                                ))}
+                            </ul>
+                        </div>
+
+                        <div className="flex-1 rounded-xl border-2 border-primary/40 bg-primary/5 p-4 space-y-3">
+                            <p className="text-xs font-semibold text-primary">With an environment or organization role</p>
+                            <div className="flex items-center justify-center gap-2">
+                                <FlowNode Icon={UsersIcon} label="Administrator" />
+                                <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                                <FlowNode Icon={ShieldIcon} label="Role assigned" />
+                                <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                                <FlowNode Icon={AppWindowIcon} label="Menus appear" />
+                            </div>
+                            <ul className="space-y-1">
+                                {WITH_ACCESS.map(label => (
+                                    <ComparisonLine key={label} label={label} variant="positive" />
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-4 border-t pt-5 md:flex-row">
+                        {FEATURE_TILES.map(({ Icon, title, description }) => (
+                            <div key={title} className="flex-1">
+                                <FeatureTile Icon={Icon} title={title} description={description} />
+                            </div>
+                        ))}
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.spec.tsx
@@ -253,6 +253,7 @@ describe('SharedPolicyGroupsPage', () => {
 
             expect(mockUseForbiddenResourceRedirect).toHaveBeenCalledWith({
                 isForbidden: true,
+                navItemKey: 'shared-policy-groups',
                 permissionPrefix: 'environment-shared_policy_group-',
                 redirectTo: '../applications',
             });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SharedPolicyGroupsPage.tsx
@@ -104,6 +104,7 @@ export function SharedPolicyGroupsPage() {
     const isForbidden = isForbiddenApiError(isError, error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'shared-policy-groups',
         permissionPrefix: ENVIRONMENT_SHARED_POLICY_GROUP_PERMISSION_PREFIX,
         redirectTo: '../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.spec.tsx
@@ -35,6 +35,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
     useEnvironment: () => ({ id: 'env-1' }),
+    permissionService: { load: jest.fn() },
 }));
 jest.mock('../features/tenants/hooks/useTenants');
 jest.mock('../features/tenants/hooks/useTenantMutations');

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/TenantsPage.tsx
@@ -45,6 +45,7 @@ export function TenantsPage() {
     const isForbidden = isForbiddenApiError(isError, error);
     useForbiddenResourceRedirect({
         isForbidden,
+        navItemKey: 'tenants',
         permissionPrefix: ['organization-tenant-', 'environment-tenant-'],
         redirectTo: '../applications',
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.spec.tsx
@@ -58,6 +58,12 @@ jest.mock('../services/environmentPermissions', () => ({
     getEnvironmentPermissions: jest.fn(),
 }));
 
+const mockNotifyError = jest.fn();
+
+jest.mock('../notify', () => ({
+    notify: { error: (error: unknown, fallback?: string) => mockNotifyError(error, fallback) },
+}));
+
 const mockUseEnvironment = jest.mocked(useEnvironment);
 const mockGetEnvironmentPermissions = jest.mocked(getEnvironmentPermissions);
 const mockLoad = jest.mocked(permissionService.load);
@@ -86,6 +92,7 @@ describe('useEnvironmentPermissions', () => {
         mockUseEnvironment.mockReturnValue({ id: ENV_ID } as ReturnType<typeof useEnvironment>);
         mockGetEnvironmentPermissions.mockResolvedValue(CURRENT_USER_PERMISSIONS);
         permissionServiceTest.__setGranted([]);
+        mockNotifyError.mockClear();
     });
 
     it('does not treat a previous login cache as ready after the permission service resets', async () => {
@@ -211,6 +218,28 @@ describe('useEnvironmentPermissions', () => {
 
         await waitFor(() => expect(result.current).toBe(true));
         expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    // An empty menu after a failed fetch otherwise reads as "your role grants nothing", which is the
+    // wrong advice. Classic draws the same line with a toast from its HTTP error interceptor.
+    it('reports a failed permission fetch as an error rather than silently emptying the menu', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        mockGetEnvironmentPermissions.mockRejectedValue(new Error('unavailable'));
+
+        renderHook(() => useEnvironmentPermissions(), { wrapper: wrapperFor(queryClient) });
+
+        await waitFor(() => expect(mockNotifyError).toHaveBeenCalled());
+        expect(mockNotifyError.mock.calls[0]?.[1]).toBe('Your permissions could not be loaded. Some menu items may be missing.');
+    });
+
+    it('does not report an error when the permission fetch succeeds', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        mockGetEnvironmentPermissions.mockResolvedValue(['environment-application-r']);
+
+        renderHook(() => useEnvironmentPermissions(), { wrapper: wrapperFor(queryClient) });
+
+        await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+        expect(mockNotifyError).not.toHaveBeenCalled();
     });
 
     it('stays ready for a later observer without refetching', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.spec.tsx
@@ -13,61 +13,294 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
-import { useHasEnvironmentPermission } from './useEnvironmentPermissions';
+import { useEnvironmentPermissions, useEnvironmentPermissionsReady, useHasEnvironmentPermission } from './useEnvironmentPermissions';
 import { getEnvironmentPermissions } from '../services/environmentPermissions';
+import { environmentPermissionKeys } from '../utils/queryKeys';
 
-jest.mock('../services/environmentPermissions');
-jest.mock('@gravitee/gamma-modules-sdk', () => ({
-    useEnvironment: jest.fn(),
+jest.mock('@gravitee/gamma-modules-sdk', () => {
+    const listeners = new Set<() => void>();
+    let granted: string[] = [];
+    let environmentGranted: string[] = [];
+    return {
+        useEnvironment: jest.fn(),
+        permissionService: {
+            load: jest.fn((_scope: string, next: string[]) => {
+                environmentGranted = next;
+            }),
+            getAllPermissions: () => [...granted, ...environmentGranted],
+            subscribe: (listener: () => void) => {
+                listeners.add(listener);
+                return () => listeners.delete(listener);
+            },
+            __setGranted: (next: string[]) => {
+                granted = next;
+                environmentGranted = [];
+            },
+            __hostLoadEnvironment: (next: string[]) => {
+                environmentGranted = next;
+                listeners.forEach(listener => listener());
+            },
+            __emitReset: () => {
+                granted = [];
+                environmentGranted = [];
+                listeners.forEach(listener => listener());
+            },
+        },
+    };
+});
+
+jest.mock('../services/environmentPermissions', () => ({
+    getEnvironmentPermissions: jest.fn(),
 }));
 
-const mockGetEnvironmentPermissions = jest.mocked(getEnvironmentPermissions);
 const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockGetEnvironmentPermissions = jest.mocked(getEnvironmentPermissions);
+const mockLoad = jest.mocked(permissionService.load);
+const permissionServiceTest = permissionService as typeof permissionService & {
+    __setGranted: (next: string[]) => void;
+    __hostLoadEnvironment: (next: string[]) => void;
+    __emitReset: () => void;
+};
 
-describe('useHasEnvironmentPermission', () => {
-    function wrapper({ children }: { children: ReactNode }) {
-        return (
-            <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
-                {children}
-            </QueryClientProvider>
-        );
-    }
+const ENV_ID = 'env-1';
+const PREVIOUS_USER_PERMISSIONS = ['environment-application-r'];
+const CURRENT_USER_PERMISSIONS: string[] = [];
+const PATCHED_AFTER_403 = ['environment-metadata-r'];
+const STALE_BACKEND_GRANT = ['environment-metadata-r', 'environment-dictionary-r'];
 
+function wrapperFor(queryClient: QueryClient) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+describe('useEnvironmentPermissions', () => {
     beforeEach(() => {
-        mockUseEnvironment.mockReturnValue({ id: 'dev' });
+        mockLoad.mockClear();
+        mockGetEnvironmentPermissions.mockReset();
+        mockUseEnvironment.mockReturnValue({ id: ENV_ID } as ReturnType<typeof useEnvironment>);
+        mockGetEnvironmentPermissions.mockResolvedValue(CURRENT_USER_PERMISSIONS);
+        permissionServiceTest.__setGranted([]);
     });
 
-    afterEach(() => {
-        jest.clearAllMocks();
+    it('does not treat a previous login cache as ready after the permission service resets', async () => {
+        permissionServiceTest.__setGranted(['organization-user-r']);
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(environmentPermissionKeys.detail(ENV_ID), PREVIOUS_USER_PERMISSIONS);
+
+        const { result } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        expect(result.current).toBe(true);
+        expect(queryClient.getQueryData(environmentPermissionKeys.detail(ENV_ID))).toEqual(PREVIOUS_USER_PERMISSIONS);
+
+        act(() => {
+            permissionServiceTest.__emitReset();
+        });
+
+        await waitFor(() => expect(mockGetEnvironmentPermissions).toHaveBeenCalledWith(ENV_ID));
+        await waitFor(() => expect(result.current).toBe(true));
+
+        expect(mockLoad).toHaveBeenCalledWith('environment', CURRENT_USER_PERMISSIONS);
+    });
+
+    it('keeps a 403-patched cache when the layout remounts without a login change', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(environmentPermissionKeys.detail(ENV_ID), PATCHED_AFTER_403);
+        mockGetEnvironmentPermissions.mockResolvedValue(STALE_BACKEND_GRANT);
+
+        const { result, unmount } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(result.current).toBe(true));
+        expect(queryClient.getQueryData(environmentPermissionKeys.detail(ENV_ID))).toEqual(PATCHED_AFTER_403);
+        expect(mockGetEnvironmentPermissions).not.toHaveBeenCalled();
+
+        unmount();
+        mockGetEnvironmentPermissions.mockClear();
+        mockLoad.mockClear();
+
+        const { result: remounted } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        expect(remounted.current).toBe(true);
+        expect(mockGetEnvironmentPermissions).not.toHaveBeenCalled();
+        expect(queryClient.getQueryData(environmentPermissionKeys.detail(ENV_ID))).toEqual(PATCHED_AFTER_403);
+        expect(mockLoad).toHaveBeenCalledWith('environment', PATCHED_AFTER_403);
+        expect(mockLoad).not.toHaveBeenCalledWith('environment', STALE_BACKEND_GRANT);
+    });
+
+    it('reloads environment permissions when the environment id changes', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        mockGetEnvironmentPermissions.mockImplementation(async (envId: string) =>
+            envId === ENV_ID ? PREVIOUS_USER_PERMISSIONS : ['environment-metadata-r'],
+        );
+
+        const { rerender } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(mockLoad).toHaveBeenCalledWith('environment', PREVIOUS_USER_PERMISSIONS));
+
+        mockUseEnvironment.mockReturnValue({ id: 'env-2' } as ReturnType<typeof useEnvironment>);
+        rerender();
+
+        await waitFor(() => expect(mockGetEnvironmentPermissions).toHaveBeenCalledWith('env-2'));
+        await waitFor(() => expect(mockLoad).toHaveBeenCalledWith('environment', ['environment-metadata-r']));
+    });
+
+    it('writes the cached map back when a host refetch restores stripped environment grants', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        queryClient.setQueryData(environmentPermissionKeys.detail(ENV_ID), PATCHED_AFTER_403);
+        mockGetEnvironmentPermissions.mockResolvedValue(STALE_BACKEND_GRANT);
+
+        renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(mockLoad).toHaveBeenCalledWith('environment', PATCHED_AFTER_403));
+        mockLoad.mockClear();
+
+        act(() => {
+            permissionServiceTest.__hostLoadEnvironment(STALE_BACKEND_GRANT);
+        });
+
+        expect(mockLoad).toHaveBeenCalledWith('environment', PATCHED_AFTER_403);
+        expect(mockGetEnvironmentPermissions).not.toHaveBeenCalled();
+    });
+
+    it('becomes ready with an empty load skipped when the environment permission fetch fails', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        mockGetEnvironmentPermissions.mockRejectedValue(new Error('unavailable'));
+
+        const { result } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(result.current).toBe(true));
+        expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    it('stays ready for a later observer without refetching', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+        const { result: layout } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(layout.current).toBe(true));
+        expect(mockGetEnvironmentPermissions).toHaveBeenCalledTimes(1);
+
+        const { result: laterGuard } = renderHook(() => useEnvironmentPermissionsReady(), {
+            wrapper: wrapperFor(queryClient),
+        });
+
+        expect(laterGuard.current).toBe(true);
+        expect(mockGetEnvironmentPermissions).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('useHasEnvironmentPermission', () => {
+    beforeEach(() => {
+        mockLoad.mockClear();
+        mockGetEnvironmentPermissions.mockReset();
+        mockUseEnvironment.mockReturnValue({ id: ENV_ID } as ReturnType<typeof useEnvironment>);
+        permissionServiceTest.__setGranted([]);
     });
 
     it('returns false until the environment permissions have loaded', () => {
         mockGetEnvironmentPermissions.mockReturnValue(new Promise(() => {}));
 
-        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), { wrapper });
+        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), {
+            wrapper: wrapperFor(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+        });
 
         expect(result.current).toBe(false);
     });
 
     it('returns true once a required permission is granted', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
         mockGetEnvironmentPermissions.mockResolvedValue(['environment-shared_policy_group-r', 'environment-group-r']);
 
-        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), { wrapper });
+        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), {
+            wrapper: wrapperFor(queryClient),
+        });
 
         await waitFor(() => expect(result.current).toBe(true));
     });
 
     it('returns false when none of the required permissions are granted', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
         mockGetEnvironmentPermissions.mockResolvedValue(['environment-group-r']);
 
-        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), { wrapper });
+        const { result } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), {
+            wrapper: wrapperFor(queryClient),
+        });
 
         await waitFor(() => expect(mockGetEnvironmentPermissions).toHaveBeenCalled());
         expect(result.current).toBe(false);
+    });
+
+    it('does not refetch when a later observer mounts after a 403 patch', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        mockGetEnvironmentPermissions.mockResolvedValue(['environment-shared_policy_group-r']);
+
+        const { result: layout } = renderHook(
+            () => {
+                useEnvironmentPermissions();
+                return useEnvironmentPermissionsReady();
+            },
+            { wrapper: wrapperFor(queryClient) },
+        );
+
+        await waitFor(() => expect(layout.current).toBe(true));
+        expect(mockGetEnvironmentPermissions).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            queryClient.setQueryData(environmentPermissionKeys.detail(ENV_ID), []);
+        });
+
+        const { result: pageGuard } = renderHook(() => useHasEnvironmentPermission(['environment-shared_policy_group-r']), {
+            wrapper: wrapperFor(queryClient),
+        });
+
+        expect(pageGuard.current).toBe(false);
+        expect(mockGetEnvironmentPermissions).toHaveBeenCalledTimes(1);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
@@ -14,50 +14,105 @@
  * limitations under the License.
  */
 import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 import { getEnvironmentPermissions } from '../services/environmentPermissions';
 import { environmentPermissionKeys } from '../utils/queryKeys';
 
+function useEnvironmentPermissionsQuery() {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
+        queryFn: () => getEnvironmentPermissions(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: Infinity,
+        gcTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+    });
+}
+
 /**
  * Fetches environment-scoped permissions and merges them into the shared
  * `permissionService` while the module layout is mounted.
  *
- * When federated, the host permission-sync also loads this scope; duplicate
- * loads are harmless. Does not clear on unmount — the host owns that scope.
+ * The query key is only the environment id, so a previous login's cache is
+ * dropped when the host permission service resets — not when this layout
+ * remounts. Remounts must keep a live 403 patch; refetching would restore a
+ * stale grant and re-arm the allow → 403 → redirect loop.
+ *
+ * This module cache is the source of truth while mounted: a host refetch that
+ * writes a stripped grant back into permissionService is overwritten from cache.
+ * Does not clear on unmount — the host owns teardown of that scope.
  */
 export function useEnvironmentPermissions(): void {
-    const env = useEnvironment();
+    const queryClient = useQueryClient();
 
-    const { data: permissions } = useQuery({
-        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
-        queryFn: () => getEnvironmentPermissions(env!.id),
-        enabled: Boolean(env?.id),
-        staleTime: 60_000,
-    });
+    // The host clears every scope on logout, so an observable drop to zero permissions is the signal
+    // that this cache belongs to a previous login — see permissionService.reset() in permission-sync.ts.
+    useEffect(() => {
+        let previousCount = permissionService.getAllPermissions().length;
+        return permissionService.subscribe(() => {
+            const nextCount = permissionService.getAllPermissions().length;
+            if (previousCount > 0 && nextCount === 0) {
+                void queryClient.resetQueries({ queryKey: environmentPermissionKeys.all });
+            }
+            previousCount = nextCount;
+        });
+    }, [queryClient]);
+
+    const { data: permissions, isSuccess } = useEnvironmentPermissionsQuery();
 
     useEffect(() => {
-        if (!permissions) return;
-        permissionService.load('environment', permissions);
-    }, [permissions]);
+        if (!isSuccess || permissions === undefined || permissions === null) return;
+        let applying = false;
+        const applyFromCache = () => {
+            applying = true;
+            try {
+                permissionService.load('environment', permissions);
+            } finally {
+                applying = false;
+            }
+        };
+        applyFromCache();
+        return permissionService.subscribe(() => {
+            if (applying) return;
+            const hostRestoredStrippedGrant = permissionService
+                .getAllPermissions()
+                .some(permission => permission.startsWith('environment-') && !permissions.includes(permission));
+            if (hostRestoredStrippedGrant) {
+                applyFromCache();
+            }
+        });
+    }, [isSuccess, permissions]);
 }
 
 /**
- * True once environment-scoped permissions are loaded into {@link permissionService}.
+ * True once environment-scoped permissions are in cache for this login, or the
+ * fetch failed (fail closed with whatever the host already loaded).
  * Shares the query with {@link useEnvironmentPermissions} (deduped by React Query).
  */
 export function useEnvironmentPermissionsReady(): boolean {
-    const env = useEnvironment();
+    const { isSuccess, isError } = useEnvironmentPermissionsQuery();
+    return isSuccess || isError;
+}
 
-    const { isSuccess } = useQuery({
-        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
-        queryFn: () => getEnvironmentPermissions(env!.id),
-        enabled: Boolean(env?.id),
-        staleTime: 60_000,
-    });
-
-    return isSuccess;
+/**
+ * Whether this module's own permission cache grants any of `anyOf`, or `undefined` when the cache
+ * holds no answer (still loading, or the fetch failed).
+ *
+ * Route guards need that third state. Treating "no answer" as a denial while the sidebar and the
+ * landing key read `permissionService` puts the two on different sources of truth, and the
+ * disagreement becomes a redirect loop: landing sends the user to a page whose guard denies it,
+ * and the denial sends them back to landing.
+ */
+export function useEnvironmentPermissionGrant(anyOf: readonly string[]): boolean | undefined {
+    const { data: permissions } = useEnvironmentPermissionsQuery();
+    if (permissions === undefined || permissions === null) return undefined;
+    return anyOf.some(permission => permissions.includes(permission));
 }
 
 /**
@@ -66,19 +121,13 @@ export function useEnvironmentPermissionsReady(): boolean {
  * by React Query), so it reflects a live 403 the moment {@link useForbiddenResourceRedirect}
  * strips the permission from the cache — unlike `useHasPermission` from the SDK's
  * federation stub, which isn't wired to this module's own permission fetch.
+ *
+ * Must keep this observer on the shared query options. A second `useQuery` on the
+ * same key with `refetchOnMount: 'always'` would overwrite the 403 patch and
+ * re-arm the allow → 403 → redirect loop.
  */
 export function useHasEnvironmentPermission(anyOf: readonly string[]): boolean {
-    const env = useEnvironment();
-
-    const { data: permissions } = useQuery({
-        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
-        queryFn: () => getEnvironmentPermissions(env!.id),
-        enabled: Boolean(env?.id),
-        staleTime: 0,
-        refetchOnMount: 'always',
-    });
-
-    if (!permissions) return false;
-    const granted = new Set(permissions);
-    return anyOf.some(permission => granted.has(permission));
+    const { data: permissions } = useEnvironmentPermissionsQuery();
+    if (permissions === undefined || permissions === null) return false;
+    return anyOf.some(permission => permissions.includes(permission));
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
@@ -17,6 +17,7 @@ import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
+import { notify } from '../notify';
 import { getEnvironmentPermissions } from '../services/environmentPermissions';
 import { environmentPermissionKeys } from '../utils/queryKeys';
 
@@ -64,7 +65,15 @@ export function useEnvironmentPermissions(): void {
         });
     }, [queryClient]);
 
-    const { data: permissions, isSuccess } = useEnvironmentPermissionsQuery();
+    const { data: permissions, error, isError, isSuccess } = useEnvironmentPermissionsQuery();
+
+    // An unreadable permission map is a server error, not a role decision. Without this the user only
+    // sees a menu filtered down to nothing, which reads as "you were not granted anything" — Classic
+    // draws the same distinction with a toast from its HTTP error interceptor.
+    useEffect(() => {
+        if (!isError) return;
+        notify.error(error, 'Your permissions could not be loaded. Some menu items may be missing.');
+    }, [error, isError]);
 
     useEffect(() => {
         if (!isSuccess || permissions === undefined || permissions === null) return;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
@@ -29,6 +29,11 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockLoad = jest.fn();
+const mockMarkNavItemDenied = jest.fn();
+
+jest.mock('../nav/deniedNavItems', () => ({
+    markNavItemDenied: (itemKey: string) => mockMarkNavItemDenied(itemKey),
+}));
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useEnvironment: jest.fn(),
@@ -43,6 +48,7 @@ function renderWithClient(
     isForbidden: boolean,
     seedPermissions: string[],
     permissionPrefix: string | readonly string[] = 'environment-dictionary-',
+    navItemKey = 'dictionaries',
 ) {
     const queryClient = new QueryClient();
     queryClient.setQueryData(['environment-permissions', 'env-1'], seedPermissions);
@@ -58,6 +64,7 @@ function renderWithClient(
         () =>
             useForbiddenResourceRedirect({
                 isForbidden,
+                navItemKey,
                 permissionPrefix,
                 redirectTo: '../applications',
             }),
@@ -71,6 +78,7 @@ describe('useForbiddenResourceRedirect', () => {
     beforeEach(() => {
         mockNavigate.mockClear();
         mockLoad.mockClear();
+        mockMarkNavItemDenied.mockClear();
         mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
     });
 
@@ -110,6 +118,7 @@ describe('useForbiddenResourceRedirect', () => {
             () =>
                 useForbiddenResourceRedirect({
                     isForbidden: true,
+                    navItemKey: 'dictionaries',
                     permissionPrefix: 'environment-dictionary-',
                     redirectTo: '../applications',
                 }),
@@ -138,6 +147,22 @@ describe('useForbiddenResourceRedirect', () => {
 
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
         expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+    });
+
+    // The strip only rewrites the environment scope, so an organization-scoped grant survives it and the
+    // item stays visible — and stays the landing key that '../applications' bounces back to.
+    it('marks the nav item denied even when the strip leaves the permissions untouched', async () => {
+        const { queryClient } = renderWithClient(true, ['environment-metadata-r'], ['organization-tenant-'], 'tenants');
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+        expect(mockMarkNavItemDenied).toHaveBeenCalledWith('tenants');
+    });
+
+    it('does not mark the nav item denied when the resource is allowed', () => {
+        renderWithClient(false, ['organization-tenant-r'], ['organization-tenant-'], 'tenants');
+
+        expect(mockMarkNavItemDenied).not.toHaveBeenCalled();
     });
 
     it('keeps every permission when no prefix is given, rather than stripping them all', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.spec.tsx
@@ -28,8 +28,13 @@ jest.mock('react-router-dom', () => ({
     useNavigate: () => mockNavigate,
 }));
 
+const mockLoad = jest.fn();
+
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useEnvironment: jest.fn(),
+    permissionService: {
+        load: (...args: unknown[]) => mockLoad(...args),
+    },
 }));
 
 const mockUseEnvironment = jest.mocked(useEnvironment);
@@ -65,6 +70,7 @@ function renderWithClient(
 describe('useForbiddenResourceRedirect', () => {
     beforeEach(() => {
         mockNavigate.mockClear();
+        mockLoad.mockClear();
         mockUseEnvironment.mockReturnValue({ id: 'env-1' } as ReturnType<typeof useEnvironment>);
     });
 
@@ -80,6 +86,7 @@ describe('useForbiddenResourceRedirect', () => {
 
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
         expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toEqual(['environment-metadata-r']);
+        expect(mockLoad).toHaveBeenCalledWith('environment', ['environment-metadata-r']);
     });
 
     it('does not invalidate the permissions query, so a stale backend grant cannot silently restore access', async () => {
@@ -87,6 +94,31 @@ describe('useForbiddenResourceRedirect', () => {
 
         await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
         expect(invalidateSpy).not.toHaveBeenCalled();
+    });
+
+    // Stripping "everything" out of an empty cache would push an empty grant into the permission
+    // service and drop every environment permission the host had already loaded.
+    it('does not touch the permission service when nothing is cached yet', async () => {
+        const queryClient = new QueryClient();
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>{children}</MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        renderHook(
+            () =>
+                useForbiddenResourceRedirect({
+                    isForbidden: true,
+                    permissionPrefix: 'environment-dictionary-',
+                    redirectTo: '../applications',
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('../applications', { replace: true }));
+        expect(mockLoad).not.toHaveBeenCalled();
+        expect(queryClient.getQueryData(['environment-permissions', 'env-1'])).toBeUndefined();
     });
 
     it('still navigates away when the environment id is unavailable', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
@@ -19,6 +19,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { markNavItemDenied } from '../nav/deniedNavItems';
 import { environmentPermissionKeys } from '../utils/queryKeys';
 
 // A live 403 overrides the cached environment-permissions map, which can otherwise still say access is granted.
@@ -27,10 +28,12 @@ import { environmentPermissionKeys } from '../utils/queryKeys';
 // re-arming the same allow -> 403 -> redirect loop on the next visit.
 export function useForbiddenResourceRedirect({
     isForbidden,
+    navItemKey,
     permissionPrefix,
     redirectTo,
 }: {
     isForbidden: boolean;
+    navItemKey: string;
     permissionPrefix: string | readonly string[];
     redirectTo: string;
 }): void {
@@ -42,6 +45,9 @@ export function useForbiddenResourceRedirect({
 
     useEffect(() => {
         if (!isForbidden) return;
+        // Hides the item and moves the landing key off it. The strip below cannot do that on its own:
+        // it only rewrites the environment scope, so an organization-scoped grant survives it.
+        markNavItemDenied(navItemKey);
         // An empty prefix would match every permission via startsWith, so an empty list strips nothing.
         const prefixesToStrip = prefixKey === '' ? [] : prefixKey.split('\0');
         if (env?.id) {
@@ -57,5 +63,5 @@ export function useForbiddenResourceRedirect({
             }
         }
         navigate(redirectTo, { replace: true });
-    }, [isForbidden, prefixKey, redirectTo, env?.id, queryClient, navigate]);
+    }, [isForbidden, navItemKey, prefixKey, redirectTo, env?.id, queryClient, navigate]);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useForbiddenResourceRedirect.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -46,9 +46,15 @@ export function useForbiddenResourceRedirect({
         const prefixesToStrip = prefixKey === '' ? [] : prefixKey.split('\0');
         if (env?.id) {
             const permissionsKey = environmentPermissionKeys.detail(env.id);
-            queryClient.setQueryData<string[]>(permissionsKey, previous =>
-                (previous ?? []).filter(permission => !prefixesToStrip.some(prefix => permission.startsWith(prefix))),
-            );
+            // Nothing cached means there is no grant of ours to strip. Writing a filtered empty list
+            // would push an empty environment scope into the permission service and revoke grants the
+            // host had loaded, dropping the user to the no-access page.
+            const previous = queryClient.getQueryData<string[]>(permissionsKey);
+            if (previous !== undefined) {
+                const next = previous.filter(permission => !prefixesToStrip.some(prefix => permission.startsWith(prefix)));
+                queryClient.setQueryData<string[]>(permissionsKey, next);
+                permissionService.load('environment', next);
+            }
         }
         navigate(redirectTo, { replace: true });
     }, [isForbidden, prefixKey, redirectTo, env?.id, queryClient, navigate]);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/nav/deniedNavItems.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/nav/deniedNavItems.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Module state, so each test needs its own copy of the store. */
+async function freshStore() {
+    jest.resetModules();
+    return import('./deniedNavItems');
+}
+
+describe('denied nav items', () => {
+    it('records a denied item', async () => {
+        const store = await freshStore();
+        store.markNavItemDenied('tenants');
+
+        expect(store.getDeniedNavItemKeys().has('tenants')).toBe(true);
+    });
+
+    // Page effects run before the layout's, so the layout's first environment callback would otherwise
+    // wipe a denial recorded during the same commit.
+    it('keeps a denial recorded before the first environment is seen', async () => {
+        const store = await freshStore();
+        store.markNavItemDenied('tenants');
+        store.resetDeniedNavItemsForEnvironment('env-1');
+
+        expect(store.getDeniedNavItemKeys().has('tenants')).toBe(true);
+    });
+
+    it('clears denials when the environment changes', async () => {
+        const store = await freshStore();
+        store.resetDeniedNavItemsForEnvironment('env-1');
+        store.markNavItemDenied('tenants');
+        store.resetDeniedNavItemsForEnvironment('env-2');
+
+        expect(store.getDeniedNavItemKeys().size).toBe(0);
+    });
+
+    it('keeps denials while the environment stays the same', async () => {
+        const store = await freshStore();
+        store.resetDeniedNavItemsForEnvironment('env-1');
+        store.markNavItemDenied('tenants');
+        store.resetDeniedNavItemsForEnvironment('env-1');
+
+        expect(store.getDeniedNavItemKeys().has('tenants')).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/nav/deniedNavItems.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/nav/deniedNavItems.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useSyncExternalStore } from 'react';
+
+const NONE: ReadonlySet<string> = new Set();
+
+let deniedKeys: ReadonlySet<string> = NONE;
+let currentEnvironmentId: string | undefined;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+    listeners.forEach(listener => listener());
+}
+
+/**
+ * Records that a live 403 denied `itemKey`, so the sidebar hides it and the landing key skips it.
+ *
+ * The permission strip in `useForbiddenResourceRedirect` only rewrites the environment scope, so a
+ * 403 on a page whose permission is organization-scoped strips nothing: the grant still comes from
+ * the host's organization scope, the item stays visible, and it stays the landing target. Every
+ * redirect out of the page then resolves back to it. Recording the denial by nav key instead of by
+ * permission works whatever scope granted it.
+ */
+export function markNavItemDenied(itemKey: string): void {
+    if (deniedKeys.has(itemKey)) return;
+    deniedKeys = new Set(deniedKeys).add(itemKey);
+    emit();
+}
+
+/**
+ * Drops the denials when the user switches environment — they describe one environment's backend,
+ * not the user's role. The first environment seen is not a switch: page-level effects run before the
+ * layout's, so a denial recorded during the very first commit would otherwise be wiped immediately.
+ */
+export function resetDeniedNavItemsForEnvironment(environmentId: string | undefined): void {
+    const isFirstEnvironment = currentEnvironmentId === undefined;
+    if (currentEnvironmentId === environmentId) return;
+    currentEnvironmentId = environmentId;
+    if (isFirstEnvironment || deniedKeys === NONE) return;
+    deniedKeys = NONE;
+    emit();
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+/** Nav items a live 403 has denied in the current environment. */
+export function getDeniedNavItemKeys(): ReadonlySet<string> {
+    return deniedKeys;
+}
+
+/** Re-renders when a 403 denies a nav item, or when an environment switch clears the denials. */
+export function useDeniedNavItemKeys(): ReadonlySet<string> {
+    return useSyncExternalStore(subscribe, getDeniedNavItemKeys, getDeniedNavItemKeys);
+}


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/FOUND-245

## Description

Align Gamma Platform nav and pasted URLs with Classic permission gating.
Organization (and Team Users) stays hidden unless the user has `organization-settings-r` or `-u`. Remaining items then require their own `-r`. Users with no visible menus land on an educational no-access page (ask an admin for an environment or organization role) instead of a forbidden screen. Empty context sidebar is hidden. Login/index prefers Applications when `environment-application-r` is present.
This is security-sensitive (authorization / nav gating). Roles UI, licenses, and Cloud multi-tenant are out of this PR.

## Additional context

Verified in multi tenant setup with 3 envs [DEV, TEST, DEFAULT] 

- admin scenario [excess to everywhere]: 

https://github.com/user-attachments/assets/84f55258-4660-48e0-a2bc-522da879925e


- User "envagent@local.test" with access to "DEV" env, & not [TEST/DEFAULT]
[dont have any platform related access]

https://github.com/user-attachments/assets/1af0e842-475b-4bab-8e2a-af16d1589d23


- User "envsplit@local.test" with ENVIRONMENT:USER on DEV & ENVIRONMENT:ADMIN on Test


https://github.com/user-attachments/assets/00c99a9e-5cd7-41fb-83b4-ab013837bd31

