### PR TITLE
chore(4.12.x): bump gravitee-endpoint-solace from 4.0.1 to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
     <gravitee-endpoint-kafka.version>6.1.5</gravitee-endpoint-kafka.version>
     <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
     <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>
-    <gravitee-endpoint-solace.version>4.0.1</gravitee-endpoint-solace.version>
+    <gravitee-endpoint-solace.version>4.1.1</gravitee-endpoint-solace.version>
     <gravitee-endpoint-azure-service-bus.version>2.0.2</gravitee-endpoint-azure-service-bus.version>
     <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
     <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-endpoint-solace](https://github.com/gravitee-io/gravitee-endpoint-solace)** from `4.0.1` to `4.1.1` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-endpoint-solace/releases) page.

## Backport

- `apply-on-4-11-x`
