### PR TITLE
chore(deps): bump the MCP plugins to their gravitee-common-mcp 2.0.0 builds

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -241,7 +241,7 @@
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
     <gravitee-reactor-native-kafka.version>7.1.0-alpha.13</gravitee-reactor-native-kafka.version>
-    <gravitee-reactor-mcp-proxy.version>3.3.1</gravitee-reactor-mcp-proxy.version>
+    <gravitee-reactor-mcp-proxy.version>4.0.0</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>4.2.0-alpha.7</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.1</gravitee-reactor-a2a-proxy.version>
     <gravitee-reactor-authz.version>1.2.0</gravitee-reactor-authz.version>
@@ -267,7 +267,7 @@
     <gravitee-policy-offloading.version>1.1.0</gravitee-policy-offloading.version>
     <gravitee-policy-token-ratelimit.version>1.1.0</gravitee-policy-token-ratelimit.version>
     <gravitee-policy-cost-ratelimit.version>1.1.1</gravitee-policy-cost-ratelimit.version>
-    <gravitee-policy-mcp-acl.version>1.0.4</gravitee-policy-mcp-acl.version>
+    <gravitee-policy-mcp-acl.version>2.0.0</gravitee-policy-mcp-acl.version>
     <gravitee-policy-pii-filtering.version>2.2.0</gravitee-policy-pii-filtering.version>
     <gravitee-policy-native-ipfiltering.version>1.0.1</gravitee-policy-native-ipfiltering.version>
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>


### PR DESCRIPTION
Relates to [AIAM-392](https://gravitee.atlassian.net/browse/AIAM-392) · epic [AIAM-224](https://gravitee.atlassian.net/browse/AIAM-224)

```diff
- <gravitee-reactor-mcp-proxy.version>3.3.1</gravitee-reactor-mcp-proxy.version>
+ <gravitee-reactor-mcp-proxy.version>4.0.0</gravitee-reactor-mcp-proxy.version>
- <gravitee-policy-mcp-acl.version>1.0.4</gravitee-policy-mcp-acl.version>
+ <gravitee-policy-mcp-acl.version>2.0.0</gravitee-policy-mcp-acl.version>
```

## This closes a window I opened

[#19470](https://github.com/gravitee-io/gravitee-api-management/pull/19470) moved `gravitee-common-mcp.version` to **2.0.0** ahead of the plugins being released. Master is currently inconsistent:

| | version | built against |
| --- | --- | --- |
| `gravitee-common-mcp` (BOM) | **2.0.0** | — |
| `gravitee-reactor-mcp-proxy` | 3.3.1 | common-mcp 1.x |
| `gravitee-policy-mcp-acl` | 1.0.4 | common-mcp 1.x |

For the reactor plugins that is only stale — they bundle their own `gravitee-common-mcp` in `lib/`, so their classloader keeps using 1.2.0.

**`gravitee-policy-mcp-acl` is different, and currently broken.** It declares the dependency `provided`:

```xml
<artifactId>gravitee-common-mcp</artifactId>
<scope>provided</scope>
```

so it takes whatever the platform supplies — and the `bundle-default` profile in `gravitee-apim-gateway-standalone-container` pulls `gravitee-common-mcp` at the BOM version into the gateway's `lib`. That is now 2.0.0, while 1.0.4's bytecode still calls the 1.x API:

```java
// mcp-acl 1.0.4, McpAclPolicy.java:48
McpSchema.JSONRPCRequest request = parseMcpRequest.request();
```

`ParseMcpRequest.request()` returns a different type in 2.0.0, so a bundle built from master today would throw `NoSuchMethodError` on every MCP request that reaches the ACL policy. I reproduced that exact failure locally on the equivalent pairing while preparing the chain.

## Verified

Both plugins built and tested from their release tags against `gravitee-common-mcp` 2.0.0:

| | |
| --- | --- |
| `gravitee-reactor-mcp-proxy` @ `4.0.0` | 8 modules, **521 tests**, 0 failures |
| `gravitee-policy-mcp-acl` @ `2.0.0` | **77 tests**, 0 failures, incl. all 28 integration tests |
| | both archrules logging checks pass |

The packaged plugin carries the right jar and no SDK:

```
gravitee-entrypoint-mcp-studio-4.0.0.zip
  lib/gravitee-common-mcp-2.0.0.jar        ← and no mcp-core
```

Both plugin majors require APIM **4.13**, which this branch is.

## Caveat on my verification

My machine gets `403` from `gravitee-artifactory-releases` for these EE artifacts, so I could not resolve the *published* binaries — everything above was built from the release tags, which is the same source CI published. CI here resolves the real ones, so treat it as the authority.

## Chain

1. `gravitee-common-mcp` **2.0.0** ✅
2. `gravitee-reactor-mcp-proxy` **4.0.0** ✅
3. `gravitee-policy-mcp-acl` **2.0.0** ✅
4. [#19470](https://github.com/gravitee-io/gravitee-api-management/pull/19470) BOM property ✅
5. **this PR** — the distribution finally ships them

[AIAM-392]: https://gravitee.atlassian.net/browse/AIAM-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIAM-224]: https://gravitee.atlassian.net/browse/AIAM-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ