### PR TITLE
chore(deps): bump gravitee-reactor-a2a-proxy to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
     <gravitee-reactor-native-kafka.version>7.0.8</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.6</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.9</gravitee-reactor-llm-proxy.version>
-    <gravitee-reactor-a2a-proxy.version>2.1.0</gravitee-reactor-a2a-proxy.version>
+    <gravitee-reactor-a2a-proxy.version>2.1.1</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.0.0</gravitee-reactor-authz.version>
     <gravitee-reactor-edge.version>1.0.0</gravitee-reactor-edge.version>
     <gravitee-resource-ai-vector-store-redis.version>2.0.0</gravitee-resource-ai-vector-store-redis.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-391
## Description

bump gravitee-reactor-a2a-proxy to 2.1.1
See https://github.com/gravitee-io/gravitee-reactor-a2a-proxy/pull/20
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

