### PR TITLE
fix(GKO-3207): reject invalid v4 health-check cron on CRD validation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -71,6 +71,7 @@ import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ValidateHealthCheckScheduleDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
@@ -888,7 +889,8 @@ public class ResourceContextConfiguration {
                     new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService),
                     new VerifyPlanPortRangesDomainService(kafkaPortRangeCrudService)
                 ),
-                new ValidatePortalNotificationDomainService(groupsValidator)
+                new ValidatePortalNotificationDomainService(groupsValidator),
+                new ValidateHealthCheckScheduleDomainService(new ObjectMapper())
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -119,6 +119,11 @@
 
 		<!-- Gravitee Dependencies -->
 		<dependency>
+			<groupId>io.gravitee.common</groupId>
+			<artifactId>gravitee-common</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.gravitee.apim.definition</groupId>
 			<artifactId>gravitee-apim-definition-jackson</artifactId>
 			<version>${project.version}</version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
@@ -70,6 +70,8 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
 
     private final ValidatePortalNotificationDomainService portalNotificationValidator;
 
+    private final ValidateHealthCheckScheduleDomainService healthCheckScheduleValidator;
+
     @Override
     public Validator.Result<ValidateApiCRDDomainService.Input> validateAndSanitize(ValidateApiCRDDomainService.Input input) {
         var errors = new ArrayList<Error>();
@@ -80,6 +82,7 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
             validateAndSanitizeNativeV4ForCreation(input, sanitizedBuilder, errors);
         } else if (!input.spec.isOnlySubscription()) {
             validateAndSanitizeHttpV4ForCreation(input, sanitizedBuilder, errors);
+            healthCheckScheduleValidator.validate(input.spec().getEndpointGroups(), errors);
         }
 
         categoryIdsValidator

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.common.cron.CronTrigger;
+import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
+import io.gravitee.definition.model.v4.service.Service;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DomainService
+@RequiredArgsConstructor
+public class ValidateHealthCheckScheduleDomainService {
+
+    static final String HTTP_HEALTH_CHECK_TYPE = "http-health-check";
+
+    private final ObjectMapper objectMapper;
+
+    public void validate(List<? extends AbstractEndpointGroup<?>> endpointGroups, List<Validator.Error> errors) {
+        if (endpointGroups == null) {
+            return;
+        }
+        for (AbstractEndpointGroup<?> group : endpointGroups) {
+            if (!(group instanceof EndpointGroup httpGroup)) {
+                continue;
+            }
+            validateGroupHealthCheck(httpGroup.getName(), httpGroup.getServices(), errors);
+            if (httpGroup.getEndpoints() == null) {
+                continue;
+            }
+            for (Endpoint endpoint : httpGroup.getEndpoints()) {
+                validateEndpointHealthCheck(httpGroup, endpoint, errors);
+            }
+        }
+    }
+
+    private void validateEndpointHealthCheck(EndpointGroup group, Endpoint endpoint, List<Validator.Error> errors) {
+        EndpointServices endpointServices = endpoint.getServices();
+        if (endpointServices == null || endpointServices.getHealthCheck() == null) {
+            return;
+        }
+        Service endpointHealthCheck = endpointServices.getHealthCheck();
+        if (!isEnabledHttpHealthCheck(endpointHealthCheck)) {
+            return;
+        }
+        if (!endpointHealthCheck.isOverrideConfiguration()) {
+            return;
+        }
+        validateSchedule(
+            "endpointGroups[%s].endpoints[%s].services.healthCheck.configuration.schedule".formatted(group.getName(), endpoint.getName()),
+            endpointHealthCheck.getConfiguration(),
+            errors
+        );
+    }
+
+    private void validateGroupHealthCheck(String groupName, EndpointGroupServices services, List<Validator.Error> errors) {
+        if (services == null || services.getHealthCheck() == null) {
+            return;
+        }
+        Service groupHealthCheck = services.getHealthCheck();
+        if (!isEnabledHttpHealthCheck(groupHealthCheck)) {
+            return;
+        }
+        validateSchedule(
+            "endpointGroups[%s].services.healthCheck.configuration.schedule".formatted(groupName),
+            groupHealthCheck.getConfiguration(),
+            errors
+        );
+    }
+
+    private static boolean isEnabledHttpHealthCheck(Service healthCheck) {
+        return healthCheck.isEnabled() && HTTP_HEALTH_CHECK_TYPE.equals(healthCheck.getType());
+    }
+
+    private void validateSchedule(String fieldPath, String configuration, List<Validator.Error> errors) {
+        String schedule;
+        try {
+            schedule = readSchedule(configuration);
+        } catch (JsonProcessingException e) {
+            errors.add(Validator.Error.severe("property [%s] has invalid JSON configuration", fieldPath));
+            return;
+        }
+        if (schedule == null || schedule.isBlank()) {
+            errors.add(Validator.Error.severe("property [%s] is required", fieldPath));
+            return;
+        }
+        try {
+            new CronTrigger(schedule);
+        } catch (IllegalArgumentException e) {
+            errors.add(Validator.Error.severe("property [%s] value [%s] is invalid: %s", fieldPath, schedule, e.getMessage()));
+        }
+    }
+
+    private String readSchedule(String configuration) throws JsonProcessingException {
+        if (configuration == null || configuration.isBlank()) {
+            return null;
+        }
+        JsonNode node = objectMapper.readTree(configuration);
+        JsonNode scheduleNode = node.get("schedule");
+        if (scheduleNode == null || scheduleNode.isNull()) {
+            return null;
+        }
+        return scheduleNode.asText();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
@@ -18,11 +18,13 @@ package io.gravitee.apim.core.api.domain_service;
 import static fixtures.core.model.ApiCRDFixtures.API_CROSS_ID;
 import static fixtures.core.model.ApiCRDFixtures.API_HRID;
 import static io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.core.model.ApiCRDFixtures;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.category.domain_service.ValidateCategoryIdsDomainService;
@@ -35,8 +37,11 @@ import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificat
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
 import io.gravitee.apim.core.resource.domain_service.ValidateResourceDomainService;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.notification.NotificationConfigType;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import java.util.List;
@@ -75,6 +80,10 @@ class ValidateApiCRDDomainServiceTest {
 
     ValidatePortalNotificationDomainService portalNotificationValidator = mock(ValidatePortalNotificationDomainService.class);
 
+    ValidateHealthCheckScheduleDomainService healthCheckScheduleValidator = new ValidateHealthCheckScheduleDomainService(
+        new ObjectMapper()
+    );
+
     ValidateApiCRDDomainService cut = new ValidateApiCRDDomainService(
         categoryIdsValidator,
         pathValidator,
@@ -84,7 +93,8 @@ class ValidateApiCRDDomainServiceTest {
         resourceValidator,
         pagesValidator,
         planValidator,
-        portalNotificationValidator
+        portalNotificationValidator,
+        healthCheckScheduleValidator
     );
 
     PortalNotificationConfigEntity consoleNotificationConfiguration = new PortalNotificationConfigEntity();
@@ -246,6 +256,70 @@ class ValidateApiCRDDomainServiceTest {
                 sanitized -> Assertions.assertThat(sanitized.spec()).isEqualTo(expected),
                 errors -> Assertions.assertThat(errors).isEmpty()
             );
+    }
+
+    @Test
+    void should_return_severe_error_for_invalid_health_check_schedule() {
+        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
+        group.setServices(
+            EndpointGroupServices.builder()
+                .healthCheck(
+                    Service.builder()
+                        .type(ValidateHealthCheckScheduleDomainService.HTTP_HEALTH_CHECK_TYPE)
+                        .enabled(true)
+                        .overrideConfiguration(false)
+                        .configuration("{\"schedule\":\"*/30 * * * *\"}")
+                        .build()
+                )
+                .build()
+        );
+        var spec = ApiCRDFixtures.newBaseSpec()
+            .endpointGroups(List.of(group))
+            .consoleNotificationConfiguration(consoleNotificationConfiguration)
+            .build();
+        var input = new ValidateApiCRDDomainService.Input(AuditInfo.builder().environmentId(ENV_ID).organizationId(ORG_ID).build(), spec);
+
+        when(categoryIdsValidator.validateAndSanitize(new ValidateCategoryIdsDomainService.Input(ENV_ID, spec.getCategories()))).thenAnswer(
+            call -> Validator.Result.ofValue(call.getArgument(0))
+        );
+
+        when(
+            membersValidator.validateAndSanitize(
+                new ValidateCRDMembersDomainService.Input(AUDIT_INFO, MembershipReferenceType.APPLICATION, any())
+            )
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
+
+        when(
+            groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, null, API_CREATE, true))
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
+
+        when(resourceValidator.validateAndSanitize(new ValidateResourceDomainService.Input(ENV_ID, any()))).thenAnswer(call ->
+            Validator.Result.ofValue(call.getArgument(0))
+        );
+
+        when(
+            pagesValidator.validateAndSanitize(new ValidatePagesDomainService.Input(AUDIT_INFO, spec.getId(), spec.getHrid(), any()))
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
+
+        when(planValidator.validateAndSanitize(any(ValidatePlanDomainService.Input.class))).thenAnswer(call ->
+            Validator.Result.ofValue(call.getArgument(0))
+        );
+
+        when(
+            portalNotificationValidator.validateAndSanitize(
+                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, null, AUDIT_INFO)
+            )
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
+
+        var severeErrors = cut.validateAndSanitize(input).severe();
+
+        assertThat(severeErrors).isPresent();
+        assertThat(severeErrors.get()).hasSize(1);
+        assertThat(severeErrors.get().getFirst().isSevere()).isTrue();
+        assertThat(severeErrors.get().getFirst().getMessage())
+            .contains("*/30 * * * *")
+            .contains("6 fields")
+            .contains("endpointGroups[default-group].services.healthCheck.configuration.schedule");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiCRDFixtures;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
+import io.gravitee.definition.model.v4.service.Service;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidateHealthCheckScheduleDomainServiceTest {
+
+    private ValidateHealthCheckScheduleDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ValidateHealthCheckScheduleDomainService(new ObjectMapper());
+    }
+
+    @Test
+    void should_reject_five_field_cron_on_group_health_check() {
+        var errors = new ArrayList<Validator.Error>();
+        var group = endpointGroupWithGroupHealthCheck("*/30 * * * *");
+
+        cut.validate(List.of(group), errors);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst().isSevere()).isTrue();
+        assertThat(errors.getFirst().getMessage()).contains("*/30 * * * *");
+        assertThat(errors.getFirst().getMessage()).contains("6 fields");
+        assertThat(errors.getFirst().getMessage()).contains("endpointGroups[default-group].services.healthCheck.configuration.schedule");
+    }
+
+    @Test
+    void should_accept_valid_six_field_cron_on_group_health_check() {
+        var errors = new ArrayList<Validator.Error>();
+        var group = endpointGroupWithGroupHealthCheck("0 */30 * * * *");
+
+        cut.validate(List.of(group), errors);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void should_skip_disabled_health_check_with_invalid_schedule() {
+        var errors = new ArrayList<Validator.Error>();
+        var healthCheck = healthCheckService("*/30 * * * *", true);
+        healthCheck.setEnabled(false);
+        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
+        group.getServices().setHealthCheck(healthCheck);
+
+        cut.validate(List.of(group), errors);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void should_reject_invalid_schedule_on_endpoint_override() {
+        var errors = new ArrayList<Validator.Error>();
+        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
+        var endpoint = group.getEndpoints().getFirst();
+        endpoint.setServices(EndpointServices.builder().healthCheck(healthCheckService("*/30 * * * *", true)).build());
+
+        cut.validate(List.of(group), errors);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst().getMessage()).contains("endpoints[default-endpoint]");
+        assertThat(errors.getFirst().getMessage()).contains("6 fields");
+    }
+
+    @Test
+    void should_reject_missing_schedule_on_enabled_health_check() {
+        var errors = new ArrayList<Validator.Error>();
+        var group = endpointGroupWithGroupHealthCheck(null);
+
+        cut.validate(List.of(group), errors);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.getFirst().getMessage()).contains("is required");
+    }
+
+    private static EndpointGroup endpointGroupWithGroupHealthCheck(String schedule) {
+        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
+        group.setServices(EndpointGroupServices.builder().healthCheck(healthCheckService(schedule, false)).build());
+        return group;
+    }
+
+    private static Service healthCheckService(String schedule, boolean overrideConfiguration) {
+        var configuration = schedule == null ? "{}" : "{\"schedule\":\"%s\"}".formatted(schedule);
+        return Service.builder()
+            .type(ValidateHealthCheckScheduleDomainService.HTTP_HEALTH_CHECK_TYPE)
+            .enabled(true)
+            .overrideConfiguration(overrideConfiguration)
+            .configuration(configuration)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -90,6 +90,7 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateNativeApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ValidateHealthCheckScheduleDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.domain_service.property.PropertyDomainService;
@@ -400,7 +401,8 @@ class ImportApiCRDUseCaseTest {
             validateResourceDomainService,
             new ValidatePagesDomainService(pageSourceValidator, accessControlValidator, validationDomainService),
             new ValidatePlanDomainService(planValidatorService, verifyPlanPortRanges),
-            new ValidatePortalNotificationDomainService(new ValidateGroupsDomainService(groupQueryService))
+            new ValidatePortalNotificationDomainService(new ValidateGroupsDomainService(groupQueryService)),
+            new ValidateHealthCheckScheduleDomainService(new ObjectMapper())
         );
 
         planQueryService = new PlanQueryServiceInMemory(planCrudService);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-3207

## Summary

- Add `ValidateHealthCheckScheduleDomainService` to validate enabled `http-health-check` schedules with `io.gravitee.common.cron.CronTrigger` (same class the v4 Gateway uses).
- Wire it into `ValidateApiCRDDomainService` so Automation API dry-run returns severe errors and GKO admission rejects malformed cron expressions before deploy.
- Real CRD import already returns HTTP 400 via `ImportApiCRDUseCase` when severe validation errors are present.

## Test plan

- [x] `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service test -Dtest=ValidateHealthCheckScheduleDomainServiceTest,ValidateApiCRDDomainServiceTest`
- [x] Validate with /peer-code-review 
- [ ] E2E: `npm run e2e -- --grep @GKO-3207` in gravitee-platform-e2e ([companion PR](https://github.com/gravitee-io/gravitee-platform-e2e/pull/28))
