### PR TITLE
fix(rest): map ConflictDomainException to 409 and keep technical code s on validation errors

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/provider/ConflictDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/provider/ConflictDomainExceptionMapper.java
@@ -15,25 +15,19 @@
  */
 package io.gravitee.rest.api.management.rest.provider;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.exception.ConflictDomainException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 
-public class ValidationDomainExceptionMapper extends AbstractExceptionMapper<ValidationDomainException> {
+public class ConflictDomainExceptionMapper extends AbstractExceptionMapper<ConflictDomainException> {
 
     @Override
-    public Response toResponse(ValidationDomainException exception) {
-        final Response.Status error = Response.Status.BAD_REQUEST;
+    public Response toResponse(ConflictDomainException exception) {
+        final Response.Status error = Response.Status.CONFLICT;
         return Response.status(error)
             .type(MediaType.APPLICATION_JSON_TYPE)
-            .entity(
-                convert(
-                    exception,
-                    error.getStatusCode(),
-                    exception.getTechnicalCode(),
-                    exception.getParameters().isEmpty() ? null : exception.getParameters()
-                )
-            )
+            .entity(convert(exception, error.getStatusCode(), null, exception.getId() == null ? null : Map.of("id", exception.getId())))
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GraviteeManagementApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GraviteeManagementApplication.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import io.gravitee.rest.api.management.rest.mapper.ObjectMapperResolver;
 import io.gravitee.rest.api.management.rest.provider.BadRequestExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.ByteArrayOutputStreamWriter;
+import io.gravitee.rest.api.management.rest.provider.ConflictDomainExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.ConstraintValidationExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.EnumParamConverterProvider;
 import io.gravitee.rest.api.management.rest.provider.JsonMappingExceptionMapper;
@@ -116,6 +117,7 @@ public class GraviteeManagementApplication extends ResourceConfig {
         register(BadRequestExceptionMapper.class);
         register(EnumParamConverterProvider.class);
         register(ValidationDomainExceptionMapper.class);
+        register(ConflictDomainExceptionMapper.class);
         register(NotAllowedDomainExceptionMapper.class);
         register(NotFoundDomainExceptionMapper.class);
         register(TechnicalDomainExceptionMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/provider/DomainExceptionMappersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/provider/DomainExceptionMappersTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.exception.ConflictDomainException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.rest.api.management.rest.model.ErrorEntity;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class DomainExceptionMappersTest {
+
+    @Test
+    public void conflict_domain_exception_maps_to_409_with_its_id() {
+        var response = new ConflictDomainExceptionMapper().toResponse(new ConflictDomainException("Slug already used", "my-slug"));
+
+        assertThat(response.getStatus()).isEqualTo(409);
+        var body = (ErrorEntity) response.getEntity();
+        assertThat(body.getMessage()).isEqualTo("Slug already used");
+        assertThat(body.getParameters()).isEqualTo(Map.of("id", "my-slug"));
+    }
+
+    @Test
+    public void conflict_domain_exception_without_id_maps_to_409() {
+        var response = new ConflictDomainExceptionMapper().toResponse(new ConflictDomainException("Conflict"));
+
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(((ErrorEntity) response.getEntity()).getParameters()).isNull();
+    }
+
+    @Test
+    public void validation_domain_exception_keeps_its_technical_code() {
+        var response = new ValidationDomainExceptionMapper().toResponse(
+            new ValidationDomainException("Credential rejected", "provider.credential.rejected")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var body = (ErrorEntity) response.getEntity();
+        assertThat(body.getTechnicalCode()).isEqualTo("provider.credential.rejected");
+        assertThat(body.getParameters()).isNull();
+    }
+
+    /**
+     * The other half of the pass-through. The two-argument constructor above leaves {@code parameters} as an empty
+     * map, so it only exercises the branch that yields null — inverting the guard, or dropping the argument, would
+     * keep that test green while every 400 lost its parameters again.
+     */
+    @Test
+    public void validation_domain_exception_forwards_its_parameters() {
+        var response = new ValidationDomainExceptionMapper().toResponse(
+            new ValidationDomainException("Invalid value", Map.of("location", "/endpointGroups"), "invalidValue")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var body = (ErrorEntity) response.getEntity();
+        assertThat(body.getParameters()).isEqualTo(Map.of("location", "/endpointGroups"));
+        assertThat(body.getTechnicalCode()).isEqualTo("invalidValue");
+    }
+
+    /** No code and no parameters: the response must gain neither field, which is what keeps existing 400s unchanged. */
+    @Test
+    public void validation_domain_exception_without_code_or_parameters_is_unchanged() {
+        var response = new ValidationDomainExceptionMapper().toResponse(new ValidationDomainException("Plain failure"));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var body = (ErrorEntity) response.getEntity();
+        assertThat(body.getMessage()).isEqualTo("Plain failure");
+        assertThat(body.getTechnicalCode()).isNull();
+        assertThat(body.getParameters()).isNull();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -30,6 +30,7 @@ import io.gravitee.gamma.rest.resources.tracing.TracingResource;
 import io.gravitee.rest.api.management.rest.mapper.ObjectMapperResolver;
 import io.gravitee.rest.api.management.rest.provider.BadRequestExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.ByteArrayOutputStreamWriter;
+import io.gravitee.rest.api.management.rest.provider.ConflictDomainExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.ConstraintValidationExceptionMapper;
 import io.gravitee.rest.api.management.rest.provider.EnumParamConverterProvider;
 import io.gravitee.rest.api.management.rest.provider.JsonMappingExceptionMapper;
@@ -82,6 +83,7 @@ public class GammaModuleApplication extends ResourceConfig {
         register(BadRequestExceptionMapper.class);
         register(EnumParamConverterProvider.class);
         register(ValidationDomainExceptionMapper.class);
+        register(ConflictDomainExceptionMapper.class);
         register(NotAllowedDomainExceptionMapper.class);
         register(NotFoundDomainExceptionMapper.class);
         register(TechnicalDomainExceptionMapper.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/exception/DashboardVersionConflictExceptionMapper.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/dashboards/exception/DashboardVersionConflictExceptionMapper.java
@@ -35,12 +35,12 @@ import jakarta.ws.rs.ext.Provider;
  * response that names one — so a client whose user chooses to reload has the validator for its next save without a
  * second request.
  *
- * <p>Domain-specific rather than a generic mapper for the exception's base type, for two reasons.
- * The platform registers no {@code ConflictDomainException} mapper at all in
- * {@code GammaModuleApplication} — management-rest ships none — so without this a refused save would
- * surface through {@code ThrowableMapper} as a 500, telling the author their work failed for an
- * unknown reason. And the body has to carry the current dashboard, which the shared error shape
- * cannot express.
+ * <p>Domain-specific rather than a generic mapper for the exception's base type. {@code GammaModuleApplication} does
+ * register a {@code ConflictDomainExceptionMapper} for the base type, so the fallback is a 409 rather than the 500 it
+ * once was; JAX-RS still resolves to this mapper because it matches the more specific type. Both reasons for keeping
+ * it are therefore about the answer, not about avoiding a crash: the status has to be 412, since the caller stated an
+ * {@code If-Match} precondition, and the body has to carry the current dashboard, which the shared error shape cannot
+ * express. Removing this class would silently turn a conditional save into a 409 with no dashboard in the body.
  *
  * @author GraviteeSource Team
  */


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-375

## Description

GammaModuleApplication registers a mapper for NotFoundDomainException, ValidationDomainException, NotAllowedDomainException and TechnicalDomainException, but none for ConflictDomainException — and no such mapper existed in the v1 provider package at all. Every conflict therefore fell through to ThrowableMapper and surfaced as a 500.

That is already visible today, independently of the AI Management work: LlmProxyAlreadyExistsException (an LLM proxy created or duplicated with an entity id already taken) answers 500 instead of 409. The console hides it by checking the entity id beforehand, so it only shows up on a race or a direct API call.

Two changes:
- a ConflictDomainExceptionMapper in the v1 provider package (409, id carried as a parameter, mirroring NotFoundDomainExceptionMapper), registered in GammaModuleApplication and GraviteeManagementApplication — the classic app had the same gap;
- ValidationDomainExceptionMapper now passes the exception's technicalCode and parameters through convert(...). They were silently dropped, so a client could not tell one 400 from another; the response gains the fields only when they are set (empty parameters stay absent).

Three unit tests cover the new mapper (with and without an id) and the technical code propagation. No behaviour change for any 400 that carries neither.

## Additional context

Needed by AIAM-375 (gravitee-gamma-module-aim), where a taken provider slug and a provider still consumed by a workspace both answer 409, and the failure taxonomy of the connection test rides on technical codes (provider.credential.rejected vs provider.service.unreachable). Verified on a local stack: 500 before, 409 with the id parameter after; technical codes now reach the client.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

