### PR TITLE
refactor(portal-next): free vacated segment slot for same-batch reuse

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -56,6 +56,7 @@ import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQuer
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -246,7 +247,20 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
             .filter(c -> c.getId() != null)
             .map(PendingSegmentClaim::forCreate);
         var fromUpdates = updates.stream().map(u -> PendingSegmentClaim.forUpdate(u.existing(), u.toUpdate()));
-        return Stream.concat(fromCreates, fromUpdates).toList();
+        // Record the old slot when an update relocates or renames, so a same-batch sibling can safely take it over.
+        var released = updates
+            .stream()
+            .filter(PortalNavigationItemValidatorService::vacatesSlot)
+            .map(u -> PendingSegmentClaim.forRelease(u.existing()));
+        return Stream.concat(Stream.concat(fromCreates, fromUpdates), released).toList();
+    }
+
+    private static boolean vacatesSlot(PendingUpdate update) {
+        var existing = update.existing();
+        var toUpdate = update.toUpdate();
+        return (
+            !Objects.equals(existing.getParentId(), toUpdate.getParentId()) || !Objects.equals(existing.getSegment(), toUpdate.getSegment())
+        );
     }
 
     private static boolean shouldFetch(List<CreatePortalNavigationItem> creates, List<PendingUpdate> updates) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PendingSegmentClaim.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/PendingSegmentClaim.java
@@ -21,16 +21,25 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 
 /**
- * A (parent, segment) slot that a create or update in the current validation batch intends to occupy.
- * Shared between {@link CreateValidationContext} and {@link UpdateValidationContext} so that segment-conflict
- * detection can spot collisions across the two sides of a single mixed batch.
+ * A (parent, segment) slot associated with a pending create or update in the current validation batch.
+ * {@link Intent#CLAIM} means the item intends to occupy the slot; {@link Intent#RELEASE} means an update is
+ * about to leave the slot free (recorded so a same-batch sibling can safely take it over).
  */
-public record PendingSegmentClaim(PortalNavigationItemId id, PortalNavigationItemId parentId, String segment) {
+public record PendingSegmentClaim(PortalNavigationItemId id, PortalNavigationItemId parentId, String segment, Intent intent) {
+    public enum Intent {
+        CLAIM,
+        RELEASE,
+    }
+
     public static PendingSegmentClaim forCreate(CreatePortalNavigationItem create) {
-        return new PendingSegmentClaim(create.getId(), create.getParentId(), create.getSegment());
+        return new PendingSegmentClaim(create.getId(), create.getParentId(), create.getSegment(), Intent.CLAIM);
     }
 
     public static PendingSegmentClaim forUpdate(PortalNavigationItem existing, UpdatePortalNavigationItem update) {
-        return new PendingSegmentClaim(existing.getId(), update.getParentId(), update.getSegment());
+        return new PendingSegmentClaim(existing.getId(), update.getParentId(), update.getSegment(), Intent.CLAIM);
+    }
+
+    public static PendingSegmentClaim forRelease(PortalNavigationItem existing) {
+        return new PendingSegmentClaim(existing.getId(), existing.getParentId(), existing.getSegment(), Intent.RELEASE);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRule.java
@@ -54,7 +54,7 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
     public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
         if (
             collidesWithPendingBatch(item.getId(), item.getParentId(), item.getSegment(), ctx.pendingSegmentClaims()) ||
-            collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId)
+            collidesWithPersistedSibling(item.getId(), item.getParentId(), item.getSegment(), environmentId, ctx.pendingSegmentClaims())
         ) {
             throw exceptionFor(item);
         }
@@ -76,7 +76,8 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
                 existingItem.getId(),
                 toUpdate.getParentId(),
                 toUpdate.getSegment(),
-                existingItem.getEnvironmentId()
+                existingItem.getEnvironmentId(),
+                ctx.pendingSegmentClaims()
             )
         ) {
             throw exceptionFor(existingItem);
@@ -93,6 +94,7 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
             .stream()
             .anyMatch(
                 claim ->
+                    claim.intent() == PendingSegmentClaim.Intent.CLAIM &&
                     !Objects.equals(claim.id(), itemId) &&
                     Objects.equals(claim.parentId(), parentId) &&
                     Objects.equals(claim.segment(), segment)
@@ -103,12 +105,31 @@ public class SegmentConflictRule implements CreatePortalNavigationItemValidation
         PortalNavigationItemId itemId,
         PortalNavigationItemId parentId,
         String segment,
-        String environmentId
+        String environmentId,
+        List<PendingSegmentClaim> claims
     ) {
         return navigationItemsQueryService
             .findByParentIdAndSegment(environmentId, parentId, segment)
             .filter(sibling -> !sibling.getId().equals(itemId))
+            .filter(sibling -> !isVacatedInBatch(sibling.getId(), parentId, segment, claims))
             .isPresent();
+    }
+
+    private static boolean isVacatedInBatch(
+        PortalNavigationItemId siblingId,
+        PortalNavigationItemId parentId,
+        String segment,
+        List<PendingSegmentClaim> claims
+    ) {
+        return claims
+            .stream()
+            .anyMatch(
+                claim ->
+                    claim.intent() == PendingSegmentClaim.Intent.RELEASE &&
+                    Objects.equals(claim.id(), siblingId) &&
+                    Objects.equals(claim.parentId(), parentId) &&
+                    Objects.equals(claim.segment(), segment)
+            );
     }
 
     private static PathConflictException exceptionFor(CreatePortalNavigationItem item) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/domain_service/PortalListingSyncDomainServiceTest.java
@@ -16,10 +16,13 @@
 package io.gravitee.apim.core.portal_listing.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.PortalListingCrudServiceInMemory;
+import inmemory.PortalNavigationItemSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -30,6 +33,7 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanExecutor;
 import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.query_service.AutomationManagedNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_listing.model.PortalListing;
@@ -44,12 +48,15 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.slug.model.Slug;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -315,6 +322,82 @@ class PortalListingSyncDomainServiceTest {
         syncService.validateApiFolderConflictsForApi(AUDIT_INFO, apiId, List.of(new NavigationPath("/guides", null)));
 
         org.mockito.Mockito.verifyNoInteractions(validator);
+    }
+
+    @Nested
+    class VacateAndFillSameSlotInOneBatch {
+
+        @BeforeEach
+        void wireInRealValidator() {
+            var realValidator = new PortalNavigationItemValidatorService(
+                navItemQuery,
+                pageContentQuery,
+                new ApiProductQueryServiceInMemory(),
+                new PortalNavigationItemSourceDomainServiceInMemory()
+            );
+            var portalListingCrud = new PortalListingCrudServiceInMemory();
+            var apiDocSync = new ApiDocumentationSyncDomainService(
+                navItemCrud,
+                navItemQuery,
+                pageContentQuery,
+                mock(PortalNavigationItemValidatorService.class)
+            );
+            var automationManaged = new AutomationManagedNavigationItemsQueryService(portalListingCrud, pageContentQuery, navItemQuery);
+            syncService = new PortalListingSyncDomainService(
+                pageContentQuery,
+                apiDocSync,
+                new NavigationItemEntryMaterializer(navItemCrud, navItemQuery, apiDocSync),
+                new ApiFolderSubtreeReconciler(
+                    navItemQuery,
+                    apiCrud,
+                    new NavigationSyncPlanExecutor(navItemCrud, navItemQuery, pageContentCrud),
+                    automationManaged
+                ),
+                realValidator
+            );
+        }
+
+        @Test
+        void accepts_a_new_entry_that_takes_the_slot_a_relocated_entry_is_vacating() {
+            // Two APIs whose hrids slugify to the same segment, so the incoming listing simultaneously
+            // vacates and fills (parentP, "pets-api") in one payload — the scenario Marek called out on
+            // the listing path in #19381 (SegmentConflictRule.java:102).
+            var apiHridA = "pets-api";
+            var apiHridB = "Pets-Api";
+            assertThat(Slug.from(apiHridA).value()).isEqualTo(Slug.from(apiHridB).value());
+            var apiIdA = HRIDToUUID.api().context(AUDIT_INFO).hrid(apiHridA).id();
+            var parentP = PortalNavigationItemId.forPortalFolder(AUDIT_INFO, PORTAL_ID.toString(), "/projects/alpha");
+
+            var existingA = PortalNavigationApi.builder()
+                .id(PortalNavigationItemId.forListingApi(AUDIT_INFO, PORTAL_ID.toString(), apiIdA))
+                .organizationId(AUDIT_INFO.organizationId())
+                .environmentId(AUDIT_INFO.environmentId())
+                .title(apiHridA)
+                .segment(Slug.from(apiHridA).value())
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .apiId(apiIdA)
+                .parentId(parentP)
+                .published(true)
+                .visibility(PortalVisibility.PUBLIC)
+                .automationMetadata(
+                    new AutomationMetadata(
+                        AutomationMetadata.ReferenceType.PORTAL,
+                        PORTAL_ID.toString(),
+                        null,
+                        Optional.of("/projects/alpha"),
+                        Optional.empty()
+                    )
+                )
+                .build();
+            navItemCrud.storage().add(existingA);
+
+            var listing = aListing(
+                List.of(new PortalListingApiEntry(apiHridA, "/projects/beta", 1), new PortalListingApiEntry(apiHridB, "/projects/alpha", 2))
+            );
+
+            assertThatCode(() -> syncService.validateForConflicts(AUDIT_INFO, PORTAL_ID, listing)).doesNotThrowAnyException();
+        }
     }
 
     private static GraviteeMarkdownPageContent anApiDocPageContent(PortalPageContentId id, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/CreatePortalNavigationItemValidatorServiceTest.java
@@ -33,6 +33,7 @@ import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationValidator;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationSourcedItemsDomainService;
 import io.gravitee.apim.core.portal_page.exception.HomepageAlreadyExistsException;
@@ -53,6 +54,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -1013,6 +1015,47 @@ class CreatePortalNavigationItemValidatorServiceTest {
             );
 
             assertDoesNotThrow(() -> validatorService.validate(List.of(), List.of(pendingUpdate), ENV_ID));
+        }
+    }
+
+    @Nested
+    class VacateAndFillSameSlotInOneBatch {
+
+        @Test
+        void should_accept_create_that_lands_in_a_slot_vacated_by_a_pending_update_in_the_same_batch() {
+            var parent = PortalNavigationItemFixtures.aFolder("root");
+            parent.markAsRoot();
+            var relocating = PortalNavigationItemFixtures.aFolder("docs", parent.getId());
+            navigationItemsQueryService.storage().add(parent);
+            navigationItemsQueryService.storage().add(relocating);
+
+            var otherParent = PortalNavigationItemFixtures.aFolder("archive");
+            otherParent.markAsRoot();
+            navigationItemsQueryService.storage().add(otherParent);
+
+            var relocatingUpdate = UpdatePortalNavigationItem.builder()
+                .type(relocating.getType())
+                .title(relocating.getTitle())
+                .segment(relocating.getSegment())
+                .order(relocating.getOrder())
+                .parentId(otherParent.getId())
+                .visibility(relocating.getVisibility())
+                .published(relocating.getPublished())
+                .build();
+            var pendingUpdate = new PortalNavigationValidator.PendingUpdate(relocatingUpdate, relocating);
+            var newItem = CreatePortalNavigationItem.builder()
+                .id(PortalNavigationItemId.random())
+                .title("docs")
+                .segment(relocating.getSegment())
+                .type(PortalNavigationItemType.FOLDER)
+                .area(PortalArea.TOP_NAVBAR)
+                .order(0)
+                .parentId(parent.getId())
+                .visibility(PortalVisibility.PUBLIC)
+                .published(true)
+                .build();
+
+            assertDoesNotThrow(() -> validatorService.validate(List.of(newItem), List.of(pendingUpdate), ENV_ID));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SegmentConflictRuleTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -122,7 +123,7 @@ class SegmentConflictRuleTest {
 
     @Test
     void validate_throws_when_another_item_in_the_pending_batch_claims_same_parent_and_segment() {
-        var pendingClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
+        var pendingClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs", PendingSegmentClaim.Intent.CLAIM);
         var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(pendingClaim));
         var item = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
 
@@ -134,13 +135,45 @@ class SegmentConflictRuleTest {
     @Test
     void validate_throws_when_a_pending_update_in_the_same_batch_targets_the_same_parent_and_segment() {
         // A create at (PARENT_ID, "docs") collides with a pending update moving another item to the same slot.
-        var pendingUpdateClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs");
+        var pendingUpdateClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs", PendingSegmentClaim.Intent.CLAIM);
         var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(pendingUpdateClaim));
         var newItem = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
 
         assertThatThrownBy(() -> rule.validate(newItem, ENV_ID, ctx))
             .isInstanceOf(PathConflictException.class)
             .hasMessageContaining("/docs");
+    }
+
+    @Test
+    void validate_accepts_create_when_persisted_sibling_is_being_vacated_by_a_pending_update_in_the_same_batch() {
+        // A same-batch RELEASE claim frees the persisted sibling's slot for a new create.
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "docs"));
+        var releaseClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs", PendingSegmentClaim.Intent.RELEASE);
+        var ctx = new CreateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(releaseClaim));
+        var newItem = item(ITEM_ID, "docs", PortalNavigationItemType.FOLDER, folderLocation("/docs"));
+
+        assertThatCode(() -> rule.validate(newItem, ENV_ID, ctx)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_accepts_update_when_persisted_sibling_is_being_vacated_by_a_pending_update_in_the_same_batch() {
+        // Update-side twin of the create-into-vacated-slot case: two updates swap slots in one batch,
+        // and the RELEASE claim excuses the collision the incoming update would otherwise hit.
+        navigationItemsQueryService.storage().add(existingFolder(OTHER_ID, PARENT_ID, "docs"));
+        var incomingExisting = existingFolder(ITEM_ID, PortalNavigationItemId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "docs");
+        var releaseClaim = new PendingSegmentClaim(OTHER_ID, PARENT_ID, "docs", PendingSegmentClaim.Intent.RELEASE);
+        var ctx = new UpdateValidationContext(List.of(), Map.of(), Map.of(), Map.of(), List.of(releaseClaim));
+        var toUpdate = UpdatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.FOLDER)
+            .title("docs")
+            .segment("docs")
+            .parentId(PARENT_ID)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .order(0)
+            .build();
+
+        assertThatCode(() -> rule.validate(toUpdate, incomingExisting, ctx)).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-179

## Description

Fixes a false-positive in SegmentConflictRule when a batch both vacates and refills the same (parent, segment) slot.

Follow-up on issue raised within #19381

