### PR TITLE
fix(gateway): report a client abort on the request span

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ClientCloseClassifier.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ClientCloseClassifier.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.http.vertx;
 
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.gravitee.gateway.reactive.core.context.ComponentScope;
@@ -112,7 +113,8 @@ public final class ClientCloseClassifier {
     }
 
     /**
-     * Decorate the in-flight request {@link Metrics} with a client-close failure, going through
+     * Decorate the in-flight request {@link Metrics} with a client-close failure, and stash the cause for the request
+     * span so the trace and the analytics name the same failure. Goes through
      * {@link DiagnosticReportHelper} — the same path {@code AbstractExecutionContext.interruptWith} uses — so the
      * {@link Diagnostic} written here is <b>component-attributed</b> (the closing {@code ENDPOINT}/{@code SYSTEM}
      * component, via {@link ComponentScope}). No-op when there is no metrics yet, when the request already completed,
@@ -154,6 +156,13 @@ public final class ClientCloseClassifier {
         // Legacy flat fields kept in sync so dashboards reading error-key/error-message still work.
         metrics.setErrorKey(diagnostic.getKey());
         metrics.setErrorMessage(diagnostic.getMessage());
+        if (cause != null) {
+            // A client abort cancels the request chain rather than failing it, so it reaches no doOnError and the
+            // dispatcher would close the root span on the response code alone - a 200 for a stream the client left
+            // mid-flight. Stashing the cause where the dispatcher already looks records it as the exception it was,
+            // with the exception event and error.type an APM breaks errors down by.
+            ctx.putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR, cause);
+        }
         ctx.withLogger(log).debug("Classified client close reason as {}", key);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ClientCloseClassifierTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ClientCloseClassifierTest.java
@@ -18,10 +18,14 @@ package io.gravitee.gateway.reactive.http.vertx;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.gravitee.gateway.reactive.http.vertx.ClientCloseClassifier.ClientCloseReason;
 import io.gravitee.reporter.api.v4.metric.Diagnostic;
@@ -213,6 +217,33 @@ class ClientCloseClassifierTest {
 
         assertThat(metrics.getErrorKey()).isNull();
         assertThat(metrics.getFailure().getKey()).isEqualTo("GATEWAY_OAUTH2_ACCESS_DENIED");
+    }
+
+    @Test
+    void should_stash_the_close_cause_for_the_request_span() {
+        // A client abort cancels the chain instead of failing it, so it reaches no doOnError: the dispatcher ends the
+        // root span from this attribute, or reports a success for a stream that never finished.
+        HttpBaseExecutionContext ctx = mockContext();
+        when(ctx.metrics()).thenReturn(Metrics.builder().build());
+        IOException cause = new IOException("Connection reset by peer");
+
+        ClientCloseClassifier.decorate(ctx, cause);
+
+        verify(ctx).putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR, cause);
+    }
+
+    @Test
+    void should_not_stash_a_close_cause_for_an_already_completed_request() {
+        // Same guard as the metrics: a close on a kept-alive connection between requests must not turn the span of
+        // the request that already completed on it into a failure.
+        HttpBaseExecutionContext ctx = mockContext();
+        Metrics metrics = Metrics.builder().build();
+        metrics.setRequestEnded(true);
+        when(ctx.metrics()).thenReturn(metrics);
+
+        ClientCloseClassifier.decorate(ctx, new IOException("Connection reset by peer"));
+
+        verify(ctx, never()).putInternalAttribute(eq(InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR), any());
     }
 
     private static HttpBaseExecutionContext mockContext() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -218,6 +218,7 @@ class DefaultHttpRequestDispatcherTest {
         lenient().when(requestTimeoutConfiguration.getRequestTimeout()).thenReturn(0L);
         lenient().when(requestTimeoutConfiguration.getRequestTimeoutGraceDelay()).thenReturn(10L);
 
+        lenient().when(globalComponentProvider.getComponent(Node.class)).thenReturn(node);
         mockConnectionCreationTimestamp();
 
         spyNoopTracer = spy(new NoOpTracer());
@@ -419,6 +420,25 @@ class DefaultHttpRequestDispatcherTest {
                 .assertError(t -> MOCK_ERROR_MESSAGE.equals(t.getMessage()));
             verify(spyNoopTracer).startRootSpanFrom(any(), any());
             verify(spyNoopTracer, timeout(1000)).endWithResponseAndError(any(), any(), any(), any(Throwable.class));
+        }
+
+        @Test
+        void shouldEndTracingSpanInErrorWhenTheClientAbortedTheResponseStream() {
+            // The write failure is swallowed by VertxHttpServerResponse, so the dispatch completes normally and the
+            // span would otherwise be closed on the response code alone - a 200 for a stream that never finished.
+            final IOException clientClose = new IOException("Connection reset by peer");
+            when(apiReactor.handle(any(MutableExecutionContext.class))).thenAnswer(invocation -> {
+                MutableExecutionContext ctx = invocation.getArgument(0);
+                ctx.metrics(Metrics.builder().build());
+                ClientCloseClassifier.decorate(ctx, clientClose);
+                return Completable.complete();
+            });
+
+            cut.dispatch(rxRequest, SERVER_ID).test().assertComplete();
+
+            ArgumentCaptor<Throwable> endedWith = ArgumentCaptor.forClass(Throwable.class);
+            verify(spyNoopTracer, timeout(1000)).endWithResponseAndError(any(), any(), any(), endedWith.capture());
+            assertThat(endedWith.getValue()).isSameAs(clientClose);
         }
     }
 


### PR DESCRIPTION
## Issue

<!-- TODO: JIRA reference. Follows on from the client-close classification work tracked as APIM-12769,
     which this extends from analytics to tracing. -->

## Description

When a client disconnects mid-response, the request's root span was recorded as a success. A cancel is
not a failure in Rx terms: it never reaches `doOnError`, so nothing was stashed in
`ATTR_INTERNAL_TRACING_ERROR`, and `doFinally` closed the span on the response code alone — `200` for a
streamed response whose headers went out long before the client left.

`ClientCloseClassifier.decorate` is the one place that already knows a close for what it is. It now
stashes the cause in `ATTR_INTERNAL_TRACING_ERROR` alongside the metrics it decorates, and the
dispatcher's existing span-ending path picks it up unchanged — no new branch, no new helper, the
dispatcher untouched.

Two consequences worth naming:

- **The span carries a real exception.** The `Throwable` overload reaches
  `InstrumenterTracer.endSpan(..., throwable)`, which emits the `exception` event and `error.type` that
  error breakdowns in Tempo/Datadog key off. Recording only a status description would have left a
  client-abort span invisible to them.
- **Both close entry points are covered.** `VertxHttpServerResponse`'s write path does
  `onErrorResumeNext(... -> Completable.complete())`, so the error is swallowed there and never reaches
  the response exception handler the dispatcher registers. That path is the motivating SSE case.

The stash sits inside `decorate`'s existing guards, deliberately: the span is written exactly when and
only when the metrics are, so a trace and its analytics can no longer disagree. A close on a
kept-alive connection between requests still decorates nothing.

**Security-sensitive:** touches tracing and diagnostics. It changes what a span records for an aborted
request; it adds no new data source, and the stashed value is an exception the gateway already handled
and already reported through the metrics.

## Additional context

**Reproduction.** An SSE stream cut off by a gateway restart: `POST /…` with `http.status_code: 200`
and no error status, while the analytics for the same request were correctly tagged
`CLIENT_ABORTED_CHANNEL_CLOSED`.

**Blast radius.** Any streaming v4 API whose client disconnects mid-response — SSE, LLM proxy, agents.
Traces for those requests change from success to failure, which is the point, but it is a visible
change for anyone alerting on span status.

Nothing else changes. A request with no classified client close ends its span exactly as before — in
particular, a keyed policy rejection (401, 403, 429) keeps the `UNSET` status the OpenTelemetry SERVER
semconv gives a 4xx (`HttpSpanStatusExtractor` with the SERVER converter, `code >= 500 || code < 100`).

**Out of scope.** The v3 path is deliberately untouched: it uses `doOnComplete`/`doOnError` with no
`doFinally`, so a cancelled v3 request appears never to end its span at all. Separate defect, separate
fix.

Two adjacent tracing defects found during review, filed for a follow-up PR rather than folded in here:
a plain `InterruptionException` marks the Request-phase span as an error even though nothing failed,
and an `InterruptionFailureException` records no failure key on either the phase span or the root span.

**Tests.** `DefaultHttpRequestDispatcherTest.shouldEndTracingSpanInErrorWhenTheClientAbortedTheResponseStream`
drives a real dispatch: the metrics are tagged through the classifier, the chain then completes normally
as the write-failure path does, and the root span must end with that exception. It fails on the
pre-change code. Two guard tests in `ClientCloseClassifierTest`: the cause is stashed, and an
already-ended request stashes nothing. RED → GREEN confirmed on all three; both gateway modules green
(321 tests), `prettier:check` green.