### PR TITLE
chore: bump gravitee-endpoint-mqtt5 from 4.0.1 to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.1.1</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-kafka.version>5.1.4</gravitee-endpoint-kafka.version>
-        <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
+        <gravitee-endpoint-mqtt5.version>4.0.2</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>3.0.3</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>1.0.2</gravitee-endpoint-azure-service-bus.version>


### PR DESCRIPTION
## Issue

Not tracked in Jira — dependency bump.

## Description

`gravitee-endpoint-mqtt5:4.0.1` was released with `gravitee-apim.version` set to
`4.6.0-alpha.4-SNAPSHOT`, a version that was never released — the lineage on Central goes straight
from `4.6.0-alpha.3` to `4.6.0`. The build resolved it only as long as that snapshot survived on
Artifactory; the retention cleanup removed it, and reading the artifact descriptor now fails:

```
Failed to read artifact descriptor for com.graviteesource.endpoint:gravitee-endpoint-mqtt5:jar:4.0.1
  Caused by: Could not find artifact io.gravitee.apim:gravitee-apim-bom:pom:4.6.0-alpha.4-SNAPSHOT
```

`4.0.2` pins the BOM to the released `4.6.0`, so the descriptor resolves from Central alone.

## Additional context

Apply on 4.10.x, which pins the same 4.0.1. **Not** on 4.11.x, 4.12.x or master — they already pin
5.0.0, and copying this bump there would move them backwards.

The same defect exists on four other artifacts still pinned by supported branches, each on a
different branch, and will surface the same way when their snapshot is cleaned up:

| Artifact | Version | BOM imported | Pinned by |
|---|---|---|---|
| `gravitee-apim-repository-bridge-http-client` | 8.4.0 | 4.11.9-SNAPSHOT | 4.11.x |
| `gravitee-apim-repository-bridge-http-server` | 8.4.0 | 4.11.9-SNAPSHOT | 4.11.x |
| `gravitee-resource-cache-redis` | 4.2.1 | 4.9.17-SNAPSHOT | 4.11.x |
| `gravitee-policy-kafka-namespace` | 1.0.0 | 4.12.0-SNAPSHOT | 4.12.x |

Checked by reading, for each of the 409 Gravitee dependencies pinned across the five supported
branches, the published pom — from Central for public artifacts, from the tag on GitHub for the
enterprise ones. `master` is clean.

Worth knowing: the enforcer rule meant to catch this cannot. `requireReleaseDeps` inspects
dependencies, and a BOM in `<scope>import</scope>` is not one — which is why nothing ever objected.
