### PR TITLE
chore(master): bump gravitee-entrypoint-webhook from 8.0.1 to 8.0.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -224,7 +224,7 @@
     <gravitee-entrypoint-http-get.version>3.0.0</gravitee-entrypoint-http-get.version>
     <gravitee-entrypoint-http-post.version>3.0.0</gravitee-entrypoint-http-post.version>
     <gravitee-entrypoint-sse.version>6.0.0</gravitee-entrypoint-sse.version>
-    <gravitee-entrypoint-webhook.version>8.0.1</gravitee-entrypoint-webhook.version>
+    <gravitee-entrypoint-webhook.version>8.0.2</gravitee-entrypoint-webhook.version>
     <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
     <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
     <gravitee-entrypoint-mcp-tool-server.version>2.0.3</gravitee-entrypoint-mcp-tool-server.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-entrypoint-webhook](https://github.com/gravitee-io/gravitee-entrypoint-webhook)** from `8.0.1` to `8.0.2` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-entrypoint-webhook/releases) page.

## Backport

- `apply-on-4-12-x`
