### PR TITLE
fix(gamma-console): read the dev server port and API target from the environment

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/rspack.config.ts
@@ -22,6 +22,9 @@ import { DefinePlugin } from '@rspack/core';
 
 import config from './module-federation.config';
 
+const devServerPort = process.env.PORT ? Number(process.env.PORT) : 4200;
+const mapiUrl = process.env.GAMMA_MAPI_URL ?? 'http://localhost:8083';
+
 /** Overrides the stub from @gravitee/gamma-modules-sdk package with the real implementation. */
 const gammaModulesSdkEntry = join(__dirname, 'src/shared/gamma-modules-sdk.ts');
 
@@ -39,17 +42,20 @@ export default {
         css: false,
     },
     devServer: {
-        port: 4200,
+        // PORT and GAMMA_MAPI_URL let several checkouts run side by side, each
+        // against its own Management API. Defaults keep a plain `nx serve` on
+        // 4200 against a default rest-api.
+        port: devServerPort,
         allowedHosts: 'all',
         proxy: [
             {
                 context: ['/management'],
-                target: 'http://localhost:8083',
+                target: mapiUrl,
                 changeOrigin: true,
             },
             {
                 context: ['/gamma'],
-                target: 'http://localhost:8083',
+                target: mapiUrl,
                 changeOrigin: true,
             },
         ],


### PR DESCRIPTION
[GMA-998](https://gravitee.atlassian.net/browse/GMA-998)

## Problem

`gravitee-gamma-control-plane-webui/rspack.config.ts` hardcodes the dev server port and the proxy target, and reads only `DEV_MODULE_ENTRIES` from the environment:

```ts
devServer: {
    port: 4200,
    proxy: [
        { context: ['/management'], target: 'http://localhost:8083', changeOrigin: true },
        { context: ['/gamma'],      target: 'http://localhost:8083', changeOrigin: true },
    ],
},
```

With more than one checkout of APIM in use locally, that costs twice:

* every checkout serves the console on 4200, so a second one just waits (`Waiting for gamma-console:serve in another nx process`);
* every console proxies `/management` and `/gamma` to a rest-api on 8083, so a checkout whose rest-api listens elsewhere gets a console that cannot load its bootstrap config, session or module list. The console comes up empty and no module appears — which reads as "the APIM module is broken" rather than "the console is talking to the wrong port".

The Angular console does not have this problem: its proxy lives in `proxy.conf.mjs`, so a file copy is enough to point it at another port.

## Change

Both values come from the environment, with the current ones as defaults, so a plain `nx serve gamma-console` behaves exactly as before:

```ts
const devServerPort = process.env.PORT ? Number(process.env.PORT) : 4200;
const mapiUrl = process.env.GAMMA_MAPI_URL ?? 'http://localhost:8083';
```

`PORT` is the name the Nx/rspack dev server ecosystem already uses; `GAMMA_MAPI_URL` matches the variable name the console's own docs use for the module dev-server workflow.

## Verification

On a checkout whose rest-api runs on 8283 and whose console is allocated 4302:

```
PORT=4302 GAMMA_MAPI_URL=http://localhost:8283 \
  DEV_MODULE_ENTRIES=aim=http://localhost:4303/mf-manifest.json yarn gamma-console:serve
```

| Request | rest-api :8283 | via console :4302 |
|---|---|---|
| `/management/v2/ui/bootstrap` | 200 | 200 |
| `/gamma/organizations/DEFAULT/modules` | 200 | 200 |

The module list comes back with `edge, aim, portals, apim, esm, platform, authz`. Before the change the same console listened on 4200, proxied to 8083, and returned nothing.

Default behaviour is unchanged: with neither variable set the dev server is on 4200 against `http://localhost:8083`.


[GMA-998]: https://gravitee.atlassian.net/browse/GMA-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ