### PR TITLE
chore(4.10.x): bump gravitee-resource-schema-registry-confluent from 4.0.0 to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <gravitee-endpoint-azure-service-bus.version>1.0.2</gravitee-endpoint-azure-service-bus.version>
         <gravitee-endpoint-agent-to-agent.version>1.0.1</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
-        <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
+        <gravitee-resource-schema-registry-confluent.version>4.0.1</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>9.0.1</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>5.0.7</gravitee-reactor-native-kafka.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-resource-schema-registry-confluent](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent)** from `4.0.0` to `4.0.1` on branch `4.10.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent/releases) page.

## Jira

[GKO-1385](https://gravitee.atlassian.net/browse/GKO-1385)

## Backport

- `apply-on-4-9-x`
