### PR TITLE
fix(gateway): stop advertising mTLS subscription certificates in the TLS handshake

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -102,6 +102,16 @@ secrets:
 #  alpn: false
 #  ssl:
 #    clientAuth: none # Supports none, request, required
+#    Whether the configured truststore is sent to clients as the list of acceptable certificate authorities during
+#    the TLS handshake, so a client holding several certificates can pick the right one. Disabled by default: the
+#    list is sent to every client of the listener, including consumers of non-mTLS APIs, and an empty list simply
+#    means "no constraint" so clients keep presenting their certificate.
+#    Only enable it when every expected client certificate is issued by an authority present in the truststore
+#    configured below. A non-empty list is a constraint, not a hint: a client whose issuer is absent from it
+#    withholds its certificate entirely. In particular, client certificates registered at runtime by mTLS plan
+#    subscriptions are never sent, so enabling this cuts off every subscription whose certificate is not issued
+#    by an authority of the configured truststore.
+#    sendClientCertificateAuthorities: false
 #    The following allows to configure a header to extract the certificate from. Only works for header processed by NGINX in the front of the Gateway.
 #    clientAuthHeader:
 #      name: # empty by default
@@ -157,6 +167,9 @@ secrets:
 #    # TCP REQUIRES SNI to be setup to match APIs
 #    sni: true
 #    clientAuth: none # Supports none, request, required
+#    # Not sent by default. See http.ssl.sendClientCertificateAuthorities above for what enabling it implies:
+#    # a non-empty list is a constraint, and certificates registered by mTLS plan subscriptions are never sent.
+#    sendClientCertificateAuthorities: false
 #    tlsProtocols: TLSv1.2, TLSv1.3
 #    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #    keystore:
@@ -252,6 +265,9 @@ secrets:
 #    # Forced to `true` when routingMode is `host`
 #    sni: true
 #    clientAuth: none # Supports none, request, required
+#    # Not sent by default. See http.ssl.sendClientCertificateAuthorities above for what enabling it implies:
+#    # a non-empty list is a constraint, and certificates registered by mTLS plan subscriptions are never sent.
+#    sendClientCertificateAuthorities: false
 #    tlsProtocols: TLSv1.2, TLSv1.3
 #    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #    keystore:

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/AbstractPlanMutualTLSCertificateAuthoritiesIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/AbstractPlanMutualTLSCertificateAuthoritiesIntegrationTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.mtls;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configureTrustedHttpClient;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getUrl;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.plan.PlanHelper;
+import io.gravitee.common.security.CertificateUtils;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
+import io.gravitee.node.api.certificate.KeyStoreLoader;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.mtls.MtlsPolicy;
+import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
+import io.vertx.core.http.HttpClientOptions;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Base for the APIM-14863 non-regression tests: what the gateway advertises in the TLS
+ * {@code CertificateRequest.certificate_authorities} when an mTLS plan subscription has registered a client
+ * certificate at runtime.
+ *
+ * <p>There is no server-side API to read that field back, but JSSE hands the decoded list to the <em>client</em> key
+ * manager, so an instrumented client captures exactly what the gateway sent. The client deliberately presents no
+ * certificate: the point of the ticket is what a caller with no client certificate — a consumer of the other,
+ * non-mTLS APIs of the same listener — gets to learn.
+ *
+ * <p>{@code clientAuth} is {@code request} so the handshake completes and the assertion cannot race a connection
+ * reset. The advertised list is identical under {@code required}: it is built from the trust store, not from the
+ * client auth mode.
+ */
+@DeployApi(value = { "/apis/plan/v4-proxy-api.json" })
+abstract class AbstractPlanMutualTLSCertificateAuthoritiesIntegrationTest extends AbstractGatewayTest {
+
+    /** The leaf a subscription registers at runtime. Not a certificate authority, and the DN the ticket reported. */
+    protected static final String SUBSCRIPTION_LEAF = "plans/mtls/client.cer";
+
+    /** Used here as the statically configured trust store, so the two origins can be told apart. */
+    protected static final String CONFIGURED_TRUST_STORE = "plans/mtls/client2.cer";
+
+    /**
+     * Deliberately shorter than the {@code @Timeout} on the test methods, so a stalled read fails with a
+     * {@link java.net.SocketTimeoutException} naming the line rather than with JUnit's generic timeout.
+     */
+    protected static final Duration HANDSHAKE_TIMEOUT = Duration.ofSeconds(10);
+
+    protected SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
+
+    /**
+     * @return the value of {@code http.ssl.sendClientCertificateAuthorities}, or {@code null} to leave it unset.
+     */
+    protected abstract Boolean sendClientCertificateAuthorities();
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("mtls", PolicyBuilder.build("mtls", MtlsPolicy.class, MtlsPolicyConfiguration.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        configurePlans((Api) api.getDefinition(), Set.of("mtls"));
+    }
+
+    @Override
+    protected void configureHttpClient(
+        HttpClientOptions options,
+        GatewayDynamicConfig.Config gatewayConfig,
+        ParameterContext parameterContext
+    ) {
+        configureTrustedHttpClient(options, gatewayConfig.httpPort(), parameterContext.findAnnotation(WithCert.class).isPresent());
+    }
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder config) {
+        config
+            .httpSecured(true)
+            .set("http.ssl.clientAuth", "request")
+            .set("http.ssl.keystore.type", KeyStoreLoader.CERTIFICATE_FORMAT_SELF_SIGNED)
+            // a statically configured trust store, so the two origins can be told apart in the advertised list
+            .set("http.ssl.truststore.type", KeyStoreLoader.CERTIFICATE_FORMAT_PEM)
+            .set("http.ssl.truststore.path", getUrl(CONFIGURED_TRUST_STORE).getPath());
+
+        Boolean sendAuthorities = sendClientCertificateAuthorities();
+        if (sendAuthorities != null) {
+            config.set("http.ssl.sendClientCertificateAuthorities", sendAuthorities);
+        }
+    }
+
+    @BeforeEach
+    void setUpSubscriptionTrustStore() {
+        subscriptionTrustStoreLoaderManager = getBean(SubscriptionTrustStoreLoaderManager.class);
+        // Cheat to use the real SubscriptionTrustStoreLoaderManager instance with SubscriptionService mock
+        final SubscriptionCacheService subscriptionService = (SubscriptionCacheService) getBean(SubscriptionService.class);
+        when(subscriptionService.getByApiAndSecurityToken(any(), any(), any())).thenCallRealMethod();
+        ReflectionTestUtils.setField(subscriptionService, "subscriptionTrustStoreLoaderManager", subscriptionTrustStoreLoaderManager);
+    }
+
+    /**
+     * Fakes the sync process of an accepted mTLS subscription, which is what puts an application leaf in the
+     * gateway trust store at runtime.
+     */
+    @SneakyThrows
+    protected Subscription registerSubscription() {
+        final Subscription subscription = new Subscription();
+        subscription.setApi("v4-proxy-api");
+        subscription.setApplication("application-id");
+        subscription.setId("subscription-id");
+        subscription.setPlan(PlanHelper.PLAN_MTLS_ID);
+        subscription.setClientCertificate(
+            Base64.getEncoder().encodeToString(Files.readAllBytes(Paths.get(getUrl(SUBSCRIPTION_LEAF).getPath())))
+        );
+        subscriptionTrustStoreLoaderManager.registerSubscription(subscription, Set.of());
+        // registerSubscription swallows MalformedCertificateException and returns nothing, so a certificate that
+        // failed to load would leave every assertion below vacuously true. Check it really made it in.
+        assertThat(
+            subscriptionTrustStoreLoaderManager.getByCertificate(
+                subscription.getApi(),
+                subscription.getPlan(),
+                CertificateUtils.generateThumbprint(readCertificate(SUBSCRIPTION_LEAF), "SHA-256")
+            )
+        )
+            .as("the subscription certificate never reached the gateway trust store")
+            .isPresent();
+        return subscription;
+    }
+
+    @SneakyThrows
+    private static X509Certificate readCertificate(String resource) {
+        try (var stream = Files.newInputStream(Paths.get(getUrl(resource).getPath()))) {
+            return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(stream);
+        }
+    }
+
+    /**
+     * Subject DN of a test certificate, in the same RFC 2253 form as the principals decoded from the handshake.
+     */
+    protected static String subjectDn(String resource) {
+        return readCertificate(resource).getSubjectX500Principal().getName();
+    }
+
+    /**
+     * Opens a raw TLS connection to the gateway with a client that holds no certificate, and returns the
+     * authorities the gateway asked for.
+     */
+    protected List<String> advertisedCertificateAuthorities(int gatewayPort, String protocol) throws Exception {
+        CapturingKeyManager keyManager = new CapturingKeyManager();
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(new KeyManager[] { keyManager }, new TrustManager[] { new TrustEverything() }, null);
+
+        try (SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket("localhost", gatewayPort)) {
+            // without this a gateway that accepts the connection and never answers hangs the whole CI job instead
+            // of failing the test
+            socket.setSoTimeout((int) HANDSHAKE_TIMEOUT.toMillis());
+            socket.setEnabledProtocols(new String[] { protocol });
+            socket.startHandshake();
+            // TLS 1.3 sends the CertificateRequest after the client considers the handshake done, so exchange
+            // application data to make sure it has been processed before asserting
+            socket.getOutputStream().write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes());
+            socket.getOutputStream().flush();
+            socket.getInputStream().read();
+        }
+        // an empty list is only meaningful if the gateway did ask for a certificate: "asked for none" and "never
+        // asked" would otherwise be indistinguishable, and the assertions below would hold for both
+        assertThat(keyManager.wasAskedForACertificate())
+            .as("the gateway did not send a CertificateRequest, so nothing was advertised to capture")
+            .isTrue();
+        return keyManager.sentAuthorities();
+    }
+
+    /**
+     * Records the {@code certificate_authorities} the gateway sent, then declines to present a certificate.
+     */
+    private static class CapturingKeyManager extends X509ExtendedKeyManager {
+
+        private volatile Principal[] sentAuthorities;
+        private volatile boolean askedForACertificate;
+
+        boolean wasAskedForACertificate() {
+            return askedForACertificate;
+        }
+
+        List<String> sentAuthorities() {
+            return sentAuthorities == null ? List.of() : Arrays.stream(sentAuthorities).map(Principal::getName).toList();
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+            this.sentAuthorities = issuers == null ? new Principal[0] : Arrays.copyOf(issuers, issuers.length);
+            this.askedForACertificate = true;
+            return null;
+        }
+
+        @Override
+        public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine engine) {
+            return chooseClientAlias(keyTypes, issuers, null);
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return null;
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return null;
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return new X509Certificate[0];
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return null;
+        }
+    }
+
+    /**
+     * The gateway certificate is self-signed here; the client side is not what is under test.
+     */
+    private static class TrustEverything extends X509ExtendedTrustManager {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/PlanMutualTLSCertificateAuthoritiesAdvertisedIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/PlanMutualTLSCertificateAuthoritiesAdvertisedIntegrationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.mtls;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.integration.tests.plan.PlanHelper;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.policy.mtls.MtlsPolicy;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * APIM-14863: {@code http.ssl.sendClientCertificateAuthorities} lets a deployment advertise the configured trust
+ * store again, for clients that need the list to pick which certificate to present. It must never widen back to the
+ * certificates registered at runtime by mTLS plan subscriptions — that is the disclosure the ticket reported.
+ *
+ * @see PlanMutualTLSCertificateAuthoritiesNotAdvertisedIntegrationTest
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@GatewayTest
+class PlanMutualTLSCertificateAuthoritiesAdvertisedIntegrationTest extends AbstractPlanMutualTLSCertificateAuthoritiesIntegrationTest {
+
+    @Override
+    protected Boolean sendClientCertificateAuthorities() {
+        return true;
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @ParameterizedTest
+    @ValueSource(strings = { "TLSv1.2", "TLSv1.3" })
+    void should_advertise_only_the_configured_trust_store(String protocol, GatewayDynamicConfig.Config gatewayConfig) throws Exception {
+        Subscription subscription = registerSubscription();
+        try {
+            List<String> advertised = advertisedCertificateAuthorities(gatewayConfig.httpPort(), protocol);
+
+            assertThat(advertised).containsExactly(subjectDn(CONFIGURED_TRUST_STORE));
+            assertThat(advertised).doesNotContain(subjectDn(SUBSCRIPTION_LEAF));
+        } finally {
+            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+        }
+    }
+
+    /**
+     * The consequence the distribution {@code gravitee.yml}, the Helm {@code values.yaml} and the chart CHANGELOG all
+     * warn about, asserted rather than only written down: a non-empty advertised list is a constraint, not a hint.
+     * Subscription certificates are self-signed leaves, so they are never issued by an authority of the configured
+     * trust store, and a JDK client withholds a certificate whose issuer is absent from the list.
+     *
+     * <p>The same call returns 200 in the default configuration
+     * ({@link PlanMutualTLSCertificateAuthoritiesNotAdvertisedIntegrationTest}). The day this goes green, the warning
+     * in both configuration files has become wrong.
+     */
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @Test
+    void should_cut_off_a_subscription_whose_certificate_is_not_issued_by_an_advertised_authority(@WithCert HttpClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        Subscription subscription = registerSubscription();
+        try {
+            client
+                .rxRequest(GET, PlanHelper.getApiPath("v4-proxy-api"))
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED_401);
+                    return response.rxBody();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(body -> {
+                    assertThat(body.toString()).contains(MtlsPolicy.FAILURE_MESSAGE);
+                    return true;
+                });
+            wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+        } finally {
+            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/PlanMutualTLSCertificateAuthoritiesNotAdvertisedIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/mtls/PlanMutualTLSCertificateAuthoritiesNotAdvertisedIntegrationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.mtls;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.integration.tests.plan.PlanHelper;
+import io.gravitee.gateway.api.service.Subscription;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * APIM-14863: with the default configuration the gateway must not disclose the client certificates it accepts.
+ *
+ * <p>Certificates registered at runtime by an mTLS plan subscription are application leaves, not authorities;
+ * advertising them told every caller of the listener which client identities are accepted. Since gravitee-node 9.8.0
+ * nothing is advertised unless {@code http.ssl.sendClientCertificateAuthorities} is enabled, and runtime
+ * certificates are never advertised even then.
+ *
+ * @see PlanMutualTLSCertificateAuthoritiesAdvertisedIntegrationTest
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@GatewayTest
+class PlanMutualTLSCertificateAuthoritiesNotAdvertisedIntegrationTest extends AbstractPlanMutualTLSCertificateAuthoritiesIntegrationTest {
+
+    @Override
+    protected Boolean sendClientCertificateAuthorities() {
+        // left unset on purpose: this pins the default, which is what deployments actually run
+        return null;
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @ParameterizedTest
+    @ValueSource(strings = { "TLSv1.2", "TLSv1.3" })
+    void should_not_advertise_any_certificate_authority(String protocol, GatewayDynamicConfig.Config gatewayConfig) throws Exception {
+        Subscription subscription = registerSubscription();
+        try {
+            List<String> advertised = advertisedCertificateAuthorities(gatewayConfig.httpPort(), protocol);
+
+            assertThat(advertised).isEmpty();
+        } finally {
+            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+        }
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @Test
+    void should_still_accept_the_certificate_registered_by_the_subscription(@WithCert HttpClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        Subscription subscription = registerSubscription();
+        try {
+            client
+                .rxRequest(GET, PlanHelper.getApiPath("v4-proxy-api"))
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(OK_200);
+                    return response.rxBody();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(body -> {
+                    assertThat(body.toString()).contains("endpoint response");
+                    return true;
+                });
+        } finally {
+            subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+        }
+    }
+}

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.11.27
+- Bump the Gravitee node Hazelcast cache and cluster plugins to 8.3.0, to stay consistent with `gravitee-node.version` in the APIM `pom.xml`.
+- The gateway no longer sends its truststore as the list of acceptable certificate authorities during the TLS handshake (APIM-14863). Certificates registered at runtime by mTLS plan subscriptions were application leaves, not authorities, and advertising them told every caller of the listener which client identities are accepted. Validation is unchanged, so mTLS plan matching is unaffected, and an empty list means "no constraint": clients keep presenting their certificate. Only a client that *relied* on the list to choose which certificate to present is affected — typically a JDK client holding several client certificates. Those deployments can send the configured truststore again with the new `gateway.ssl.sendClientCertificateAuthorities` (also available per server under `gateway.servers[].ssl` and for the Kafka listener under `gateway.kafka.ssl`). **Do not enable it on a listener serving mTLS plans**: a non-empty advertised list is a constraint, not a hint, and subscription certificates are self-signed leaves that are never issued by an authority of the configured truststore — so every client presenting one withholds it and the subscription stops working. Only enable it when every expected client certificate is issued by an authority present in the configured truststore.
+
 ### 4.11.14
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
 

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -171,6 +171,9 @@ data:
             secret: {{ $server.ssl.keystore.secret }}
             {{- end }}
           clientAuth: {{ $server.ssl.clientAuth }}
+          {{- if hasKey $server.ssl "sendClientCertificateAuthorities" }}
+          sendClientCertificateAuthorities: {{ $server.ssl.sendClientCertificateAuthorities }}
+          {{- end }}
           {{- if $server.ssl.truststore }}
           truststore:
             {{- if $server.ssl.truststore.type }}
@@ -244,6 +247,9 @@ data:
           secret: {{ .Values.gateway.ssl.keystore.secret }}
           {{- end }}
         clientAuth: {{ .Values.gateway.ssl.clientAuth }}
+        {{- if hasKey .Values.gateway.ssl "sendClientCertificateAuthorities" }}
+        sendClientCertificateAuthorities: {{ .Values.gateway.ssl.sendClientCertificateAuthorities }}
+        {{- end }}
         {{- if .Values.gateway.ssl.truststore }}
         truststore:
           {{- if .Values.gateway.ssl.truststore.type }}
@@ -337,6 +343,9 @@ data:
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.ssl "clientAuth" }}
         clientAuth: {{ .Values.gateway.kafka.ssl.clientAuth }}
+        {{- end}}
+        {{- if hasKey .Values.gateway.kafka.ssl "sendClientCertificateAuthorities" }}
+        sendClientCertificateAuthorities: {{ .Values.gateway.kafka.ssl.sendClientCertificateAuthorities }}
         {{- end}}
         {{- if hasKey .Values.gateway.kafka.ssl "tlsProtocols" }}
         tlsProtocols: {{ .Values.gateway.kafka.ssl.tlsProtocols }}

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-8.1.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.1.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-8.1.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.1.0.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-8.3.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.3.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-8.3.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.3.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/tests/gateway/configmap_ssl_test.yaml
+++ b/helm/tests/gateway/configmap_ssl_test.yaml
@@ -166,3 +166,94 @@ tests:
             \s   crl:
             \s     path: \$\{gravitee\.home\}/security/crl\.pem
             \s     watch: true
+
+  - it: Client certificate authorities not sent by default
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          keystore:
+            type: jks
+          clientAuth: required
+          truststore:
+            type: jks
+            path: ${gravitee.home}/security/truststore.jks
+            password: secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "sendClientCertificateAuthorities"
+
+  - it: Client certificate authorities sent when explicitly enabled
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        ssl:
+          enabled: true
+          keystore:
+            type: jks
+          clientAuth: required
+          sendClientCertificateAuthorities: true
+          truststore:
+            type: jks
+            path: ${gravitee.home}/security/truststore.jks
+            password: secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s   clientAuth: required
+            \s   sendClientCertificateAuthorities: true
+
+  - it: Client certificate authorities sent on a server of the servers list
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        servers:
+          - type: http
+            port: 8082
+            secured: true
+            ssl:
+              keystore:
+                type: jks
+              clientAuth: required
+              sendClientCertificateAuthorities: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s     clientAuth: required
+            \s     sendClientCertificateAuthorities: true
+
+  - it: Client certificate authorities sent on the Kafka listener
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        kafka:
+          enabled: true
+          ssl:
+            clientAuth: required
+            sendClientCertificateAuthorities: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s   clientAuth: required
+            \s   sendClientCertificateAuthorities: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -502,8 +502,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.1.0.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.1.0.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.3.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.3.0.zip
 
 api:
   enabled: true
@@ -1142,6 +1142,9 @@ gateway:
 #      alpn: false
 #      ssl:
 #        clientAuth: none # Supports none, request, required
+#        # Not sent by default. See gateway.ssl.sendClientCertificateAuthorities for what enabling it implies:
+#        # a non-empty list is a constraint, and certificates registered by mTLS plan subscriptions are never sent.
+#        sendClientCertificateAuthorities: false
 #        tlsProtocols: TLSv1.2, TLSv1.3
 #        tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #        keystore:
@@ -1295,6 +1298,9 @@ gateway:
 #      # Forced to `true` when routingMode is `host`
 #      sni: true
 #      clientAuth: none # Supports none, request, required
+#      # Not sent by default. See gateway.ssl.sendClientCertificateAuthorities for what enabling it implies:
+#      # a non-empty list is a constraint, and certificates registered by mTLS plan subscriptions are never sent.
+#      sendClientCertificateAuthorities: false
 #      tlsProtocols: TLSv1.2, TLSv1.3
 #      tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #      keystore:
@@ -1518,6 +1524,14 @@ gateway:
   #    path: ${gravitee.home}/security/keystore.jks
   #    password: secret
     clientAuth: false # Supports false/none, request, true/requires
+  #  # Send the configured truststore to clients as the list of acceptable certificate authorities, so a client
+  #  # holding several certificates can pick the right one. Disabled by default: the list reaches every client of
+  #  # the listener, and an empty list means "no constraint" so clients keep presenting their certificate.
+  #  # Only enable it when every expected client certificate is issued by an authority of the truststore below:
+  #  # a client whose issuer is absent from a non-empty list withholds its certificate entirely. Certificates
+  #  # registered at runtime by mTLS plan subscriptions are never sent, so enabling this cuts off every
+  #  # subscription whose certificate is not issued by an authority of the configured truststore.
+  #  sendClientCertificateAuthorities: false
   #  truststore:
   #    type: jks # Supports jks, pem, pkcs12
   #    path: ${gravitee.home}/security/truststore.jks

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
-        <gravitee-node.version>8.1.0</gravitee-node.version>
+        <gravitee-node.version>8.3.0</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.5</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14863

Backport to `4.11.x`. Completes the set: `master` → 4.13 ([#19349](https://github.com/gravitee-io/gravitee-api-management/pull/19349), approved), `4.12.x` ([#19514](https://github.com/gravitee-io/gravitee-api-management/pull/19514)), and this one. 4.10.x and 4.9.x are deliberately out of scope.

## Description

With `http.ssl.clientAuth` set to `request` or `required`, `SubscriptionTrustStoreLoader` loads each mTLS application **leaf** into the gateway trust store. JSSE uses `X509TrustManager#getAcceptedIssuers()` as the TLS `CertificateRequest.certificate_authorities`, so that list was sent to **every** client of the listener — including callers of the listener's other, non-mTLS APIs, who present no certificate at all. Those entries are leaves, not authorities: advertising them disclosed which client identities the gateway accepts.

**⚠️ security-sensitive**: this changes TLS handshake behaviour and certificate handling.

The fix itself is [gravitee-node#605](https://github.com/gravitee-io/gravitee-node/pull/605), the `8.x` cherry-pick of [#603](https://github.com/gravitee-io/gravitee-node/pull/603), released in **node 8.3.0**.

### Behaviour change

**Nothing is advertised by default now**, where the configured trust store used to be. Validation is untouched — the full trust store still validates client certificates, so mTLS plan matching and subscriptions are unaffected. An empty list means "no constraint": clients keep presenting their certificate.

The one case that changes is a client that *relied* on the list to choose which certificate to present — typically a JDK client holding several client certificates. Those deployments can restore the previous behaviour with `ssl.sendClientCertificateAuthorities: true`, which sends **only the configured trust store**. Certificates registered at runtime by subscriptions are never advertised, whatever the setting — so enabling it on a listener serving mTLS plans cuts those subscriptions off. That consequence is asserted by a test, not only documented.

### Differences from the 4.12 backport

- **The node bump is two minors, not one**: 8.1.0 → 8.3.0, so 8.1.1 and 8.2.0 come along. Worth a conscious nod on a support branch rather than a surprise.
- **No Edge listener here.** `4.11.x` has no `#edge:` block at all in the distribution `gravitee.yml`, so unlike 4.13 there is nothing to document for it. The option is documented on `http`, `tcp` and `kafka`.

## Additional context

### Checked

- `helm lint` clean; `helm unittest` **640 tests, 0 failures**, including the 11 cases of `configmap_ssl_test.yaml` — the four new ones cover all three render paths (`gateway.ssl`, `gateway.servers[].ssl`, `gateway.kafka.ssl`). Mutation-checked on this branch: shifting the key two spaces in the `$server` block reds exactly one case.
- The distribution `gravitee.yml` parses, and its net diff is exactly the three `sendClientCertificateAuthorities` insertions.
- Both Hazelcast 8.3.0 plugin zips return **200** on download.gravitee.io, and no `8.1.0` node reference is left, so the Danger consistency rule is satisfied against the bumped `gravitee-node.version`.
- The three node 8.3.0 publication jobs (download.gravitee.io, Nexus, Artifactory) all succeeded.
- The mTLS test fixtures (`client.cer`, `client2.cer` and their keys) exist on this branch.
- Only the three new test classes were added under `plan/mtls`; the four pre-existing ones are untouched.

### Not checked locally

- **Maven resolution of `io.gravitee.node:*:8.3.0`.** Central had not synced it yet at the time of writing and the Azure feed needs credentials I don't have. Nexus and Artifactory publication succeeded, so CI is the check.
- The integration tests, for the same reason plus unrelated pre-existing compile errors in this module on my machine.

### Docs

[gravitee-platform-docs#2283](https://github.com/gravitee-io/gravitee-platform-docs/pull/2283) covers 4.13, 4.12 and 4.11. The 4.11 pages name **4.11.27** as the release this ships in — that holds only if this merges before the next 4.11.x patch, and is worth re-checking at merge time.
