### PR TITLE
fix(idp): scope the identity provider enabled flag back to portal login

### DIFF
--- a/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/console-social-identity-providers.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/console-social-identity-providers.spec.ts
@@ -18,15 +18,32 @@ import { faker } from '@faker-js/faker';
 
 import { ANONYMOUS, forManagement, forManagementAsAdminUser } from '@gravitee/utils/configuration';
 import { ConfigurationApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/ConfigurationApi';
+import { DefaultApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/DefaultApi';
 import { OrganizationApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/OrganizationApi';
 import { PortalApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/PortalApi';
+import type { IdentityProviderActivationEntity } from '../../../../lib/management-webclient-sdk/src/lib/models';
 import { created, noContent, succeed } from '@lib/jest-utils';
 
 const orgId = 'DEFAULT';
 
 const configurationApiAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
+const defaultApiAsAdmin = new DefaultApi(forManagementAsAdminUser());
 const organizationApiAsAdmin = new OrganizationApi(forManagementAsAdminUser());
 const portalApiAsAnonymous = new PortalApi(forManagement(ANONYMOUS));
+
+/**
+ * PUT /organizations/{orgId}/identities replaces the whole activation set — updateTargetIdp
+ * removes every activation absent from the body — so the original set is read up front, extended,
+ * and put back verbatim on teardown rather than cleared.
+ */
+async function setOrganizationActivations(identityProviderIds: string[]) {
+  await noContent(
+    organizationApiAsAdmin.updateOrganizationIdentitiesRaw({
+      orgId,
+      identityProviderActivationEntity: identityProviderIds.map((identityProvider) => ({ identityProvider })),
+    }),
+  );
+}
 
 /**
  * The Console login page reads GET /organizations/{orgId}/social-identities unauthenticated to
@@ -36,8 +53,14 @@ const portalApiAsAnonymous = new PortalApi(forManagement(ANONYMOUS));
  */
 describe('Console social identity providers', () => {
   let identityProviderId: string;
+  let originalActivationIds: string[];
 
   beforeAll(async () => {
+    const originalActivations: IdentityProviderActivationEntity[] = await succeed(
+      defaultApiAsAdmin.listIdentityProviderActivationsRaw({ orgId }),
+    );
+    originalActivationIds = originalActivations.map((activation) => activation.identityProvider);
+
     const identityProvider = await created(
       configurationApiAsAdmin.createIdentityProviderRaw({
         orgId,
@@ -51,27 +74,28 @@ describe('Console social identity providers', () => {
     );
     identityProviderId = identityProvider.id;
 
-    await noContent(
-      organizationApiAsAdmin.updateOrganizationIdentitiesRaw({
-        orgId,
-        identityProviderActivationEntity: [{ identityProvider: identityProviderId }],
-      }),
-    );
+    await setOrganizationActivations([...originalActivationIds, identityProviderId]);
   });
 
   afterAll(async () => {
-    await organizationApiAsAdmin.updateOrganizationIdentities({ orgId, identityProviderActivationEntity: [] });
+    if (!identityProviderId) {
+      return;
+    }
+    await setOrganizationActivations(originalActivationIds);
     await configurationApiAsAdmin.deleteIdentityProvider({ orgId, identityProvider: identityProviderId });
   });
 
   it('should list an identity provider that is disabled but activated on the organization', async () => {
+    // getSocialIdentityProviders1 is the org-level /organizations/{orgId}/social-identities. The
+    // deprecated /environments/{envId}/portal/identities variant takes an envId, so a regeneration
+    // that renumbered them would fail to compile here rather than silently retarget the test.
     const socialIdentityProviders = await succeed(portalApiAsAnonymous.getSocialIdentityProviders1Raw({ orgId }));
 
     expect(socialIdentityProviders.map((idp) => idp.id)).toContain(identityProviderId);
   });
 
   it('should stop listing it once it is deactivated on the organization', async () => {
-    await organizationApiAsAdmin.updateOrganizationIdentities({ orgId, identityProviderActivationEntity: [] });
+    await setOrganizationActivations(originalActivationIds);
 
     const socialIdentityProviders = await succeed(portalApiAsAnonymous.getSocialIdentityProviders1Raw({ orgId }));
 

--- a/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/console-social-identity-providers.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/authentication/mapi-v1/console-social-identity-providers.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { faker } from '@faker-js/faker';
+
+import { ANONYMOUS, forManagement, forManagementAsAdminUser } from '@gravitee/utils/configuration';
+import { ConfigurationApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/ConfigurationApi';
+import { OrganizationApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/OrganizationApi';
+import { PortalApi } from '../../../../lib/management-webclient-sdk/src/lib/apis/PortalApi';
+import { created, noContent, succeed } from '@lib/jest-utils';
+
+const orgId = 'DEFAULT';
+
+const configurationApiAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
+const organizationApiAsAdmin = new OrganizationApi(forManagementAsAdminUser());
+const portalApiAsAnonymous = new PortalApi(forManagement(ANONYMOUS));
+
+/**
+ * The Console login page reads GET /organizations/{orgId}/social-identities unauthenticated to
+ * decide which SSO buttons to render. "enabled" governs Portal visibility only, so an identity
+ * provider activated on the organization must appear here even when it is disabled — otherwise an
+ * organization whose local login is off is locked out of its own Console.
+ */
+describe('Console social identity providers', () => {
+  let identityProviderId: string;
+
+  beforeAll(async () => {
+    const identityProvider = await created(
+      configurationApiAsAdmin.createIdentityProviderRaw({
+        orgId,
+        newIdentityProviderEntity: {
+          name: `e2e-console-sso-${faker.string.alphanumeric(8)}`,
+          type: 'GOOGLE',
+          enabled: false,
+          configuration: { clientId: 'a-client-id', clientSecret: 'a-client-secret' },
+        },
+      }),
+    );
+    identityProviderId = identityProvider.id;
+
+    await noContent(
+      organizationApiAsAdmin.updateOrganizationIdentitiesRaw({
+        orgId,
+        identityProviderActivationEntity: [{ identityProvider: identityProviderId }],
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await organizationApiAsAdmin.updateOrganizationIdentities({ orgId, identityProviderActivationEntity: [] });
+    await configurationApiAsAdmin.deleteIdentityProvider({ orgId, identityProvider: identityProviderId });
+  });
+
+  it('should list an identity provider that is disabled but activated on the organization', async () => {
+    const socialIdentityProviders = await succeed(portalApiAsAnonymous.getSocialIdentityProviders1Raw({ orgId }));
+
+    expect(socialIdentityProviders.map((idp) => idp.id)).toContain(identityProviderId);
+  });
+
+  it('should stop listing it once it is deactivated on the organization', async () => {
+    await organizationApiAsAdmin.updateOrganizationIdentities({ orgId, identityProviderActivationEntity: [] });
+
+    const socialIdentityProviders = await succeed(portalApiAsAnonymous.getSocialIdentityProviders1Raw({ orgId }));
+
+    expect(socialIdentityProviders.map((idp) => idp.id)).not.toContain(identityProviderId);
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -77,8 +77,12 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
             Stream<IdentityProviderEntity> identityProviderEntityStream = identityProviderService
                 .findAll(executionContext)
                 .stream()
-                .filter(idp -> allIdpByTarget.contains(idp.getId()))
-                .filter(IdentityProviderEntity::isEnabled);
+                .filter(idp -> allIdpByTarget.contains(idp.getId()));
+
+            // "enabled" only governs Portal visibility. Console access is revoked by removing the ORGANIZATION activation.
+            if (target.getReferenceType() == IdentityProviderActivationReferenceType.ENVIRONMENT) {
+                identityProviderEntityStream = identityProviderEntityStream.filter(IdentityProviderEntity::isEnabled);
+            }
 
             return identityProviderEntityStream
                 .sorted((idp1, idp2) -> String.CASE_INSENSITIVE_ORDER.compare(idp1.getName(), idp2.getName()))
@@ -106,7 +110,7 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
 
             IdentityProviderEntity identityProvider = identityProviderService.findById(id);
 
-            if (!identityProvider.isEnabled()) {
+            if (target.getReferenceType() == IdentityProviderActivationReferenceType.ENVIRONMENT && !identityProvider.isEnabled()) {
                 throw new IdentityProviderNotFoundException(identityProvider.getId());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImplTest.java
@@ -60,7 +60,7 @@ public class SocialIdentityProviderImplTest {
     private IdentityProviderActivationService identityProviderActivationService;
 
     @Test
-    public void find_all_should_exclude_disabled_idp_for_organization_target() {
+    public void find_all_should_include_disabled_idp_for_organization_target() {
         givenActivatedIdps(ORGANIZATION_TARGET, googleIdp("enabled-idp", "Enabled", true), googleIdp("disabled-idp", "Disabled", false));
 
         Set<String> ids = socialIdentityProvider
@@ -69,7 +69,23 @@ public class SocialIdentityProviderImplTest {
             .map(SocialIdentityProviderEntity::getId)
             .collect(Collectors.toSet());
 
-        assertEquals(Set.of("enabled-idp"), ids);
+        assertEquals(Set.of("enabled-idp", "disabled-idp"), ids);
+    }
+
+    @Test
+    public void find_all_should_exclude_idp_not_activated_on_organization_target() {
+        IdentityProviderEntity activated = googleIdp("activated-idp", "Activated", true);
+        IdentityProviderEntity deactivated = googleIdp("deactivated-idp", "Deactivated", true);
+        when(identityProviderActivationService.findAllByTarget(ORGANIZATION_TARGET)).thenReturn(Set.of(activation(activated.getId())));
+        when(identityProviderService.findAll(EXECUTION_CONTEXT)).thenReturn(Set.of(activated, deactivated));
+
+        Set<String> ids = socialIdentityProvider
+            .findAll(EXECUTION_CONTEXT, ORGANIZATION_TARGET)
+            .stream()
+            .map(SocialIdentityProviderEntity::getId)
+            .collect(Collectors.toSet());
+
+        assertEquals(Set.of("activated-idp"), ids);
     }
 
     @Test
@@ -95,11 +111,13 @@ public class SocialIdentityProviderImplTest {
         assertEquals("enabled-idp", result.getId());
     }
 
-    @Test(expected = IdentityProviderNotFoundException.class)
-    public void find_by_id_should_reject_disabled_idp_for_organization_target() {
+    @Test
+    public void find_by_id_should_return_disabled_idp_for_organization_target() {
         givenActivatedIdp(ORGANIZATION_TARGET, googleIdp("disabled-idp", "Disabled", false));
 
-        socialIdentityProvider.findById("disabled-idp", ORGANIZATION_TARGET);
+        SocialIdentityProviderEntity result = socialIdentityProvider.findById("disabled-idp", ORGANIZATION_TARGET);
+
+        assertEquals("disabled-idp", result.getId());
     }
 
     @Test(expected = IdentityProviderNotFoundException.class)


### PR DESCRIPTION

https://gravitee.atlassian.net/browse/APIM-15029

## Problem

A previous fix (commit `65b72f3ae4` and its siblings) made `IdentityProviderEntity.enabled` gate
every activation target instead of only `ENVIRONMENT`. Before that, `enabled` decided whether an
identity provider appeared on the **Portal** login page; Console (`ORGANIZATION`) login ignored it.

The Console toggle for that field reads *"Allow portal authentication to use this identity
provider"*. Organizations that took the label at its word — turning it off to keep an identity
provider off the Portal while keeping Console SSO — lost Console SSO the moment they upgraded. Where
local login was also disabled, the organization was locked out of its own Console with no
in-product way back in.

Affected releases: 4.9.33, 4.10.29, 4.11.26, 4.12.18.

## What this changes

**1. `enabled` is portal-scoped again** (`SocialIdentityProviderImpl`)

`findAll` and `findById` filter on `enabled` only for the `ENVIRONMENT` target. Console login no
longer consults the flag.

**2. Deactivation is the Console off switch** — already true, now pinned by a test

Both methods already reject an identity provider with no activation row for the requested target.
That is the supported way to revoke Console access, it is what the **Deactivate** toggle on the
identity provider list does, and it is what Cockpit uses (`DisableEnvironmentCommandHandler`,
`DeleteOrganizationCommandHandler` remove activation rows, never touch `enabled`). A new test
covers it so the real off switch cannot regress unnoticed.

## No data migration, deliberately

An earlier revision of this PR carried a Mongo upgrader and a Liquibase changeset setting
`enabled = true` for identity providers activated on the organization and on no environment. It was
dropped, for two reasons:

- It rescues nobody. The migration only runs on a build that already contains the fix above, and
  that fix alone restores Console SSO for every affected installation.
- It removes a protection. `enabled = true` is inert only while the provider has no environment
  activation. The moment an administrator later activates it on an environment, the Portal button
  appears immediately — whereas today `enabled = false` would still have held it back.

Zero data writes on a security-sensitive fix shipping to five branches is the safer trade.

## Breaking change

**A "disabled" identity provider is accepted on Console login again.** If you relied on
`enabled = false` to block Console SSO on 4.9.33 / 4.10.29 / 4.11.26 / 4.12.18, that no longer
blocks it.

To actually turn an identity provider off for the Console, **deactivate it**: Organization settings
→ Authentication → the identity provider list → the *Activated / Deactivated* toggle. This removes
the `ORGANIZATION` activation and is enforced on every Console authentication path. The `enabled`
flag governs Portal visibility only, as its label states.

A known-issue note for the four already-published patch releases is tracked separately.

## Security-sensitive

This change touches authentication and identity provider activation. It intentionally reverses the
Console-side tightening shipped in the earlier fix; the reporting path for that issue should be
directed at the Deactivate toggle described above.

## Tests

`SocialIdentityProviderImplTest` — 8 cases, green on a clean build of this branch
(4.12.19-SNAPSHOT).

The two Console cases were written first and watched fail against the old code
(`expected:<[disabled-idp, enabled-idp]> but was:<[enabled-idp]>`, and
`IdentityProviderNotFoundException`), then made green. The Portal cases are unchanged and still
assert that `enabled = false` hides the provider from the `ENVIRONMENT` target.

**Gap:** no test asserts the reported symptom end to end — the SSO button on the Console login
page. `gravitee-apim-e2e/ui-test/.../ui-login.spec.ts` covers username/password only, and the
committed management SDK has no identity provider client, so that test needs an SDK regeneration
plus fixtures. Tracked separately rather than added to a hotfix.

https://gravitee.atlassian.net/browse/APIM-15029
