### PR TITLE
fix(gateway): restore v3 template context before propagating the terminal event

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
@@ -29,7 +29,9 @@ import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailur
 import io.gravitee.gateway.reactive.policy.adapter.context.ExecutionContextAdapter;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Action;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 
 /**
@@ -72,6 +74,16 @@ public class InvokerAdapter implements HttpInvoker, Invoker, io.gravitee.gateway
     @Override
     public Completable invoke(HttpExecutionContext ctx) {
         final ExecutionContextAdapter adaptedCtx = ExecutionContextAdapter.create(ctx);
+
+        // APIM-14749: restore must land BEFORE the terminal event reaches the downstream (doOnTerminate, not doFinally),
+        // as the adapted context is shared with the v3 policies of the chain. The two legs below do not guard each
+        // other like doFinally does, so make sure a dispose arriving after termination does not restore a second time.
+        final AtomicBoolean restored = new AtomicBoolean();
+        final Action restoreOnce = () -> {
+            if (restored.compareAndSet(false, true)) {
+                adaptedCtx.restore();
+            }
+        };
         return Completable.create(nextEmitter -> {
             ctx.withLogger(log).debug("Executing invoker {}", id);
 
@@ -94,7 +106,7 @@ public class InvokerAdapter implements HttpInvoker, Invoker, io.gravitee.gateway
                 nextEmitter.tryOnError(new Exception("An error occurred while trying to execute invoker " + id, t));
             }
         })
-            .doOnTerminate(adaptedCtx::restore)
+            .doOnTerminate(restoreOnce)
             .doOnDispose(() -> {
                 if (ctx.response().status() == 0) {
                     ctx.response().status(499);
@@ -115,7 +127,7 @@ public class InvokerAdapter implements HttpInvoker, Invoker, io.gravitee.gateway
                         }
                     }
                 }
-                adaptedCtx.restore();
+                restoreOnce.run();
             })
             .onErrorResumeNext(throwable -> {
                 // In case of any error, make sure to reset the response content.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapter.java
@@ -25,6 +25,7 @@ import io.gravitee.gateway.reactive.policy.adapter.context.ExecutionContextAdapt
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -103,7 +104,23 @@ public class PolicyAdapter implements HttpPolicy {
             completable = completable.andThen(this.policyStream(adaptedCtx, phase));
         }
 
-        return completable.doFinally(adaptedCtx::restore);
+        // APIM-14749: restore must land BEFORE the terminal event reaches the downstream, so this is deliberately not a
+        // doFinally. Every v3 policy of the chain shares this ExecutionContextAdapter, and doFinally runs after the next
+        // policy has been subscribed - and, since the PEN-88 worker offload, is already running on another thread -
+        // so a late restore would replay the previous policy's backup over the variables of the next one.
+        // doOnTerminate runs before the terminal event is propagated; doOnDispose covers the cancelled request
+        // (client abort, timeout). Unlike doFinally, the two legs do not guard each other, hence the at-most-once
+        // guard: a dispose arriving after termination must not restore a second time, for the same reason as above.
+        // Consequence, shared with InvokerAdapter: an exception thrown by restore() fails the request instead of
+        // being reported to RxJavaPlugins.onError as it was under doFinally.
+        final AtomicBoolean restored = new AtomicBoolean();
+        final Action restoreOnce = () -> {
+            if (restored.compareAndSet(false, true)) {
+                adaptedCtx.restore();
+            }
+        };
+
+        return completable.doOnTerminate(restoreOnce).doOnDispose(restoreOnce);
     }
 
     private Completable policyExecute(ExecutionContextAdapter adaptedCtx) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapterTest.java
@@ -17,13 +17,18 @@ package io.gravitee.gateway.reactive.policy.adapter.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.el.TemplateContext;
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -39,13 +44,20 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.policy.adapter.context.ExecutionContextAdapter;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -54,6 +66,16 @@ import org.mockito.ArgumentCaptor;
 class PolicyAdapterTest {
 
     protected static final String MOCK_EXCEPTION_MESSAGE = "Mock exception";
+
+    /**
+     * Best-effort head start given to the next policy before the previous one replays its backup, to reproduce the
+     * production timing where the restore runs on the event loop while the next policy already runs on a worker thread.
+     * With the fix applied this wait always times out: the restore lands before the next policy is even subscribed.
+     */
+    private static final long RESTORE_HEAD_START_MS = 200L;
+
+    /** How long the next policy waits for the restore of the previous one to land before evaluating its template. */
+    private static final long RESTORE_AWAIT_TIMEOUT_MS = 5_000L;
 
     @Test
     public void shouldCompleteInErrorWhenOnMessageRequest() {
@@ -458,6 +480,195 @@ class PolicyAdapterTest {
             .isTrue();
 
         releasePolicy.countDown();
+    }
+
+    @Test
+    void should_restore_context_before_completion_is_propagated_downstream() throws PolicyException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final ExecutionContextAdapter adaptedExecutionContext = mock(ExecutionContextAdapter.class);
+        final List<String> events = new ArrayList<>();
+
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ADAPTED_CONTEXT)).thenReturn(adaptedExecutionContext);
+        when(policy.isRunnable()).thenReturn(true);
+        mockPolicyExecution(policy);
+        doAnswer(invocation -> {
+            events.add("restore");
+            return null;
+        })
+            .when(adaptedExecutionContext)
+            .restore();
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+
+        final TestObserver<Void> obs = cut
+            .onRequest(ctx)
+            .doOnComplete(() -> events.add("downstream"))
+            .test();
+
+        obs.assertComplete();
+        assertThat(events).containsExactly("restore", "downstream");
+    }
+
+    @Test
+    void should_restore_context_before_error_is_propagated_downstream() throws PolicyException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final ExecutionContextAdapter adaptedExecutionContext = mock(ExecutionContextAdapter.class);
+        final List<String> events = new ArrayList<>();
+
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ADAPTED_CONTEXT)).thenReturn(adaptedExecutionContext);
+        when(policy.isRunnable()).thenReturn(true);
+        doThrow(new PolicyException(MOCK_EXCEPTION_MESSAGE))
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+        doAnswer(invocation -> {
+            events.add("restore");
+            return null;
+        })
+            .when(adaptedExecutionContext)
+            .restore();
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+
+        final TestObserver<Void> obs = cut
+            .onRequest(ctx)
+            .doOnError(t -> events.add("downstream"))
+            .test();
+
+        obs.assertError(e -> e.getCause().getMessage().equals(MOCK_EXCEPTION_MESSAGE));
+        assertThat(events).containsExactly("restore", "downstream");
+    }
+
+    @Test
+    void should_restore_context_when_disposed_before_completion() throws PolicyException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final ExecutionContextAdapter adaptedExecutionContext = mock(ExecutionContextAdapter.class);
+
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ADAPTED_CONTEXT)).thenReturn(adaptedExecutionContext);
+        when(policy.isRunnable()).thenReturn(true);
+        // The policy never calls the chain back: the request is cancelled (client abort, timeout) while it is in flight.
+        doAnswer(invocation -> null)
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+
+        final Disposable disposable = cut.onRequest(ctx).subscribe();
+        verify(adaptedExecutionContext, times(0)).restore();
+
+        disposable.dispose();
+
+        verify(adaptedExecutionContext, times(1)).restore();
+    }
+
+    @Test
+    void should_restore_context_only_once_when_disposed_after_completion() throws PolicyException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final ExecutionContextAdapter adaptedExecutionContext = mock(ExecutionContextAdapter.class);
+
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ADAPTED_CONTEXT)).thenReturn(adaptedExecutionContext);
+        when(policy.isRunnable()).thenReturn(true);
+        mockPolicyExecution(policy);
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        // A late dispose must not replay the backup a second time: by then it may hold the next policy's variables.
+        obs.dispose();
+
+        verify(adaptedExecutionContext, times(1)).restore();
+    }
+
+    @Test
+    void should_not_restore_context_of_previous_policy_while_next_policy_runs() throws Exception {
+        final String variableName = "group";
+        final String firstGroup = "/v1/hello";
+        final String secondGroup = "hello";
+
+        final Map<String, Object> variables = new ConcurrentHashMap<>();
+        final TemplateContext templateContext = mock(TemplateContext.class);
+        doAnswer(invocation -> {
+            variables.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        })
+            .when(templateContext)
+            .setVariable(anyString(), any());
+        when(templateContext.lookupVariable(anyString())).thenAnswer(invocation -> variables.get(invocation.getArgument(0)));
+
+        final TemplateEngine templateEngine = mock(TemplateEngine.class);
+        when(templateEngine.getTemplateContext()).thenReturn(templateContext);
+
+        // The adapted context is cached on the execution context, so both policies share the same template context.
+        final AtomicReference<Object> cachedAdaptedContext = new AtomicReference<>();
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ADAPTED_CONTEXT)).thenAnswer(invocation ->
+            cachedAdaptedContext.get()
+        );
+        final ExecutionContextAdapter adaptedContext = spy(ExecutionContextAdapter.create(ctx));
+        cachedAdaptedContext.set(adaptedContext);
+
+        final CountDownLatch secondPolicyOverrodeGroup = new CountDownLatch(1);
+        final CountDownLatch previousPolicyRestored = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            // Best-effort head start for the second policy; it cannot be asserted because, once fixed, the restore runs
+            // before the second policy is subscribed and this await always times out. The await below carries the test.
+            secondPolicyOverrodeGroup.await(RESTORE_HEAD_START_MS, TimeUnit.MILLISECONDS);
+            invocation.callRealMethod();
+            previousPolicyRestored.countDown();
+            return null;
+        })
+            .when(adaptedContext)
+            .restore();
+
+        final Policy firstPolicy = mock(Policy.class);
+        when(firstPolicy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            templateContextOf(invocation).setVariable(variableName, firstGroup);
+            invocation.<PolicyChainAdapter>getArgument(0).doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(firstPolicy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        final AtomicBoolean previousPolicyRestoredBeforeLookup = new AtomicBoolean();
+        final AtomicReference<Object> groupSeenByTheSecondPolicy = new AtomicReference<>();
+        final Policy secondPolicy = mock(Policy.class);
+        when(secondPolicy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            final TemplateContext policyContext = templateContextOf(invocation);
+            policyContext.setVariable(variableName, secondGroup);
+            secondPolicyOverrodeGroup.countDown();
+            // Evaluate the template only once a restore of the previous policy could have landed.
+            previousPolicyRestoredBeforeLookup.set(previousPolicyRestored.await(RESTORE_AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            groupSeenByTheSecondPolicy.set(policyContext.lookupVariable(variableName));
+            invocation.<PolicyChainAdapter>getArgument(0).doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(secondPolicy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        final PolicyAdapter first = new PolicyAdapter(firstPolicy, Schedulers.io());
+        final PolicyAdapter second = new PolicyAdapter(secondPolicy, Schedulers.io());
+
+        first.onRequest(ctx).andThen(second.onRequest(ctx)).blockingAwait();
+
+        // Without this the test would pass vacuously if the restore never ran at all: nothing would clobber the variable.
+        assertThat(previousPolicyRestoredBeforeLookup)
+            .as("the previous policy must have restored before the template is evaluated")
+            .isTrue();
+        assertThat(groupSeenByTheSecondPolicy.get())
+            .as("the policy must evaluate its template with its own capture group")
+            .isEqualTo(secondGroup);
+    }
+
+    private TemplateContext templateContextOf(InvocationOnMock invocation) {
+        return invocation.<ExecutionContext>getArgument(1).getTemplateEngine().getTemplateContext();
     }
 
     private void mockPolicyExecution(Policy policy) throws PolicyException {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14749

## Description

When a v4 API chains two v3 policies that write the same EL variable (reported with two
`dynamic-routing` policies, which both publish their regex captures under `group`), the second
policy intermittently evaluates its URL template with the first policy's captures, producing a
corrupted upstream path (`/v1//v1/hello`) and a backend 404.

All v3 policies of a request share one `TemplateContextAdapter`, and `PolicyAdapter` restored its
backed-up variables in `doFinally` — which runs *after* the terminal event reaches the downstream.
Since the worker offload (PEN-88, present from 4.10.x), the next policy is by then already running on
another thread, so the late `restore()` races with it. The fix restores in `doOnTerminate` (before the
terminal event propagates), keeping `doOnDispose` for cancellation — same pattern as
`InvokerAdapter` (728a6315cf). `restore()` keeps the at-most-once property `doFinally` gave it, in `PolicyAdapter` and `InvokerAdapter`
alike. Covered by five new `PolicyAdapterTest` tests, red before the fix.

## Additional context

Gateway only; `dynamic-routing` is a victim of the shared context, not the cause. Validated on a
real gateway under load (interleaved rounds, 60 000 requests per variant): without the fix
4 corrupted paths; with the fix, or with the offload disabled (`gateway.policy.v3.timeoutMs=0`,
which isolates the cause), 0.
