### PR TITLE
chore(4.12.x): bump gravitee-policy-kafka-topic-mapping from 2.0.2 to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
     <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>
     <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
     <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
-    <gravitee-policy-kafka-topic-mapping.version>2.0.2</gravitee-policy-kafka-topic-mapping.version>
+    <gravitee-policy-kafka-topic-mapping.version>2.1.0</gravitee-policy-kafka-topic-mapping.version>
     <gravitee-policy-kafka-acl.version>3.0.3</gravitee-policy-kafka-acl.version>
     <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
     <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-kafka-topic-mapping](https://github.com/gravitee-io/gravitee-policy-kafka-topic-mapping)** from `2.0.2` to `2.1.0` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-kafka-topic-mapping/releases) page.