### PR TITLE
feat(portal-next): resolve navigation visibility with caller-then-par…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -35,7 +35,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
-import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
@@ -159,7 +158,6 @@ public class PortalNavigationSyncDomainService {
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
             .parentId(df.parentPath() == null ? null : idFactory.apply(df.parentPath()))
-            .visibility(PortalVisibility.PUBLIC)
             .published(true)
             .automationMetadata(
                 new AutomationMetadata(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/NavigationFolderMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/NavigationFolderMapper.java
@@ -18,7 +18,7 @@ package io.gravitee.apim.core.portal.domain_service.navigation;
 import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
-import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import jakarta.annotation.Nullable;
 import java.util.Objects;
 
@@ -29,13 +29,14 @@ public final class NavigationFolderMapper {
     public static boolean matches(
         PortalNavigationFolder existing,
         FolderActions.DesiredFolder desired,
-        @Nullable PortalNavigationItemId parentId
+        @Nullable PortalNavigationItemContainer parent
     ) {
         return (
             Objects.equals(existing.getTitle(), desired.title()) &&
             Objects.equals(existing.getSegment(), desired.segment().value()) &&
             existing.getOrder() == desired.order() &&
-            Objects.equals(existing.getParentId(), parentId)
+            Objects.equals(existing.getParentId(), parent == null ? null : parent.getId()) &&
+            Objects.equals(existing.getVisibility(), PortalVisibility.inheritedFrom(parent))
         );
     }
 
@@ -43,6 +44,7 @@ public final class NavigationFolderMapper {
         target.setTitle(source.title());
         target.setSegment(source.segment().value());
         target.setOrder(source.order());
+        target.setVisibility(PortalVisibility.inheritedFrom(parent));
         if (parent == null) {
             target.markAsRoot();
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
@@ -149,7 +149,7 @@ public final class NavigationSyncPlanExecutor {
         FolderActions.DesiredFolder desired,
         PortalNavigationItemContainer parent
     ) {
-        if (NavigationFolderMapper.matches(existing, desired, parent == null ? null : parent.getId())) return existing;
+        if (NavigationFolderMapper.matches(existing, desired, parent)) return existing;
         NavigationFolderMapper.apply(desired, parent, existing);
         return (PortalNavigationFolder) crudService.update(existing);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutor.java
@@ -30,7 +30,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
-import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import jakarta.annotation.Nullable;
 import java.util.HashMap;
@@ -123,7 +122,6 @@ public final class NavigationSyncPlanExecutor {
             .area(area)
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
-            .visibility(PortalVisibility.PUBLIC)
             .published(true)
             .build();
         return (PortalNavigationFolder) crudService.create(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ApiFolderSubtreeReconciler.java
@@ -36,7 +36,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
-import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
@@ -127,7 +126,6 @@ class ApiFolderSubtreeReconciler {
             .type(PortalNavigationItemType.FOLDER)
             .order(df.order())
             .parentId(df.parentPath() == null ? navApiId : idFactory.apply(df.parentPath()))
-            .visibility(PortalVisibility.PUBLIC)
             .published(true)
             .automationMetadata(
                 new AutomationMetadata(AutomationMetadata.ReferenceType.API, apiId, null, Optional.of(df.path()), Optional.empty())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/NavigationItemEntryMaterializer.java
@@ -67,7 +67,6 @@ class NavigationItemEntryMaterializer {
             .type(PortalNavigationItemType.API)
             .order(entry.order() != null ? entry.order() : 0)
             .apiId(apiId)
-            .visibility(PortalVisibility.PUBLIC)
             .published(true)
             .build();
         return (PortalNavigationApi) navigationItemCrudService.create(
@@ -93,19 +92,23 @@ class NavigationItemEntryMaterializer {
         PortalListingApiEntry entry,
         PortalNavigationApi existing
     ) {
+        var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
+        var visibility = PortalVisibility.inheritedFrom(parent);
         var toUpdate = UpdatePortalNavigationItem.builder()
             .type(PortalNavigationItemType.API)
             .title(entry.apiHrid())
             .segment(Slug.from(entry.apiHrid()).value())
             .order(entry.order() != null ? entry.order() : 0)
-            .parentId(resolveParentId(auditInfo, portalId, entry.location()))
-            .visibility(PortalVisibility.PUBLIC)
+            .parentId(parent != null ? parent.getId() : null)
+            .visibility(visibility)
             .published(true)
             .build();
         return new PortalNavigationValidator.PendingUpdate(toUpdate, existing);
     }
 
     CreatePortalNavigationItem itemForValidation(AuditInfo auditInfo, PortalId portalId, String apiId, PortalListingApiEntry entry) {
+        var parent = resolveParent(auditInfo, portalId.toString(), entry.location());
+        var visibility = PortalVisibility.inheritedFrom(parent);
         return CreatePortalNavigationItem.builder()
             .id(rowId(auditInfo, portalId, apiId))
             .title(entry.apiHrid())
@@ -114,16 +117,11 @@ class NavigationItemEntryMaterializer {
             .type(PortalNavigationItemType.API)
             .order(entry.order() != null ? entry.order() : 0)
             .apiId(apiId)
-            .parentId(resolveParentId(auditInfo, portalId, entry.location()))
-            .visibility(PortalVisibility.PUBLIC)
+            .parentId(parent != null ? parent.getId() : null)
+            .visibility(visibility)
             .published(true)
             .automationMetadata(portalAutomationMetadata(portalId, entry.location()))
             .build();
-    }
-
-    private PortalNavigationItemId resolveParentId(AuditInfo auditInfo, PortalId portalId, String location) {
-        var parent = resolveParent(auditInfo, portalId.toString(), location);
-        return Optional.ofNullable(parent).map(PortalNavigationItemContainer::getId).orElse(null);
     }
 
     private void rejectIfSegmentTakenByForeignItem(
@@ -158,11 +156,12 @@ class NavigationItemEntryMaterializer {
         PortalListingApiEntry entry,
         PortalNavigationItemContainer parent
     ) {
+        var visibility = PortalVisibility.inheritedFrom(parent);
         navApi.setApiId(apiId);
         navApi.setOrder(entry.order() != null ? entry.order() : 0);
         navApi.setTitle(entry.apiHrid());
         navApi.setSegment(Slug.from(entry.apiHrid()).value());
-        navApi.setVisibility(PortalVisibility.PUBLIC);
+        navApi.setVisibility(visibility);
         navApi.setPublished(true);
         if (parent == null) {
             navApi.markAsRoot();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainService.java
@@ -62,7 +62,6 @@ public class ApiDocumentationSyncDomainService {
     private static final int MAX_CASCADE_DEPTH = 50;
     private static final PortalArea API_DOCUMENTATION_AREA = PortalArea.TOP_NAVBAR;
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
-    private static final PortalVisibility DEFAULT_VISIBILITY = PortalVisibility.PUBLIC;
     private static final int DEFAULT_ORDER = 0;
     private static final boolean DEFAULT_PUBLISHED = true;
 
@@ -190,13 +189,14 @@ public class ApiDocumentationSyncDomainService {
 
         if (existing instanceof PortalNavigationPage page && page.getArea() == API_DOCUMENTATION_AREA) {
             var segment = Slug.from(meta.name(), siblingSlugs(envId, parentId, pageId));
+            var visibility = PortalVisibility.inheritedFrom(parent);
             var update = UpdatePortalNavigationItem.builder()
                 .title(meta.name())
                 .segment(segment.value())
                 .type(TYPE)
                 .order(meta.order().orElse(DEFAULT_ORDER))
                 .parentId(parentId)
-                .visibility(DEFAULT_VISIBILITY)
+                .visibility(visibility)
                 .published(DEFAULT_PUBLISHED)
                 .build();
             validatorService.validateToUpdate(update, page);
@@ -219,7 +219,6 @@ public class ApiDocumentationSyncDomainService {
             .portalPageContentId(contentId)
             .parentId(parentId)
             .reference(meta.reference())
-            .visibility(DEFAULT_VISIBILITY)
             .published(DEFAULT_PUBLISHED)
             .automationMetadata(meta.trimmedForNavItem())
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
@@ -41,7 +41,6 @@ import lombok.RequiredArgsConstructor;
 public class PortalDocumentationSyncDomainService {
 
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.PAGE;
-    private static final PortalVisibility DEFAULT_VISIBILITY = PortalVisibility.PUBLIC;
     private static final int DEFAULT_ORDER = 0;
     private static final boolean DEFAULT_PUBLISHED = true;
 
@@ -87,13 +86,14 @@ public class PortalDocumentationSyncDomainService {
         if (isUpdatableInPlace(existing, targetArea)) {
             var page = (PortalNavigationPage) existing;
             final var segment = Slug.from(meta.name(), siblingsSlugs(envId, parentId, navigationItemId));
+            var visibility = PortalVisibility.inheritedFrom(parent);
             var update = UpdatePortalNavigationItem.builder()
                 .title(meta.name())
                 .segment(segment.value())
                 .type(TYPE)
                 .order(meta.order().orElse(DEFAULT_ORDER))
                 .parentId(parentId)
-                .visibility(DEFAULT_VISIBILITY)
+                .visibility(visibility)
                 .published(DEFAULT_PUBLISHED)
                 .build();
             validatorService.validateToUpdate(update, page);
@@ -119,7 +119,6 @@ public class PortalDocumentationSyncDomainService {
             .portalPageContentId(pageContent.getId())
             .parentId(parentId)
             .reference(meta.reference())
-            .visibility(DEFAULT_VISIBILITY)
             .published(DEFAULT_PUBLISHED)
             .automationMetadata(meta.trimmedForNavItem())
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainService.java
@@ -99,12 +99,13 @@ public class PortalLinkSyncDomainService {
         }
 
         if (existingLink != null) {
+            var visibility = PortalVisibility.inheritedFrom(parent);
             var toUpdate = UpdatePortalNavigationItem.builder()
                 .title(name)
                 .segment(segment)
                 .order(order != null ? order : 0)
                 .url(href)
-                .visibility(PortalVisibility.PUBLIC)
+                .visibility(visibility)
                 .published(true)
                 .build();
             existingLink.update(toUpdate, automationMetadata);
@@ -126,7 +127,6 @@ public class PortalLinkSyncDomainService {
             .url(href)
             .reference(automationMetadata.reference())
             .automationMetadata(automationMetadata)
-            .visibility(PortalVisibility.PUBLIC)
             .published(true)
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemCreationExpansionDomainService.java
@@ -78,7 +78,7 @@ public class PortalNavigationItemCreationExpansionDomainService {
             .filter(product -> environmentId.equals(product.getEnvironmentId()))
             .orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
         var apis = resolveApis(apiProduct, environmentId);
-        var visibility = root.getVisibility() != null ? root.getVisibility() : PortalVisibility.PUBLIC;
+        var visibility = PortalVisibility.resolve(root.getVisibility(), PortalVisibility.PUBLIC);
 
         var children = new ArrayList<CreatePortalNavigationItem>(apis.size());
         for (int order = 0; order < apis.size(); order++) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -130,10 +130,28 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
             .stream()
             .filter(item -> item.getId() != null)
             .collect(Collectors.toMap(CreatePortalNavigationItem::getId, Function.identity(), (first, ignored) -> first));
-        List<PendingSegmentClaim> pendingSegmentClaims = collectPendingSegmentClaims(creates, updates);
 
-        CreateValidationContext createCtx = new CreateValidationContext(navigationItems, itemsById, pendingItemsById, pendingSegmentClaims);
-        UpdateValidationContext updateCtx = new UpdateValidationContext(navigationItems, itemsById, pendingItemsById, pendingSegmentClaims);
+        List<PendingUpdate> augmentedUpdates = withDescendantsOfPendingContainers(creates, updates, environmentId);
+        List<PendingSegmentClaim> pendingSegmentClaims = collectPendingSegmentClaims(creates, augmentedUpdates);
+        Map<PortalNavigationItemId, PendingUpdate> pendingUpdatesByExistingId = updates
+            .stream()
+            .filter(u -> u.existing() != null && u.existing().getId() != null)
+            .collect(Collectors.toMap(u -> u.existing().getId(), Function.identity(), (first, ignored) -> first));
+
+        CreateValidationContext createCtx = new CreateValidationContext(
+            navigationItems,
+            itemsById,
+            pendingItemsById,
+            pendingUpdatesByExistingId,
+            pendingSegmentClaims
+        );
+        UpdateValidationContext updateCtx = new UpdateValidationContext(
+            navigationItems,
+            itemsById,
+            pendingItemsById,
+            pendingUpdatesByExistingId,
+            pendingSegmentClaims
+        );
 
         for (BulkCreatePortalNavigationItemValidationRule rule : bulkCreateRules) {
             rule.validate(creates, environmentId, createCtx);
@@ -141,9 +159,67 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
         for (CreatePortalNavigationItem item : creates) {
             applyValidationRules(item, createCtx, environmentId);
         }
-        for (PendingUpdate pending : updates) {
+        for (PendingUpdate pending : augmentedUpdates) {
             applyValidationRules(pending, updateCtx);
         }
+    }
+
+    // Include pre-existing descendants of pending container creates and of pending container updates that change visibility.
+    private List<PendingUpdate> withDescendantsOfPendingContainers(
+        List<CreatePortalNavigationItem> creates,
+        List<PendingUpdate> updates,
+        String environmentId
+    ) {
+        var descendantsOfCreates = creates
+            .stream()
+            .filter(PortalNavigationItemValidatorService::isPendingContainer)
+            .flatMap(container -> descendantsOf(container.getId(), environmentId).stream());
+        var descendantsOfUpdates = updates
+            .stream()
+            .filter(PortalNavigationItemValidatorService::isContainerVisibilityChange)
+            .flatMap(update -> descendantsOf(update.existing().getId(), environmentId).stream());
+        var descendantUpdates = Stream.concat(descendantsOfCreates, descendantsOfUpdates).map(
+            PortalNavigationItemValidatorService::asUnchangedUpdate
+        );
+        return Stream.concat(updates.stream(), descendantUpdates).toList();
+    }
+
+    private static boolean isPendingContainer(CreatePortalNavigationItem item) {
+        return item.getId() != null && item.getType().isContainer();
+    }
+
+    private static boolean isContainerVisibilityChange(PendingUpdate update) {
+        var existing = update.existing();
+        var toUpdate = update.toUpdate();
+        return (
+            existing != null &&
+            existing.getId() != null &&
+            existing.getType().isContainer() &&
+            toUpdate.getVisibility() != null &&
+            toUpdate.getVisibility() != existing.getVisibility()
+        );
+    }
+
+    private List<PortalNavigationItem> descendantsOf(PortalNavigationItemId containerId, String environmentId) {
+        return navigationItemsQueryService.findByParentIdAndEnvironmentId(environmentId, containerId);
+    }
+
+    // Wraps a persisted descendant as a no-op update so the update rules re-run against the pending parent.
+    private static PendingUpdate asUnchangedUpdate(PortalNavigationItem descendant) {
+        return new PendingUpdate(unchangedUpdateFor(descendant), descendant);
+    }
+
+    private static UpdatePortalNavigationItem unchangedUpdateFor(PortalNavigationItem item) {
+        return UpdatePortalNavigationItem.builder()
+            .type(item.getType())
+            .title(item.getTitle())
+            .segment(item.getSegment())
+            .order(item.getOrder())
+            .parentId(item.getParentId())
+            .visibility(item.getVisibility())
+            .published(item.getPublished())
+            .source(item.getSource())
+            .build();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/CreateValidationContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -28,9 +29,10 @@ public record CreateValidationContext(
     List<PortalNavigationItem> navigationItems,
     Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
     Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById,
+    Map<PortalNavigationItemId, PendingUpdate> pendingUpdatesByExistingId,
     List<PendingSegmentClaim> pendingSegmentClaims
 ) {
     public static CreateValidationContext empty() {
-        return new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of());
+        return new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -82,9 +82,9 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId);
         }
 
-        var itemVisibility = item.getVisibility() != null ? item.getVisibility() : PortalVisibility.PUBLIC;
-        var parentVisibility = parentItem.getVisibility() != null ? parentItem.getVisibility() : PortalVisibility.PUBLIC;
-        if (PortalVisibility.PUBLIC.equals(itemVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
+        var parentVisibility = Optional.ofNullable(parentItem.getVisibility()).orElse(PortalVisibility.PUBLIC);
+        var effectiveVisibility = PortalVisibility.resolve(item.getVisibility(), parentVisibility);
+        if (PortalVisibility.PUBLIC.equals(effectiveVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
             throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId);
         }
     }
@@ -173,7 +173,8 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
         if (itemPublished && !parentItem.getPublished()) {
             throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId.toString());
         }
-        if (PortalVisibility.PUBLIC.equals(itemVisibility) && PortalVisibility.PRIVATE.equals(parentItem.getVisibility())) {
+        var effectiveVisibility = PortalVisibility.resolve(itemVisibility, parentItem.getVisibility());
+        if (PortalVisibility.PUBLIC.equals(effectiveVisibility) && PortalVisibility.PRIVATE.equals(parentItem.getVisibility())) {
             throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId.toString());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRule.java
@@ -104,6 +104,12 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             return;
         }
 
+        var pendingParentUpdate = ctx.pendingUpdatesByExistingId().get(toUpdate.getParentId());
+        if (pendingParentUpdate != null && !Objects.equals(pendingParentUpdate.existing().getId(), existingItem.getId())) {
+            validatePendingParentUpdate(toUpdate, existingItem, pendingParentUpdate);
+            return;
+        }
+
         validateParent(
             toUpdate.getParentId(),
             existingItem.getArea(),
@@ -112,6 +118,36 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             toUpdate.getVisibility(),
             existingItem.getAutomationMetadata() != null
         );
+    }
+
+    private void validatePendingParentUpdate(
+        UpdatePortalNavigationItem toUpdate,
+        PortalNavigationItem existingItem,
+        io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate parentUpdate
+    ) {
+        var parentExisting = parentUpdate.existing();
+        var parentToUpdate = parentUpdate.toUpdate();
+        var parentId = parentExisting.getId().toString();
+        if (!parentExisting.getType().isContainer()) {
+            throw new ParentTypeMismatchException(parentId);
+        }
+        if (!Objects.equals(parentExisting.getArea(), existingItem.getArea())) {
+            throw new ParentAreaMismatchException(parentId);
+        }
+
+        boolean itemPublished = Boolean.TRUE.equals(toUpdate.getPublished());
+        boolean parentPublished = Boolean.TRUE.equals(
+            parentToUpdate.getPublished() != null ? parentToUpdate.getPublished() : parentExisting.getPublished()
+        );
+        if (itemPublished && !parentPublished) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId);
+        }
+
+        var parentVisibility = Optional.ofNullable(parentToUpdate.getVisibility()).orElse(parentExisting.getVisibility());
+        var effectiveVisibility = PortalVisibility.resolve(toUpdate.getVisibility(), parentVisibility);
+        if (PortalVisibility.PUBLIC.equals(effectiveVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
+            throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId);
+        }
     }
 
     private void validatePendingParent(
@@ -133,9 +169,9 @@ public class ParentRule implements CreatePortalNavigationItemValidationRule, Upd
             throw InvalidPortalNavigationItemDataException.parentMustBePublished(parentId);
         }
 
-        var itemVisibility = toUpdate.getVisibility() != null ? toUpdate.getVisibility() : PortalVisibility.PUBLIC;
-        var parentVisibility = parentItem.getVisibility() != null ? parentItem.getVisibility() : PortalVisibility.PUBLIC;
-        if (PortalVisibility.PUBLIC.equals(itemVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
+        var parentVisibility = Optional.ofNullable(parentItem.getVisibility()).orElse(PortalVisibility.PUBLIC);
+        var effectiveVisibility = PortalVisibility.resolve(toUpdate.getVisibility(), parentVisibility);
+        if (PortalVisibility.PUBLIC.equals(effectiveVisibility) && PortalVisibility.PRIVATE.equals(parentVisibility)) {
             throw InvalidPortalNavigationItemDataException.parentMustBePublic(parentId);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/UpdateValidationContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -28,9 +29,10 @@ public record UpdateValidationContext(
     List<PortalNavigationItem> navigationItems,
     Map<PortalNavigationItemId, PortalNavigationItem> itemsById,
     Map<PortalNavigationItemId, CreatePortalNavigationItem> pendingItemsById,
+    Map<PortalNavigationItemId, PendingUpdate> pendingUpdatesByExistingId,
     List<PendingSegmentClaim> pendingSegmentClaims
 ) {
     public static UpdateValidationContext empty() {
-        return new UpdateValidationContext(List.of(), Map.of(), Map.of(), List.of());
+        return new UpdateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -174,7 +174,7 @@ public abstract sealed class PortalNavigationItem
         final var apiProductId = item.getApiProductId();
         final var categoryIds = item.getCategoryIds();
         final var order = item.getOrder();
-        final var visibility = null != item.getVisibility() ? item.getVisibility() : PortalVisibility.PUBLIC;
+        final var visibility = PortalVisibility.resolve(item.getVisibility(), parent);
         final var published = null != item.getPublished() ? item.getPublished() : false;
 
         final PortalNavigationItem newItem = switch (item.getType()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemContainer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemContainer.java
@@ -26,6 +26,8 @@ public interface PortalNavigationItemContainer {
 
     PortalNavigationItemId getRootId();
 
+    PortalVisibility getVisibility();
+
     /**
      * Placeholder parent used by materializers when the actual folder hasn't been persisted yet.
      * Returns {@code null} when the given id is {@code null}.
@@ -41,6 +43,11 @@ public interface PortalNavigationItemContainer {
             @Override
             public PortalNavigationItemId getRootId() {
                 return id;
+            }
+
+            @Override
+            public PortalVisibility getVisibility() {
+                return PortalVisibility.PUBLIC;
             }
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalVisibility.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalVisibility.java
@@ -15,7 +15,24 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+
 public enum PortalVisibility {
     PUBLIC,
-    PRIVATE,
+    PRIVATE;
+
+    public static PortalVisibility inheritedFrom(@Nullable PortalNavigationItemContainer parent) {
+        return Optional.ofNullable(parent).map(PortalNavigationItemContainer::getVisibility).orElse(PUBLIC);
+    }
+
+    public static PortalVisibility resolve(@Nullable PortalVisibility callerVisibility, @Nullable PortalNavigationItemContainer parent) {
+        return Optional.ofNullable(callerVisibility).orElseGet(() -> inheritedFrom(parent));
+    }
+
+    public static PortalVisibility resolve(@Nullable PortalVisibility callerVisibility, @Nullable PortalVisibility parentVisibility) {
+        return Optional.ofNullable(callerVisibility)
+            .or(() -> Optional.ofNullable(parentVisibility))
+            .orElse(PUBLIC);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -426,7 +426,28 @@ class PortalNavigationSyncDomainServiceTest {
         assertThat(findByPath("/a")).isPresent();
     }
 
+    @Test
+    void re_sync_re_derives_stale_folder_visibility_from_inheritance() {
+        var input = List.of(new NavigationPath("/root", null));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, PortalNavigationStructure.empty(), PortalNavigationStructure.ofTopNavbar(input));
+
+        // External drift: someone flips the folder to PRIVATE outside the automation flow.
+        var root = (PortalNavigationFolder) findByPath("/root").orElseThrow();
+        root.setVisibility(PortalVisibility.PRIVATE);
+        crud.update(root);
+
+        // Next sync should re-derive the folder's visibility from its (null) parent → PUBLIC.
+        syncService.sync(AUDIT_INFO, PORTAL_ID, PortalNavigationStructure.ofTopNavbar(input), PortalNavigationStructure.ofTopNavbar(input));
+
+        var reSynced = (PortalNavigationFolder) findByPath("/root").orElseThrow();
+        assertThat(reSynced.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+    }
+
     private PortalNavigationFolder folderRow(String title, PortalNavigationItemId parentId, int order) {
+        return folderRow(title, parentId, order, PortalVisibility.PUBLIC);
+    }
+
+    private PortalNavigationFolder folderRow(String title, PortalNavigationItemId parentId, int order, PortalVisibility visibility) {
         return PortalNavigationFolder.builder()
             .id(PortalNavigationItemId.random())
             .organizationId(AUDIT_INFO.organizationId())
@@ -437,7 +458,7 @@ class PortalNavigationSyncDomainServiceTest {
             .order(order)
             .parentId(parentId)
             .published(true)
-            .visibility(PortalVisibility.PUBLIC)
+            .visibility(visibility)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanExecutorTest.java
@@ -176,6 +176,50 @@ class NavigationSyncPlanExecutorTest {
     }
 
     @Test
+    void create_folder_inherits_private_visibility_from_parent() {
+        var privateRoot = folderRow(PortalNavigationItemId.random(), "root", null, 0, PortalVisibility.PRIVATE);
+        privateRoot.markAsRoot();
+        crud.initWith(List.of(privateRoot));
+        var plan = new NavigationSyncPlan(List.of(new FolderActions.CreateFolder(desired("/a", null, "a", 0))));
+
+        executor.execute(plan, AUDIT_INFO, PortalArea.TOP_NAVBAR, privateRoot, path -> FIXED_ID, new DeleteStrategy(item -> false, false));
+
+        var created = (PortalNavigationFolder) crud
+            .storage()
+            .stream()
+            .filter(item -> item.getId().equals(FIXED_ID))
+            .findFirst()
+            .orElseThrow();
+        assertThat(created.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+    }
+
+    @Test
+    void update_folder_re_derives_visibility_when_stored_visibility_is_stale() {
+        var privateParent = folderRow(PortalNavigationItemId.random(), "parent", null, 0, PortalVisibility.PRIVATE);
+        privateParent.markAsRoot();
+        var stalePublicChild = folderRow(FIXED_ID, "a", privateParent.getId(), 0, PortalVisibility.PUBLIC);
+        crud.initWith(List.of(privateParent, stalePublicChild));
+        var plan = new NavigationSyncPlan(List.of(new FolderActions.UpdateFolder(stalePublicChild, desired("/a", null, "a", 0))));
+
+        executor.execute(
+            plan,
+            AUDIT_INFO,
+            PortalArea.TOP_NAVBAR,
+            privateParent,
+            path -> PortalNavigationItemId.random(),
+            new DeleteStrategy(item -> false, false)
+        );
+
+        var updated = (PortalNavigationFolder) crud
+            .storage()
+            .stream()
+            .filter(item -> item.getId().equals(FIXED_ID))
+            .findFirst()
+            .orElseThrow();
+        assertThat(updated.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+    }
+
+    @Test
     void skip_filter_short_circuits_subtree() {
         var parent = folderRow(PortalNavigationItemId.random(), "parent", null, 0);
         parent.markAsRoot();
@@ -204,6 +248,16 @@ class NavigationSyncPlanExecutorTest {
     }
 
     private PortalNavigationFolder folderRow(PortalNavigationItemId id, String title, PortalNavigationItemId parentId, int order) {
+        return folderRow(id, title, parentId, order, PortalVisibility.PUBLIC);
+    }
+
+    private PortalNavigationFolder folderRow(
+        PortalNavigationItemId id,
+        String title,
+        PortalNavigationItemId parentId,
+        int order,
+        PortalVisibility visibility
+    ) {
         return PortalNavigationFolder.builder()
             .id(id)
             .organizationId(AUDIT_INFO.organizationId())
@@ -214,7 +268,7 @@ class NavigationSyncPlanExecutorTest {
             .order(order)
             .parentId(parentId)
             .published(true)
-            .visibility(PortalVisibility.PUBLIC)
+            .visibility(visibility)
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/ApiDocumentationSyncDomainServiceTest.java
@@ -216,11 +216,45 @@ class ApiDocumentationSyncDomainServiceTest {
             .doesNotContain(removedNavApiId, pageId);
     }
 
+    @Test
+    void materialize_inherits_private_visibility_from_private_nav_api_row() {
+        seedNavApi(PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), API_ID, PortalVisibility.PRIVATE);
+
+        var meta = new AutomationMetadata(
+            AutomationMetadata.ReferenceType.API,
+            API_ID,
+            "Getting Started",
+            Optional.empty(),
+            Optional.of(1)
+        );
+        var doc = new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello"),
+            meta
+        );
+        syncService.materialize(AUDIT_INFO, doc);
+
+        var pageId = PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, API_ID, DOC_ID);
+        var page = (PortalNavigationPage) navItemCrud
+            .storage()
+            .stream()
+            .filter(item -> item.getId().equals(pageId))
+            .findFirst()
+            .orElseThrow();
+        assertThat(page.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+    }
+
     private PortalNavigationApi seedNavApi(PortalNavigationItemId id) {
-        return seedNavApi(id, API_ID);
+        return seedNavApi(id, API_ID, PortalVisibility.PUBLIC);
     }
 
     private PortalNavigationApi seedNavApi(PortalNavigationItemId id, String apiId) {
+        return seedNavApi(id, apiId, PortalVisibility.PUBLIC);
+    }
+
+    private PortalNavigationApi seedNavApi(PortalNavigationItemId id, String apiId, PortalVisibility visibility) {
         var create = CreatePortalNavigationItem.builder()
             .id(id)
             .title("api")
@@ -229,7 +263,7 @@ class ApiDocumentationSyncDomainServiceTest {
             .type(PortalNavigationItemType.API)
             .order(0)
             .apiId(apiId)
-            .visibility(PortalVisibility.PUBLIC)
+            .visibility(visibility)
             .published(true)
             .build();
         var navApi = (PortalNavigationApi) PortalNavigationItem.from(create, AUDIT_INFO.organizationId(), AUDIT_INFO.environmentId(), null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
@@ -888,4 +888,131 @@ class CreatePortalNavigationItemValidatorServiceTest {
             assertDoesNotThrow(() -> validatorService.validateOne(aPageUnder(folder.getId()).build(), ENV_ID));
         }
     }
+
+    @Nested
+    class PhantomThenPrivateParent {
+
+        @Test
+        void should_reject_when_new_private_folder_has_pre_existing_public_descendant() {
+            var folderId = PortalNavigationItemId.of("cafecafe-cafe-cafe-cafe-cafecafecafe");
+            var preExistingChild = PortalNavigationItemFixtures.aPage("Setup", folderId);
+            navigationItemsQueryService.storage().add(preExistingChild);
+
+            var newPrivateFolder = CreatePortalNavigationItem.builder()
+                .id(folderId)
+                .title("Private Guides")
+                .segment("private-guides")
+                .type(PortalNavigationItemType.FOLDER)
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .published(true)
+                .visibility(PortalVisibility.PRIVATE)
+                .build();
+
+            Exception exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validateAll(List.of(newPrivateFolder), ENV_ID)
+            );
+            assertThat(exception.getMessage()).contains("must be PUBLIC");
+        }
+
+        @Test
+        void should_accept_when_new_private_folder_has_pre_existing_private_descendant() {
+            var folderId = PortalNavigationItemId.of("deaddead-dead-dead-dead-deaddeaddead");
+            var preExistingChild = PortalNavigationItemFixtures.aPage("Setup", folderId);
+            preExistingChild.setVisibility(PortalVisibility.PRIVATE);
+            navigationItemsQueryService.storage().add(preExistingChild);
+
+            var newPrivateFolder = CreatePortalNavigationItem.builder()
+                .id(folderId)
+                .title("Private Guides")
+                .segment("private-guides")
+                .type(PortalNavigationItemType.FOLDER)
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .published(true)
+                .visibility(PortalVisibility.PRIVATE)
+                .build();
+
+            assertDoesNotThrow(() -> validatorService.validateAll(List.of(newPrivateFolder), ENV_ID));
+        }
+
+        @Test
+        void should_accept_when_new_public_folder_has_pre_existing_public_descendant() {
+            var folderId = PortalNavigationItemId.of("beefbeef-beef-beef-beef-beefbeefbeef");
+            var preExistingChild = PortalNavigationItemFixtures.aPage("Setup", folderId);
+            navigationItemsQueryService.storage().add(preExistingChild);
+
+            var newPublicFolder = CreatePortalNavigationItem.builder()
+                .id(folderId)
+                .title("Public Guides")
+                .segment("public-guides")
+                .type(PortalNavigationItemType.FOLDER)
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .build();
+
+            assertDoesNotThrow(() -> validatorService.validateAll(List.of(newPublicFolder), ENV_ID));
+        }
+    }
+
+    @Nested
+    class UpdateContainerVisibility {
+
+        @Test
+        void should_reject_when_folder_is_updated_to_private_with_pre_existing_public_descendant() {
+            var folder = PortalNavigationItemFixtures.aFolder("public-folder");
+            folder.markAsRoot();
+            navigationItemsQueryService.storage().add(folder);
+            var preExistingChild = PortalNavigationItemFixtures.aPage("Setup", folder.getId());
+            navigationItemsQueryService.storage().add(preExistingChild);
+
+            var toUpdate = io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem.builder()
+                .type(folder.getType())
+                .title(folder.getTitle())
+                .segment(folder.getSegment())
+                .order(folder.getOrder())
+                .parentId(folder.getParentId())
+                .visibility(PortalVisibility.PRIVATE)
+                .published(folder.getPublished())
+                .build();
+            var pendingUpdate = new io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate(
+                toUpdate,
+                folder
+            );
+
+            Exception exception = assertThrows(InvalidPortalNavigationItemDataException.class, () ->
+                validatorService.validate(List.of(), List.of(pendingUpdate), ENV_ID)
+            );
+            assertThat(exception.getMessage()).contains("must be PUBLIC");
+        }
+
+        @Test
+        void should_accept_when_folder_is_updated_to_public_with_pre_existing_private_descendant() {
+            var folder = PortalNavigationItemFixtures.aFolder("public-folder");
+            folder.markAsRoot();
+            folder.setVisibility(PortalVisibility.PRIVATE);
+            navigationItemsQueryService.storage().add(folder);
+            var preExistingChild = PortalNavigationItemFixtures.aPage("Setup", folder.getId());
+            preExistingChild.setVisibility(PortalVisibility.PRIVATE);
+            navigationItemsQueryService.storage().add(preExistingChild);
+
+            var toUpdate = io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem.builder()
+                .type(folder.getType())
+                .title(folder.getTitle())
+                .segment(folder.getSegment())
+                .order(folder.getOrder())
+                .parentId(folder.getParentId())
+                .visibility(PortalVisibility.PUBLIC)
+                .published(folder.getPublished())
+                .build();
+            var pendingUpdate = new io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator.PendingUpdate(
+                toUpdate,
+                folder
+            );
+
+            assertDoesNotThrow(() -> validatorService.validate(List.of(), List.of(pendingUpdate), ENV_ID));
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
@@ -38,11 +38,14 @@ import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsExceptio
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.NavigationItemReference;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -168,6 +171,36 @@ class PortalDocumentationSyncDomainServiceTest {
         var page = (PortalNavigationPage) navItemCrud.storage().get(0);
         assertThat(page.getParentId()).isNull();
         assertThat(page.getRootId()).isEqualTo(page.getId());
+    }
+
+    @Test
+    void materialize_inherits_private_visibility_from_persisted_parent_folder() {
+        var parentFolderId = expectedFolderId("/private-guides");
+        navItemCrud.initWith(
+            List.of(
+                PortalNavigationFolder.builder()
+                    .id(parentFolderId)
+                    .organizationId(AUDIT_INFO.organizationId())
+                    .environmentId(AUDIT_INFO.environmentId())
+                    .title("private-guides")
+                    .segment("private-guides")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+
+        syncService.materialize(AUDIT_INFO, markdownDoc("Setup", "/private-guides", 0));
+
+        var page = (PortalNavigationPage) navItemCrud
+            .storage()
+            .stream()
+            .filter(PortalNavigationPage.class::isInstance)
+            .findFirst()
+            .orElseThrow();
+        assertThat(page.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalLinkSyncDomainServiceTest.java
@@ -302,6 +302,38 @@ class PortalLinkSyncDomainServiceTest {
         assertThat(link.getReference()).isEqualTo(new NavigationItemReference.PortalReference(PortalId.of(PORTAL_ID)));
     }
 
+    @Test
+    void materialize_inherits_private_visibility_from_persisted_parent_folder() {
+        var parentFolderId = expectedFolderId("/private-guides");
+        navItemCrud.initWith(
+            List.of(
+                PortalNavigationFolder.builder()
+                    .id(parentFolderId)
+                    .organizationId(AUDIT_INFO.organizationId())
+                    .environmentId(AUDIT_INFO.environmentId())
+                    .title("private-guides")
+                    .segment("private-guides")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+
+        var link = syncService.materialize(
+            AUDIT_INFO,
+            PORTAL_ID,
+            "internal-docs",
+            "Internal Docs",
+            "https://internal.example.com",
+            "/private-guides",
+            0
+        );
+
+        assertThat(link.getVisibility()).isEqualTo(PortalVisibility.PRIVATE);
+    }
+
     private static PortalNavigationItemId expectedLinkId() {
         return PortalNavigationItemId.of(HRIDToUUID.portalLink().context(AUDIT_INFO).portal(PORTAL_ID).hrid("external-docs").id());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/AncestorValidationTest.java
@@ -59,6 +59,7 @@ class AncestorValidationTest {
             List.of(),
             Map.of(),
             Map.of(firstFolder.getId(), firstFolder, secondFolder.getId(), secondFolder),
+            Map.of(),
             List.of()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ApiProductItemCreateRuleTest.java
@@ -89,7 +89,7 @@ class ApiProductItemCreateRuleTest {
     void should_reject_nested_product_in_pending_payload() {
         var parent = apiProductItem().toBuilder().id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000103")).build();
         var nested = apiProductItem().toBuilder().parentId(parent.getId()).build();
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(parent.getId(), parent), List.of());
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(parent.getId(), parent), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(nested, ENVIRONMENT_ID, ctx)).isInstanceOf(InvalidPortalNavigationItemDataException.class);
     }
@@ -97,7 +97,7 @@ class ApiProductItemCreateRuleTest {
     @Test
     void should_reject_existing_product_reference() {
         var existing = PortalNavigationItemFixtures.anApiProduct("00000000-0000-0000-0000-000000000104", "Product", null, API_PRODUCT_ID);
-        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of(), List.of());
+        var ctx = new CreateValidationContext(List.of(existing), Map.of(existing.getId(), existing), Map.of(), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(apiProductItem(), ENVIRONMENT_ID, ctx)).isInstanceOf(
             ApiProductNavigationItemAlreadyExistsException.class
@@ -112,6 +112,7 @@ class ApiProductItemCreateRuleTest {
             List.of(existing),
             Map.of(existing.getId(), existing),
             Map.of(parent.getId(), parent),
+            Map.of(),
             List.of()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/ParentRuleTest.java
@@ -129,7 +129,7 @@ class ParentRuleTest {
     void create_uses_pending_parent_from_same_batch() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR);
         var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), Map.of(), List.of());
 
         assertThatCode(() -> rule.validate(child, ENV_ID, ctx)).doesNotThrowAnyException();
     }
@@ -138,7 +138,7 @@ class ParentRuleTest {
     void create_pending_parent_area_mismatch_throws() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.HOMEPAGE);
         var child = pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(child, ENV_ID, ctx)).isInstanceOf(ParentAreaMismatchException.class);
     }
@@ -171,7 +171,7 @@ class ParentRuleTest {
     void update_uses_pending_parent_from_same_batch() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR);
         var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), Map.of(), List.of());
 
         assertThatCode(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx)).doesNotThrowAnyException();
     }
@@ -180,7 +180,7 @@ class ParentRuleTest {
     void update_pending_parent_area_mismatch_throws() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.HOMEPAGE);
         var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx)).isInstanceOf(ParentAreaMismatchException.class);
     }
@@ -189,9 +189,28 @@ class ParentRuleTest {
     void update_pending_parent_public_under_private_throws() {
         var pendingParent = folderCreate(FOLDER_ID, PortalArea.TOP_NAVBAR).toBuilder().visibility(PortalVisibility.PRIVATE).build();
         var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
-        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), List.of());
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(FOLDER_ID, pendingParent), Map.of(), List.of());
 
         assertThatThrownBy(() -> rule.validate(pageUpdate(FOLDER_ID), existing, ctx))
+            .isInstanceOf(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("must be PUBLIC");
+    }
+
+    @Test
+    void create_public_child_under_persisted_private_parent_throws() {
+        navigationItemsQueryService.storage().add(privatePublishedFolder(FOLDER_ID, PortalArea.TOP_NAVBAR));
+
+        assertThatThrownBy(() -> rule.validate(pageCreate(FOLDER_ID, PortalArea.TOP_NAVBAR, null), ENV_ID, CreateValidationContext.empty()))
+            .isInstanceOf(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("must be PUBLIC");
+    }
+
+    @Test
+    void update_public_child_under_persisted_private_parent_throws() {
+        navigationItemsQueryService.storage().add(privatePublishedFolder(FOLDER_ID, PortalArea.TOP_NAVBAR));
+        var existing = pageExisting(ITEM_ID, PortalArea.TOP_NAVBAR, null);
+
+        assertThatThrownBy(() -> rule.validate(pageUpdate(FOLDER_ID), existing, UpdateValidationContext.empty()))
             .isInstanceOf(io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException.class)
             .hasMessageContaining("must be PUBLIC");
     }
@@ -239,6 +258,14 @@ class ParentRuleTest {
     }
 
     private static PortalNavigationFolder publicPublishedFolder(PortalNavigationItemId id, PortalArea area) {
+        return folder(id, area, PortalVisibility.PUBLIC);
+    }
+
+    private static PortalNavigationFolder privatePublishedFolder(PortalNavigationItemId id, PortalArea area) {
+        return folder(id, area, PortalVisibility.PRIVATE);
+    }
+
+    private static PortalNavigationFolder folder(PortalNavigationItemId id, PortalArea area, PortalVisibility visibility) {
         return PortalNavigationFolder.builder()
             .id(id)
             .organizationId(ORG_ID)
@@ -248,7 +275,7 @@ class ParentRuleTest {
             .area(area)
             .order(0)
             .published(true)
-            .visibility(PortalVisibility.PUBLIC)
+            .visibility(visibility)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
@@ -123,7 +123,7 @@ class SegmentConflictRuleTest {
     @Test
     void validate_throws_when_another_item_in_the_pending_batch_claims_same_parent_and_segment() {
         var pendingClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of(pendingClaim));
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(pendingClaim));
         var item = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
 
         assertThatThrownBy(() -> rule.validate(item, ENV_ID, ctx))
@@ -135,7 +135,7 @@ class SegmentConflictRuleTest {
     void validate_throws_when_a_pending_update_in_the_same_batch_targets_the_same_parent_and_segment() {
         // A create at (PARENT_ID, "docs") collides with a pending update moving another item to the same slot.
         var pendingUpdateClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
-        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), List.of(pendingUpdateClaim));
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(pendingUpdateClaim));
         var newItem = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
 
         assertThatThrownBy(() -> rule.validate(newItem, ENV_ID, ctx))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalVisibilityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalVisibilityTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalVisibilityTest {
+
+    @Test
+    void inheritedFrom_returns_parent_visibility_when_container_present() {
+        var phantom = PortalNavigationItemContainer.phantom(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000001"));
+        assertThat(PortalVisibility.inheritedFrom(phantom)).isEqualTo(PortalVisibility.PUBLIC);
+    }
+
+    @Test
+    void inheritedFrom_defaults_to_public_when_parent_is_null() {
+        assertThat(PortalVisibility.inheritedFrom(null)).isEqualTo(PortalVisibility.PUBLIC);
+    }
+
+    @Test
+    void resolve_with_visibilities_returns_caller_when_present() {
+        assertThat(PortalVisibility.resolve(PortalVisibility.PRIVATE, PortalVisibility.PUBLIC)).isEqualTo(PortalVisibility.PRIVATE);
+        assertThat(PortalVisibility.resolve(PortalVisibility.PUBLIC, PortalVisibility.PRIVATE)).isEqualTo(PortalVisibility.PUBLIC);
+    }
+
+    @Test
+    void resolve_with_visibilities_falls_back_to_parent_when_caller_is_null() {
+        assertThat(PortalVisibility.resolve(null, PortalVisibility.PRIVATE)).isEqualTo(PortalVisibility.PRIVATE);
+    }
+
+    @Test
+    void resolve_with_container_falls_back_to_inheritance() {
+        var phantom = PortalNavigationItemContainer.phantom(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000001"));
+        assertThat(PortalVisibility.resolve(null, phantom)).isEqualTo(PortalVisibility.PUBLIC);
+        assertThat(PortalVisibility.resolve(PortalVisibility.PRIVATE, phantom)).isEqualTo(PortalVisibility.PRIVATE);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-179

## Description

Removes hardcoded `PortalVisibility.PUBLIC` from every automation-api related sync service that materializes portal navigation items. Producers now inherit the parent's visibility (fallback: PUBLIC at root), so a PUBLIC child under a PRIVATE parent can no longer be materialized silently.

Existing `ParentRule` is reused to validate parent-child visibility constraints.

Requires follow-up PR to expose visibility property on automation-api
