### PR TITLE
chore(4.12.x): bump gravitee-reactor-native-kafka from 7.0.8 to 7.1.0

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/nativeapi/logging/MetricsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/nativeapi/logging/MetricsIntegrationTest.java
@@ -66,7 +66,7 @@ import org.junit.jupiter.api.*;
  *
  * <ul>
  *   <li>{@link BrokerStopMidSession} (Order 1) — first connection succeeds, then the testcontainers Kafka backend
- *       is stopped: next connection emits {@code INTERNAL_ERROR}. Container is restarted in {@code finally} so
+ *       is stopped: next connection emits {@code CONNECTION_ERROR}. Container is restarted in {@code finally} so
  *       the remaining scenarios still see a healthy broker.</li>
  *   <li>{@link HealthyConnection} (Order 2) — gateway reaches a healthy backend; emits {@code CONNECTED}.</li>
  *   <li>{@link ConnectPolicyInterrupts} (Order 3) — a test-only policy on the {@code entrypointConnect} flow phase
@@ -108,7 +108,7 @@ class MetricsIntegrationTest {
     class BrokerStopMidSession extends AbstractTest {
 
         @Test
-        void broker_stop_emits_internal_error() throws Exception {
+        void broker_stop_emits_connection_error() throws Exception {
             triggerKafkaConnection();
             var openMetric = awaitFirstMetricFor(PASSTHROUGH_API_ID);
 
@@ -126,9 +126,9 @@ class MetricsIntegrationTest {
                     soft.assertThat(openMetric.getErrorKey()).isNull();
                     soft.assertThat(openMetric.getErrorMessage()).isNull();
 
-                    // post-broker-stop (INTERNAL_ERROR — close-event after broker became unreachable)
+                    // post-broker-stop (CONNECTION_ERROR — upstream broker unreachable, broker-facing failure)
                     soft.assertThat(failedMetric.getEntrypointId()).isEqualTo(EXPECTED_ENTRYPOINT_ID);
-                    soft.assertThat(statusOf(failedMetric)).isEqualTo("INTERNAL_ERROR");
+                    soft.assertThat(statusOf(failedMetric)).isEqualTo("CONNECTION_ERROR");
                     soft.assertThat(failedMetric.getErrorKey()).isEqualTo("UNKNOWN_SERVER_ERROR");
                     soft.assertThat(failedMetric.getErrorMessage()).containsIgnoringCase("Connection refused");
                 });

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.0.8</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.1.0</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>3.1.6</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>3.3.9</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.1</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `7.0.8` to `7.1.0` on branch `4.12.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page.

## Jira

[KIP-511](https://gravitee.atlassian.net/browse/KIP-511)