### PR TITLE
fix: improve subscription filters layout

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
@@ -43,7 +43,7 @@
       />
 
       <app-dropdown-search
-        class="subscriptions__filter"
+        class="subscriptions__filter subscriptions__filter--status"
         i18n-label="@@subscriptionFilterStatus"
         label="Status"
         i18n-placeholder="@@subscriptionFilterStatusPlaceholder"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.scss
@@ -29,7 +29,6 @@
   &__filters {
     display: flex;
     flex-wrap: wrap;
-    max-width: 50rem;
     align-items: center;
     margin-bottom: 24px;
     gap: 16px;
@@ -37,6 +36,10 @@
 
   &__filter {
     flex: 1 1 200px;
+
+    &--status {
+      flex-grow: 0;
+    }
   }
 
   &__count {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PORTAL-134

## Summary

Fix the subscription filters layout by removing the fixed maximum width from the filters container.

The filters now use the available page width while preserving the existing responsive wrapping behavior.

## Changes

- Remove the `50rem` maximum width from the subscription filters container.
- Keep the existing responsive layout and filter behavior unchanged.


<img width="852" height="248" alt="Zrzut ekranu 2026-08-28 o 09 02 41" src="https://github.com/user-attachments/assets/de679a87-9f51-4740-abaf-5be6bc8f1a56" />

