### PR TITLE
chore(deps): bump gravitee-common-mcp to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <logback-ecs-encoder.version>1.7.0</logback-ecs-encoder.version>
     <gravitee-common.version>5.2.0</gravitee-common.version>
     <gravitee-common-elasticsearch.version>7.1.0</gravitee-common-elasticsearch.version>
-    <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
+    <gravitee-common-mcp.version>2.0.0</gravitee-common-mcp.version>
     <gravitee-connector-api.version>2.0.0</gravitee-connector-api.version>
     <gravitee-exchange.version>3.0.0</gravitee-exchange.version>
     <gravitee-expression-language.version>4.4.1</gravitee-expression-language.version>


### PR DESCRIPTION
Relates to [AIAM-392](https://gravitee.atlassian.net/browse/AIAM-392) · epic [AIAM-224](https://gravitee.atlassian.net/browse/AIAM-224)

Last in the chain:

1. [gravitee-common-mcp#27](https://github.com/gravitee-io/gravitee-common-mcp/pull/27) — **2.0.0**, released
2. [gravitee-reactor-mcp-proxy#81](https://github.com/gravitee-io/gravitee-reactor-mcp-proxy/pull/81)
3. [gravitee-policy-mcp-acl#26](https://github.com/gravitee-io/gravitee-policy-mcp-acl/pull/26)
4. **this PR**

## What and why

One property. `gravitee-apim-bom` is what the MCP plugins resolve `gravitee-common-mcp` through, so it has to name the version they are built against.

```diff
- <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
+ <gravitee-common-mcp.version>2.0.0</gravitee-common-mcp.version>
```

2.0.0 replaces the MCP Java SDK's closed `McpSchema` records with a JSON-RPC model the library owns. `params` and `result` stay untyped, so a gateway forwards fields it does not model — including the ones MCP 2026-07-28 requires, which the previous shape silently dropped whenever a response was rebuilt.

## Risk

Low. **Nothing in this repository compiles against `gravitee-common-mcp`** — `grep -rl "com.graviteesource.common.mcp" --include="*.java"` is empty. The BOM only publishes the version for downstream plugins.

Verified the effective POM resolves it: `mvn -f gravitee-apim-bom/pom.xml help:effective-pom` → `BUILD SUCCESS`, `<gravitee-common-mcp.version>2.0.0`.

## Ordering

The API change is binary-breaking: a plugin built against 1.x fails at runtime with `NoSuchMethodError` on `ParseMcpRequest.request()`. This PR should land alongside or after #81 and #26 so a distribution never pairs the new BOM with plugins built against the old jar.

[AIAM-392]: https://gravitee.atlassian.net/browse/AIAM-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIAM-224]: https://gravitee.atlassian.net/browse/AIAM-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ