### PR TITLE
fix(automation): proper API item naming from GKO CRD

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -1815,9 +1815,10 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ValidatePortalListingDomainService validatePortalListingDomainService(
-        PortalAutomationScopeDomainService portalAutomationScopeDomainService
+        PortalAutomationScopeDomainService portalAutomationScopeDomainService,
+        ApiCrudService apiCrudService
     ) {
-        return new ValidatePortalListingDomainService(portalAutomationScopeDomainService);
+        return new ValidatePortalListingDomainService(portalAutomationScopeDomainService, apiCrudService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -17,7 +17,6 @@ package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
-import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
@@ -55,7 +54,7 @@ class NavigationItemEntryMaterializer {
     PortalNavigationApi upsert(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
         var navApiId = rowId(auditInfo, portalId, apiId);
         var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
-        var title = apiCrudService.findById(apiId).map(Api::getName).orElse(entry.apiHrid());
+        var title = apiCrudService.get(apiId).getName();
 
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId);
         if (existing instanceof PortalNavigationApi navApi) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.exception.PathConflictException;
@@ -48,20 +50,22 @@ class NavigationItemEntryMaterializer {
     private final PortalNavigationItemCrudService navigationItemCrudService;
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
     private final ApiDocumentationSyncDomainService apiDocumentationSyncDomainService;
+    private final ApiCrudService apiCrudService;
 
     PortalNavigationApi upsert(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
         var navApiId = rowId(auditInfo, portalId, apiId);
         var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
+        var title = apiCrudService.findById(apiId).map(Api::getName).orElse(entry.apiHrid());
 
         var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navApiId);
         if (existing instanceof PortalNavigationApi navApi) {
-            applyUpdate(navApi, apiId, entry, parent);
+            applyUpdate(navApi, apiId, entry, parent, title);
             return (PortalNavigationApi) navigationItemCrudService.update(navApi);
         }
         rejectIfSegmentTakenByForeignItem(auditInfo, parent, Slug.from(entry.apiHrid()).value(), navApiId, entry.location());
         var create = CreatePortalNavigationItem.builder()
             .id(navApiId)
-            .title(entry.apiHrid())
+            .title(title)
             .segment(Slug.from(entry.apiHrid()).value())
             .area(AREA)
             .type(PortalNavigationItemType.API)
@@ -154,12 +158,13 @@ class NavigationItemEntryMaterializer {
         PortalNavigationApi navApi,
         String apiId,
         PortalListingApiEntry entry,
-        PortalNavigationItemContainer parent
+        PortalNavigationItemContainer parent,
+        String title
     ) {
         var visibility = PortalVisibility.inheritedFrom(parent);
         navApi.setApiId(apiId);
         navApi.setOrder(entry.order() != null ? entry.order() : 0);
-        navApi.setTitle(entry.apiHrid());
+        navApi.setTitle(title);
         navApi.setSegment(Slug.from(entry.apiHrid()).value());
         navApi.setVisibility(visibility);
         navApi.setPublished(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ValidatePortalListingDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ValidatePortalListingDomainService.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.portal_listing.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
 import io.gravitee.apim.core.portal.model.PortalId;
@@ -25,10 +27,13 @@ import io.gravitee.apim.core.portal_listing.model.PortalListingId;
 import io.gravitee.apim.core.validation.Validator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Validates Portal Listing input. Format checks only — no reference-existence checks.
+ * Validates Portal Listing input. Format checks, plus API-reference-existence checks — the referenced
+ * portal itself is not existence-checked (that reference is allowed to arrive out of order).
  *
  * @author GraviteeSource Team
  */
@@ -37,6 +42,7 @@ import lombok.RequiredArgsConstructor;
 public class ValidatePortalListingDomainService implements Validator<ValidatePortalListingDomainService.Input> {
 
     private final PortalAutomationScopeDomainService portalAutomationScopeEnforcer;
+    private final ApiCrudService apiCrudService;
 
     public record Input(AuditInfo auditInfo, PortalListingId listingId, PortalId portalId, List<PortalListingApiEntry> apis) implements
         Validator.Input {}
@@ -46,8 +52,17 @@ public class ValidatePortalListingDomainService implements Validator<ValidatePor
         var errors = new ArrayList<Error>();
         errors.addAll(portalAutomationScopeEnforcer.validate(input.auditInfo(), input.portalId(), "portalHrid"));
         List<PortalListingApiEntry> apis = input.apis() == null ? List.of() : input.apis();
+        var apiIds = apis
+            .stream()
+            .map(entry -> entry.apiId(input.auditInfo()))
+            .toList();
+        Set<String> existingApiIds = apiCrudService.findByIds(apiIds).stream().map(Api::getId).collect(Collectors.toSet());
         for (int i = 0; i < apis.size(); i++) {
-            errors.addAll(NavigationPathValidator.validate(apis.get(i).location(), "apis[" + i + "].location"));
+            var entry = apis.get(i);
+            errors.addAll(NavigationPathValidator.validate(entry.location(), "apis[" + i + "].location"));
+            if (!existingApiIds.contains(apiIds.get(i))) {
+                errors.add(Error.severe("apis[%d]: API [%s] not found", i, entry.apiHrid()));
+            }
         }
         return Result.ofBoth(input, errors);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_listing.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import inmemory.ApiCrudServiceInMemory;
@@ -24,6 +25,7 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -111,6 +113,7 @@ class PortalListingSyncDomainServiceTest {
     @Test
     void should_create_nav_api_row_at_deterministic_id_under_portal_folder() {
         var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        apiCrud.initWith(List.of(anApi(API_HRID)));
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
 
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
@@ -139,34 +142,15 @@ class PortalListingSyncDomainServiceTest {
     }
 
     @Test
-    void should_fall_back_to_hrid_as_title_when_api_not_yet_synced() {
+    void should_throw_api_not_found_when_api_does_not_exist() {
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
-
-        assertThat(navItemCrud.storage())
-            .filteredOn(PortalNavigationApi.class::isInstance)
-            .extracting(PortalNavigationItem::getTitle)
-            .containsExactly(API_HRID);
-    }
-
-    @Test
-    void should_refresh_title_on_resync_once_api_exists() {
-        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
-        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
-
-        apiCrud.initWith(List.of(Api.builder().id(apiId).name("Echo API Declarative").environmentId(AUDIT_INFO.environmentId()).build()));
-        syncService.sync(AUDIT_INFO, PORTAL_ID, listing.getApis(), listing);
-
-        assertThat(navItemCrud.storage())
-            .filteredOn(PortalNavigationApi.class::isInstance)
-            .extracting(PortalNavigationItem::getTitle)
-            .containsExactly("Echo API Declarative");
+        assertThatThrownBy(() -> syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing)).isInstanceOf(ApiNotFoundException.class);
     }
 
     @Test
     void should_be_idempotent_when_syncing_twice() {
+        apiCrud.initWith(List.of(anApi(API_HRID)));
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
 
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
@@ -183,6 +167,7 @@ class PortalListingSyncDomainServiceTest {
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api(API_HRID).hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(anApiDocPageContent(docContentId, apiId)));
+        apiCrud.initWith(List.of(anApi(API_HRID)));
 
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
@@ -209,6 +194,7 @@ class PortalListingSyncDomainServiceTest {
         var removeHrid = "pets-api";
         var removeApiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(removeHrid).id();
         var keepApiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(keepHrid).id();
+        apiCrud.initWith(List.of(anApi(removeHrid), anApi(keepHrid)));
 
         var initial = aListing(
             List.of(new PortalListingApiEntry(removeHrid, "/projects/alpha", 1), new PortalListingApiEntry(keepHrid, "/projects/beta", 2))
@@ -234,6 +220,7 @@ class PortalListingSyncDomainServiceTest {
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api(API_HRID).hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(anApiDocPageContent(docContentId, apiId)));
+        apiCrud.initWith(List.of(anApi(API_HRID)));
 
         var initial = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), initial);
@@ -251,6 +238,7 @@ class PortalListingSyncDomainServiceTest {
             HRIDToUUID.apiDocumentation().context(AUDIT_INFO).api(API_HRID).hrid("getting-started").id()
         );
         pageContentQuery.initWith(List.of(anApiDocPageContent(docContentId, apiId)));
+        apiCrud.initWith(List.of(anApi(API_HRID)));
 
         var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
@@ -258,6 +246,14 @@ class PortalListingSyncDomainServiceTest {
         syncService.dematerialize(AUDIT_INFO, PORTAL_ID, listing);
 
         assertThat(navItemCrud.storage()).isEmpty();
+    }
+
+    private static Api anApi(String hrid) {
+        return Api.builder()
+            .id(HRIDToUUID.api().context(AUDIT_INFO).hrid(hrid).id())
+            .name(hrid)
+            .environmentId(AUDIT_INFO.environmentId())
+            .build();
     }
 
     private static PortalListing aListing(List<PortalListingApiEntry> apis) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -24,6 +24,7 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
@@ -96,7 +97,7 @@ class PortalListingSyncDomainServiceTest {
         syncService = new PortalListingSyncDomainService(
             pageContentQuery,
             apiDocSync,
-            new NavigationItemEntryMaterializer(navItemCrud, navItemQuery, apiDocSync),
+            new NavigationItemEntryMaterializer(navItemCrud, navItemQuery, apiDocSync, apiCrud),
             new ApiFolderSubtreeReconciler(
                 navItemQuery,
                 apiCrud,
@@ -121,6 +122,47 @@ class PortalListingSyncDomainServiceTest {
             .filteredOn(PortalNavigationApi.class::isInstance)
             .extracting(PortalNavigationItem::getId)
             .containsExactly(expectedNavApiId);
+    }
+
+    @Test
+    void should_use_api_name_as_title_when_api_exists() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        apiCrud.initWith(List.of(Api.builder().id(apiId).name("Echo API Declarative").environmentId(AUDIT_INFO.environmentId()).build()));
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
+
+        assertThat(navItemCrud.storage())
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .extracting(PortalNavigationItem::getTitle)
+            .containsExactly("Echo API Declarative");
+    }
+
+    @Test
+    void should_fall_back_to_hrid_as_title_when_api_not_yet_synced() {
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
+
+        assertThat(navItemCrud.storage())
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .extracting(PortalNavigationItem::getTitle)
+            .containsExactly(API_HRID);
+    }
+
+    @Test
+    void should_refresh_title_on_resync_once_api_exists() {
+        var apiId = HRIDToUUID.api().context(AUDIT_INFO).hrid(API_HRID).id();
+        var listing = aListing(List.of(new PortalListingApiEntry(API_HRID, "/projects/alpha", 1)));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), listing);
+
+        apiCrud.initWith(List.of(Api.builder().id(apiId).name("Echo API Declarative").environmentId(AUDIT_INFO.environmentId()).build()));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, listing.getApis(), listing);
+
+        assertThat(navItemCrud.storage())
+            .filteredOn(PortalNavigationApi.class::isInstance)
+            .extracting(PortalNavigationItem::getTitle)
+            .containsExactly("Echo API Declarative");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
@@ -19,8 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalListingCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -56,13 +58,16 @@ class CreateOrUpdatePortalListingUseCaseTest {
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
     private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ValidatePortalListingDomainService validator = new ValidatePortalListingDomainService(
-        new PortalAutomationScopeDomainService(portalCrudService, () -> false)
+        new PortalAutomationScopeDomainService(portalCrudService, () -> false),
+        apiCrudService
     );
     private CreateOrUpdatePortalListingUseCase useCase;
 
     @BeforeEach
     void setUp() {
+        apiCrudService.initWith(List.of(anApi("pets-api"), anApi("shop-api")));
         useCase = new CreateOrUpdatePortalListingUseCase(validator, portalListingCrudService, mock(PortalListingSyncDomainService.class));
     }
 
@@ -162,6 +167,19 @@ class CreateOrUpdatePortalListingUseCaseTest {
     }
 
     @Test
+    void should_throw_validation_error_when_referenced_api_does_not_exist() {
+        var apis = List.of(new PortalListingApiEntry("ghost-api", "/projects/alpha", 1));
+
+        var throwable = catchThrowable(() ->
+            useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, apis))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("apis[0]").contains("ghost-api");
+        assertThat(portalListingCrudService.storage()).isEmpty();
+    }
+
+    @Test
     void should_accept_empty_apis_list() {
         var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, List.of()));
 
@@ -183,7 +201,7 @@ class CreateOrUpdatePortalListingUseCaseTest {
         var establishedCrud = new PortalCrudServiceInMemory();
         establishedCrud.initWith(List.of(Portal.of(PORTAL_ID, AUDIT_INFO.environmentId(), AUDIT_INFO.organizationId(), "Established")));
         var restrictedUseCase = new CreateOrUpdatePortalListingUseCase(
-            new ValidatePortalListingDomainService(new PortalAutomationScopeDomainService(establishedCrud, () -> false)),
+            new ValidatePortalListingDomainService(new PortalAutomationScopeDomainService(establishedCrud, () -> false), apiCrudService),
             portalListingCrudService,
             mock(PortalListingSyncDomainService.class)
         );
@@ -197,5 +215,13 @@ class CreateOrUpdatePortalListingUseCaseTest {
         assertThat(throwable).isInstanceOf(ValidationDomainException.class);
         assertThat(throwable.getMessage()).contains("portalHrid").contains("established portal");
         assertThat(portalListingCrudService.storage()).isEmpty();
+    }
+
+    private static Api anApi(String hrid) {
+        return Api.builder()
+            .id(HRIDToUUID.api().context(AUDIT_INFO).hrid(hrid).id())
+            .name(hrid)
+            .environmentId(AUDIT_INFO.environmentId())
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
@@ -16,8 +16,16 @@
 package io.gravitee.apim.core.portal_listing.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.domain_service.PortalAutomationScopeDomainService;
@@ -47,13 +55,16 @@ class ValidatePortalListingUseCaseTest {
         HRIDToUUID.portalListing().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(LISTING_HRID).id()
     );
 
+    private final ApiCrudServiceInMemory apiCrud = new ApiCrudServiceInMemory();
     private final ValidatePortalListingDomainService validator = new ValidatePortalListingDomainService(
-        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false)
+        new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false),
+        apiCrud
     );
     private ValidatePortalListingUseCase useCase;
 
     @BeforeEach
     void setUp() {
+        apiCrud.initWith(List.of(anApi("pets-api"), anApi("shop-api")));
         useCase = new ValidatePortalListingUseCase(validator);
     }
 
@@ -99,5 +110,53 @@ class ValidatePortalListingUseCaseTest {
         );
 
         assertThat(output.errors()).anyMatch(e -> e.getMessage().contains("apis[1].location"));
+    }
+
+    @Test
+    void should_surface_error_when_referenced_api_does_not_exist() {
+        var output = useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("ghost-api", "/projects/alpha", 1))
+            )
+        );
+
+        assertThat(output.errors()).anyMatch(e -> e.getMessage().contains("apis[0]") && e.getMessage().contains("ghost-api"));
+    }
+
+    @Test
+    void should_check_api_existence_in_a_single_batched_call_for_multiple_entries() {
+        ApiCrudService apiCrudSpy = spy(apiCrud);
+        var spiedUseCase = new ValidatePortalListingUseCase(
+            new ValidatePortalListingDomainService(
+                new PortalAutomationScopeDomainService(new PortalCrudServiceInMemory(), () -> false),
+                apiCrudSpy
+            )
+        );
+
+        spiedUseCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(
+                    new PortalListingApiEntry("pets-api", "/projects/alpha", 1),
+                    new PortalListingApiEntry("shop-api", "/projects/beta", 2)
+                )
+            )
+        );
+
+        verify(apiCrudSpy).findByIds(anyList());
+        verify(apiCrudSpy, never()).existsById(any());
+    }
+
+    private static Api anApi(String hrid) {
+        return Api.builder()
+            .id(HRIDToUUID.api().context(AUDIT_INFO).hrid(hrid).id())
+            .name(hrid)
+            .environmentId(AUDIT_INFO.environmentId())
+            .build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-181

## Description

When an API was published to the nextgen dev portal via a GKO `PortalListing` CRD, the resulting navigation entry's title showed the CRD's `apiHrid` (e.g. `my-api-name`) instead of the API's real display name (e.g. `Echo API Declarative`).

`NavigationItemEntryMaterializer` set the navigation item's title directly from `entry.apiHrid()` on both create and update, with no way to resolve the referenced API's actual name. The console path (`PortalNavigationItemDomainService`) already did this correctly, looking up the `Api` aggregate via `ApiCrudService.get(...)` and using `api.getName()` — including throwing `ApiNotFoundException` when the API doesn't exist.

The fix brings the `PortalListing` automation path in line with console on both counts:

1. **Correct title.** `NavigationItemEntryMaterializer.upsert()` now resolves the title via `apiCrudService.get(apiId).getName()` — the same call console makes — applied on both the create and update branches. Segment/slug derivation is unchanged, still based on `apiHrid`, so URLs stay stable if the API is later renamed.

2. **Consistent failure on a missing API.** Rather than silently falling back to the hrid when the referenced API doesn't exist, `upsert()` now throws `ApiNotFoundException`, matching console's behavior exactly.

3. **Dry-run parity.** `ValidatePortalListingDomainService` — the single validator already shared by both `CreateOrUpdatePortalListingUseCase` (real apply) and `ValidatePortalListingUseCase` (dry-run) — now checks `apiCrudService.existsById(...)` per listing entry and reports a severe `Validator.Error` when an entry's API can't be found. Because both use cases already consume this one validator (real apply already throws `ValidationDomainException` on any severe error; dry-run already returns `output.errors()`), the Automation API's `?dryRun=true` path gets the same "API not found" signal as the real apply, with no changes needed to either use case or the REST resource.

The portal-reference tolerance (a `PortalListing` may still reference a portal that doesn't exist yet) is untouched — this change is scoped to the API reference only.

