### PR TITLE
apim 14969 org policies read permission 4.9.x

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.spec.ts
@@ -51,6 +51,21 @@ describe('OrgSettingsPlatformPoliciesConfigComponent', () => {
     flowMode: 'BEST_MATCH',
   });
 
+  const createComponent = (isReadonly = false) => {
+    fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesConfigComponent);
+    component = fixture.componentInstance;
+    component.isReadonly = isReadonly;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/configuration-schema`)
+      .flush(flowConfigurationSchema);
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule],
@@ -61,26 +76,28 @@ describe('OrgSettingsPlatformPoliciesConfigComponent', () => {
         },
       })
       .compileComponents();
-
-    fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesConfigComponent);
-    component = fixture.componentInstance;
-
-    httpTestingController = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
-
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/configuration-schema`)
-      .flush(flowConfigurationSchema);
-
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
   });
 
   describe('ngOnInit', () => {
     it('should setup properties', async () => {
+      createComponent();
+
       expect(component.flowConfigurationSchema).toStrictEqual(flowConfigurationSchema);
       expect(component.formControl.value).toStrictEqual({
         flow_mode: 'BEST_MATCH',
       });
+    });
+
+    it('should enable the flow mode form when not readonly', async () => {
+      createComponent();
+
+      expect(component.formControl.enabled).toEqual(true);
+    });
+
+    it('should disable the flow mode form when readonly', async () => {
+      createComponent(true);
+
+      expect(component.formControl.disabled).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
 import { UntypedFormControl } from '@angular/forms';
@@ -35,6 +35,9 @@ export class OrgSettingsPlatformPoliciesConfigComponent implements OnInit, OnDes
 
   formControl: UntypedFormControl;
   isLoading = true;
+
+  @Input()
+  isReadonly = false;
 
   @Output()
   change = new EventEmitter<DefinitionVM['flow_mode']>();
@@ -57,6 +60,9 @@ export class OrgSettingsPlatformPoliciesConfigComponent implements OnInit, OnDes
           this.formControl = new UntypedFormControl({
             flow_mode: organization.flowMode,
           });
+          if (this.isReadonly) {
+            this.formControl.disable();
+          }
 
           this.formControl.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((value) => {
             this.change.emit(value.flow_mode);

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
@@ -21,6 +21,7 @@
     <a mat-tab-link [active]="activeTab === 'config'" (click)="activeTab = 'config'"> Configuration </a>
     <!-- save button -->
     <button
+      *ngIf="!isReadonly"
       class="header__nav__saveButton"
       mat-flat-button
       color="primary"
@@ -35,11 +36,17 @@
 <mat-tab-nav-panel #tabPanel>
   <div class="content">
     <ng-container *ngIf="!isLoading && activeTab === 'design'">
-      <org-settings-platform-policies-studio (change)="onChangeStudio($event)"></org-settings-platform-policies-studio>
+      <org-settings-platform-policies-studio
+        [isReadonly]="isReadonly"
+        (change)="onChangeStudio($event)"
+      ></org-settings-platform-policies-studio>
     </ng-container>
 
     <ng-container *ngIf="!isLoading && activeTab === 'config'">
-      <org-settings-platform-policies-config (change)="onConfigChange($event)"></org-settings-platform-policies-config>
+      <org-settings-platform-policies-config
+        [isReadonly]="isReadonly"
+        (change)="onConfigChange($event)"
+      ></org-settings-platform-policies-config>
     </ng-container>
 
     <ng-container *ngIf="isLoading"> Loading... </ng-container>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
@@ -27,6 +27,7 @@ import { OrgSettingsPlatformPoliciesComponent } from './org-settings-platform-po
 
 import { OrganizationSettingsModule } from '../organization-settings.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { fakePolicyListItem } from '../../../entities/policy';
 import { fakeOrganization } from '../../../entities/organization/organization.fixture';
 import { fakePlatformFlowSchema } from '../../../entities/flow/platformFlowSchema.fixture';
@@ -37,6 +38,7 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
   let component: OrgSettingsPlatformPoliciesComponent;
   let httpTestingController: HttpTestingController;
   let rootLoader: HarnessLoader;
+  let loader: HarnessLoader;
 
   const platformFlowSchema = fakePlatformFlowSchema();
   const policies = [fakePolicyListItem()];
@@ -59,9 +61,15 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
     flowMode: 'BEST_MATCH',
   });
 
-  beforeEach(() => {
+  const createComponent = (permissions: string[] = ['organization-policies-r', 'organization-policies-u']) => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, GioLicenseTestingModule],
+      providers: [
+        {
+          provide: GioTestingPermissionProvider,
+          useValue: permissions,
+        },
+      ],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -73,6 +81,7 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
     fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesComponent);
     component = fixture.componentInstance;
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    loader = TestbedHarnessEnvironment.loader(fixture);
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
@@ -84,9 +93,39 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/resources?expand=schema&expand=icon`).flush(organization);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
+  };
+
+  describe('save button', () => {
+    describe('when the user can update policies', () => {
+      beforeEach(() => {
+        createComponent(['organization-policies-r', 'organization-policies-u']);
+      });
+
+      it('should be displayed', async () => {
+        expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: /^Save$/ }))).toHaveLength(1);
+
+        httpTestingController.match(`${CONSTANTS_TESTING.env.baseURL}/configuration/spel/grammar`);
+      });
+    });
+
+    describe('when the user can only read policies', () => {
+      beforeEach(() => {
+        createComponent(['organization-policies-r']);
+      });
+
+      it('should be hidden', async () => {
+        expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: /^Save$/ }))).toHaveLength(0);
+
+        httpTestingController.match(`${CONSTANTS_TESTING.env.baseURL}/configuration/spel/grammar`);
+      });
+    });
   });
 
   describe('onSave', () => {
+    beforeEach(() => {
+      createComponent();
+    });
+
     it('should call the API with updated organization', async () => {
       component.definitionToSave = {
         flow_mode: 'DEFAULT',

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { EMPTY, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
@@ -24,6 +24,7 @@ import { OrganizationService } from '../../../services-ngx/organization.service'
 import { Organization } from '../../../entities/organization/organization';
 import { PathOperator, Step } from '../../../entities/flow/flow';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 interface FlowVM {
   name?: string;
@@ -48,6 +49,14 @@ export interface DefinitionVM {
   standalone: false,
 })
 export class OrgSettingsPlatformPoliciesComponent implements OnInit, OnDestroy {
+  private readonly permissionService = inject(GioPermissionService);
+
+  readonly isReadonly = !this.permissionService.hasAnyMatching([
+    'organization-policies-c',
+    'organization-policies-u',
+    'organization-policies-d',
+  ]);
+
   isLoading = true;
   activeTab: 'design' | 'config' = 'design';
 

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
@@ -24,6 +24,7 @@
     has-policy-filter
     has-conditional-steps
     sortable
+    [attr.readonly]="isReadonly ? isReadonly : null"
     [flowSchema]="platformFlowSchema"
     [policies]="policies"
     [definition]="definition"

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
@@ -54,19 +54,10 @@ describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
     flowMode: 'BEST_MATCH',
   });
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, GioLicenseTestingModule],
-    })
-      .overrideProvider(InteractivityChecker, {
-        useValue: {
-          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
-        },
-      })
-      .compileComponents();
-
+  const createComponent = (isReadonly = false) => {
     fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesStudioComponent);
     component = fixture.componentInstance;
+    component.isReadonly = isReadonly;
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
@@ -78,10 +69,26 @@ describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/resources?expand=schema&expand=icon`).flush(organization);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
+
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, OrganizationSettingsModule, GioLicenseTestingModule],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
   });
 
   describe('ngOnInit', () => {
     it('should setup properties', async () => {
+      createComponent();
+
       expect(component.policies).toStrictEqual(policies);
       expect(component.platformFlowSchema).toStrictEqual(platformFlowSchema);
       expect(component.organization).toStrictEqual(organization);
@@ -99,6 +106,20 @@ describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('readonly mode', () => {
+    it('should let the design be edited when not readonly', async () => {
+      createComponent();
+
+      expect(fixture.nativeElement.querySelector('gv-design').hasAttribute('readonly')).toEqual(false);
+    });
+
+    it('should make the design readonly when readonly', async () => {
+      createComponent(true);
+
+      expect(fixture.nativeElement.querySelector('gv-design').hasAttribute('readonly')).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
 import { ComponentCustomEvent } from '@gravitee/ui-components/src/lib/events';
@@ -52,6 +52,9 @@ export class OrgSettingsPlatformPoliciesStudioComponent implements OnInit, OnDes
   resourceTypes: ResourceListItem[];
   selectedFlowsIds: string[] = [];
   policyDocumentation!: { id: string; image: string; content: string };
+
+  @Input()
+  isReadonly = false;
 
   @Output()
   change = new EventEmitter<DefinitionVM['flows']>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -140,12 +140,7 @@ public class OrganizationResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @Permissions(
-        @Permission(
-            value = RolePermission.ORGANIZATION_POLICIES,
-            acls = { RolePermissionAction.CREATE, RolePermissionAction.DELETE, RolePermissionAction.UPDATE }
-        )
-    )
+    @Permissions(@Permission(value = RolePermission.ORGANIZATION_POLICIES, acls = RolePermissionAction.READ))
     @Operation(summary = "GET organization", tags = { "Organization" })
     @ApiResponse(
         responseCode = "200",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResourceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.organization;
+
+import static jakarta.ws.rs.client.Entity.json;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.model.UpdateOrganizationEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OrganizationResourceTest extends AbstractResourceTest {
+
+    private static final String ORGANIZATION_ID = "DEFAULT";
+
+    private Set<RolePermissionAction> grantedPolicyActions = EnumSet.noneOf(RolePermissionAction.class);
+
+    @Override
+    protected String contextPath() {
+        return "";
+    }
+
+    @Before
+    public void setUpOrganization() {
+        grantedPolicyActions = EnumSet.noneOf(RolePermissionAction.class);
+        when(
+            permissionService.hasPermission(
+                any(ExecutionContext.class),
+                any(RolePermission.class),
+                anyString(),
+                any(RolePermissionAction[].class)
+            )
+        ).thenAnswer(invocation -> {
+            final Object[] arguments = invocation.getArguments();
+            if (!RolePermission.ORGANIZATION_POLICIES.equals(arguments[1])) {
+                return false;
+            }
+            return requiredActions(arguments).anyMatch(grantedPolicyActions::contains);
+        });
+
+        final OrganizationEntity organization = new OrganizationEntity();
+        organization.setId(ORGANIZATION_ID);
+        organization.setName("Default organization");
+        when(organizationService.findById(ORGANIZATION_ID)).thenReturn(organization);
+        when(organizationService.updateOrganizationAndFlows(eq(ORGANIZATION_ID), any(UpdateOrganizationEntity.class))).thenReturn(
+            organization
+        );
+    }
+
+    @Test
+    public void should_get_organization_with_policies_read_permission() {
+        userIsGrantedOnPolicies(RolePermissionAction.READ);
+
+        final Response response = orgTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void should_not_update_organization_with_policies_read_permission() {
+        userIsGrantedOnPolicies(RolePermissionAction.READ);
+
+        final Response response = orgTarget().request().put(json(anUpdateOrganization()));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void should_not_get_organization_without_policies_permission() {
+        final Response response = orgTarget().request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void should_update_organization_with_policies_update_permission() {
+        userIsGrantedOnPolicies(RolePermissionAction.UPDATE);
+
+        final Response response = orgTarget().request().put(json(anUpdateOrganization()));
+
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+    }
+
+    @Test
+    public void should_update_organization_with_policies_create_permission() {
+        userIsGrantedOnPolicies(RolePermissionAction.CREATE);
+
+        final Response response = orgTarget().request().put(json(anUpdateOrganization()));
+
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+    }
+
+    private void userIsGrantedOnPolicies(final RolePermissionAction... actions) {
+        grantedPolicyActions = EnumSet.copyOf(Arrays.asList(actions));
+    }
+
+    /**
+     * Mockito expands the varargs of {@link io.gravitee.rest.api.service.PermissionService#hasPermission} inconsistently:
+     * they may show up either as trailing arguments or as a single array argument.
+     */
+    private Stream<Object> requiredActions(final Object[] arguments) {
+        return Arrays.stream(arguments, 3, arguments.length).flatMap(argument ->
+            argument instanceof Object[] array ? Arrays.stream(array) : Stream.of(argument)
+        );
+    }
+
+    private UpdateOrganizationEntity anUpdateOrganization() {
+        final UpdateOrganizationEntity organization = new UpdateOrganizationEntity();
+        organization.setName("Default organization");
+        return organization;
+    }
+}


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14969

## Description
`GET /organizations/{orgId}` carried the same ACL list as `PUT`
(`ORGANIZATION_POLICIES[CREATE, DELETE, UPDATE]`) and ignored `READ`.
Because the permission filter passes when the user holds *any* of the
listed ACLs, there was no way to grant read-only access to organization
policies: a role with `POLICIES[READ]` got a 403 on the page, and granting
a write ACL to unlock the read also unlocked `PUT`.

The GET now requires `ORGANIZATION_POLICIES[READ]`. `PUT` is unchanged and
still requires CREATE, DELETE or UPDATE. This matches how the rest of the
API scopes reads (roles, identity providers, notification templates,
shared policy groups).

The Console side is completed too: the page is reachable with `READ` alone,
so without this a read-only user could edit flows, enable Save and only
then hit a 403 on `PUT`. The design studio and the flow mode form now
render read-only and the Save button is hidden unless the user holds a
write ACL.

| `ORGANIZATION_POLICIES` | GET before | PUT before | GET after | PUT after |
|---|---|---|---|---|
| `R` only          | 403 | 403 | **200** | 403 |
| `U` only          | 200 | 204 | **403** | 204 |
| `R` + `U`         | 200 | 204 | 200 | 204 |

**Security-sensitive:** this changes an authorization rule.

**Behaviour change to note in the release notes:** a custom role holding a
write ACL *without* `READ` can no longer read the organization. Such roles
exist in the wild, because granting a write ACL was until now the only way
to make the page load. The fix is one click — tick `READ` on the role.

## Additional context
Affects every supported version (4.9.x, 4.10.x, 4.11.x, 4.12.x, master) —
the annotation is identical on all of them. Introduced in 0c3fc6708a
("feat(management): platform policies", May 2021), where the GET was added
with the ACL list copied from the PUT.

Reproduction note: the steps in the ticket also require `SETTINGS = READ`
on the custom role. The whole Organization section of the Console menu is
gated on `organization-settings-r`, so with `POLICIES = READ` alone the
page is only reachable by deep link (`#/_organization/policies`).

### Tests
- `OrganizationResourceTest` (new): READ -> GET 200, READ -> PUT 403, no
  permission -> GET 403, plus UPDATE -> PUT 204 and CREATE -> PUT 204 to
  guard against narrowing the PUT.
- Console specs cover the Save button visibility, the `readonly` attribute
  on `gv-design` and the disabled flow mode form.

🎬

https://github.com/user-attachments/assets/e464b2b3-49af-46af-b109-00b241432ea5

