### PR TITLE
chore: bump gravitee-policy-ipfiltering to 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
         <gravitee-policy-interrupt.version>2.2.1</gravitee-policy-interrupt.version>
-        <gravitee-policy-ipfiltering.version>2.0.4</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-ipfiltering.version>2.0.5</gravitee-policy-ipfiltering.version>
         <gravitee-policy-javascript.version>1.4.0</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>


### PR DESCRIPTION
Picks up gravitee-policy-ipfiltering 2.0.5, the backport of https://github.com/gravitee-io/gravitee-policy-ipfiltering/pull/122 to the 2.x line. Fixes the "Use X-Forwarded-For header" option being hidden in the IP Filtering policy form whenever useCustomIPAddress was never explicitly stored.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

