### PR TITLE
fix(release): let the shell expand the test glob

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -11,7 +11,7 @@
     "zx": "8.3.2"
   },
   "scripts": {
-    "test": "node --test \"helpers/*.test.mjs\"",
+    "test": "node --test helpers/*.test.mjs",
     "prettier": "prettier --check \"**/*.{js,mjs,json}\"",
     "prettier:fix": "prettier --write \"**/*.{js,mjs,json}\"",
     "full_release": "zx steps/full_release.mjs",


### PR DESCRIPTION
## Issue

No Jira ticket. One-line fix to unblock a release in flight; the commit that introduced the line (`chore(release): gather changelog tickets from every product board`) carries none either.

## Description

`release/package.json` ran the helper tests as `node --test "helpers/*.test.mjs"`. The quotes stop the shell from expanding the pattern, so `node` has to do it — and `node --test` only expands glob patterns from Node 21 on. This branch runs `cimg/node:20.11.1` (`.circleci/ci/src/config.ts`), so the step failed with:

```
Could not find '/home/circleci/project/release/helpers/*.test.mjs'
```

Dropping the quotes hands the expansion back to the shell, which every version does.

## Additional context

- The step only runs in `job-release-notes-apim`, and that job only exists in `workflow-full-release`. No pull request can reach it, so the defect could only surface on a real release — which is how it was found.
- `master`, `4.12.x` and `4.11.x` run `cimg/node:22.12.0` and are unaffected. They keep the quoted form; the underlying divergence in executor version between the maintenance branches is left alone here.
- Measured on this branch's `release/`: `node --test helpers/*.test.mjs` gives 58 tests, 10 suites, 58 passing on Node 20.11.1, 22.12.0 and 24.18.0. The quoted form fails on 20.11.1 with the message above and passes on the other two.
