### PR TITLE
fix(console): allow read-only access to endpoint group details

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.harness.ts
@@ -27,6 +27,10 @@ export class ApiHealthCheckV4FormHarness extends ComponentHarness {
     return this.getEnableToggle().then(toggle => toggle.isChecked());
   }
 
+  public async isEnableToggleDisabled(): Promise<boolean> {
+    return this.getEnableToggle().then(toggle => toggle.isDisabled());
+  }
+
   public async toggleEnableInput(): Promise<void> {
     return this.getEnableToggle().then(toggle => toggle.toggle());
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
@@ -64,6 +64,21 @@ function expectApiSchemaGetRequests(api: ApiV4, fixture: ComponentFixture<any>, 
   fixture.detectChanges();
 }
 
+function expectSharedConfigurationSchemaGet(
+  api: ApiV4,
+  fixture: ComponentFixture<ApiEndpointGroupComponent>,
+  httpTestingController: HttpTestingController,
+  sharedConfigurationSchema: unknown,
+): void {
+  httpTestingController
+    .expectOne({
+      url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${api.endpointGroups[0].type}/shared-configuration-schema`,
+      method: 'GET',
+    })
+    .flush(sharedConfigurationSchema);
+  fixture.detectChanges();
+}
+
 /**
  * Expect that a single PUT request has been made which matches the specified URL
  *
@@ -101,18 +116,33 @@ describe('ApiEndpointGroupComponent', () => {
     },
     required: ['dummy'],
   };
+  const SHARED_CONFIGURATION_SCHEMA = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    properties: {
+      sharedDummy: {
+        title: 'Shared dummy',
+        type: 'string',
+        description: 'A dummy shared configuration string',
+      },
+    },
+  };
   let fixture: ComponentFixture<ApiEndpointGroupComponent>;
   let httpTestingController: HttpTestingController;
   let componentHarness: ApiEndpointGroupHarness;
   let api: ApiV4;
   let rootLoader: HarnessLoader;
 
-  const initComponent = async (api: ApiV4, routerParams: unknown = { apiId: API_ID, groupIndex: 0 }) => {
+  const initComponent = async (
+    api: ApiV4,
+    routerParams: unknown = { apiId: API_ID, groupIndex: 0 },
+    permissions: string[] = ['api-definition-u', 'api-definition-c', 'api-definition-r'],
+  ) => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiEndpointGroupModule, MatIconTestingModule, FormsModule],
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: { params: routerParams } } },
-        { provide: GioTestingPermissionProvider, useValue: ['api-definition-u', 'api-definition-c', 'api-definition-r'] },
+        { provide: GioTestingPermissionProvider, useValue: permissions },
         { provide: SnackBarService, useValue: SnackBarService },
       ],
     }).overrideProvider(InteractivityChecker, {
@@ -136,6 +166,40 @@ describe('ApiEndpointGroupComponent', () => {
   afterEach(() => {
     jest.clearAllMocks();
     httpTestingController.verify();
+  });
+
+  describe('read-only mode', () => {
+    it('should disable endpoint group configuration if user can only read', async () => {
+      api = fakeProxyApiV4({
+        id: API_ID,
+        endpointGroups: [
+          fakeHTTPProxyEndpointGroupV4({
+            services: {
+              healthCheck: {
+                enabled: true,
+                overrideConfiguration: false,
+                type: 'http-health-check',
+                configuration: { dummy: 'Current health check value' },
+              },
+            },
+          }),
+        ],
+      });
+      await initComponent(api, { apiId: API_ID, groupIndex: 0 }, ['api-definition-r']);
+
+      await componentHarness.clickGeneralTab();
+      expectSharedConfigurationSchemaGet(api, fixture, httpTestingController, SHARED_CONFIGURATION_SCHEMA);
+      expect(await componentHarness.isEndpointGroupNameInputDisabled()).toEqual(true);
+      expect(await componentHarness.isEndpointGroupLoadBalancerSelectorDisabled()).toEqual(true);
+
+      await componentHarness.clickConfigurationTab();
+      expect(await componentHarness.isGroupConfigurationInputDisabled('sharedDummy')).toEqual(true);
+
+      await componentHarness.clickHealthCheckTab();
+      expectHealthCheckSchemaGet(fixture, httpTestingController, HEALTH_CHECK_SCHEMA);
+      expect(await componentHarness.isHealthCheckEnableInputDisabled()).toEqual(true);
+      expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toEqual(true);
+    });
   });
 
   describe('endpoint group update - configuration', () => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
@@ -122,7 +122,9 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']) || api.definitionContext?.origin === 'KUBERNETES';
+    const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+    const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
+    this.isReadOnly = isKubernetesOrigin || !canUpdate;
 
     this.generalForm = new UntypedFormGroup({
       name: new UntypedFormControl(
@@ -173,7 +175,7 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
       this.healthCheckForm.controls.enabled.valueChanges
         .pipe(startWith(this.healthCheckForm.controls.enabled.value), takeUntil(this.unsubscribe$))
         .subscribe(enabled => {
-          if (enabled) {
+          if (enabled && !this.isReadOnly) {
             this.healthCheckForm.controls.configuration.enable({ emitEvent: false });
           } else {
             this.healthCheckForm.controls.configuration.disable({ emitEvent: false });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
 import { MatTabHarness } from '@angular/material/tabs/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
@@ -30,6 +31,7 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
   private getConfigurationTab = this.locatorFor(MatTabHarness.with({ label: 'Configuration' }));
   private getHealthCheckTab = this.locatorFor(MatTabHarness.with({ label: 'Health-check' }));
   private getEndpointGroupGeneralHarness = this.locatorFor(ApiEndpointGroupGeneralHarness);
+  private getGroupConfigurationInput = (id: string) => this.locatorFor(MatInputHarness.with({ selector: `[id*="${id}"]` }))();
   private getHealthCheckGeneralHarness = this.locatorFor(ApiHealthCheckV4FormHarness);
   private getEndpointGroupSubmissionBar = this.locatorFor(GioSaveBarHarness);
 
@@ -41,8 +43,16 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
     return this.getGeneralTab().then(tab => tab.select());
   }
 
+  public async clickConfigurationTab() {
+    return this.getConfigurationTab().then(tab => tab.select());
+  }
+
   public async readEndpointGroupNameInput() {
     return this.getEndpointGroupGeneralHarness().then(harness => harness.getNameValue());
+  }
+
+  public async isEndpointGroupNameInputDisabled(): Promise<boolean> {
+    return this.getEndpointGroupGeneralHarness().then(harness => harness.isNameDisabled());
   }
 
   public writeToEndpointGroupNameInput(inputValue) {
@@ -58,6 +68,14 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
 
   public async readEndpointGroupLoadBalancerSelector() {
     return this.getEndpointGroupGeneralHarness().then(harness => harness.getLoadBalancerValue());
+  }
+
+  public async isEndpointGroupLoadBalancerSelectorDisabled(): Promise<boolean> {
+    return this.getEndpointGroupGeneralHarness().then(harness => harness.isLoadBalancerDisabled());
+  }
+
+  public async isGroupConfigurationInputDisabled(inputId: string): Promise<boolean> {
+    return this.getGroupConfigurationInput(inputId).then(input => input.isDisabled());
   }
 
   public async writeToEndpointGroupLoadBalancerSelector(selectorValue) {
@@ -82,6 +100,10 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
 
   public async toggleEnableHealthCheckInput() {
     return this.getHealthCheckGeneralHarness().then(harness => harness.toggleEnableInput());
+  }
+
+  public async isHealthCheckEnableInputDisabled(): Promise<boolean> {
+    return this.getHealthCheckGeneralHarness().then(harness => harness.isEnableToggleDisabled());
   }
 
   public async isHealthCheckConfigurationInputDisabled(inputId: string): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.harness.ts
@@ -27,12 +27,20 @@ export class ApiEndpointGroupGeneralHarness extends ComponentHarness {
     return this.getEndpointGroupNameInput().then(input => input.getValue());
   }
 
+  public async isNameDisabled(): Promise<boolean> {
+    return this.getEndpointGroupNameInput().then(input => input.isDisabled());
+  }
+
   public setNameValue(inputValue: string): Promise<void> {
     return this.getEndpointGroupNameInput().then(input => input.setValue(inputValue));
   }
 
   public async getLoadBalancerValue(): Promise<string> {
     return this.getEndpointGroupLoadBalancerSelector().then(selector => selector.getValueText());
+  }
+
+  public async isLoadBalancerDisabled(): Promise<boolean> {
+    return this.getEndpointGroupLoadBalancerSelector().then(selector => selector.isDisabled());
   }
 
   public async setLoadBalancerValue(selectorValue: string): Promise<void> {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
@@ -65,7 +65,7 @@
               <mat-icon svgIcon="gio:arrow-down"></mat-icon>
             </button>
             <button
-              *gioPermission="{ anyOf: ['api-definition-u'] }"
+              *gioPermission="{ anyOf: ['api-definition-r'] }"
               mat-stroked-button
               [attr.aria-label]="isReadOnly ? 'View endpoint group' : 'Edit endpoint group'"
               [routerLink]="['./', i]"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
@@ -21,7 +21,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioLicenseTestingModule } from '@gravitee/ui-particles-angular';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { deepClone } from '@gravitee/ui-components/src/lib/utils';
 import { cloneDeep } from 'lodash';
 
@@ -498,12 +498,21 @@ describe('ApiEndpointGroupsStandardComponent', () => {
   });
 
   describe('read-only mode', () => {
-    it('should not allow deleting, adding or editing endpoints if user can only read', async () => {
+    it('should allow viewing endpoint groups and endpoints without allowing updates if user can only read', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [group1, group2],
       });
       await initComponent(apiV4, ['api-definition-r']);
+
+      expect(await componentHarness.isEndpointGroupDeleteButtonVisible()).toEqual(false);
+      expect(await componentHarness.isAddEndpointGroupDisplayed()).toEqual(false);
+      expect(await componentHarness.isEditEndpointGroupNameFieldAvailable(0)).toEqual(false);
+      expect(await componentHarness.isViewEndpointGroupButtonVisible()).toEqual(true);
+
+      const navigateByUrl = jest.spyOn(TestBed.inject(Router), 'navigateByUrl').mockResolvedValue(true);
+      await componentHarness.clickViewEndpointGroup(0);
+      expect(navigateByUrl).toHaveBeenCalled();
 
       expect(await componentHarness.isEndpointDeleteButtonVisible()).toEqual(false);
       expect(await componentHarness.isAddEndpointButtonVisible()).toEqual(false);

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.harness.ts
@@ -28,6 +28,7 @@ export class ApiEndpointGroupsStandardHarness extends ComponentHarness {
   private getEditEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint"]' }));
   private getViewEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="View endpoint"]' }));
   private getEditEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint group"]' }));
+  private getViewEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="View endpoint group"]' }));
   private getAddEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add endpoint group"]' }));
   public getWarningFailoverBanner = this.locatorForAll(DivHarness.with({ selector: '.banner__wrapper__title' }));
 
@@ -113,6 +114,15 @@ export class ApiEndpointGroupsStandardHarness extends ComponentHarness {
   public async clickEditEndpointGroup(index: number) {
     const button = await this.getEditEndpointGroupButtons();
     return button[index].click();
+  }
+
+  public async isViewEndpointGroupButtonVisible(): Promise<boolean> {
+    return this.getViewEndpointGroupButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async clickViewEndpointGroup(index: number): Promise<void> {
+    const buttons = await this.getViewEndpointGroupButtons();
+    return buttons[index].click();
   }
 
   public async isAddEndpointGroupDisplayed(): Promise<boolean> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15026

## Description

API members with `api-definition-r` could see endpoint groups but could not open their details from the Endpoints page because the group action incorrectly required `api-definition-u`.

The endpoint group details component also used the read permission to determine editability, which could expose editable controls to read-only users.

## Changes

- Allow users with `api-definition-r` to see and use the **View endpoint group** action.
- Keep **Edit**, add, delete, and reorder actions restricted to users with update permission.
- Determine endpoint group read-only mode using `api-definition-u`.
- Keep Kubernetes-origin API definitions read-only.
- Prevent an enabled health-check configuration from being re-enabled in read-only mode.
- Add regression coverage for:
  - the endpoint group **View** action and navigation;
  - hidden mutation actions for read-only users;
  - disabled general and health-check configuration fields.

## Expected behavior

- A reviewer with `api-definition-r` sees **View**, can open endpoint group details, and cannot modify the configuration.
- An API owner/editor with `api-definition-u` continues to see **Edit** and can update the endpoint group.

