### PR TITLE
feat(authz): route schema documents by engine identity rather than by routing scope

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzHostedScopes.java
@@ -84,6 +84,18 @@ public class AuthzHostedScopes {
         return hostedByBase.containsKey(key(environmentId, baseOf(targetPdpId)));
     }
 
+    /**
+     * Whether this node hosts the engine a scope names, ignoring the sharding tag. An engine is
+     * {@code environmentId:targetPdpId} with the tag stripped, which is what
+     * {@code EventBusAuthzEnginePort#addressFor} already computes, so {@code stock@eu} and {@code stock@us}
+     * are one engine. A document bound to the engine rather than to a routing scope is therefore served
+     * wherever that engine runs, whatever tags this node carries. Schema documents route this way;
+     * policies and entities keep the tag-gated {@link #serves(String, String)}.
+     */
+    public boolean hostsEngine(String environmentId, String scope) {
+        return DEFAULT_SCOPE.equals(baseOf(scope)) || isHosted(environmentId, scope);
+    }
+
     /** The routing scopes whose engine is provisioned on this node for the given environment.
      *  A wildcard ("*") document expands to these (plus the always-on default) so it is routed per-scope to
      *  exactly the engines this node hosts, rather than via a fire-and-forget broadcast. */

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePort.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiPredicate;
 import lombok.CustomLog;
 
 @CustomLog
@@ -159,10 +160,13 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     ) {
         // The PDP consumer reads docId and schemaText and nothing else; name stays on the deployable
         // for gateway-side logging.
+        // Routed by engine identity, not by routing scope: a schema belongs to the engine, and the engine
+        // is the base with the tag stripped, so a node hosting "stock@eu" must take a schema bound to
+        // "stock". Tag-gated serves() would drop it there. Policies and entities keep serves().
         JsonObject command = new JsonObject().put("op", OP_ADD_OR_UPDATE_SCHEMA).put("docId", docId).put("schemaText", schemaText);
         Set<String> scopes = expandWildcardWithoutBootstrap(environmentId, targetPdpIds);
         warnOnceIfWildcardReachesNothing(environmentId, docId, targetPdpIds, scopes, updatedAt);
-        return routeGated(environmentId, command, scopes, docId, updatedAt);
+        return routeGated(environmentId, command, scopes, docId, updatedAt, hostedScopes::hostsEngine);
     }
 
     @Override
@@ -171,7 +175,8 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
             environmentId,
             new JsonObject().put("op", OP_REMOVE_SCHEMA).put("docId", docId),
             expandWildcardWithoutBootstrap(environmentId, targetPdpIds),
-            docId
+            docId,
+            hostedScopes::hostsEngine
         );
     }
 
@@ -259,12 +264,23 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     }
 
     private Completable routeGated(String environmentId, JsonObject command, Set<String> scopes, String docId, long updatedAt) {
+        return routeGated(environmentId, command, scopes, docId, updatedAt, hostedScopes::serves);
+    }
+
+    private Completable routeGated(
+        String environmentId,
+        JsonObject command,
+        Set<String> scopes,
+        String docId,
+        long updatedAt,
+        BiPredicate<String, String> locality
+    ) {
         if (scopes.isEmpty()) {
             return Completable.complete();
         }
         List<Completable> sends = new ArrayList<>();
         for (String scope : scopes) {
-            if (!hostedScopes.serves(environmentId, scope)) {
+            if (!locality.test(environmentId, scope)) {
                 continue;
             }
             if (!revisions.shouldApply(environmentId, scope, docId, updatedAt)) {
@@ -289,12 +305,22 @@ public class EventBusAuthzEnginePort implements AuthzEnginePort {
     }
 
     private Completable routeForget(String environmentId, JsonObject command, Set<String> scopes, String docId) {
+        return routeForget(environmentId, command, scopes, docId, hostedScopes::serves);
+    }
+
+    private Completable routeForget(
+        String environmentId,
+        JsonObject command,
+        Set<String> scopes,
+        String docId,
+        BiPredicate<String, String> locality
+    ) {
         if (scopes.isEmpty()) {
             return Completable.complete();
         }
         List<Completable> sends = new ArrayList<>();
         for (String scope : scopes) {
-            if (!hostedScopes.serves(environmentId, scope)) {
+            if (!locality.test(environmentId, scope)) {
                 continue;
             }
             String address = addressFor(environmentId, scope);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortSchemaEngineIdentityTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/EventBusAuthzEnginePortSchemaEngineIdentityTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * A schema is bound to an engine, and an engine is the base scope with the sharding tag stripped, so it
+ * must reach every node hosting that engine whatever tags the node carries. Policies and entities are
+ * bound to a routing scope instead and stay tag-gated.
+ */
+@ExtendWith(VertxExtension.class)
+class EventBusAuthzEnginePortSchemaEngineIdentityTest {
+
+    private static final String STOCK_ADDRESS = "service:authz-pdp:sync:scope:env-1:stock";
+    private static final String SCHEMA_TEXT = "entity User;";
+    private static final String POLICY_TEXT = "permit(principal, action, resource);";
+
+    private Vertx vertx;
+    private final ConcurrentLinkedQueue<String> hits = new ConcurrentLinkedQueue<>();
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() {
+        vertx.close();
+    }
+
+    private EventBusAuthzEnginePort portOn(AuthzHostedScopes hosted) {
+        return new EventBusAuthzEnginePort(vertx, hosted, new AuthzAppliedRevisions());
+    }
+
+    private AuthzHostedScopes nodeTagged(String tag, String hostedScope) {
+        AuthzHostedScopes hosted = new AuthzHostedScopes(Set.of(tag));
+        hosted.markHosted("env-1", hostedScope);
+        return hosted;
+    }
+
+    private void recordAndReplyOn(String address) {
+        vertx
+            .eventBus()
+            .<JsonObject>consumer(address, msg -> {
+                hits.add(address);
+                msg.reply(new JsonObject().put("commitGeneration", 1L));
+            });
+    }
+
+    @Test
+    void a_schema_bound_to_the_engine_reaches_a_node_that_hosts_it_under_a_tag() {
+        recordAndReplyOn(STOCK_ADDRESS);
+
+        portOn(nodeTagged("eu", "stock@eu")).addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly(STOCK_ADDRESS);
+    }
+
+    @Test
+    void removing_it_follows_the_same_rule() {
+        recordAndReplyOn(STOCK_ADDRESS);
+
+        portOn(nodeTagged("eu", "stock@eu")).removeSchema("env-1", "s1", Set.of("stock")).blockingAwait();
+
+        assertThat(hits).containsExactly(STOCK_ADDRESS);
+    }
+
+    @Test
+    void a_policy_bound_to_the_same_bare_scope_is_still_tag_gated() {
+        // The engine-identity rule is deliberately schema-only: a bare scope carries no tag, so a tagged
+        // node does not serve it, exactly as before.
+        recordAndReplyOn(STOCK_ADDRESS);
+
+        portOn(nodeTagged("eu", "stock@eu")).addOrUpdatePolicy("env-1", "p1", "n", POLICY_TEXT, Set.of("stock"), 1L).blockingAwait();
+
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void a_schema_does_not_reach_a_node_hosting_no_engine_of_that_name() {
+        recordAndReplyOn(STOCK_ADDRESS);
+        AuthzHostedScopes elsewhere = nodeTagged("eu", "orders@eu");
+
+        portOn(elsewhere).addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock"), 1L).blockingAwait();
+
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void the_engine_is_addressed_once_even_though_two_tagged_scopes_share_it() {
+        // An untagged catch-all node hosts stock@eu and stock@us, which are one engine. Routing by engine
+        // identity sends one command, where expanding the id into both scopes would send two.
+        recordAndReplyOn(STOCK_ADDRESS);
+        AuthzHostedScopes catchAll = new AuthzHostedScopes();
+        catchAll.markHosted("env-1", "stock@eu");
+        catchAll.markHosted("env-1", "stock@us");
+
+        portOn(catchAll).addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly(STOCK_ADDRESS);
+    }
+
+    @Test
+    void an_explicitly_tagged_schema_target_still_reaches_the_engine_it_names() {
+        recordAndReplyOn(STOCK_ADDRESS);
+
+        portOn(nodeTagged("eu", "stock@eu")).addOrUpdateSchema("env-1", "s1", "n", SCHEMA_TEXT, Set.of("stock@eu"), 1L).blockingAwait();
+
+        assertThat(hits).containsExactly(STOCK_ADDRESS);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/HostedScopesFixtures.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/HostedScopesFixtures.java
@@ -31,6 +31,11 @@ final class HostedScopesFixtures {
             public boolean serves(String environmentId, String targetPdpId) {
                 return true;
             }
+
+            @Override
+            public boolean hostsEngine(String environmentId, String scope) {
+                return true;
+            }
         };
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AUTHZ-33

## Description

A schema belongs to an engine, not to a routing scope. The engine is `environmentId:targetPdpId` with the sharding tag stripped, which is exactly what `addressFor` computes through `baseScope`, so `stock@eu` and `stock@us` are one engine and one address.

The locality filter did not agree with that. `AuthzHostedScopes.serves` gates by tag through `EnvironmentUtils.hasMatchingTags`, and a scope carrying no tag is served only by an untagged node. A schema bound to the bare engine id was therefore dropped on every tagged node hosting that very engine: node N1 with tag `eu` hosts `E:stock`, receives the document, and skips it.

Schema routing now asks `hostsEngine`, which resolves the base and ignores the tag. Policies and entities are bound to a routing scope rather than to an engine, so they keep `serves` and are deliberately untouched.

Routing by identity rather than expanding the bare id into the scopes it is provisioned under also keeps one command per engine. An untagged catch-all node hosting both `stock@eu` and `stock@us` would otherwise receive the same document twice and mark two revisions for one engine.

What changed:

- `AuthzHostedScopes.hostsEngine(environmentId, scope)`: hosts-the-engine, tag ignored, with the always-on bootstrap engine still answering true
- `routeGated` and `routeForget` take the locality predicate as a parameter; the existing signatures delegate with `serves`, so policy and entity routing is byte-identical
- `addOrUpdateSchema` and `removeSchema` pass `hostsEngine`
- `HostedScopesFixtures.servingAll` overrides `hostsEngine` too, otherwise a fixture whose whole purpose is "every scope is hosted" silently stopped serving schema

## Additional context

**Why now.** This is the transport half of a decision taken 2026-08-28: a schema is bound to exactly one engine, and composition of several documents onto one engine is removed. The multi-document model existed only to absorb this same collapse of `stock@eu` and `stock@us` onto one engine, which the address layer already handles. The control-plane half is AUTHZ-46, and this PR is independent of it: nothing here assumes the new binding, it only stops the router from dropping a document aimed at an engine rather than at a scope.

**Tests.** `EventBusAuthzEnginePortSchemaEngineIdentityTest`, six cases: the schema reaches a node that hosts the engine under a tag, removal follows the same rule, a policy on the same bare scope is still gated (this is the test that pins the change as schema-only), a node hosting no engine of that name gets nothing, two tag variants of one engine still produce one command, and an explicitly tagged target still works.

Verified by mutation: reverting the two call sites to `serves` fails exactly the two cases that assert the new reach, and leaves the other four green.

```
authz suite in gravitee-apim-gateway-services-sync   220/220   BUILD SUCCESS
```

Five tests in `EventBusAuthzEnginePortSchemaTest` failed on the first run, all through the fixture rather than through production behaviour: `servingAll` overrode `serves` only, so the schema path fell through to the real implementation and reported nothing hosted. That is the fixture change above, and it is worth knowing that the same trap waits for any future route that stops calling `serves`.
