### PR TITLE
chore(4.9.x): bump gravitee-entrypoint-webhook from 5.1.2 to 5.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>5.1.2</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>5.1.3</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.1.1</gravitee-entrypoint-mcp.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-entrypoint-webhook](https://github.com/gravitee-io/gravitee-entrypoint-webhook)** from `5.1.2` to `5.1.3` on branch `4.9.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-entrypoint-webhook/releases) page.