### PR TITLE
Stop shipping the authz PDP service to the Management API

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/assembly/plugin-assembly-distribution.xml
@@ -186,7 +186,7 @@
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>
                 <exclude>com.graviteesource.service:gravitee-service-secrets:zip</exclude>
-                <exclude>com.graviteesource.service:gravitee-service-authz-pdp:zip</exclude>
+                <exclude>com.graviteesource.gamma:gravitee-service-authz-pdp:zip</exclude>
                 <exclude>io.gravitee.inference.service:gravitee-inference-service:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The exclusion targeted com.graviteesource.service, while the dependency is declared under com.graviteesource.gamma, so it never matched and the PDP service plugin ended up in the Management API plugins directory.