### PR TITLE
chore: bump gravitee-endpoint-mqtt5 to 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <gravitee-entrypoint-mcp.version>1.1.1</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-jms.version>1.0.1</gravitee-endpoint-jms.version>
         <gravitee-endpoint-kafka.version>5.2.2</gravitee-endpoint-kafka.version>
-        <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
+        <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>3.0.3</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>1.0.2</gravitee-endpoint-azure-service-bus.version>


### PR DESCRIPTION
## Issue

N/A — CI maintenance on `4.10.x` (unblocks #19521 and every other PR targeting the branch).

## Description

Bump `gravitee-endpoint-mqtt5` from 4.0.1 to 5.0.0 in the integration-tests dependency set. The 4.0.1 pom imports `gravitee-apim-bom:4.6.0-alpha.4-SNAPSHOT`, which has been purged from Artifactory, so Maven can no longer resolve the `gravitee-apim-integration-tests` dependency graph and the "Validate backend" job fails before compiling anything. 5.0.0 is what 4.11.x and 4.12.x already use (5940cfdf8b) and its pom imports a released bom.

## Additional context

The 4.10.x job still passed on 2026-08-31 on the same branch head: the CircleCI Maven cache still held the snapshot; it was recycled since. 4.0.0 has the same snapshot import, so there is no fallback on the 4.x line. Runtime compatibility of the 5.0.0 plugin with the 4.10 gateway is what the MQTT5 integration tests of this pipeline will tell.
