### PR TITLE
fix(analytics): stop hiding Message APIs served over http-get and http-post

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -137,6 +137,21 @@ public class FilterAdapter {
         return jsonFilters;
     }
 
+    /**
+     * Selects the connection documents whose messages a message query aggregates over.
+     *
+     * <p>Deliberately carries no entrypoint predicate. Which API a connection belongs to is already
+     * expressed by the {@code API} filter every query carries — {@code ApiTypeFilterTransformer}
+     * appends one unconditionally — and the second phase keeps only the request ids that have
+     * message documents, an index no other api type writes to. An entrypoint predicate would
+     * restate that guess in terms the entrypoint ids cannot support: they name plugins, and
+     * {@code http-get} / {@code http-post} serve Message APIs and LLM/MCP proxies alike.
+     *
+     * <p>This used to be {@code must_not(httpFilter())}, which read as "not a plain HTTP proxy" when
+     * {@code httpFilter()} held a single id. Every later widening of that list silently narrowed
+     * this one, and GMA-513 — adding http-get and http-post to fix LLM/MCP dashboards — made every
+     * Message API exposed over them invisible to message analytics.
+     */
     public JsonArray adaptForMessageConnexion(Query query) {
         var jsonFilters = JsonArray.of(TimeRangeAdapter.adapt(query));
         for (var filter : query.filters()) {
@@ -144,7 +159,7 @@ public class FilterAdapter {
                 jsonFilters.add(filter(filter));
             }
         }
-        return jsonFilters.add(messageFilter());
+        return jsonFilters;
     }
 
     public JsonArray adaptForNative(Query query) {
@@ -226,10 +241,6 @@ public class FilterAdapter {
 
     public JsonObject edgeFilter() {
         return JsonObject.of("term", JsonObject.of(ENTRYPOINT_FIELD, EDGE_ENTRYPOINT_ID));
-    }
-
-    public JsonObject messageFilter() {
-        return JsonObject.of("bool", JsonObject.of("must_not", JsonArray.of(httpFilter())));
     }
 
     private JsonObject filter(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.A2A_PROXY_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.ENTRYPOINT_FIELD;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_GET_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_POST_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_PROXY_ENTRYPOINT_ID;
@@ -274,6 +275,23 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
         assertThat(nestedMeasures).isNotNull();
     }
 
+    /**
+     * GMA-513 regression guard, from the side that broke.
+     *
+     * <p>{@code http-get} and {@code http-post} are Message API entrypoints as much as LLM/MCP ones
+     * — a plugin id says nothing about the api type. Adding them to the HTTP allow-list to fix
+     * LLM/MCP dashboards silently removed them here, because this query was that list's complement.
+     */
+    @Test
+    void should_not_exclude_connections_on_the_shared_http_entrypoints() throws JsonProcessingException {
+        var query = new MeasuresQuery(buildTimeRange(), buildFilters(), buildMetrics());
+
+        var jsonQuery = JSON.readTree(adapter.adaptRequestIDsQuery(query, null));
+
+        var filters = jsonQuery.at("/query/bool/filter").toString();
+        assertThat(filters).doesNotContain(HTTP_GET_ENTRYPOINT_ID).doesNotContain(HTTP_POST_ENTRYPOINT_ID);
+    }
+
     @Test
     void should_build_request_ids_query_with_composite_aggregation() throws JsonProcessingException {
         var timeRange = buildTimeRange();
@@ -290,35 +308,12 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
         assertThat(filterArray).isNotNull();
         assertThat(filterArray.isArray()).isTrue();
 
-        var messageFilter = filterArray.findValue("bool");
-        assertThat(messageFilter).isNotNull();
-
-        var mustNot = messageFilter.at("/must_not");
-        assertThat(mustNot).isNotNull();
-        assertThat(mustNot.isArray()).isTrue();
-
-        var httpFilterInMustNot = mustNot.at("/0/bool");
-        assertThat(httpFilterInMustNot).isNotNull();
-        var should = httpFilterInMustNot.at("/should");
-        assertThat(should).isNotNull();
-        assertThat(should.isArray()).isTrue();
-        assertThat(should.size()).isEqualTo(2);
-
-        var entrypointFilter = should.at("/0/terms/entrypoint-id");
-        assertThat(entrypointFilter).isNotNull();
-        assertThat(entrypointFilter.size()).isEqualTo(6);
-        assertThat(entrypointFilter.at("/0").asText()).isEqualTo(HTTP_GET_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/1").asText()).isEqualTo(HTTP_POST_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/2").asText()).isEqualTo(HTTP_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/3").asText()).isEqualTo(LLM_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/4").asText()).isEqualTo(MCP_PROXY_ENTRYPOINT_ID);
-        assertThat(entrypointFilter.at("/5").asText()).isEqualTo(A2A_PROXY_ENTRYPOINT_ID);
-
-        var fieldMissingFilter = should.at("/1/bool/must_not/exists/field");
-        assertThat(fieldMissingFilter).isNotNull();
-        assertThat(fieldMissingFilter.asText()).isEqualTo("entrypoint-id");
-
-        assertThat(httpFilterInMustNot.at("/minimum_should_match").asInt()).isEqualTo(1);
+        // No entrypoint predicate. Which API a connection belongs to is already carried by the API
+        // filter every query gets, and the second phase keeps only request ids that have message
+        // documents. Guessing it from entrypoint ids is what made Message APIs on http-get /
+        // http-post invisible when GMA-513 added those ids to the HTTP side — this query used to be
+        // the complement of that list.
+        assertThat(filterArray.toString()).doesNotContain(ENTRYPOINT_FIELD);
 
         var aggs = jsonQuery.at("/aggs");
         assertThat(aggs).isNotEmpty();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-143

Backport of the fix half of #19356 (merged as `6995d8fb3d`). Cherry-picked by hand rather than through
the `apply-on-4-12-x` label, because that label would carry the second commit of #19356 too — the
`feat` adding message facets and time series, which does not belong on a maintenance branch. On
4.12.x `MessageDataPlaneQueryService` still answers `UnsupportedOperationException` for both, and that
is a deliberate limitation, not a bug.

## Description

`FilterAdapter.adaptForMessageConnexion` appended `messageFilter()` — `must_not(httpFilter())` — to
every message connection query. Message APIs are served over http-get and http-post entrypoints, so
that predicate excluded the very connections it was meant to collect: those APIs are invisible in all
message analytics.

The predicate dates from a time when "message" and "HTTP" were disjoint in this code. They stopped
being disjoint once Message APIs gained HTTP entrypoints, and the two-phase message join then rests
on an amputated set of request ids.

Dropping the append is the whole fix; `messageFilter()` had no other caller and goes with it.

## Scope on 4.12.x

This widens the connection set the first phase resolves, so `searchMessageConnectionRequestIDs`
accumulates more request ids into the phase-2 `terms` filter. That paging (10k per page, up to 1000
iterations) is unchanged by this PR and already present on 4.12.x, but it is worth stating: an
environment busy enough to exceed Elasticsearch's default `index.max_terms_count` of 65,536 would see
the search rejected. Today those same APIs return nothing at all, silently, so the trade is a loud
failure at high volume against a silent wrong answer at every volume.

The follow-up on `master` — pushing the API filter down into the second phase, since message documents
carry `api-id` — is tracked separately and is not part of this backport.

## Tests

`should_not_exclude_connections_on_the_shared_http_entrypoints` guards the regression.
`gravitee-apim-repository-elasticsearch`: 752 tests, 0 failures (Java 21 — 4.12.x is on Lombok
1.18.36, which does not support JDK 25).
