### PR TITLE
fix(rest-api): skip FreeMarker processing for OpenAPI pages

### DIFF
--- a/gravitee-apim-console-webui/src/docs/management-api-documentation.md
+++ b/gravitee-apim-console-webui/src/docs/management-api-documentation.md
@@ -5,7 +5,7 @@ At this date, two types of document are supported:
 * Swagger
 * Markdown (MD)
 
-You can access to your API data (name, version, description ...) on your API’s documentation by writing: `${api.name}` or `${api.metadata['foo-bar']}` in your documentation's content.
+In Markdown documentation pages, you can access your API data (name, version, description, and so on) by writing `${api.name}` or `${api.metadata['foo-bar']}` in the page content. OpenAPI documentation is treated as specification data and does not support these template expressions.
 
 By default, documentation pages are in staging mode and will be visible to API owners and API members with specific documentation roles.
 To make documentation visible for all users, you can switch on the *published* button.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -593,9 +593,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             );
             transformSwagger(executionContext, pageEntity, genericApiEntity);
         } else {
-            if (markdownSanitize && MARKDOWN.name().equalsIgnoreCase(pageEntity.getType())) {
+            String pageType = resolvePageType(pageEntity);
+            if (markdownSanitize && MARKDOWN.name().equalsIgnoreCase(pageType)) {
                 sanitizeMarkdown(pageEntity);
-            } else if (SWAGGER.name().equalsIgnoreCase(pageEntity.getType())) {
+            } else if (SWAGGER.name().equalsIgnoreCase(pageType)) {
                 SwaggerDescriptor<?> descriptor = swaggerService.parse(pageEntity.getContent());
                 Collection<SwaggerTransformer<OAIDescriptor>> transformers = new ArrayList<>();
                 transformers.add(new PageConfigurationOAITransformer(pageEntity));
@@ -607,12 +608,12 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
     @Override
     public void transformSwagger(final ExecutionContext executionContext, PageEntity pageEntity, GenericApiEntity genericApiEntity) {
-        // First apply templating if required
-        transformWithTemplate(executionContext, pageEntity, genericApiEntity.getId());
+        String pageType = resolvePageType(pageEntity);
+        transformWithTemplate(executionContext, pageEntity, genericApiEntity.getId(), pageType);
 
-        if (markdownSanitize && MARKDOWN.name().equalsIgnoreCase(pageEntity.getType())) {
+        if (markdownSanitize && MARKDOWN.name().equalsIgnoreCase(pageType)) {
             sanitizeMarkdown(pageEntity);
-        } else if (SWAGGER.name().equalsIgnoreCase(pageEntity.getType())) {
+        } else if (SWAGGER.name().equalsIgnoreCase(pageType)) {
             // If swagger page, let's try to apply transformations
             SwaggerDescriptor<?> descriptor;
 
@@ -794,6 +795,20 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
     @Override
     public void transformWithTemplate(final ExecutionContext executionContext, final PageEntity pageEntity, final String api) {
+        transformWithTemplate(executionContext, pageEntity, api, resolvePageType(pageEntity));
+    }
+
+    private void transformWithTemplate(
+        final ExecutionContext executionContext,
+        final PageEntity pageEntity,
+        final String api,
+        final String pageType
+    ) {
+        if (SWAGGER.name().equalsIgnoreCase(pageType)) {
+            // OpenAPI specifications are data and must not be interpreted as FreeMarker templates.
+            return;
+        }
+
         if (pageEntity.getContent() != null) {
             final Map<String, Object> model = new HashMap<>();
             if (api == null) {
@@ -2573,22 +2588,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     @Override
     public List<String> validateSafeContent(ExecutionContext executionContext, PageEntity pageEntity, String apiId) {
         if (pageEntity != null) {
-            var pageType = pageEntity.getType();
+            var pageType = resolvePageType(pageEntity);
 
-            if (pageEntity.getParentId() != null && TRANSLATION.name().equals(pageType)) {
-                final Optional<Page> optParent;
-                try {
-                    optParent = pageRepository.findById(pageEntity.getParentId());
-                    if (optParent.isPresent()) {
-                        pageType = optParent.get().getType();
-                    }
-                } catch (TechnicalException e) {
-                    log.error("An error occurs while trying to fetch parent page of page '{}'", pageEntity.getId(), e);
-                }
-            }
-
-            if (markdownSanitize && MARKDOWN.name().equals(pageType)) {
-                this.transformWithTemplate(executionContext, pageEntity, apiId);
+            if (markdownSanitize && MARKDOWN.name().equalsIgnoreCase(pageType)) {
+                this.transformWithTemplate(executionContext, pageEntity, apiId, pageType);
                 HtmlSanitizer.SanitizeInfos sanitizeInfos = this.htmlSanitizer.isSafe(pageEntity.getContent());
                 if (!sanitizeInfos.isSafe()) {
                     throw new PageContentUnsafeException(sanitizeInfos.getRejectedMessage());
@@ -2596,7 +2599,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 if (!CollectionUtils.isEmpty(pageEntity.getMessages())) {
                     return asList(pageEntity.getMessages().toString());
                 }
-            } else if (swaggerValidateSafeContent && SWAGGER.name().equals(pageEntity.getType()) && pageEntity.getContent() != null) {
+            } else if (swaggerValidateSafeContent && SWAGGER.name().equalsIgnoreCase(pageType) && pageEntity.getContent() != null) {
                 OAIDescriptor openApiDescriptor = new OAIParser().parse(pageEntity.getContent());
                 if (openApiDescriptor != null && openApiDescriptor.getMessages() != null) {
                     return openApiDescriptor.getMessages();
@@ -2604,6 +2607,21 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             }
         }
         return new ArrayList<>();
+    }
+
+    private String resolvePageType(PageEntity pageEntity) {
+        String pageType = pageEntity.getType();
+        if (pageEntity.getParentId() != null && TRANSLATION.name().equalsIgnoreCase(pageType)) {
+            try {
+                Optional<Page> parent = pageRepository.findById(pageEntity.getParentId());
+                if (parent.isPresent()) {
+                    pageType = parent.get().getType();
+                }
+            } catch (TechnicalException e) {
+                log.error("An error occurs while trying to fetch parent page of page '{}'", pageEntity.getId(), e);
+            }
+        }
+        return pageType;
     }
 
     private void validateSafeSource(PageSourceEntity source) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_TransformSwaggerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_TransformSwaggerTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.model.PageType.MARKDOWN;
+import static io.gravitee.rest.api.model.PageType.SWAGGER;
+import static io.gravitee.rest.api.model.PageType.TRANSLATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PageRepository;
+import io.gravitee.repository.management.model.Page;
+import io.gravitee.rest.api.model.PageEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.SwaggerService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PageService_TransformSwaggerTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_ID = "api-id";
+    private static final String PAGE_ID = "page-id";
+    private static final String PARENT_PAGE_ID = "parent-page-id";
+    private static final String OPENAPI_CONTENT = """
+        {
+          "openapi": "3.0.0",
+          "info": {
+            "title": "Rundeck API",
+            "version": "1.0.0",
+            "description": "-payload ${raw}"
+          },
+          "paths": {}
+        }
+        """;
+
+    @InjectMocks
+    private PageServiceImpl pageService;
+
+    @Mock
+    private SwaggerService swaggerService;
+
+    @Mock
+    private NotificationTemplateService notificationTemplateService;
+
+    @Mock
+    private ApiTemplateService apiTemplateService;
+
+    @Mock
+    private ApiEntrypointService apiEntrypointService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    @Mock
+    private PageRepository pageRepository;
+
+    @Test
+    void should_preserve_openapi_expression_when_transforming_swagger_page() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        PageEntity page = PageEntity.builder()
+            .id(PAGE_ID)
+            .type(SWAGGER.name())
+            .content(OPENAPI_CONTENT)
+            .contentType(MediaType.APPLICATION_JSON)
+            .build();
+
+        when(swaggerService.parse(OPENAPI_CONTENT)).thenReturn(new OAIParser().parse(OPENAPI_CONTENT));
+
+        pageService.transformSwagger(executionContext, page, api);
+
+        assertThat(page.getContent()).contains("${raw}");
+        assertThat(page.getMessages()).isNullOrEmpty();
+        verifyNoInteractions(notificationTemplateService);
+    }
+
+    @Test
+    void should_preserve_known_template_expression_when_transforming_swagger_page() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        String openApiContent = OPENAPI_CONTENT.replace("${raw}", "${api.name}");
+        PageEntity page = PageEntity.builder()
+            .id(PAGE_ID)
+            .type(SWAGGER.name())
+            .content(openApiContent)
+            .contentType(MediaType.APPLICATION_JSON)
+            .build();
+
+        when(swaggerService.parse(openApiContent)).thenReturn(new OAIParser().parse(openApiContent));
+
+        pageService.transformSwagger(executionContext, page, api);
+
+        assertThat(page.getContent()).contains("${api.name}");
+        verifyNoInteractions(notificationTemplateService);
+    }
+
+    @Test
+    void should_preserve_openapi_expression_when_transforming_environment_swagger_page() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        PageEntity page = PageEntity.builder().id(PAGE_ID).type(SWAGGER.name()).content(OPENAPI_CONTENT).build();
+
+        pageService.transformWithTemplate(executionContext, page, null);
+
+        assertThat(page.getContent()).isEqualTo(OPENAPI_CONTENT);
+        verifyNoInteractions(notificationTemplateService);
+    }
+
+    @Test
+    void should_preserve_openapi_expression_when_transforming_swagger_translation() throws TechnicalException {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        Page parentPage = new Page();
+        parentPage.setId(PARENT_PAGE_ID);
+        parentPage.setType(SWAGGER.name());
+        PageEntity translation = PageEntity.builder()
+            .id(PAGE_ID)
+            .parentId(PARENT_PAGE_ID)
+            .type(TRANSLATION.name())
+            .content(OPENAPI_CONTENT)
+            .contentType(MediaType.APPLICATION_JSON)
+            .build();
+
+        when(pageRepository.findById(PARENT_PAGE_ID)).thenReturn(Optional.of(parentPage));
+        when(swaggerService.parse(OPENAPI_CONTENT)).thenReturn(new OAIParser().parse(OPENAPI_CONTENT));
+
+        pageService.transformSwagger(executionContext, translation, api);
+
+        assertThat(translation.getContent()).contains("${raw}");
+        verifyNoInteractions(notificationTemplateService);
+    }
+
+    @Test
+    void should_validate_swagger_translation_as_openapi() throws TechnicalException {
+        ReflectionTestUtils.setField(pageService, "swaggerValidateSafeContent", true);
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        Page parentPage = new Page();
+        parentPage.setId(PARENT_PAGE_ID);
+        parentPage.setType(SWAGGER.name());
+        PageEntity translation = PageEntity.builder()
+            .id(PAGE_ID)
+            .parentId(PARENT_PAGE_ID)
+            .type(TRANSLATION.name())
+            .content("{\"openapi\":\"3.0.0\"}")
+            .build();
+
+        when(pageRepository.findById(PARENT_PAGE_ID)).thenReturn(Optional.of(parentPage));
+
+        var messages = pageService.validateSafeContent(executionContext, translation, API_ID);
+
+        assertThat(messages).contains("attribute paths is missing");
+    }
+
+    @Test
+    void should_resolve_template_when_transforming_markdown_page() {
+        ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        PageEntity page = PageEntity.builder().id(PAGE_ID).type(MARKDOWN.name()).content("# ${api.name}").build();
+
+        when(
+            notificationTemplateService.resolveInlineTemplateWithParam(
+                eq(ORGANIZATION_ID),
+                eq(PAGE_ID),
+                eq("# ${api.name}"),
+                anyMap(),
+                eq(false)
+            )
+        ).thenReturn("# Rundeck API");
+
+        pageService.transformSwagger(executionContext, page, api);
+
+        assertThat(page.getContent()).isEqualTo("# Rundeck API");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14972

## Description

OpenAPI documentation pages were processed as FreeMarker templates before being parsed and transformed.

As a result, valid OpenAPI content containing expressions such as `${raw}` could be interpreted as a template expression and fail with a template-processing error.

## Changes

- Skip FreeMarker processing for pages of type `SWAGGER`.
- Preserve the existing OpenAPI parsing and transformation pipeline.
- Keep template processing unchanged for Markdown and other supported page types.
- Add a regression test covering literal `${...}` expressions in OpenAPI content.
- Add coverage confirming that Markdown templates are still resolved.

