### PR TITLE
fix(console): keep sidebar navigation working when an environment has no hrids

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.harness.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.harness.ts
@@ -19,6 +19,21 @@ export class GioSideNavHarness extends ComponentHarness {
   public static readonly hostSelector = 'gio-side-nav';
 
   private readonly getAllAnchors = this.locatorForAll('a');
+  private readonly getGroupHeaders = this.locatorForAll('mat-expansion-panel-header');
+
+  /**
+   * Clicks the header of a collapsible menu group, which navigates to the group's base path.
+   * Matches the title exactly: several groups share a word, so a substring match picks whichever
+   * happens to render first.
+   */
+  async clickGroup(title: string): Promise<void> {
+    for (const header of await this.getGroupHeaders()) {
+      if ((await header.text()).trim() === title) {
+        return header.click();
+      }
+    }
+    throw new Error(`No sidebar group titled "${title}"`);
+  }
 
   async getAnchorsWithTarget(target: string): Promise<TestElement[]> {
     const result: TestElement[] = [];

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -37,6 +37,7 @@ import { GioPermissionService } from '../../shared/components/gio-permission/gio
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { Constants } from '../../entities/Constants';
 import { EnvironmentSettingsService } from '../../services-ngx/environment-settings.service';
+import { Environment } from '../../entities/environment/environment';
 
 const PORTAL_SETTINGS_PERMISSIONS_SET = new Set(PORTAL_SETTINGS_PERMISSIONS);
 
@@ -114,7 +115,7 @@ describe('GioSideNavComponent', () => {
           },
         },
         { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },
-        { provide: ActivatedRoute, useValue: { params: of({ envId: 'DEFAULT' }) } },
+        { provide: ActivatedRoute, useValue: { params: of({ envHrid: 'DEFAULT' }) } },
         { provide: GioMenuSearchService, useValue: menuSearchService },
       ],
     })
@@ -355,6 +356,81 @@ describe('GioSideNavComponent', () => {
       expect(kafka?.routerBasePath).toBe(`/${envHrid}/clusters`);
 
       ctrl.verify();
+    });
+  });
+
+  describe('environment segment in menu paths (APIM-14748)', () => {
+    const buildMenuForEnvironment = async (environment: Environment, envHrid: string) => {
+      await TestBed.configureTestingModule({
+        declarations: [GioSideNavComponent],
+        imports: [NoopAnimationsModule, GioTestingModule, GioSideNavModule, MatIconTestingModule],
+        providers: [
+          { provide: GioPermissionService, useValue: { hasAnyMatching: () => true } },
+          {
+            provide: Constants,
+            useFactory: () => ({
+              ...CONSTANTS_TESTING,
+              org: {
+                ...CONSTANTS_TESTING.org,
+                settings: { ...CONSTANTS_TESTING.org.settings, licenseExpirationNotification: { enabled: true } },
+                currentEnv: environment,
+                environments: [environment],
+              },
+            }),
+          },
+          {
+            provide: EnvironmentSettingsService,
+            useValue: { get: () => of({ apiScore: { enabled: true }, portalNext: { access: { enabled: true } } }) },
+          },
+          { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },
+          { provide: ActivatedRoute, useValue: { params: of({ envHrid }) } },
+          { provide: GioMenuSearchService, useValue: menuSearchService },
+        ],
+      })
+        .overrideProvider(InteractivityChecker, {
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        })
+        .compileComponents();
+
+      const fix = TestBed.createComponent(GioSideNavComponent);
+      httpTestingController = TestBed.inject(HttpTestingController);
+
+      fix.detectChanges();
+      httpTestingController
+        .expectOne(`${LICENSE_CONFIGURATION_TESTING.resourceURL}`)
+        .flush({ tier: '', features: [], packs: [], expiresAt: new Date() });
+      fix.detectChanges();
+
+      return fix;
+    };
+
+    // The guard resolves the segment to either an hrid or the environment id, so the menu must mirror
+    // whichever one the URL carries rather than re-deriving one from the environment.
+    it.each([
+      ['no hrids', undefined, 'DEFAULT'],
+      ['empty hrids', [], 'DEFAULT'],
+      ['a single hrid', ['my-env'], 'my-env'],
+    ])('should build group base paths from the URL segment when the environment has %s', async (_label, hrids, envHrid) => {
+      const fix = await buildMenuForEnvironment({ id: 'DEFAULT', name: 'default', hrids, organizationId: 'org' }, envHrid);
+
+      const basePathOf = (displayName: string) =>
+        fix.componentInstance.mainMenuItems.find(i => i.displayName === displayName)?.routerBasePath;
+
+      expect(basePathOf('Observability')).toBe(`/${envHrid}/observability`);
+      expect(basePathOf('Analytics')).toBe(`/${envHrid}/analytics`);
+      expect(basePathOf('Kafka')).toBe(`/${envHrid}/clusters`);
+    });
+
+    it('should build menu search router links from the URL segment', async () => {
+      const addMenuSearchItems = jest.spyOn(menuSearchService, 'addMenuSearchItems');
+      addMenuSearchItems.mockClear();
+
+      await buildMenuForEnvironment({ id: 'DEFAULT', name: 'default', hrids: undefined, organizationId: 'org' }, 'DEFAULT');
+
+      const searchItems: { name: string; routerLink: string }[] = addMenuSearchItems.mock.calls[0][0];
+      expect(searchItems.find(i => i.name === 'Dashboard')?.routerLink).toBe('/DEFAULT/home');
+
+      addMenuSearchItems.mockRestore();
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -73,6 +73,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
   public environments: SelectorItem[] = [];
 
   public currentEnv: Environment;
+  private envHrid: string;
   public licenseExpirationDate$: Observable<Date>;
   public licenseExpirationNotificationEnabled = true;
 
@@ -91,7 +92,12 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       .pipe(
         map(p => p.envHrid),
         distinctUntilChanged(),
-        switchMap(_ => {
+        switchMap(envHrid => {
+          // The segment the URL actually carries. Building absolute paths from it keeps them in
+          // agreement with router.url by construction: hrids are optional, an environment can hold
+          // several, and the guard accepts the id as well -- so anything re-derived from currentEnv
+          // can name the environment differently from the address bar the user is on.
+          this.envHrid = envHrid;
           this.environments = this.constants.org.environments.map(env => ({ value: env.id, displayValue: env.name }));
           this.currentEnv = this.constants.org.currentEnv;
 
@@ -201,7 +207,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       permissions: ['environment-cluster-r'],
       licenseOptions: clusterLicenseOptions,
       iconRight$: clusterIconRight$,
-      routerBasePath: `/${this.currentEnv.hrids}/clusters`,
+      routerBasePath: `/${this.envHrid}/clusters`,
       items: [
         {
           displayName: 'Standalone',
@@ -236,7 +242,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       displayName: 'Observability',
       category: 'Observability',
       permissions: ['environment-platform-r'],
-      routerBasePath: `/${this.currentEnv.hrids}/observability`,
+      routerBasePath: `/${this.envHrid}/observability`,
       items: [
         {
           displayName: 'Overview',
@@ -261,7 +267,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       displayName: 'Analytics',
       category: 'Analytics',
       permissions: ['environment-platform-r'],
-      routerBasePath: `/${this.currentEnv.hrids}/analytics`,
+      routerBasePath: `/${this.envHrid}/analytics`,
       iconRight$: of('gio:info'),
       iconRightTooltip: 'This interface supports API V2 only. For API V4, switch to the new Observability interface.',
       items: [
@@ -382,7 +388,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       .map(item => {
         return {
           name: item.displayName,
-          routerLink: `/${this.currentEnv.hrids}/${cleanRouterLink(item.routerLink)}`,
+          routerLink: `/${this.envHrid}/${cleanRouterLink(item.routerLink)}`,
           category: item.category,
           groupIds: [SIDE_NAV_GROUP_ID],
         };

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.navigation.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.navigation.spec.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Router, RouterModule, Routes } from '@angular/router';
+import { GioMenuSearchService, LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
+import { of } from 'rxjs';
+
+import { GioSideNavModule } from './gio-side-nav.module';
+import { GioSideNavHarness } from './gio-side-nav.component.harness';
+
+import { Constants } from '../../entities/Constants';
+import { Environment } from '../../entities/environment/environment';
+import { EnvironmentGuard } from '../../management/environment.guard';
+import { SettingsNavigationService } from '../../management/settings/settings-navigation/settings-navigation.service';
+import { EnvironmentSettingsService } from '../../services-ngx/environment-settings.service';
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { CONSTANTS_TESTING } from '../../shared/testing';
+import { ApimFeature, getFeatureInfoData } from '../../shared/components/gio-license/gio-license-data';
+
+@Component({ template: '', standalone: false })
+class PageComponent {}
+
+// Stands in for ManagementComponent: instantiated by the router only once EnvironmentGuard has resolved.
+@Component({ template: '<gio-side-nav></gio-side-nav><router-outlet></router-outlet>', standalone: false })
+class ManagementShellComponent {}
+
+// Stands in for the application root: only the root outlet, so nothing renders before the first navigation.
+@Component({ template: '<router-outlet></router-outlet>', standalone: false })
+class RootComponent {}
+
+// Mirrors the license configuration built at bootstrap in index.ts, so the gioLicense directive can
+// resolve the APIM features the side nav declares.
+const LICENSE_CONFIGURATION = { ...LICENSE_CONFIGURATION_TESTING, featureInfoData: getFeatureInfoData(undefined) };
+
+// Mirrors the real route tree: management-routing.module.ts plus the default redirects declared by
+// observability.module.ts, env-analytics-legacy.module.ts and cluster-routing.module.ts.
+const routes: Routes = [
+  {
+    path: ':envHrid',
+    component: ManagementShellComponent,
+    canActivate: [EnvironmentGuard.initEnvConfigAndLoadPermissions],
+    children: [
+      { path: 'home', component: PageComponent },
+      {
+        path: 'observability',
+        children: [
+          { path: 'overview', component: PageComponent },
+          { path: '', pathMatch: 'full', redirectTo: 'overview' },
+        ],
+      },
+      {
+        path: 'analytics',
+        children: [
+          { path: 'dashboard', component: PageComponent },
+          { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
+        ],
+      },
+      {
+        path: 'clusters',
+        children: [
+          { path: 'kafka-standalone', component: PageComponent },
+          { path: '', pathMatch: 'full', redirectTo: 'kafka-standalone' },
+        ],
+      },
+      { path: '', pathMatch: 'full', redirectTo: 'home' },
+    ],
+  },
+];
+
+/**
+ * Drives the real navigation chain a user triggers by clicking a sidebar group:
+ * GioSideNavComponent builds routerBasePath -> GioMenuItemsComponent#onHeaderClick calls
+ * router.navigate -> EnvironmentGuard resolves the :envHrid segment.
+ *
+ * Only the HTTP boundary is stubbed; the environments payload is the one a Management API returns
+ * for an environment that predates hrids.
+ */
+describe('GioSideNavComponent navigation (APIM-14748)', () => {
+  let fixture: ComponentFixture<RootComponent>;
+  let router: Router;
+  let httpTestingController: HttpTestingController;
+
+  const MAX_SETTLE_ROUNDS = 20;
+
+  const DEFAULT_ENV_WITHOUT_HRIDS: Environment = {
+    id: 'DEFAULT',
+    name: 'Default environment',
+    organizationId: 'DEFAULT',
+  };
+
+  const flushPendingEnvironmentCalls = (environment: Environment): number => {
+    const requests = httpTestingController.match(req => req.url.endsWith('/environments'));
+    requests.forEach(request => request.flush([environment]));
+    return requests.length;
+  };
+
+  /**
+   * An enterprise license, so the license directive lets every group through to the router instead of
+   * intercepting the click to offer an upgrade.
+   */
+  const flushLicense = (): number => {
+    const requests = httpTestingController.match(req => req.url === LICENSE_CONFIGURATION_TESTING.resourceURL);
+    requests.forEach(request =>
+      request.flush({
+        tier: 'universe',
+        features: [ApimFeature.APIM_CLUSTER, ApimFeature.APIM_AUDIT_TRAIL, ApimFeature.APIM_API_PRODUCTS, ApimFeature.ALERT_ENGINE],
+        packs: [],
+        expiresAt: new Date(),
+      }),
+    );
+    return requests.length;
+  };
+
+  /**
+   * Answers requests until the router is idle and nothing is left to answer. Each guard hop fetches
+   * the environment list again, so the number of rounds is not knowable here; looping on quiescence
+   * rather than a fixed count keeps assertions off half-finished navigations, and the throw makes a
+   * chain that grows an extra hop fail with its own message instead of a puzzling URL mismatch.
+   */
+  const settleNavigation = (environment: Environment) => {
+    for (let round = 0; round < MAX_SETTLE_ROUNDS; round++) {
+      tick();
+      fixture.detectChanges();
+
+      const answered = flushPendingEnvironmentCalls(environment) + flushLicense();
+      if (answered === 0 && !router.getCurrentNavigation()) {
+        return;
+      }
+    }
+    throw new Error(`Navigation did not settle within ${MAX_SETTLE_ROUNDS} rounds (router.url=${router.url})`);
+  };
+
+  const setup = (environment: Environment) => {
+    TestBed.configureTestingModule({
+      declarations: [RootComponent, ManagementShellComponent, PageComponent],
+      imports: [NoopAnimationsModule, MatIconTestingModule, GioSideNavModule, RouterModule.forRoot(routes)],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: Constants, useValue: { ...CONSTANTS_TESTING, org: { ...CONSTANTS_TESTING.org, environments: [environment] } } },
+        { provide: GioPermissionService, useValue: { hasAnyMatching: () => true, loadEnvironmentPermissions: () => of(undefined) } },
+        {
+          provide: EnvironmentSettingsService,
+          useValue: {
+            load: () => of(undefined),
+            get: () => of({ apiScore: { enabled: true }, portalNext: { access: { enabled: false } } }),
+          },
+        },
+        { provide: SettingsNavigationService, useValue: { getSettingsNavigationSearchItems: () => [] } },
+        { provide: GioMenuSearchService, useValue: new GioMenuSearchService() },
+        { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION },
+      ],
+    }).overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true, isTabbable: () => true } });
+
+    router = TestBed.inject(Router);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(RootComponent);
+    fixture.detectChanges();
+  };
+
+  /** The environment segment plus the group, dropping whatever the group's own module redirects to. */
+  const groupPathOf = (url: string): string => url.split('?')[0].split('/').slice(0, 3).join('/');
+
+  const landOnUrl = (url: string, environment: Environment) => {
+    let navigationError: unknown;
+    router.navigateByUrl(url).catch(error => (navigationError = error));
+    settleNavigation(environment);
+
+    // A guard blowing up on the way in would otherwise resurface as a puzzling assertion on the
+    // post-click URL, several lines later.
+    if (navigationError) {
+      throw navigationError;
+    }
+    expect(router.url).toBe(url);
+  };
+
+  const clickSidebarGroup = (title: string, environment: Environment) => {
+    // The harness is async while the test drives a virtual clock, so the promise chain is started
+    // and then flushed by tick() rather than awaited.
+    let clicked = false;
+    TestbedHarnessEnvironment.harnessForFixture(fixture, GioSideNavHarness)
+      .then(sideNav => sideNav.clickGroup(title))
+      .then(() => (clicked = true));
+    tick();
+    expect(clicked).toBe(true);
+
+    settleNavigation(environment);
+  };
+
+  afterEach(() => {
+    httpTestingController.verify({ ignoreCancelled: true });
+  });
+
+  it('should navigate to Observability when the environment has no hrids', fakeAsync(() => {
+    setup(DEFAULT_ENV_WITHOUT_HRIDS);
+
+    landOnUrl('/DEFAULT/home', DEFAULT_ENV_WITHOUT_HRIDS);
+    clickSidebarGroup('Observability', DEFAULT_ENV_WITHOUT_HRIDS);
+
+    expect(groupPathOf(router.url)).toBe('/DEFAULT/observability');
+  }));
+
+  it('should navigate to Analytics when the environment has no hrids', fakeAsync(() => {
+    setup(DEFAULT_ENV_WITHOUT_HRIDS);
+
+    landOnUrl('/DEFAULT/home', DEFAULT_ENV_WITHOUT_HRIDS);
+
+    clickSidebarGroup('Analytics', DEFAULT_ENV_WITHOUT_HRIDS);
+
+    expect(groupPathOf(router.url)).toBe('/DEFAULT/analytics');
+  }));
+
+  it('should navigate to Kafka when the environment has no hrids', fakeAsync(() => {
+    setup(DEFAULT_ENV_WITHOUT_HRIDS);
+
+    landOnUrl('/DEFAULT/home', DEFAULT_ENV_WITHOUT_HRIDS);
+
+    clickSidebarGroup('Kafka', DEFAULT_ENV_WITHOUT_HRIDS);
+
+    expect(groupPathOf(router.url)).toBe('/DEFAULT/clusters');
+  }));
+
+  it('should keep using the hrid when the environment has one', fakeAsync(() => {
+    const environmentWithHrid: Environment = { ...DEFAULT_ENV_WITHOUT_HRIDS, hrids: ['default'] };
+    setup(environmentWithHrid);
+
+    landOnUrl('/default/home', environmentWithHrid);
+
+    clickSidebarGroup('Observability', environmentWithHrid);
+
+    expect(groupPathOf(router.url)).toBe('/default/observability');
+  }));
+});


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14748

## Description

Environments that were carried through upgrades from before `hrids` existed have no `hrids` value in the `environments` collection. `GioSideNavComponent` interpolated the raw array into the group base paths:

```ts
routerBasePath: `/${this.currentEnv.hrids}/observability`
```

With `hrids` undefined that yields `/undefined/observability`; with an empty array, `//observability`. `GioMenuItemsComponent#onHeaderClick` then calls `router.navigate([routerBasePath])`, `EnvironmentGuard` cannot resolve the environment segment, falls back to the first environment, and `{ path: '', pathMatch: 'full', redirectTo: 'home' }` lands the user on the Dashboard. Direct URL access worked because the URL carries a resolvable environment segment.

This is not a data/migration gap: "`hrids` is optional, fall back to the id" is already the contract everywhere else — `EnvironmentGuard` and `EnvironmentServiceImpl.findByOrgAndIdOrHrid` on the backend both accept either. The side nav was the only place that violated it. Fixing it in the console repairs every affected installation without a database migration.

Rather than re-deriving a name for the environment, the fix uses the one the URL already carries: the `envHrid` route param, which the component received and dropped. That keeps the group header, its children (relative links) and the address bar in agreement by construction — an environment may hold several hrids, and the guard accepts the id as well, so anything re-derived from `currentEnv` can name the environment differently from the URL the user is on. Caught in review: with `hrids: ['prod', 'production']`, landing on `/production/home` and clicking Observability used to navigate to `/prod/observability/overview`, switching the alias under the user.

## Changes

- `GioSideNavComponent` captures the `envHrid` route param and builds the three group base paths (Kafka, Observability, Analytics) and the menu-search router links from it.
- `gio-side-nav.component.spec.ts`: regression tests on the base paths for `hrids: undefined`, `[]` and `['my-env']`.
- `gio-side-nav.navigation.spec.ts` (new): drives the whole navigation chain — real `Router`, real `EnvironmentGuard`, a real click on the rendered menu group — and asserts the environment segment and group the user ends up on.
- `GioSideNavHarness` gained `clickGroup(title)`, used by the navigation spec.

## Test report

### Manual verification on a running stack

**Environment.** MongoDB + Management API from `docker/quick-setup/mongodb` (Management API on `:8083`), console served from this branch on `:4000` proxying to it, signed in as `admin`. The legacy state was reproduced on the real database:

```
db.environments.updateOne({_id:"DEFAULT"}, {$unset:{hrids:""}})
```

After restarting the Management API, `GET /management/organizations/DEFAULT/environments` returned the environment with **no `hrids` field at all**:

```json
[ { "id": "DEFAULT", "name": "Default environment", "description": "Default environment", "organizationId": "DEFAULT" } ]
```

**Scenario.** Start on the Dashboard (`#!/default/home/overview`), click a sidebar group header, read the resulting URL. Each group was tested against the unmodified `master` component and then against this branch, on the same running stack.

| Group clicked | Expected | Observed before fix | Observed after fix |
|---|---|---|---|
| Observability | `#!/…/observability/overview` | `#!/DEFAULT/home/overview` ❌ | `#!/DEFAULT/observability/overview` ✅ |
| Analytics | `#!/…/analytics/dashboard` | `#!/DEFAULT/home/overview` ❌ | `#!/DEFAULT/analytics/dashboard?from=…&to=…` ✅ |
| Kafka | `#!/…/clusters/kafka-standalone` | `#!/DEFAULT/home/overview` ❌ | `#!/DEFAULT/clusters/kafka-standalone` ✅ |

All three landed on `#!/DEFAULT/home/overview` before the fix — byte for byte the URL the ticket reports. No browser console error accompanied the redirect, matching the report.

**No regression with `hrids` present.** After restoring `hrids: ["default"]` and restarting the Management API, from the Dashboard, clicking Observability navigates to `#!/default/observability/overview` — still the hrid, not the id.

### Automated

`gio-side-nav.navigation.spec.ts` reproduces the same scenario in-process (real `Router`, real `EnvironmentGuard`, real click on the rendered group, HTTP boundary stubbed with the payload above), so the regression stays covered in CI:

| Scenario | Before fix | After fix |
|---|---|---|
| No `hrids` → Observability / Analytics / Kafka | `/DEFAULT/home` ❌ | the group's own path ✅ |
| `hrids: ['default']` → Observability | `/default/observability` ✅ | ✅ |

The navigation tests assert the environment segment and the group (`/DEFAULT/observability`), not the leaf each group's module redirects to — that redirect belongs to those modules, and asserting it here against a local copy of the route tree would go stale silently.

`gio-side-nav.component.spec.ts` covers the base paths the side nav builds:

| URL segment | `currentEnv.hrids` | Expected base path | Before fix | After fix |
|---|---|---|---|---|
| `DEFAULT` | `undefined` | `/DEFAULT/observability` | `/undefined/observability` ❌ | ✅ |
| `DEFAULT` | `[]` | `/DEFAULT/observability` | `//observability` ❌ | ✅ |
| `my-env` | `['my-env']` | `/my-env/observability` | ✅ | ✅ |

**Suite result:** `nx test console` on `gio-side-nav` — **29/29 passing**. `tsc --noEmit` and `eslint` clean on the changed files.

## Additional context

- Same symptom as APIM-14285 (fixed in 4.11.10), different cause: that one was a build-order race, this one is the missing-hrids fallback.
- Backport labels `apply-on-4-12-x` and `apply-on-4-11-x` are set. `4.12.x` carries the same four `currentEnv.hrids` sites as `master`, so it should apply as is. `4.11.x` has three: the Kafka entry exists there as a **flat** item (`displayName: 'Kafka Clusters'`, relative `routerLink: './clusters'`, no `routerBasePath`), which is why it escapes the bug — it is not absent.
- Noticed in passing and deliberately left out of scope: `EnvironmentServiceImpl.findByOrgAndIdOrHrid` calls `env.getHrids().contains(...)` with no null check, on the same population of legacy environments. Worth its own ticket.

## Reviewer notes

- `gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts` is the whole fix; everything else is tests.
- **Compatibility-sensitive:** this changes navigation behaviour and touches route construction.
- The manual run above was done on `master` + this branch, and is worth a quick repeat on `4.11.x` once the backport PR opens.
- **The `4.11.x` backport will not apply cleanly.** Everything the new specs lean on is present there (`ApimFeature.APIM_CLUSTER` / `APIM_API_PRODUCTS` / `ALERT_ENGINE` / `APIM_AUDIT_TRAIL`, `getFeatureInfoData`, `EnvironmentGuard.initEnvConfigAndLoadPermissions`, `observability.module.ts`, `cluster-routing.module.ts`) **except** the Kafka strand and the harness:
  - the Kafka case in `gio-side-nav.navigation.spec.ts` and the `clusters` branch of its route tree have no counterpart — the flat item has no group header to click;
  - `basePathOf('Kafka')` in `gio-side-nav.component.spec.ts` likewise;
  - `gio-side-nav.component.harness.ts` **does not exist on `4.11.x`** — the whole file has to come along, since the navigation spec now goes through `clickGroup()`.
  
  So four files need a hand, not a clean cherry-pick.
