### PR TITLE
chore(master): bump gravitee-reactor-native-kafka from 7.1.0-alpha.13 to 7.1.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -240,7 +240,7 @@
     <gravitee-resource-schema-registry-embedded.version>1.0.0</gravitee-resource-schema-registry-embedded.version>
     <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
     <gravitee-reactor-message.version>11.0.0</gravitee-reactor-message.version>
-    <gravitee-reactor-native-kafka.version>7.1.0-alpha.13</gravitee-reactor-native-kafka.version>
+    <gravitee-reactor-native-kafka.version>7.1.0</gravitee-reactor-native-kafka.version>
     <gravitee-reactor-mcp-proxy.version>4.0.0</gravitee-reactor-mcp-proxy.version>
     <gravitee-reactor-llm-proxy.version>4.2.0-alpha.7</gravitee-reactor-llm-proxy.version>
     <gravitee-reactor-a2a-proxy.version>2.1.1</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `7.1.0-alpha.13` to `7.1.0` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page.

## Jira

[KIP-511](https://gravitee.atlassian.net/browse/KIP-511)