### PR TITLE
Found 246 shared policy bug

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared-policy-groups/components/SharedPolicyGroupDetailLayout.tsx
@@ -46,7 +46,7 @@ function SharedPolicyGroupHeader({ sharedPolicyGroup, listHref }: Readonly<{ sha
                     {toReadableApiType(sharedPolicyGroup.apiType)} · {toReadableFlowPhase(sharedPolicyGroup.phase)}
                 </p>
                 {sharedPolicyGroup.prerequisiteMessage ? (
-                    <p className="text-sm text-muted-foreground">
+                    <p className="truncate text-sm text-muted-foreground" title={sharedPolicyGroup.prerequisiteMessage}>
                         <span className="font-medium">Prerequisite: </span>
                         {sharedPolicyGroup.prerequisiteMessage}
                     </p>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-246

## Description

Prerequisite line now truncates with an ellipsis at the edge of the container, matching the Description field's behavior right above it, instead of overflowing the page

<img width="1610" height="761" alt="Screenshot 2026-08-31 at 7 30 33 PM" src="https://github.com/user-attachments/assets/03c4b705-7676-4ff1-a9ce-0dc4fd7eda61" />
