### PR TITLE
fix(release): exclude coverage aggregates from the Maven Central bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,26 @@
                         </mapping>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <!--
+                        The Central publishing plugin takes over the deploy phase from
+                        maven-deploy-plugin, so maven.deploy.skip never reaches it. excludeArtifacts
+                        is its own filter, and the only one honoured per module by the plugin version
+                        this branch inherits.
+                    -->
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <configuration>
+                        <excludeArtifacts>
+                            <excludeArtifact>gravitee-apim-definition-coverage</excludeArtifact>
+                            <excludeArtifact>gravitee-apim-gateway-coverage</excludeArtifact>
+                            <excludeArtifact>gravitee-apim-plugin-coverage</excludeArtifact>
+                            <excludeArtifact>gravitee-apim-reporter-coverage</excludeArtifact>
+                            <excludeArtifact>gravitee-apim-repository-coverage</excludeArtifact>
+                            <excludeArtifact>gravitee-apim-rest-api-coverage</excludeArtifact>
+                        </excludeArtifacts>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-353

## Description

The six `-coverage` aggregates declare `maven.deploy.skip=true`, and are published to Maven Central
anyway — on every version since 3.10.15, 521 of them for `gravitee-apim-gateway-coverage` alone.
They are empty jars nobody depends on and that nothing is parent of.

The property has never had any effect on that lane. `gravitee-parent` declares
`central-publishing-maven-plugin` with `<extensions>true</extensions>`; its
`DeployLifecycleParticipant` clears every `maven-deploy-plugin` execution from the model and binds
`publish:publish` to the `deploy` phase in its place. `maven.deploy.skip` is a parameter of
`maven-deploy-plugin`, which no longer runs at all under `-P gravitee-release` — so the property
commands nothing there. It keeps working on the `gio-release` lane, which does not activate the
Central plugin, and that is why it must stay where it is.

This adds `excludeArtifacts` — the Central plugin's own filter — to the root `pluginManagement`.

**Why `excludeArtifacts` rather than the plugin's `skipPublishing`:** this branch inherits
`central-publishing-maven-plugin` **0.8.0**, where `skipPublishing` is only tested once in
`postProcessRelease`, right before the bundle is uploaded — it is not a per-module filter, and the
value read is the one from the last project in the reactor. The per-artifact filter for
`skipPublishing` only appears in 0.9.0. `excludeArtifacts` has filtered per artifact since 0.8.0, so
it is the one lever that works identically on every support branch, which keeps the Mergify copies
byte-identical.

**Why `pluginManagement` and not `build/plugins`:** declaring the plugin in `build/plugins` would
put it in the model outside the release profile, which would activate the lifecycle participant on
every build — including the internal publication in `job-publish.ts`, which relies on
`maven-deploy-plugin`. In `pluginManagement` the configuration only applies where the plugin is
actually declared, that is under `-P gravitee-release`.

`gravitee-apim-reporter-coverage` is listed even though the module does not exist on this branch: an
artifactId absent from the reactor is ignored without error (verified), and listing it keeps this
commit copyable as-is onto 4.11.x and 4.12.x where the module does exist.

## Additional context

Measured on 2026-08-31 against a reproducer built on `gravitee-parent` (`mvn -P gravitee-release
deploy` with the upload pointed at a local address, staging directory inspected before the bundle is
sent):

| Parent / plugin | `maven.deploy.skip=true` | `skipPublishing=true` | `excludeArtifacts` |
|---|---|---|---|
| 23.5.0 / 0.8.0 (4.9.x, 4.10.x) | published | published | **excluded** |
| 24.0.1 / 0.10.0 (4.11.x, 4.12.x) | published | excluded | **excluded** |

Also verified on this branch's own reactor: the effective pom of
`gravitee-apim-gateway-coverage` carries the plugin in 0.8.0 with the `excludeArtifacts` list, and a
`deploy` without `-P gravitee-release` still runs `maven-deploy-plugin` unchanged.

For scale, release 4.12.18 published **138 artifacts, 2928 files, 183.4 MB** to Central. The six
aggregates are 72 files and 59 kB of that — 2.5% of the files, 0.03% of the bytes. The point is not
the volume: it is that a stated exclusion has been silently ineffective for four years, while
Sonatype starts enforcing per-organisation publishing limits on 1 October 2026.

The root cause is fixed separately in `gravitee-parent` (BX-354), by binding the plugin's own switch to the
property that already exists — which cannot be used here, since these branches will not move from
parent 23.5.0/24.0.1 to the 25.x lineage.

Apply on 4.10.x, 4.11.x and 4.12.x. Not on master, which is on parent 25.1.0 and will be covered by
the `gravitee-parent` fix.
