### PR TITLE
chore(deps): bump gravitee-parent from 25.1.0 to 25.1.2

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
@@ -49,7 +49,7 @@
 
             Do not add @{argLine} here. It is surefire's late-replacement syntax for the property
             Jacoco's prepare-agent sets, and Jacoco left the chain with gravitee-apim-parent —
-            gravitee-parent 24.0.2 does not configure it, and no pom in this tree does either. With
+            gravitee-parent 25.1.2 does not configure it, and no pom in this tree does either. With
             nothing defining the property, surefire passes the token through literally and the fork
             dies on `could not open '{argLine}'` before a single test starts. Restoring coverage
             means declaring jacoco-maven-plugin here first; that is a separate decision.

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -30,7 +30,7 @@
         -->
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>25.1.0</version>
+        <version>25.1.2</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>25.1.0</version>
+    <version>25.1.2</version>
   </parent>
 
   <groupId>io.gravitee.apim</groupId>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-354

## Description

Bumps both reactors from `gravitee-parent` 25.1.0 to 25.1.2, which brings two fixes:

* **25.1.1** — `maven.deploy.skip` now reaches the Maven Central lane. Until now the Central
  publishing plugin took the `deploy` phase away from `maven-deploy-plugin`, so the property
  commanded nothing there and the six `-coverage` aggregates were published on every release since
  3.10.15 despite declaring it.
* **25.1.2** — the release profiles no longer activate on `performRelease`; the destination is now an
  explicit `-P`. The APIM jobs already select explicitly (`-P gravitee-release` for Central,
  `-P gio-release,engine-snapshot` for the internal lane), so nothing changes for them.

The nine exclusions already declared in this repository become effective with this bump: the six
`-coverage` aggregates, plus `gravitee-apim-distribution` and the two modules under it.

The support branches are not concerned — they are on parent 23.5.0/24.0.1 and were fixed in their own
way, with `excludeArtifacts` (#19523).

## Additional context

Verified on both reactors after the bump, with `help:evaluate` under `-P gravitee-release`:

| Module | `central.publishing.skip` |
|---|---|
| `gravitee-apim-gateway-coverage` | `true` |
| `gravitee-apim-gateway-core` | `false` |
| `gravitee-apim-distribution` | `true` |
| `gravitee-apim-distribution-es-index-mappings` | `false` |
| `gravitee-apim-distribution-jdbc-migrations` | `false` |

The last two opt back in, as their POMs intend.

The comment in `gravitee-apim-distribution-integration-tests` naming the parent version is refreshed
to 25.1.2. Both statements it makes still hold: the parent declares `<argLine>${surefireArgLine}</argLine>`
and configures no Jacoco.

One thing this bump makes worth deciding, but does not change: `gravitee-apim-distribution` is
excluded while `-es-index-mappings` opts back in, and a published POM keeps its `<parent>`. Should
that subtree ever go out through `gravitee-release`, the child would land on Central with an
unresolvable parent. It does not today — the distribution releases through `gio-release` — and the
question belongs to BX-355.
