### PR TITLE
chore(master): bump gravitee-resource-schema-registry-confluent from 5.1.0 to 6.0.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -236,7 +236,7 @@
     <gravitee-endpoint-azure-service-bus.version>2.0.2</gravitee-endpoint-azure-service-bus.version>
     <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
     <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
-    <gravitee-resource-schema-registry-confluent.version>5.1.0</gravitee-resource-schema-registry-confluent.version>
+    <gravitee-resource-schema-registry-confluent.version>6.0.0</gravitee-resource-schema-registry-confluent.version>
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-resource-schema-registry-confluent](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent)** from `5.1.0` to `6.0.0` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent/releases) page.