### PR TITLE
chore: bump gravitee-policy-ipfiltering from 3.0.0 to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
     <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
     <gravitee-policy-interrupt.version>2.2.1</gravitee-policy-interrupt.version>
-    <gravitee-policy-ipfiltering.version>3.0.0</gravitee-policy-ipfiltering.version>
+    <gravitee-policy-ipfiltering.version>3.0.1</gravitee-policy-ipfiltering.version>
     <gravitee-policy-javascript.version>3.0.0</gravitee-policy-javascript.version>
     <gravitee-policy-js.version>1.0.1</gravitee-policy-js.version>
     <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>


### PR DESCRIPTION
## Description

Manual replacement for #19540, whose cherry-pick conflicted — the gravitee-policy-ipfiltering.version property is in gravitee-apim-distribution/pom.xml on master but in the root pom.xml on 4.12.x, so the change can't be backported automatically.

Picks up gravitee-policy-ipfiltering 3.0.1, which fixes the "Use X-Forwarded-For header" option being hidden in the IP Filtering policy form. No label needed.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

