### PR TITLE
refactor(observability): centralise the entrypoint-id allowlist

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
@@ -78,6 +78,13 @@
             <version>${apim.server.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- ObservabilityEntrypointsDistributionTest holds the registry to the bundled entrypoint plugins. -->
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${apim.server.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Test tooling -->
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/observability/ObservabilityEntrypointsDistributionTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/observability/ObservabilityEntrypointsDistributionTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.gravitee.repository.analytics.engine.api.query.ObservabilityEntrypoints;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Holds {@link ObservabilityEntrypoints} to the entrypoint plugins the distribution actually ships.
+ *
+ * <p>Elasticsearch stores {@code connector.id()} as {@code entrypoint-id}, so the only faithful
+ * source for the ids is each plugin's own {@code plugin.properties}. This test opens every bundled
+ * entrypoint zip and reads it from there; the artifact-name check in {@code ObservabilityEntrypointsTest}
+ * stays as the fast unit-level complement, because it is the one that runs when only the registry
+ * changes.
+ *
+ * <p>Runs in the {@code Integration tests} CI job, which attaches the workspace where
+ * {@code Build backend} assembled both distributions with {@code -Dbundle=dev}. That job is the one
+ * triggered by a change to the distribution pom — the moment a new entrypoint reaches the product.
+ *
+ * @author GraviteeSource Team
+ */
+class ObservabilityEntrypointsDistributionTest {
+
+    private static final String ENTRYPOINT_CONNECTOR_TYPE = "entrypoint-connector";
+    private static final Pattern VERSION_SUFFIX = Pattern.compile("-\\d.*$");
+
+    /** One bundled entrypoint plugin, as the gateway would load it. */
+    record InstalledEntrypoint(String zip, String artifactId, String id) {}
+
+    @Test
+    void should_declare_every_entrypoint_plugin_the_distribution_ships() {
+        var installed = installedEntrypoints();
+        var registryIds = Arrays.stream(ObservabilityEntrypoints.values()).map(ObservabilityEntrypoints::id).toList();
+
+        var undecided = installed
+            .values()
+            .stream()
+            .filter(e -> !registryIds.contains(e.id()))
+            .toList();
+
+        assertThat(undecided).as("bundled entrypoints whose id has no ObservabilityEntrypoints constant stating its scope").isEmpty();
+    }
+
+    @Test
+    void should_not_keep_a_decision_for_a_plugin_the_distribution_no_longer_ships() {
+        var installedArtifacts = installedEntrypoints().keySet();
+
+        var stale = Arrays.stream(ObservabilityEntrypoints.values())
+            .flatMap(constant ->
+                constant
+                    .pluginArtifactId()
+                    .stream()
+                    .map(artifact -> Map.entry(constant, artifact))
+            )
+            .filter(entry -> !installedArtifacts.contains(entry.getValue()))
+            .map(entry -> entry.getKey() + " -> " + entry.getValue())
+            .toList();
+
+        assertThat(stale).as("registry constants declaring a plugin artifact that is not bundled any more").isEmpty();
+    }
+
+    @Test
+    void should_record_the_id_the_plugin_really_declares() {
+        var declaredIdByArtifact = Arrays.stream(ObservabilityEntrypoints.values())
+            .filter(constant -> constant.pluginArtifactId().isPresent())
+            .collect(Collectors.toMap(constant -> constant.pluginArtifactId().get(), ObservabilityEntrypoints::id));
+
+        var mismatches = installedEntrypoints()
+            .values()
+            .stream()
+            .filter(e -> declaredIdByArtifact.containsKey(e.artifactId()))
+            .filter(e -> !declaredIdByArtifact.get(e.artifactId()).equals(e.id()))
+            .map(
+                e ->
+                    e.artifactId() +
+                    ": plugin.properties says '" +
+                    e.id() +
+                    "', registry says '" +
+                    declaredIdByArtifact.get(e.artifactId()) +
+                    "'"
+            )
+            .toList();
+
+        assertThat(mismatches).as("registry ids that differ from the id the plugin itself declares").isEmpty();
+    }
+
+    /** Union of both distributions: the gateway assembly leaves the native-kafka zip out, the rest-api one ships it. */
+    private static Map<String, InstalledEntrypoint> installedEntrypoints() {
+        var installed = new LinkedHashMap<String, InstalledEntrypoint>();
+        for (var pluginsDir : assembledPluginDirectories()) {
+            try (Stream<Path> zips = Files.list(pluginsDir)) {
+                zips
+                    .filter(zip -> zip.getFileName().toString().endsWith(".zip"))
+                    .sorted()
+                    .map(ObservabilityEntrypointsDistributionTest::readEntrypoint)
+                    .flatMap(Optional::stream)
+                    .forEach(e -> installed.putIfAbsent(e.artifactId(), e));
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to list " + pluginsDir, e);
+            }
+        }
+        assertThat(installed).as("no entrypoint plugin found under %s — the parsing is stale", assembledPluginDirectories()).isNotEmpty();
+        return installed;
+    }
+
+    /** The plugin's own jar sits at the zip root; {@code lib/} only holds its dependencies. */
+    private static Optional<InstalledEntrypoint> readEntrypoint(Path zip) {
+        try (var zipFile = new ZipFile(zip.toFile())) {
+            var pluginJar = zipFile
+                .stream()
+                .filter(entry -> !entry.getName().contains("/") && entry.getName().endsWith(".jar"))
+                .findFirst();
+            if (pluginJar.isEmpty()) {
+                return Optional.empty();
+            }
+            var properties = pluginProperties(zipFile, pluginJar.get());
+            if (properties.isEmpty() || !ENTRYPOINT_CONNECTOR_TYPE.equals(properties.get().getProperty("type"))) {
+                return Optional.empty();
+            }
+            var zipName = zip.getFileName().toString();
+            var artifactId = VERSION_SUFFIX.matcher(zipName.substring(0, zipName.length() - ".zip".length())).replaceFirst("");
+            return Optional.of(new InstalledEntrypoint(zipName, artifactId, properties.get().getProperty("id")));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to read " + zip, e);
+        }
+    }
+
+    private static Optional<Properties> pluginProperties(ZipFile zipFile, ZipEntry pluginJar) throws IOException {
+        try (var jar = new ZipInputStream(zipFile.getInputStream(pluginJar))) {
+            for (ZipEntry entry = jar.getNextEntry(); entry != null; entry = jar.getNextEntry()) {
+                if ("plugin.properties".equals(entry.getName())) {
+                    var properties = new Properties();
+                    properties.load(jar);
+                    return Optional.of(properties);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<Path> assembledPluginDirectories() {
+        var standalone = Path.of("gravitee-apim-distribution-standalone");
+        for (var candidate = Path.of("").toAbsolutePath(); candidate != null; candidate = candidate.getParent()) {
+            var root = candidate.resolve(standalone);
+            if (Files.isDirectory(root)) {
+                var dirs = new ArrayList<Path>();
+                for (var component : List.of("rest-api", "gateway")) {
+                    var plugins = root.resolve("gravitee-apim-distribution-standalone-" + component).resolve("target/distribution/plugins");
+                    if (Files.isDirectory(plugins)) {
+                        dirs.add(plugins);
+                    }
+                }
+                if (dirs.isEmpty()) {
+                    return fail(
+                        "No assembled distribution under %s. Assemble it first: mvn -f gravitee-apim-distribution/pom.xml install -Pengine-snapshot -DskipTests -Dbundle=dev",
+                        root
+                    );
+                }
+                return dirs;
+            }
+        }
+        return fail("Unable to locate %s from %s", standalone, Path.of("").toAbsolutePath());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.query;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Canonical registry of the {@code entrypoint-id} values observability knows about, each with the
+ * scope it was given. Single source of truth for the default entrypoint scoping applied by:
+ * <ul>
+ *   <li>the analytics engine ({@code FilterAdapter})</li>
+ *   <li>Gamma analytics and dashboards ({@code AnalyticsRequestPipeline})</li>
+ *   <li>Gamma logs ({@code SearchObservabilityLogsUseCase})</li>
+ * </ul>
+ *
+ * <p>The set is declared by hand rather than derived from the installed entrypoint plugins:
+ * analytics and logs read <em>historical</em> documents, so a derived set would drop past traffic
+ * from totals the day a plugin is uninstalled, and {@code FilterAdapter} runs inside the
+ * Elasticsearch repository plugin, which cannot see the entrypoint plugin registry. Drift is
+ * prevented instead by {@code ObservabilityEntrypointsTest}, which fails when the distribution
+ * bundles an entrypoint plugin no constant here accounts for.
+ */
+public enum ObservabilityEntrypoints {
+    /*
+     * Declaration order is the order the ids reach Elasticsearch. Kept stable so query bodies stay
+     * comparable across versions.
+     */
+    HTTP_GET("http-get", "gravitee-entrypoint-http-get", Scope.HTTP),
+    HTTP_POST("http-post", "gravitee-entrypoint-http-post", Scope.HTTP),
+    HTTP_PROXY("http-proxy", "gravitee-apim-plugin-entrypoint-http-proxy", Scope.HTTP),
+    LLM_PROXY("llm-proxy", "gravitee-entrypoint-llm-proxy", Scope.HTTP),
+    MCP_PROXY("mcp-proxy", "gravitee-entrypoint-mcp-proxy", Scope.HTTP),
+    A2A_PROXY("a2a-proxy", "gravitee-entrypoint-a2a-proxy", Scope.HTTP),
+
+    NATIVE_KAFKA("native-kafka", "gravitee-entrypoint-native-kafka", Scope.LOGS_ONLY),
+
+    /** Reported by Edge agents, which ship no entrypoint plugin of their own. */
+    EDGE("edge", null, Scope.DEDICATED_FAMILY),
+    /** The plugin id differs from the artifact name: {@code plugin.properties} of gravitee-entrypoint-authz 1.2.0 says {@code authzen}. */
+    AUTHZ("authzen", "gravitee-entrypoint-authz", Scope.DEDICATED_FAMILY),
+
+    MCP("mcp", "gravitee-entrypoint-mcp-tool-server", Scope.PENDING),
+    MCP_STUDIO("mcp-studio", "gravitee-entrypoint-mcp-studio", Scope.PENDING),
+    AGENT_TO_AGENT("agent-to-agent", "gravitee-entrypoint-agent-to-agent", Scope.PENDING),
+
+    SSE("sse", "gravitee-entrypoint-sse", Scope.EXCLUDED),
+    WEBHOOK("webhook", "gravitee-entrypoint-webhook", Scope.EXCLUDED),
+    WEBSOCKET("websocket", "gravitee-entrypoint-websocket", Scope.EXCLUDED),
+    TCP_PROXY("tcp-proxy", "gravitee-apim-plugin-entrypoint-tcp-proxy", Scope.EXCLUDED);
+
+    /**
+     * What observability does with an entrypoint's traffic. Every entrypoint must pick one, so a
+     * new one cannot reach the product without someone stating the intent.
+     */
+    public enum Scope {
+        /** Counted by the HTTP request scope: the analytics engine, Gamma analytics and Gamma logs. */
+        HTTP,
+
+        /**
+         * Served by Gamma logs but not by analytics. Native connections have their own documents and
+         * their own dashboard tiles; adding them to the analytics default would change every
+         * environment-wide total. The divergence is deliberate and tracked by OBS-18.
+         */
+        LOGS_ONLY,
+
+        /**
+         * Selected by a query family of its own — the Edge and Authz families each scope themselves —
+         * never by the default entrypoint predicate.
+         */
+        DEDICATED_FAMILY,
+
+        /**
+         * Carries traffic observability should count but does not yet. Listed so the gap is visible
+         * rather than accidental; OBS-18 promotes these to {@link #HTTP}.
+         */
+        PENDING,
+
+        /** Message and TCP APIs, outside what the observability signals cover today. */
+        EXCLUDED,
+    }
+
+    /** Entrypoints counted by the analytics engine, Gamma analytics and Gamma logs alike. */
+    public static final List<String> HTTP_SCOPE_IDS = idsWithScope(Scope.HTTP);
+
+    /** {@link #HTTP_SCOPE_IDS} plus the entrypoints only the logs signal serves. */
+    public static final List<String> LOGS_SCOPE_IDS = Stream.concat(
+        HTTP_SCOPE_IDS.stream(),
+        idsWithScope(Scope.LOGS_ONLY).stream()
+    ).toList();
+
+    private final String id;
+    private final String pluginArtifactId;
+    private final Scope scope;
+
+    ObservabilityEntrypoints(String id, String pluginArtifactId, Scope scope) {
+        this.id = id;
+        this.pluginArtifactId = pluginArtifactId;
+        this.scope = scope;
+    }
+
+    /** The {@code entrypoint-id} value carried by the reported documents. */
+    public String id() {
+        return id;
+    }
+
+    /** The plugin the distribution bundles this entrypoint as, absent when it ships no plugin. */
+    public Optional<String> pluginArtifactId() {
+        return Optional.ofNullable(pluginArtifactId);
+    }
+
+    private static List<String> idsWithScope(Scope scope) {
+        return Arrays.stream(values())
+            .filter(entrypoint -> entrypoint.scope == scope)
+            .map(ObservabilityEntrypoints::id)
+            .toList();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
@@ -21,20 +21,32 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Canonical registry of the {@code entrypoint-id} values observability knows about, each with the
- * scope it was given. Single source of truth for the default entrypoint scoping applied by:
+ * Registry of the {@code entrypoint-id} values observability knows about, each with the scope it
+ * was given. The default entrypoint scoping of the observability signals is declared here and
+ * nowhere else:
  * <ul>
  *   <li>the analytics engine ({@code FilterAdapter})</li>
  *   <li>Gamma analytics and dashboards ({@code AnalyticsRequestPipeline})</li>
  *   <li>Gamma logs ({@code SearchObservabilityLogsUseCase})</li>
  * </ul>
+ * The legacy v4 analytics adapters under {@code repository-elasticsearch/v4/analytics/adapter} keep
+ * their own lists on purpose: they serve the Console's v4 analytics endpoints, and widening them is a
+ * behaviour change owned by OBS-69, not by this registry.
  *
- * <p>The set is declared by hand rather than derived from the installed entrypoint plugins:
- * analytics and logs read <em>historical</em> documents, so a derived set would drop past traffic
- * from totals the day a plugin is uninstalled, and {@code FilterAdapter} runs inside the
- * Elasticsearch repository plugin, which cannot see the entrypoint plugin registry. Drift is
- * prevented instead by {@code ObservabilityEntrypointsTest}, which fails when the distribution
- * bundles an entrypoint plugin no constant here accounts for.
+ * <p>The set is declared by hand rather than derived from the installed entrypoint plugins, because
+ * the scope is a dashboard decision, not a plugin property: {@code mcp} carries the same metadata as
+ * {@code http-proxy} yet is not counted yet, and {@code http-get} / {@code http-post} are Message
+ * entrypoints counted on purpose. A derived set would also fail silently — the gateway and the
+ * Management API load separate plugin trees, an entrypoint missing on one side would simply vanish
+ * from the totals, and uninstalling a plugin would erase its historical traffic — while
+ * {@code FilterAdapter} runs inside the Elasticsearch repository plugin and cannot see the plugin
+ * registry at all.
+ *
+ * <p>Two tests hold the registry to the product instead: {@code ObservabilityEntrypointsTest} checks
+ * the artifacts the distribution pom bundles (fast, runs whenever this module changes), and
+ * {@code ObservabilityEntrypointsDistributionTest} in the distribution reactor reads the id every
+ * bundled plugin declares in its {@code plugin.properties} (runs whenever the distribution changes,
+ * i.e. when a new entrypoint reaches the product).
  */
 public enum ObservabilityEntrypoints {
     /*

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
@@ -69,6 +69,11 @@ class ObservabilityEntrypointsTest {
      * own repositories, so nothing here can observe a new {@code entrypoint-id} directly; bundling
      * the plugin in the distribution is the first moment a new entrypoint becomes visible to this
      * repository, and that is where this test intervenes.
+     *
+     * <p>It matches artifact names, which is all this reactor can see. The id each plugin really
+     * declares is checked by {@code ObservabilityEntrypointsDistributionTest} in the distribution
+     * reactor, against the assembled plugins; this one stays as the fast check that runs whenever
+     * this module changes.
      */
     @Nested
     class DistributionCoverage {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class ObservabilityEntrypointsTest {
+
+    @Nested
+    class Scopes {
+
+        @Test
+        void should_expose_the_http_scope_in_declaration_order() {
+            assertThat(ObservabilityEntrypoints.HTTP_SCOPE_IDS).containsExactly(
+                "http-get",
+                "http-post",
+                "http-proxy",
+                "llm-proxy",
+                "mcp-proxy",
+                "a2a-proxy"
+            );
+        }
+
+        @Test
+        void should_extend_the_http_scope_with_native_kafka_only_for_logs() {
+            assertThat(ObservabilityEntrypoints.LOGS_SCOPE_IDS).containsExactly(
+                "http-get",
+                "http-post",
+                "http-proxy",
+                "llm-proxy",
+                "mcp-proxy",
+                "a2a-proxy",
+                "native-kafka"
+            );
+        }
+    }
+
+    /**
+     * Guards the registry against the drift it exists to prevent. Entrypoint plugins live in their
+     * own repositories, so nothing here can observe a new {@code entrypoint-id} directly; bundling
+     * the plugin in the distribution is the first moment a new entrypoint becomes visible to this
+     * repository, and that is where this test intervenes.
+     */
+    @Nested
+    class DistributionCoverage {
+
+        private static final Pattern ENTRYPOINT_PLUGIN_ARTIFACT = Pattern.compile(
+            "<artifactId>((?:gravitee-entrypoint|gravitee-apim-plugin-entrypoint)-[^<]+)</artifactId>"
+        );
+
+        /** The plugin SPI every entrypoint is built against, not an entrypoint itself. */
+        private static final String ENTRYPOINT_PLUGIN_SPI_ARTIFACT = "gravitee-apim-plugin-entrypoint-handler";
+
+        @Test
+        void should_declare_every_entrypoint_plugin_bundled_by_the_distribution() {
+            assertThat(bundledEntrypointPluginArtifacts())
+                .as("every bundled entrypoint plugin needs an ObservabilityEntrypoints entry stating its scope")
+                .isSubsetOf(declaredPluginArtifacts());
+        }
+
+        @Test
+        void should_not_declare_an_entrypoint_plugin_the_distribution_no_longer_bundles() {
+            assertThat(declaredPluginArtifacts())
+                .as("a declared entrypoint plugin that is no longer bundled leaves a stale scope decision behind")
+                .isSubsetOf(bundledEntrypointPluginArtifacts());
+        }
+
+        private Set<String> declaredPluginArtifacts() {
+            return Arrays.stream(ObservabilityEntrypoints.values())
+                .map(ObservabilityEntrypoints::pluginArtifactId)
+                .flatMap(Optional::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        private Set<String> bundledEntrypointPluginArtifacts() {
+            var pom = standaloneDistributionPom();
+            String content;
+            try {
+                content = Files.readString(pom);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to read " + pom, e);
+            }
+
+            var artifacts = new LinkedHashSet<String>();
+            var matcher = ENTRYPOINT_PLUGIN_ARTIFACT.matcher(content);
+            while (matcher.find()) {
+                var artifact = matcher.group(1);
+                if (!ENTRYPOINT_PLUGIN_SPI_ARTIFACT.equals(artifact)) {
+                    artifacts.add(artifact);
+                }
+            }
+
+            assertThat(artifacts).as("no entrypoint plugin found in %s — the parsing is stale", pom).isNotEmpty();
+            return artifacts;
+        }
+
+        private Path standaloneDistributionPom() {
+            var relativeToRoot = Path.of("gravitee-apim-distribution", "gravitee-apim-distribution-standalone", "pom.xml");
+            for (var candidate = Path.of("").toAbsolutePath(); candidate != null; candidate = candidate.getParent()) {
+                var pom = candidate.resolve(relativeToRoot);
+                if (Files.isRegularFile(pom)) {
+                    return pom;
+                }
+            }
+            throw new IllegalStateException("Unable to locate " + relativeToRoot + " from " + Path.of("").toAbsolutePath());
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
 import io.gravitee.repository.analytics.engine.api.query.Filter;
+import io.gravitee.repository.analytics.engine.api.query.ObservabilityEntrypoints;
 import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.api.FieldResolver;
 import io.gravitee.repository.elasticsearch.v4.shared.StatusCodeGroups;
@@ -30,13 +31,6 @@ import java.util.*;
 public class FilterAdapter {
 
     static final String ENTRYPOINT_FIELD = "entrypoint-id";
-    static final String HTTP_GET_ENTRYPOINT_ID = "http-get";
-    static final String HTTP_POST_ENTRYPOINT_ID = "http-post";
-    static final String HTTP_PROXY_ENTRYPOINT_ID = "http-proxy";
-    static final String LLM_PROXY_ENTRYPOINT_ID = "llm-proxy";
-    static final String MCP_PROXY_ENTRYPOINT_ID = "mcp-proxy";
-    static final String A2A_PROXY_ENTRYPOINT_ID = "a2a-proxy";
-    static final String EDGE_ENTRYPOINT_ID = "edge";
 
     static final List<Filter.Name> HTTP_FILTER_NAMES = List.of(
         Filter.Name.API,
@@ -263,17 +257,7 @@ public class FilterAdapter {
     public JsonObject httpFilter() {
         JsonObject termsFilter = JsonObject.of(
             "terms",
-            JsonObject.of(
-                ENTRYPOINT_FIELD,
-                JsonArray.of(
-                    HTTP_GET_ENTRYPOINT_ID,
-                    HTTP_POST_ENTRYPOINT_ID,
-                    HTTP_PROXY_ENTRYPOINT_ID,
-                    LLM_PROXY_ENTRYPOINT_ID,
-                    MCP_PROXY_ENTRYPOINT_ID,
-                    A2A_PROXY_ENTRYPOINT_ID
-                )
-            )
+            JsonObject.of(ENTRYPOINT_FIELD, new JsonArray(new ArrayList<>(ObservabilityEntrypoints.HTTP_SCOPE_IDS)))
         );
 
         // This is needed for now to get APIs that don't pass the security chain.
@@ -298,7 +282,7 @@ public class FilterAdapter {
     }
 
     public JsonObject edgeFilter() {
-        return JsonObject.of("term", JsonObject.of(ENTRYPOINT_FIELD, EDGE_ENTRYPOINT_ID));
+        return JsonObject.of("term", JsonObject.of(ENTRYPOINT_FIELD, ObservabilityEntrypoints.EDGE.id()));
     }
 
     private JsonObject filter(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -446,12 +446,12 @@ class FilterAdapterTest {
             var entrypointIds = termsFilter.getJsonObject("terms").getJsonArray(ENTRYPOINT_FIELD);
 
             assertThat(entrypointIds.getList()).containsExactly(
-                HTTP_GET_ENTRYPOINT_ID,
-                HTTP_POST_ENTRYPOINT_ID,
-                HTTP_PROXY_ENTRYPOINT_ID,
-                LLM_PROXY_ENTRYPOINT_ID,
-                MCP_PROXY_ENTRYPOINT_ID,
-                A2A_PROXY_ENTRYPOINT_ID
+                "http-get",
+                "http-post",
+                "http-proxy",
+                "llm-proxy",
+                "mcp-proxy",
+                "a2a-proxy"
             );
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -15,13 +15,7 @@
  */
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.A2A_PROXY_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.ENTRYPOINT_FIELD;
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_GET_ENTRYPOINT_ID;
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_POST_ENTRYPOINT_ID;
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_PROXY_ENTRYPOINT_ID;
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.LLM_PROXY_ENTRYPOINT_ID;
-import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.MCP_PROXY_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.MessageFacetExtractor.REQUEST_ID_AGG_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -289,7 +283,7 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
         var jsonQuery = JSON.readTree(adapter.adaptRequestIDsQuery(query, null));
 
         var filters = jsonQuery.at("/query/bool/filter").toString();
-        assertThat(filters).doesNotContain(HTTP_GET_ENTRYPOINT_ID).doesNotContain(HTTP_POST_ENTRYPOINT_ID);
+        assertThat(filters).doesNotContain("http-get").doesNotContain("http-post");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
@@ -23,6 +23,7 @@ import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.EntrypointScopeProvider;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -45,10 +46,9 @@ public class AnalyticsRequestPipeline {
 
     static final Set<ApiType> ANALYTICS_SUPPORTED_API_TYPES = ApiType.ALL;
 
-    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of("http-get", "http-post", "http-proxy", "llm-proxy", "mcp-proxy", "a2a-proxy");
-
     private final ObservabilityFilterValidator filterValidator;
     private final AccessibleApiScopeDomainService accessibleApiScope;
+    private final EntrypointScopeProvider entrypointScope;
 
     /**
      * Validated and RBAC-scoped request data, expressed entirely in Gamma-native types. The infra
@@ -118,13 +118,13 @@ public class AnalyticsRequestPipeline {
             .toList();
     }
 
-    private static List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
+    private List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
         boolean hasEntrypoint = conditions.stream().anyMatch(c -> "ENTRYPOINT".equals(c.name()));
         if (hasEntrypoint) {
             return conditions;
         }
         var result = new ArrayList<>(conditions);
-        result.add(new FilterCondition("ENTRYPOINT", FilterOperator.IN, List.copyOf(DEFAULT_ENTRYPOINT_IDS)));
+        result.add(new FilterCondition("ENTRYPOINT", FilterOperator.IN, entrypointScope.analyticsScope()));
         return List.copyOf(result);
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/EntrypointScopeProvider.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/EntrypointScopeProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.port.service_provider;
+
+import java.util.List;
+
+/**
+ * Supplies the entrypoint ids a query covers when the caller set no explicit entrypoint filter.
+ *
+ * <p>A port rather than a constant because the canonical declaration is shared with the analytics
+ * engine and therefore lives in the platform's analytics-engine query package, which core must not
+ * reach (AGENTS.md §5). The core decides <em>whether</em> a query is entrypoint-scoped; infra says
+ * <em>which</em> ids that means.
+ *
+ * @author GraviteeSource Team
+ */
+public interface EntrypointScopeProvider {
+    /** Entrypoints an unfiltered analytics or dashboard query covers. */
+    List<String> analyticsScope();
+
+    /** Entrypoints an unfiltered logs query covers. Wider than {@link #analyticsScope()}. */
+    List<String> logsScope();
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -21,9 +21,11 @@ import io.gravitee.gamma.rest.core.observability.filter.domain_service.Observabi
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.ExtensibleFilters;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.core.observability.filter.model.RecordType;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.EntrypointScopeProvider;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
@@ -67,28 +69,10 @@ public class SearchObservabilityLogsUseCase {
         ApiType.AUTHZ
     );
 
-    /**
-     * Canonical entrypoints applied when no explicit entrypoint filter is set. The HTTP subset
-     * mirrors {@code FilterAdapter.httpFilter()} from the analytics ES adapter; {@code native-kafka}
-     * is additionally included so native connection documents are served by the LOGS signal.
-     * NOTE: the analytics default has NOT been widened to native yet, so in a mixed environment the
-     * unfiltered logs total includes native connections while dashboard totals do not — aligning
-     * the analytics side is a pending decision with the Gamma team. The ES query builder adds a
-     * field-missing fallback alongside these terms.
-     */
-    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of(
-        "http-get",
-        "http-post",
-        "http-proxy",
-        "llm-proxy",
-        "mcp-proxy",
-        "a2a-proxy",
-        "native-kafka"
-    );
-
     private final ObservabilityLogsDataPort logsDataPort;
     private final ObservabilityFilterValidator filterValidator;
     private final AccessibleApiScopeDomainService accessibleApiScope;
+    private final EntrypointScopeProvider entrypointScope;
 
     public record Input(
         String organizationId,
@@ -265,22 +249,19 @@ public class SearchObservabilityLogsUseCase {
     }
 
     /**
-     * If the caller didn't supply an explicit entrypoint filter, inject the canonical HTTP
-     * entrypoint set so the logs table matches the dashboard totals.
+     * If the caller didn't supply an explicit entrypoint filter, inject the canonical logs
+     * entrypoint scope. It is wider than the analytics one — native connections are served by the
+     * logs signal alone — so an unfiltered logs total exceeds the dashboard total on a mixed
+     * environment. The difference is deliberate and recorded on {@link EntrypointScopeProvider}.
+     * The ES query builder adds a field-missing fallback alongside these terms.
      */
-    private static List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
+    private List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
         boolean hasEntrypoint = conditions.stream().anyMatch(c -> "ENTRYPOINT".equals(c.name()));
         if (hasEntrypoint) {
             return conditions;
         }
         var result = new ArrayList<>(conditions);
-        result.add(
-            new FilterCondition(
-                "ENTRYPOINT",
-                io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.IN,
-                List.copyOf(DEFAULT_ENTRYPOINT_IDS)
-            )
-        );
+        result.add(new FilterCondition("ENTRYPOINT", FilterOperator.IN, entrypointScope.logsScope()));
         return List.copyOf(result);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/EntrypointScopeProviderAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/EntrypointScopeProviderAdapter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.EntrypointScopeProvider;
+import io.gravitee.repository.analytics.engine.api.query.ObservabilityEntrypoints;
+import java.util.List;
+
+/**
+ * Reads the entrypoint scopes from {@link ObservabilityEntrypoints}, the declaration the analytics
+ * engine's own default scoping is built from, so Gamma and the engine cannot drift apart.
+ *
+ * @author GraviteeSource Team
+ */
+public class EntrypointScopeProviderAdapter implements EntrypointScopeProvider {
+
+    @Override
+    public List<String> analyticsScope() {
+        return ObservabilityEntrypoints.HTTP_SCOPE_IDS;
+    }
+
+    @Override
+    public List<String> logsScope() {
+        return ObservabilityEntrypoints.LOGS_SCOPE_IDS;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
@@ -19,8 +19,10 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetFilterValuesUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.ResolveFilterLabelsUseCase;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.EntrypointScopeProvider;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
+import io.gravitee.gamma.rest.infra.adapter.EntrypointScopeProviderAdapter;
 import io.gravitee.gamma.rest.infra.adapter.ObservabilityFilterDataPortAdapter;
 import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
 import org.springframework.context.annotation.Bean;
@@ -54,6 +56,11 @@ public class GammaObservabilityFilterConfiguration {
     @Bean
     public FilterRegistry gammaFilterRegistry() {
         return new SpiFilterRegistry();
+    }
+
+    @Bean
+    public EntrypointScopeProvider entrypointScopeProvider() {
+        return new EntrypointScopeProviderAdapter();
     }
 
     /**

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
@@ -33,6 +33,7 @@ import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import io.gravitee.gamma.rest.infra.adapter.EntrypointScopeProviderAdapter;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
@@ -64,7 +65,7 @@ class AnalyticsRequestPipelineTest {
     void setUp() {
         var accessibleApiScope = new AccessibleApiScopeDomainService();
         var filterValidator = new ObservabilityFilterValidator(filterRegistry);
-        pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope);
+        pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope, new EntrypointScopeProviderAdapter());
 
         when(filterRegistry.getFilters(any(), any())).thenReturn(
             List.of(

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
@@ -36,6 +36,7 @@ import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import io.gravitee.gamma.rest.infra.adapter.EntrypointScopeProviderAdapter;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,7 @@ class ComputeObservabilityMeasuresUseCaseTest {
     void setUp() {
         var accessibleApiScope = new AccessibleApiScopeDomainService();
         var filterValidator = new ObservabilityFilterValidator(filterRegistry);
-        var pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope);
+        var pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope, new EntrypointScopeProviderAdapter());
         useCase = new ComputeObservabilityMeasuresUseCase(analyticsDataPort, pipeline);
 
         when(filterRegistry.getFilters(any(), any())).thenReturn(

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -43,6 +43,7 @@ import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import io.gravitee.gamma.rest.infra.adapter.EntrypointScopeProviderAdapter;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -79,7 +80,12 @@ class SearchObservabilityLogsUseCaseTest {
     void setUp() {
         accessibleApiScope = new AccessibleApiScopeDomainService();
         var filterValidator = new ObservabilityFilterValidator(filterRegistry);
-        useCase = new SearchObservabilityLogsUseCase(logsDataPort, filterValidator, accessibleApiScope);
+        useCase = new SearchObservabilityLogsUseCase(
+            logsDataPort,
+            filterValidator,
+            accessibleApiScope,
+            new EntrypointScopeProviderAdapter()
+        );
 
         when(filterRegistry.getFilters(any(), any())).thenReturn(
             List.of(


### PR DESCRIPTION
## Summary

The set of `entrypoint-id` values observability scopes its queries to was copied by hand into three modules — the Elasticsearch analytics engine, Gamma analytics and Gamma logs. The copies had already drifted, and nothing made a missing entrypoint visible: the A2A rollout had to touch each one independently, and `mcp` / `mcp-studio` / `agent-to-agent` were forgotten in all three (see [OBS-18](https://gravitee.atlassian.net/browse/OBS-18)).

This introduces a single declaration, `ObservabilityEntrypoints`, in which every entrypoint carries an explicit observability scope, plus a test that fails when a new entrypoint plugin reaches the distribution without one.

Closes [OBS-19](https://gravitee.atlassian.net/browse/OBS-19).

**Behaviour is unchanged** — the same ids, in the same order, reach Elasticsearch.

## Changes

- **New** `ObservabilityEntrypoints` (`gravitee-apim-repository-api`, `io.gravitee.repository.analytics.engine.api.query`) — 16 entrypoints, each with a mandatory `Scope`:

  | Scope | Entrypoints | Meaning |
  | --- | --- | --- |
  | `HTTP` | `http-get`, `http-post`, `http-proxy`, `llm-proxy`, `mcp-proxy`, `a2a-proxy` | counted by analytics, dashboards and logs |
  | `LOGS_ONLY` | `native-kafka` | the logs/analytics divergence, now a named exception instead of a code comment |
  | `DEDICATED_FAMILY` | `edge`, `authz` | scoped by their own query family, never by the default predicate |
  | `PENDING` | `mcp`, `mcp-studio`, `agent-to-agent` | the OBS-18 gap, recorded so it is visible rather than accidental |
  | `EXCLUDED` | `sse`, `webhook`, `websocket`, `tcp-proxy` | message and TCP APIs, deliberate product scoping |

- `FilterAdapter.httpFilter()` and `edgeFilter()` read from it; the seven literal id constants are gone.
- `AnalyticsRequestPipeline.DEFAULT_ENTRYPOINT_IDS` and `SearchObservabilityLogsUseCase.DEFAULT_ENTRYPOINT_IDS` are gone. Gamma reaches the registry through a port — `EntrypointScopeProvider` (core) implemented by `EntrypointScopeProviderAdapter` (infra) — because `CoreRulesTest` forbids `io.gravitee.gamma.rest.core` from depending on `io.gravitee.repository..`. The core decides *whether* a query is entrypoint-scoped; infra says *which* ids that means.
- **Two guard tests** hold the registry to the product:
  - `ObservabilityEntrypointsTest.DistributionCoverage` (repository-api) parses the entrypoint artifacts bundled by the distribution pom — the fast check that runs whenever the registry changes.
  - `ObservabilityEntrypointsDistributionTest` (distribution integration tests) opens every bundled entrypoint zip and reads the id the plugin itself declares in `plugin.properties`; fails when an id has no registry decision, when a decision names a plugin no longer bundled, or when the registry's id differs from the plugin's. It runs in the `Integration tests` job — the one triggered by a change to the distribution pom, i.e. exactly when a new entrypoint reaches the product.

### Why a hand-maintained registry rather than a derived set (stress-tested after review)

Recorded on the ticket, repeated here for reviewers:

- The scope is a dashboard decision, not a plugin property: `mcp` carries the same metadata as `http-proxy` (PROXY / HTTP / REQUEST_RESPONSE) yet stays out until OBS-18, and `http-get` / `http-post` are MESSAGE entrypoints counted on purpose (GMA-513). Any derivation still needs a hand-written exception list.
- A derived set fails silently: gateway and Management API load separate plugin trees, so a gateway-only entrypoint would write ids the API never lists; a missing or corrupted plugin shrinks the totals with no error; uninstalling a plugin erases its historical traffic.
- `FilterAdapter` runs inside the Elasticsearch repository plugin, which has no access to the entrypoint plugin registry — a static default survives there regardless.

Drift is prevented by the guard test instead of by runtime derivation.

## Test plan

- [ ] `mvn -pl gravitee-apim-repository/gravitee-apim-repository-api -am -DskipTests install`, then `mvn -pl gravitee-apim-repository/gravitee-apim-repository-api test` — 71 tests green, including the 4 new ones.
- [ ] Assemble the distribution (`-Pengine-snapshot -Dbundle=dev`), then `mvn -f gravitee-apim-distribution/pom.xml -pl gravitee-apim-distribution-integration-tests test -Pengine-snapshot,integration-tests-modules -Dtest=ObservabilityEntrypointsDistributionTest` — 3 green on the 15 bundled entrypoints; delete any registry constant and it fails naming the zip.
- [ ] `mvn -pl gravitee-apim-repository/gravitee-apim-repository-elasticsearch test -Dtest='io.gravitee.repository.elasticsearch.v4.analytics.**.*Test'` — 448 tests green.
- [ ] `mvn -pl gravitee-gamma/gravitee-gamma-rest-api test -Dskip.ui.build=true` — full module, 394 tests green, including `CoreRulesTest` / `OnionArchitectureTest` / `NamingConventionTest`.
- [ ] **No behavioural change** — the three pre-existing default-scoping tests still spell out the literal ids rather than reading the registry, so they remain real evidence and not tautologies: `FilterAdapterTest.should_include_all_http_entrypoint_ids_in_http_filter`, `AnalyticsRequestPipelineTest.should_inject_default_entrypoint_filter_when_none_provided`, `SearchObservabilityLogsUseCaseTest.should_inject_default_entrypoint_filter_when_none_provided`.
- [ ] **The guard actually bites** — delete any constant (e.g. `SSE`) and re-run `ObservabilityEntrypointsTest`: `should_declare_every_entrypoint_plugin_bundled_by_the_distribution` fails naming the uncovered artifact. Restore it and it passes again.
- [ ] Edge and Authz signals still resolve their entrypoint scoping (`edgeFilter()` term is unchanged; the Authz family carries no entrypoint predicate).

## Regression proof — real HTTP calls, master vs branch

**📊 [OBS-19 Regression Proof](https://claude.ai/code/artifact/313323d0-705d-42cc-8e87-69cb7749a225)** — interactive report, filterable by scenario.

The same **62 requests** were replayed against two Management API images built from the same reactor (`-Pengine-snapshot -Dbundle=dev`): one from `master` at the merge-base (`4cc91ba16e`), one from this branch. Same Elasticsearch, same data, `admin` on `DEFAULT`. A scenario passes when both responses are byte-identical after normalisation.

| | |
| --- | --- |
| Scenarios | 62 across Gamma analytics (measures / facets / time-series), Gamma logs, Management API v2 analytics (measures / facets) |
| Identical master ↔ branch | **62 / 62** |
| Data | 719 real `v4-metrics` documents + 96 synthetic ones in a separate daily index covering **every entrypoint id the registry knows** (HTTP scope, `native-kafka`, `edge`, `authzen`, the three PENDING ids, the four EXCLUDED ids) plus 5 documents with no `entrypoint-id` — crossed with three time windows and filters on API, API type, entrypoint, status group, method, gateway |
| Oracle | expected counts computed straight in Elasticsearch from the registry semantics, independent of either build — every default-scope scenario matches it (analytics 57 / 644 / 701, logs 54 / 503 / 557, v2 62 / 644 / 706) |
| Provenance | each capture records the jars inside the container: the branch image carries `ObservabilityEntrypoints` and `EntrypointScopeProvider`, the master image none |
| Captured at | an earlier rebase of this branch (`55dec5ae45`, shown in the report's provenance chips). Since then the branch was only rebased onto master and the reporter-test workaround was dropped in favour of #19593 — the observability diff is byte-identical, so the proof still describes this code |

The report also replays the same 62 requests against the **4.12.18 release** image that was running locally: 13 differ from master, all attributed to changes that landed on master before this branch (`RECORD_TYPE` filter, `native-kafka` in the logs scope, the GMA-513 message-family fix, two new log-row fields) — and each of those stays identical between master and the branch.

## Reviewer notes

- **`Test reporters` may show red on this branch** — a pre-existing Elasticsearch container leak in `gravitee-apim-reporter-elasticsearch`'s integration tests, unrelated to this change. It is being fixed properly by [#19593](https://github.com/gravitee-io/gravitee-api-management/pull/19593); the workaround this branch briefly carried was dropped in its favour.
- **The `PENDING` scope changes nothing today.** `mcp`, `mcp-studio` and `agent-to-agent` are declared but excluded from `HTTP_SCOPE_IDS`, so what is queried is identical to before. OBS-18 flips them to `HTTP`, which is a one-line change per entrypoint once this lands.
- **Why a port for what is only a list of strings.** No module is reachable by both `FilterAdapter` (Elasticsearch repository plugin) and Gamma's `core` package, so a shared compile-time constant is impossible: the layering rules that out. The port is how the single declaration survives the boundary. Gamma's infra layer already reaches `io.gravitee.repository.analytics.engine.api.query` for `HttpStatusCodeGroups`, so the adapter is on well-trodden ground.
- **Every entrypoint id was checked against the plugin's own `plugin.properties`** (the enterprise zips pulled by `-Dbundle=dev`). One inference was wrong: the Authz entrypoint's id is `authzen`, not `authz` — corrected in the registry. No runtime effect (that family never emits it), but the registry must be right if it is to be the source of truth. `mcp` (mcp-tool-server), `mcp-studio` and `agent-to-agent` are confirmed.
- **The guard test reads a file outside its module** — `gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml`, located by walking up from the working directory. That is a deliberate coupling: entrypoint plugins live in their own repositories and ship as zips, so bundling in the distribution is the earliest in-repo signal that a new entrypoint has reached the product. If the file cannot be found the test fails loudly rather than skipping.

## Second commit — verifying the registry against the bundled plugin ids

`test(observability): verify the entrypoint registry against the bundled plugin ids` answers the review question on hard-coded ids. It adds `ObservabilityEntrypointsDistributionTest` (see *Changes*), a test-scoped dependency of the integration-tests module on `gravitee-apim-repository-api`, and rewrites the registry javadoc: exact scope (the five legacy v4 analytics adapters keep their lists until OBS-69) and the real reasons the set is not derived from installed plugins. Verified locally against the assembled distributions (15 entrypoints, 3 tests green) and proven to bite three ways — a deleted constant, `authz` in place of `authzen`, a stale artifact — each with its own message. OBS-85 files the remaining blind spot (customer-installed entrypoints) as a startup warning.

## Out of scope

Five **legacy v4 analytics** adapters carry their own, differently drifted entrypoint lists — `SearchHistogramQueryAdapter` (5 ids), `GroupByQueryAdapter` (3), `ResponseTimeRangeQueryAdapter` (4), `SearchResponseStatusOverTimeAdapter` (4), `SearchRequestResponseTimeAdapter` (3), all under `gravitee-apim-repository-elasticsearch`, `v4/analytics/adapter`. They serve the legacy Console v4 analytics endpoints, not the observability engine; pointing them at the shared set would widen what they count and break "no behavioural change".

Filed as [OBS-69](https://gravitee.atlassian.net/browse/OBS-69) — and it is more than duplication: those lists are applied as `terms entrypoint-id` allowlists too, so the legacy endpoints under-report the same traffic. On an MCP proxy API the histogram widget counts requests while the response-time and group-by widgets on the same screen report nothing, because their lists disagree.


[OBS-18]: https://gravitee.atlassian.net/browse/OBS-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBS-19]: https://gravitee.atlassian.net/browse/OBS-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBS-69]: https://gravitee.atlassian.net/browse/OBS-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ