### PR TITLE
fix: let organization-policies-r read the platform policies

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
@@ -21,6 +21,7 @@
     <a mat-tab-link [active]="activeTab === 'config'" (click)="activeTab = 'config'"> Configuration </a>
     <!-- save button -->
     <button
+      *gioPermission="{ anyOf: ['organization-policies-u'] }"
       class="header__nav__saveButton"
       mat-flat-button
       color="primary"

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
@@ -31,6 +31,7 @@ import { fakePolicyListItem } from '../../../entities/policy';
 import { fakeOrganization } from '../../../entities/organization/organization.fixture';
 import { fakePlatformFlowSchema } from '../../../entities/flow/platformFlowSchema.fixture';
 import { fakeFlow } from '../../../entities/flow/flow.fixture';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 
 describe('OrgSettingsPlatformPoliciesComponent', () => {
   let fixture: ComponentFixture<OrgSettingsPlatformPoliciesComponent>;
@@ -59,9 +60,10 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
     flowMode: 'BEST_MATCH',
   });
 
-  beforeEach(() => {
+  const createComponent = (permissions: string[]) => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, GioLicenseTestingModule],
+      providers: [{ provide: GioTestingPermissionProvider, useValue: permissions }],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -84,9 +86,11 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/resources?expand=schema&expand=icon`).flush(organization);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
-  });
+  };
 
   describe('onSave', () => {
+    beforeEach(() => createComponent(['organization-policies-r', 'organization-policies-u']));
+
     it('should call the API with updated organization', async () => {
       component.definitionToSave = {
         flow_mode: 'DEFAULT',
@@ -154,6 +158,26 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
         ],
       });
       // no flush to stop test here
+      httpTestingController.match(`${CONSTANTS_TESTING.env.baseURL}/configuration/spel/grammar`);
+    });
+  });
+
+  describe('save button', () => {
+    const saveButton = () => fixture.nativeElement.querySelector('.header__nav__saveButton');
+
+    it('should be offered to a user holding the update permission', () => {
+      createComponent(['organization-policies-r', 'organization-policies-u']);
+
+      expect(saveButton()).not.toBeNull();
+
+      httpTestingController.match(`${CONSTANTS_TESTING.env.baseURL}/configuration/spel/grammar`);
+    });
+
+    it('should be withheld from a user holding only the read permission', () => {
+      createComponent(['organization-policies-r']);
+
+      expect(saveButton()).toBeNull();
+
       httpTestingController.match(`${CONSTANTS_TESTING.env.baseURL}/configuration/spel/grammar`);
     });
   });

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
@@ -16,25 +16,29 @@
 
 -->
 <div class="policy-studio-design">
-  <gv-design
-    *ngIf="!isLoading"
-    #gvDesignComponent
-    flowsTitle="Platform flows"
-    can-add
-    has-policy-filter
-    has-conditional-steps
-    sortable
-    [flowSchema]="platformFlowSchema"
-    [policies]="policies"
-    [definition]="definition"
-    [resourceTypes]="resourceTypes"
-    [selectedFlowsId]="selectedFlowsIds"
-    [documentation]="policyDocumentation"
-    (:gv-design:change)="onChange($any($event))"
-    (:gv-design:fetch-documentation)="fetchPolicyDocumentation($any($event).detail)"
-    (:gv-design:display-policy-cta)="displayPolicyCTA()"
-    (:gv-design:select-flows)="onFlowSelectionChanged($any($event).detail)"
-    (:gv-expression-language:ready)="fetchSpelGrammar($any($event).detail)"
-  ></gv-design>
+  @if (loadError) {
+    {{ loadError }}
+  } @else if (isLoading) {
+    Loading...
+  } @else {
+    <gv-design
+      #gvDesignComponent
+      flowsTitle="Platform flows"
+      can-add
+      has-policy-filter
+      has-conditional-steps
+      sortable
+      [flowSchema]="platformFlowSchema"
+      [policies]="policies"
+      [definition]="definition"
+      [resourceTypes]="resourceTypes"
+      [selectedFlowsId]="selectedFlowsIds"
+      [documentation]="policyDocumentation"
+      (:gv-design:change)="onChange($any($event))"
+      (:gv-design:fetch-documentation)="fetchPolicyDocumentation($any($event).detail)"
+      (:gv-design:display-policy-cta)="displayPolicyCTA()"
+      (:gv-design:select-flows)="onFlowSelectionChanged($any($event).detail)"
+      (:gv-expression-language:ready)="fetchSpelGrammar($any($event).detail)"
+    ></gv-design>
+  }
 </div>
-<ng-container *ngIf="isLoading"> Loading... </ng-container>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
@@ -15,7 +15,7 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, TestRequest } from '@angular/common/http/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioLicenseTestingModule } from '@gravitee/ui-particles-angular';
 
@@ -70,17 +70,28 @@ describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
+  });
 
+  const expectLoadRequests = (respondToOrganization: (request: TestRequest) => void) => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/flow-schema`).flush(platformFlowSchema);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/policies?expand=schema&expand=icon`).flush(policies);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/resources?expand=schema&expand=icon`).flush(organization);
 
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
-  });
+    respondToOrganization(httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`));
+  };
 
   describe('ngOnInit', () => {
+    beforeEach(() => {
+      expectLoadRequests(request => request.flush(organization));
+      fixture.detectChanges();
+    });
+
+    it('should render the studio', () => {
+      expect(fixture.nativeElement.querySelector('gv-design')).not.toBeNull();
+    });
+
     it('should setup properties', async () => {
       expect(component.policies).toStrictEqual(policies);
       expect(component.platformFlowSchema).toStrictEqual(platformFlowSchema);
@@ -99,6 +110,28 @@ describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('when the load fails', () => {
+    it('should report the error instead of loading forever', async () => {
+      expectLoadRequests(request =>
+        request.flush({ message: 'You do not have sufficient rights to access this resource' }, { status: 403, statusText: 'Forbidden' }),
+      );
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('You do not have sufficient rights to access this resource');
+      expect(fixture.nativeElement.textContent).not.toContain('Loading...');
+      expect(fixture.nativeElement.querySelector('gv-design')).toBeNull();
+    });
+
+    it('should report a fallback message when the failure carries none', async () => {
+      expectLoadRequests(request => request.error(new ProgressEvent('error')));
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Platform policies could not be loaded');
+      expect(fixture.nativeElement.textContent).not.toContain('Loading...');
+      expect(fixture.nativeElement.querySelector('gv-design')).toBeNull();
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
@@ -15,8 +15,8 @@
  */
 
 import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
-import { combineLatest, Subject } from 'rxjs';
-import { takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Subject } from 'rxjs';
+import { catchError, takeUntil, tap } from 'rxjs/operators';
 import { ComponentCustomEvent } from '@gravitee/ui-components/src/lib/events';
 import { Location } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
@@ -44,6 +44,8 @@ export class OrgSettingsPlatformPoliciesStudioComponent implements OnInit, OnDes
   get isLoading() {
     return !this.definition;
   }
+
+  loadError: string;
 
   organization: Organization;
   definition: DefinitionVM;
@@ -87,6 +89,10 @@ export class OrgSettingsPlatformPoliciesStudioComponent implements OnInit, OnDes
           };
 
           this.resourceTypes = resourceTypes;
+        }),
+        catchError(({ error }) => {
+          this.loadError = error?.message ?? 'Platform policies could not be loaded.';
+          return EMPTY;
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -143,7 +143,7 @@ public class OrganizationResource extends AbstractResource {
     @Permissions(
         @Permission(
             value = RolePermission.ORGANIZATION_POLICIES,
-            acls = { RolePermissionAction.CREATE, RolePermissionAction.DELETE, RolePermissionAction.UPDATE }
+            acls = { RolePermissionAction.READ, RolePermissionAction.CREATE, RolePermissionAction.DELETE, RolePermissionAction.UPDATE }
         )
     )
     @Operation(summary = "GET organization", tags = { "Organization" })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResourceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.organization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.model.UpdateOrganizationEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class OrganizationResourceTest extends AbstractResourceTest {
+
+    private static final String ORGANIZATION_ID = "DEFAULT";
+
+    @Override
+    protected String contextPath() {
+        return "organizations/" + ORGANIZATION_ID;
+    }
+
+    @BeforeEach
+    public void init() {
+        reset(organizationService);
+
+        OrganizationEntity organization = new OrganizationEntity();
+        organization.setId(ORGANIZATION_ID);
+        organization.setName("Default organization");
+        when(organizationService.findById(ORGANIZATION_ID)).thenReturn(organization);
+    }
+
+    @Test
+    public void should_get_organization_when_holding_only_policies_read() {
+        givenUserHolds(RolePermissionAction.READ);
+
+        final Response response = rootTarget("").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(organizationService).findById(ORGANIZATION_ID);
+    }
+
+    @Test
+    public void should_get_organization_when_holding_only_policies_update() {
+        givenUserHolds(RolePermissionAction.UPDATE);
+
+        final Response response = rootTarget("").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(organizationService).findById(ORGANIZATION_ID);
+    }
+
+    @Test
+    public void should_not_get_organization_when_holding_no_policies_acl() {
+        givenUserHolds();
+
+        final Response response = rootTarget("").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        verify(organizationService, never()).findById(anyString());
+    }
+
+    @Test
+    public void should_not_update_organization_when_holding_only_policies_read() {
+        givenUserHolds(RolePermissionAction.READ);
+
+        final Response response = rootTarget("").request().put(Entity.json(new UpdateOrganizationEntity()));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        verify(organizationService, never()).updateOrganizationAndFlows(anyString(), any(UpdateOrganizationEntity.class));
+    }
+
+    /**
+     * Answers the ORGANIZATION_POLICIES check the way the role service does: the user passes only when one of the acls
+     * the endpoint declares is one it actually holds, so an acl the endpoint omits can never be granted.
+     */
+    private void givenUserHolds(RolePermissionAction... held) {
+        Set<RolePermissionAction> heldAcls = held.length == 0
+            ? EnumSet.noneOf(RolePermissionAction.class)
+            : EnumSet.copyOf(Arrays.asList(held));
+
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                eq(RolePermission.ORGANIZATION_POLICIES),
+                anyString(),
+                any(RolePermissionAction[].class)
+            )
+        ).thenAnswer(invocation -> {
+            // Mockito expands varargs, so the declared acls are the arguments after the reference id.
+            Object[] arguments = invocation.getArguments();
+            return Arrays.stream(arguments, 3, arguments.length).map(RolePermissionAction.class::cast).anyMatch(heldAcls::contains);
+        });
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -691,12 +691,32 @@ describe('AppRoutes', () => {
         expect(visibleNavKeys()).toContain('policy-studio');
     });
 
-    // The organization GET refuses READ, so `-r` alone must not open the page: it would 403 on load.
-    it('hides the organization Policy Studio from a user who only holds the read permission', () => {
-        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => {
-            const platformPolicyChecks = anyOf.filter(permission => permission.startsWith('organization-policies-'));
-            return platformPolicyChecks.length === 0 || platformPolicyChecks.includes('organization-policies-r');
-        });
+    // The organization GET accepts READ, CREATE, DELETE and UPDATE, so every acl that can reach the
+    // endpoint must also reach the page.
+    it.each(['organization-policies-r', 'organization-policies-c', 'organization-policies-d', 'organization-policies-u'])(
+        'opens the organization Policy Studio for a user who only holds %s',
+        heldPermission => {
+            mockUseModuleRouting.mockReturnValue({
+                activeNavKey: 'policy-studio',
+                navigateToKey: jest.fn(),
+                rootPath: '/platform',
+            });
+            mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => {
+                const platformPolicyChecks = anyOf.filter(permission => permission.startsWith('organization-policies-'));
+                return platformPolicyChecks.length === 0 || platformPolicyChecks.includes(heldPermission);
+            });
+
+            renderPlatform('/policy-studio');
+
+            expect(screen.getByTestId('organization-policy-studio-page')).not.toBeNull();
+            expect(visibleNavKeys()).toContain('policy-studio');
+        },
+    );
+
+    it('hides the organization Policy Studio from a user who holds no platform policy permission', () => {
+        mockUseHasPermission.mockImplementation(
+            ({ anyOf }: { anyOf: string[] }) => !anyOf.some(permission => permission.startsWith('organization-policies-')),
+        );
 
         renderPlatform('/policy-studio');
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/platform-policies/utils/platformPolicyPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/platform-policies/utils/platformPolicyPermissions.ts
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-/**
- * `GET /organizations/{orgId}` is annotated `ORGANIZATION_POLICIES` with CREATE, DELETE and UPDATE, and
- * does not accept READ. Gating the page on `-r` would open a studio whose very first request answers 403,
- * so the route mirrors the acls the API actually accepts. Serving read-only users takes a backend change
- * first, tracked separately.
- */
+/** Mirrors the acls `GET /organizations/{orgId}` accepts, so every user the API will serve is offered the page. */
 export const ORGANIZATION_POLICIES_ACCESS_PERMISSIONS = [
+    'organization-policies-r',
     'organization-policies-c',
     'organization-policies-d',
     'organization-policies-u',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-248

## Description

`GET /organizations/{orgId}` was annotated `ORGANIZATION_POLICIES` with only `CREATE`, `DELETE` and `UPDATE`, so it refused `READ`. Both consoles gate the platform policies page on `organization-policies-r`, so a user holding exactly that permission was offered a page whose very first request answered 403. It never surfaced in manual testing because `PermissionServiceImpl.hasPermission` returns `true` immediately for `isOrganizationAdmin()`.

Three commits, one per component:

- **`fix(rest-api)`** — added `READ` to the acls on `OrganizationResource.get()`. The write acls stay listed so a role granting only write keeps reading the page it edits. `update()` is untouched and still requires a write acl.
- **`fix(gamma-platform)`** — moved the route and nav guard back to `organization-policies-r` and dropped the stale comment explaining the workaround. `readOnly` already follows `-u` and is unchanged.
- **`fix(console)`** — the secondary defect: the load pipeline had no `catchError` and its `subscribe()` no error handler, so **any** failure (403, 500, network) left the page on "Loading..." forever. It now reports the failure instead.

### Beyond the ticket's scope list

The ticket said the classic console needed no guard change, but its acceptance criteria say a reader "cannot save". The Save button was gated only on `isSaveButtonDisabled`, not on any permission — so letting the page load newly exposed a working-looking Save button to a read-only user (the `PUT` would then 403). It is now gated on `*gioPermission="{ anyOf: ['organization-policies-u'] }"`, the console's established pattern. Happy to split this out if you would rather keep the PR to the three listed items.

## Security-sensitive

This **relaxes an authorization check**: `GET /organizations/{orgId}` now also accepts `ORGANIZATION_POLICIES` `READ`. That widens read access to the organization entity — which carries `flows`, `flowMode`, `name`, `description` — to holders of that acl. This is the intended fix, and it is the same acl both consoles already require to render the page. No write path is changed.

## Additional context

### Acceptance criteria

- [x] A non-admin holding only `organization-policies-r` opens the platform policies page in both consoles, sees the stored flows, and cannot save.
- [x] A user holding `-u` keeps the current editing behaviour.
- [x] The classic console reports an error instead of hanging when the load fails.

### Tests

Every test was confirmed RED before the corresponding fix and GREEN after.

| Test | Covers | Before the fix |
| --- | --- | --- |
| `OrganizationResourceTest` (new, 4 tests) | GET with only `READ` → 200; with only `UPDATE` → 200; with no policies acl → 403; PUT with only `READ` → 403 | 4/4 failing |
| `AppRoutes.spec.tsx` | inverted "hides from `-r`" into "opens for `-r`", plus a new no-permission case | 1 failing |
| `org-settings-platform-policies-studio.component.spec.ts` | 403 and network-error load failures both report and stop loading | 2 failing |
| `org-settings-platform-policies.component.spec.ts` | Save offered with `-u`, withheld with only `-r` | 1 failing |

### Reproduction

1. Create an organization role granting `ORGANIZATION_POLICIES` with READ only.
2. Assign it to a user who is **not** an organization admin.
3. Open **Organization > Gateway > Policies** (classic) or **Organization > Design > Policy Studio** (gamma).

Before: the classic console hangs on "Loading..." forever; the gamma entry is not offered at all. After: both show the flows read-only.

### Related

FOUND-230 — the read-only experience it describes was blocked on this ticket and is now unblocked.
