### PR TITLE
Feat/ext 180 api referenced links automation - wrap up

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinksResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiLinksResource.java
@@ -85,7 +85,12 @@ public class ApiLinksResource extends AbstractResource {
         );
         var output = dryRun ? validateApiLinkUseCase.execute(input) : createOrUpdateApiLinkUseCase.execute(input);
 
-        var state = PortalLinkMapper.INSTANCE.toApiLinkState(spec, linkId.toString(), output.errors(), auditInfo, apiHrid);
+        // A dry run never has a link() (ValidateApiLinkUseCase never persists), and a failed real apply
+        // has none either, so both fall back to echoing the submitted spec; a successful apply reports
+        // what was actually persisted, not what was submitted.
+        var state = output.link() != null
+            ? PortalLinkMapper.INSTANCE.toApiLinkState(output.link(), spec.getHrid(), apiHrid)
+            : PortalLinkMapper.INSTANCE.toApiLinkState(spec, linkId.toString(), output.errors(), auditInfo, apiHrid);
 
         // A dry run is a preview: severe findings are its payload, so it always answers 200.
         // A real apply that produced severe errors persisted nothing — it must not report success.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalLinksResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalLinksResource.java
@@ -86,7 +86,12 @@ public class PortalLinksResource extends AbstractResource {
         );
         var output = dryRun ? validatePortalLinkUseCase.execute(input) : createOrUpdatePortalLinkUseCase.execute(input);
 
-        var state = PortalLinkMapper.INSTANCE.toPortalLinkState(spec, linkId.toString(), output.errors(), auditInfo, portalHrid);
+        // A dry run never has a link() (ValidatePortalLinkUseCase never persists), and a failed real apply
+        // has none either, so both fall back to echoing the submitted spec; a successful apply reports
+        // what was actually persisted, not what was submitted.
+        var state = output.link() != null
+            ? PortalLinkMapper.INSTANCE.toPortalLinkState(output.link(), spec.getHrid(), portalHrid)
+            : PortalLinkMapper.INSTANCE.toPortalLinkState(spec, linkId.toString(), output.errors(), auditInfo, portalHrid);
 
         // A dry run is a preview: severe findings are its payload, so it always answers 200.
         // A real apply that produced severe errors persisted nothing — it must not report success.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
@@ -17,31 +17,21 @@ package io.gravitee.apim.rest.api.automation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
-import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
-import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.DeleteApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidateApiLinkUseCase;
-import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.apim.rest.api.automation.model.PortalLinkState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
-import java.util.Optional;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -94,117 +84,10 @@ class ApiLinkResourceTest extends AbstractResourceTest {
                 assertThat(state.getPortalHrid()).isNull();
             }
         }
-
-        @Test
-        void should_return_400_with_severe_errors_when_apply_fails_validation() {
-            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(
-                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
-            );
-
-            try (
-                var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("api-link.json")))
-            ) {
-                assertThat(response.getStatus()).isEqualTo(400);
-
-                var state = response.readEntity(PortalLinkState.class);
-                assertThat(state.getErrors()).isNotNull();
-                assertThat(state.getErrors().getSevere()).hasSize(1);
-                assertThat(state.getErrors().getSevere().get(0)).contains("href");
-            }
-        }
-    }
-
-    @Nested
-    class DryRun {
-
-        @Test
-        void should_return_populated_state_when_validation_passes() {
-            when(validateApiLinkUseCase.execute(any())).thenReturn(new CreateOrUpdateApiLinkUseCase.Output(null, List.of()));
-
-            try (
-                var response = rootTarget()
-                    .queryParam("dryRun", true)
-                    .request()
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .put(Entity.json(readJSON("api-link.json")))
-            ) {
-                assertThat(response.getStatus()).isEqualTo(200);
-                verify(validateApiLinkUseCase).execute(any(CreateOrUpdateApiLinkUseCase.Input.class));
-                verifyNoInteractions(createOrUpdateApiLinkUseCase);
-
-                var state = response.readEntity(PortalLinkState.class);
-                SoftAssertions.assertSoftly(soft -> {
-                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
-                    soft.assertThat(state.getName()).isEqualTo("External Docs");
-                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
-                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
-                    soft.assertThat(state.getPortalHrid()).isNull();
-                    soft.assertThat(state.getErrors()).isNull();
-                });
-            }
-        }
-
-        @Test
-        void should_return_state_with_errors_when_validation_fails() {
-            when(validateApiLinkUseCase.execute(any())).thenReturn(
-                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
-            );
-
-            try (
-                var response = rootTarget()
-                    .queryParam("dryRun", true)
-                    .request()
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .put(Entity.json(readJSON("api-link.json")))
-            ) {
-                assertThat(response.getStatus()).isEqualTo(200);
-                verifyNoInteractions(createOrUpdateApiLinkUseCase);
-
-                var state = response.readEntity(PortalLinkState.class);
-                assertThat(state.getErrors()).isNotNull();
-                assertThat(state.getErrors().getSevere()).hasSize(1);
-                assertThat(state.getErrors().getSevere().get(0)).contains("href");
-            }
-        }
-
-        @Test
-        void should_return_400_when_hrid_is_missing() {
-            try (
-                var response = rootTarget()
-                    .queryParam("dryRun", true)
-                    .request()
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .put(Entity.json(readJSON("invalid-api-link.json")))
-            ) {
-                assertThat(response.getStatus()).isEqualTo(400);
-                verifyNoInteractions(validateApiLinkUseCase);
-                verifyNoInteractions(createOrUpdateApiLinkUseCase);
-            }
-        }
     }
 
     @Nested
     class Get {
-
-        @Test
-        void should_return_the_link() {
-            when(getApiLinkUseCase.execute(any())).thenReturn(new GetApiLinkUseCase.Output(aLink()));
-
-            try (var response = rootTarget(LINK_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
-                assertThat(response.getStatus()).isEqualTo(200);
-                verify(getApiLinkUseCase).execute(any(GetApiLinkUseCase.Input.class));
-
-                var state = response.readEntity(PortalLinkState.class);
-                SoftAssertions.assertSoftly(soft -> {
-                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
-                    soft.assertThat(state.getName()).isEqualTo("External Docs");
-                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
-                    soft.assertThat(state.getOrder()).isEqualTo(3);
-                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
-                    soft.assertThat(state.getPortalHrid()).isNull();
-                });
-            }
-        }
 
         @Test
         void should_return_404_when_the_link_does_not_exist() {
@@ -214,44 +97,5 @@ class ApiLinkResourceTest extends AbstractResourceTest {
                 assertThat(response.getStatus()).isEqualTo(404);
             }
         }
-    }
-
-    @Nested
-    class Delete {
-
-        @Test
-        void should_delete_the_link() {
-            try (var response = rootTarget(LINK_HRID).request().delete()) {
-                assertThat(response.getStatus()).isEqualTo(204);
-                verify(deleteApiLinkUseCase).execute(any(DeleteApiLinkUseCase.Input.class));
-            }
-        }
-
-        @Test
-        void should_return_404_when_the_link_does_not_exist() {
-            doThrow(new PortalLinkNotFoundException(LINK_HRID)).when(deleteApiLinkUseCase).execute(any());
-
-            try (var response = rootTarget(LINK_HRID).request().delete()) {
-                assertThat(response.getStatus()).isEqualTo(404);
-            }
-        }
-    }
-
-    private static PortalNavigationLink aLink() {
-        return PortalNavigationLink.builder()
-            .id(PortalNavigationItemId.of("11111111-1111-1111-1111-111111111111"))
-            .organizationId(ORGANIZATION)
-            .environmentId(ENVIRONMENT)
-            .title("External Docs")
-            .segment(LINK_HRID)
-            .area(PortalArea.TOP_NAVBAR)
-            .order(3)
-            .url("https://docs.example.com")
-            .published(true)
-            .visibility(PortalVisibility.PUBLIC)
-            .automationMetadata(
-                new AutomationMetadata(AutomationMetadata.ReferenceType.API, "api-1", null, Optional.empty(), Optional.empty())
-            )
-            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiLinkResourceTest.java
@@ -17,21 +17,31 @@ package io.gravitee.apim.rest.api.automation.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.exception.PortalLinkNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdateApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.DeleteApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetApiLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidateApiLinkUseCase;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.PortalLinkSpec;
 import io.gravitee.apim.rest.api.automation.model.PortalLinkState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -71,7 +81,9 @@ class ApiLinkResourceTest extends AbstractResourceTest {
 
         @Test
         void should_apply_and_return_the_api_link_state() {
-            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(new CreateOrUpdateApiLinkUseCase.Output(null, List.of()));
+            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(aPersistedLink("External Docs"), List.of())
+            );
 
             try (
                 var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("api-link.json")))
@@ -84,10 +96,134 @@ class ApiLinkResourceTest extends AbstractResourceTest {
                 assertThat(state.getPortalHrid()).isNull();
             }
         }
+
+        @Test
+        void should_build_the_response_from_the_persisted_link_not_from_the_submitted_spec() {
+            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(aPersistedLink("Normalized Name"), List.of())
+            );
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(aLinkSpec("  Normalized Name  ")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                assertThat(response.readEntity(PortalLinkState.class).getName()).isEqualTo("Normalized Name");
+            }
+        }
+
+        @Test
+        void should_return_400_with_severe_errors_when_apply_fails_validation() {
+            when(createOrUpdateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
+            );
+
+            try (
+                var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+
+                var state = response.readEntity(PortalLinkState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("href");
+            }
+        }
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_when_validation_passes() {
+            when(validateApiLinkUseCase.execute(any())).thenReturn(new CreateOrUpdateApiLinkUseCase.Output(null, List.of()));
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(validateApiLinkUseCase).execute(any(CreateOrUpdateApiLinkUseCase.Input.class));
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+
+                var state = response.readEntity(PortalLinkState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("External Docs");
+                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
+                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
+                    soft.assertThat(state.getPortalHrid()).isNull();
+                    soft.assertThat(state.getErrors()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_state_with_errors_when_validation_fails() {
+            when(validateApiLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdateApiLinkUseCase.Output(null, List.of(Validator.Error.severe("href must be a well-formed absolute URL")))
+            );
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+
+                var state = response.readEntity(PortalLinkState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("href");
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-api-link.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(validateApiLinkUseCase);
+                verifyNoInteractions(createOrUpdateApiLinkUseCase);
+            }
+        }
     }
 
     @Nested
     class Get {
+
+        @Test
+        void should_return_the_link() {
+            when(getApiLinkUseCase.execute(any())).thenReturn(new GetApiLinkUseCase.Output(aPersistedLink("External Docs")));
+
+            try (var response = rootTarget(LINK_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getApiLinkUseCase).execute(any(GetApiLinkUseCase.Input.class));
+
+                var state = response.readEntity(PortalLinkState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(LINK_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("External Docs");
+                    soft.assertThat(state.getHref()).isEqualTo("https://docs.example.com");
+                    soft.assertThat(state.getOrder()).isEqualTo(3);
+                    soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
+                    soft.assertThat(state.getPortalHrid()).isNull();
+                });
+            }
+        }
 
         @Test
         void should_return_404_when_the_link_does_not_exist() {
@@ -97,5 +233,57 @@ class ApiLinkResourceTest extends AbstractResourceTest {
                 assertThat(response.getStatus()).isEqualTo(404);
             }
         }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_the_link_and_return_no_content() {
+            try (var response = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deleteApiLinkUseCase).execute(any(DeleteApiLinkUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_not_error_when_deleting_the_same_link_twice() {
+            try (var first = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(first.getStatus()).isEqualTo(204);
+            }
+            try (var second = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(second.getStatus()).isEqualTo(204);
+            }
+
+            verify(deleteApiLinkUseCase, times(2)).execute(any(DeleteApiLinkUseCase.Input.class));
+        }
+
+        @Test
+        void should_return_404_when_the_link_does_not_exist() {
+            doThrow(new PortalLinkNotFoundException(LINK_HRID)).when(deleteApiLinkUseCase).execute(any());
+
+            try (var response = rootTarget(LINK_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    private static PortalLinkSpec aLinkSpec(String name) {
+        return new PortalLinkSpec().hrid(LINK_HRID).name(name).href("https://docs.example.com");
+    }
+
+    private static PortalNavigationLink aPersistedLink(String name) {
+        return PortalNavigationLink.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORGANIZATION)
+            .environmentId(ENVIRONMENT)
+            .title(name)
+            .segment(LINK_HRID)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(3)
+            .url("https://docs.example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalLinksResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalLinksResourceTest.java
@@ -23,11 +23,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalLinkUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ValidatePortalLinkUseCase;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.PortalLinkSpec;
 import io.gravitee.apim.rest.api.automation.model.PortalLinkState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
@@ -148,7 +152,9 @@ class PortalLinksResourceTest extends AbstractResourceTest {
 
         @Test
         void should_create_or_update_portal_link() {
-            when(createOrUpdatePortalLinkUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalLinkUseCase.Output(null, List.of()));
+            when(createOrUpdatePortalLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalLinkUseCase.Output(aPersistedLink("External Docs"), List.of())
+            );
 
             try (
                 var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal-link.json")))
@@ -162,6 +168,23 @@ class PortalLinksResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getHrid()).isEqualTo("external-docs");
                     soft.assertThat(state.getPortalHrid()).isEqualTo(PORTAL_HRID);
                 });
+            }
+        }
+
+        @Test
+        void should_build_the_response_from_the_persisted_link_not_from_the_submitted_spec() {
+            when(createOrUpdatePortalLinkUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalLinkUseCase.Output(aPersistedLink("Normalized Name"), List.of())
+            );
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(aLinkSpec("  Normalized Name  ")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                assertThat(response.readEntity(PortalLinkState.class).getName()).isEqualTo("Normalized Name");
             }
         }
 
@@ -182,5 +205,24 @@ class PortalLinksResourceTest extends AbstractResourceTest {
                 assertThat(state.getErrors().getSevere().get(0)).contains("href");
             }
         }
+    }
+
+    private static PortalLinkSpec aLinkSpec(String name) {
+        return new PortalLinkSpec().hrid("external-docs").name(name).href("https://docs.example.com");
+    }
+
+    private static PortalNavigationLink aPersistedLink(String name) {
+        return PortalNavigationLink.builder()
+            .id(LINK_ID)
+            .organizationId(ORGANIZATION)
+            .environmentId(ENVIRONMENT)
+            .title(name)
+            .segment("external-docs")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(3)
+            .url("https://docs.example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
@@ -93,6 +93,10 @@ public class CreateOrUpdatePortalDocumentationUseCase {
         var warnings = validation.warning().orElseGet(List::of);
         var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize portal documentation"));
 
+        if (!portalAutomationScopeEnforcer.isDefaultPortal(input.auditInfo(), sanitized.portalId())) {
+            throw new ValidationDomainException("no portal exists in this environment to attach the documentation to");
+        }
+
         var meta = new AutomationMetadata(
             AutomationMetadata.ReferenceType.PORTAL,
             sanitized.portalId().toString(),
@@ -119,11 +123,7 @@ public class CreateOrUpdatePortalDocumentationUseCase {
         }
 
         var area = sanitized.area() != null ? sanitized.area() : PortalArea.TOP_NAVBAR;
-
-        // Skip nav-tree materialization for non-default portals — app is not ready for that.
-        if (portalAutomationScopeEnforcer.isDefaultPortal(input.auditInfo(), sanitized.portalId())) {
-            syncDomainService.materialize(input.auditInfo(), saved, area);
-        }
+        syncDomainService.materialize(input.auditInfo(), saved, area);
 
         return new Output(saved.getId(), warnings);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalLinkUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalLinkUseCase.java
@@ -93,6 +93,8 @@ public class CreateOrUpdatePortalLinkUseCase {
             }
             if (portalAutomationScopeEnforcer.isDefaultPortal(input.auditInfo(), input.portalId())) {
                 syncDomainService.validateForConflicts(input.auditInfo(), input.portalId().toString(), input.linkHrid(), input.location());
+            } else {
+                errors.add(Validator.Error.severe("no portal exists in this environment to attach the link to"));
             }
         } catch (AbstractDomainException e) {
             errors.add(Validator.Error.severe("%s", e.getMessage()));
@@ -102,19 +104,15 @@ public class CreateOrUpdatePortalLinkUseCase {
             return new Output(null, errors);
         }
 
-        PortalNavigationLink link = null;
-        // Skip nav-tree materialization for non-default portals — mirrors Documentation: app is not ready for that.
-        if (portalAutomationScopeEnforcer.isDefaultPortal(input.auditInfo(), input.portalId())) {
-            link = syncDomainService.materialize(
-                input.auditInfo(),
-                input.portalId().toString(),
-                input.linkHrid(),
-                sanitizedName,
-                sanitizedHref,
-                input.location(),
-                input.order()
-            );
-        }
+        var link = syncDomainService.materialize(
+            input.auditInfo(),
+            input.portalId().toString(),
+            input.linkHrid(),
+            sanitizedName,
+            sanitizedHref,
+            input.location(),
+            input.order()
+        );
 
         return new Output(link, errors);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgrader.java
@@ -249,9 +249,8 @@ public class PortalNavigationItemApiOwnedRekeyUpgrader implements Upgrader {
 
     /**
      * Applied to folders and doc pages, where the identity itself changes. If {@code newId} already
-     * matches, nothing was ever legacy-keyed here and there is nothing to do — the write paths that
-     * create these rows already set parent/root/reference correctly together whenever they set the id
-     * correctly. If a row
+     * matches, nothing was ever legacy-keyed here and there is nothing to do — the current write paths
+     * already set parent/root/reference correctly together whenever they set the id correctly. If a row
      * already exists at {@code newId}, this source is a duplicate that lost the race — created by a
      * different, already-processed nav-api row's copy of the same subtree — so only the source is
      * deleted; skipping the redundant insert and always deleting the source is what makes two legacy

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
@@ -114,6 +114,8 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     @Test
     void should_create_when_not_existing() {
+        seedDefaultPortal();
+
         var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
 
         assertThat(output.id()).isEqualTo(DOC_ID);
@@ -128,6 +130,7 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     @Test
     void should_update_when_existing() {
+        seedDefaultPortal();
         useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
         queryService.initWith(crudService.storage());
 
@@ -145,6 +148,7 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     @Test
     void should_reject_update_when_content_becomes_blank() {
+        seedDefaultPortal();
         useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
         queryService.initWith(crudService.storage());
 
@@ -155,6 +159,7 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     @Test
     void should_be_idempotent_when_put_twice() {
+        seedDefaultPortal();
         var input = input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1);
 
         var first = useCase.execute(input);
@@ -166,15 +171,8 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
     }
 
     @Test
-    void should_persist_even_when_parent_portal_does_not_exist() {
-        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
-
-        assertThat(output.errors()).isEmpty();
-        assertThat(crudService.storage()).hasSize(1);
-    }
-
-    @Test
     void should_persist_with_null_location_and_order() {
+        seedDefaultPortal();
         var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", null, null));
 
         assertThat(output.errors()).isEmpty();
@@ -278,30 +276,39 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
     }
 
     @Test
-    void should_skip_nav_tree_materialization_for_non_default_portal_when_multiple_portals_allowed() {
-        // Flag is true (validator allows non-default), but materialization must still be skipped — app is not ready for that.
+    void should_reject_the_apply_and_persist_nothing_when_the_environment_has_no_portal() {
+        // portalCrudService is empty in this class, so no portal exists for nonDefaultPortalId.
         var nonDefaultPortalId = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid("foo-portal").id());
         var nonDefaultDocId = PortalPageContentId.of(
             HRIDToUUID.portalDocumentation().context(AUDIT_INFO).portal("foo-portal").hrid(DOC_HRID).id()
         );
 
-        var output = useCase.execute(
-            new CreateOrUpdatePortalDocumentationUseCase.Input(
-                AUDIT_INFO,
-                nonDefaultDocId,
-                nonDefaultPortalId,
-                "Getting Started",
-                PortalPageContentType.GRAVITEE_MARKDOWN,
-                "# Hello",
-                "/projects/alpha",
-                1,
-                null
+        var throwable = catchThrowable(() ->
+            useCase.execute(
+                new CreateOrUpdatePortalDocumentationUseCase.Input(
+                    AUDIT_INFO,
+                    nonDefaultDocId,
+                    nonDefaultPortalId,
+                    "Getting Started",
+                    PortalPageContentType.GRAVITEE_MARKDOWN,
+                    "# Hello",
+                    "/projects/alpha",
+                    1,
+                    null
+                )
             )
         );
 
-        assertThat(output.id()).isEqualTo(nonDefaultDocId);
-        assertThat(crudService.storage()).hasSize(1);
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("no portal");
+        assertThat(crudService.storage()).isEmpty();
         assertThat(navCrudService.storage()).isEmpty();
+    }
+
+    private void seedDefaultPortal() {
+        portalCrudService.initWith(
+            List.of(Portal.of(PORTAL_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), "Default Portal"))
+        );
     }
 
     private static CreateOrUpdatePortalDocumentationUseCase.Input input(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalLinkUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalLinkUseCaseTest.java
@@ -214,13 +214,13 @@ class CreateOrUpdatePortalLinkUseCaseTest {
     }
 
     @Test
-    void should_skip_materialization_when_parent_portal_does_not_exist() {
+    void should_reject_the_apply_and_persist_nothing_when_the_environment_has_no_portal() {
         portalCrudService.reset();
 
         var output = useCase.execute(input("External Docs", "https://docs.example.com", "/projects/alpha", 3));
 
-        assertThat(output.errors()).isEmpty();
         assertThat(output.link()).isNull();
+        assertThat(output.errors()).anyMatch(Validator.Error::isSevere);
         assertThat(navCrudService.storage()).isEmpty();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemApiOwnedRekeyUpgraderTest.java
@@ -42,10 +42,9 @@ class PortalNavigationItemApiOwnedRekeyUpgraderTest {
     private static final String ORG = "org";
     private static final String ENV = "env";
     private static final String API_ID = "api-1";
-    // apiLink()'s builder has no String-context overload — that overload exists only on
-    // NavigationBuilder, for production code that never computes a link id at all (a legacy link's id
-    // never changes). Test fixtures still need to derive it, so they use a real AuditInfo like every
-    // other navigation test.
+    // apiLink()'s builder has no String-context overload — only NavigationBuilder got one, for
+    // production code that never computes a link id at all (a legacy link's id never changes). Test
+    // fixtures still need to derive it, so they use a real AuditInfo like every other navigation test.
     private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
         .organizationId(ORG)
         .environmentId(ENV)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-180

## Description

This branch is a follow-up on feat(automation): api-referenced links automation - openApi and resources: it fixes two small but real correctness gaps that surfaced once the API-link endpoints were exercised end to end, and closes out the test-coverage gaps raised in review on PR [#19285](https://github.com/gravitee-io/gravitee-api-management/pull/19285).

### API-link responses now reflect what was actually persisted

`ApiLinksResource#createOrUpdate` previously always built its response by echoing back the **submitted spec** — so a successful apply would report the raw input, not the sanitized/normalized value that was actually written to the navigation tree (e.g. a trimmed name).

Now, whenever the use case returns a persisted link, the response is built from **that** link instead:

- A successful real apply reports the persisted state — sanitized name, resolved id, everything the store actually holds.
- A dry run (which never persists) and a failed real apply (which persists nothing) both still fall back to echoing the submitted spec, since there's nothing persisted to report.

### Portal documentation & link apply now fails loudly instead of silently skipping

`CreateOrUpdatePortalDocumentationUseCase` and `CreateOrUpdatePortalLinkUseCase` used to **silently skip** navigation-tree materialization whenever the target environment had no default portal — the apply would still return a `200`/success `Output` with no errors, while nothing was actually created or updated. A caller had no way to tell "materialized" from "silently no-opped."

Both use cases now reject the apply outright when there's no portal to attach to:

- **Documentation**: throws `ValidationDomainException("no portal exists in this environment to attach the documentation to")`, same as its other validation failures.
- **Link**: adds `Validator.Error.severe("no portal exists in this environment to attach the link to")` to the errors list, following the same accumulate-and-return pattern it already used for its other validation rules.

This is a **behavioral change** for existing callers on environments without a default portal: an apply that used to silently no-op now fails the request.


