### PR TITLE
fix(rest-api): normalize legacy SSL none values on subscription validation path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/LegacySslConfigurationNormalizer.java
@@ -44,6 +44,9 @@ public class LegacySslConfigurationNormalizer {
      * therefore carry the legacy empty-string discriminator. Plugins declaring their own SSL schema
      * (kafka, native-kafka) never used that representation and must be left untouched, since
      * normalization drops the sibling fields of the store it rewrites.
+     * <p>
+     * {@code webhook} is listed for its <em>subscription</em> schema: no endpoint bears that type, and
+     * its classic portal form still submits the empty string.
      */
     private static final Set<String> SHARED_SSL_SCHEMA_TYPES = Set.of(
         "http-proxy",
@@ -51,7 +54,8 @@ public class LegacySslConfigurationNormalizer {
         "mcp-proxy",
         "llm-proxy",
         "a2a-proxy",
-        "http-dynamic-properties"
+        "http-dynamic-properties",
+        "webhook"
     );
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.JsonSchemaService;
+import io.gravitee.rest.api.service.common.LegacySslConfigurationNormalizer;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import java.io.IOException;
@@ -79,6 +80,10 @@ public class EntrypointConnectorPluginServiceImpl
     public String validateEntrypointSubscriptionConfiguration(String entrypointId, String configuration) {
         // Only to check if plugin exists
         findById(entrypointId);
-        return validatePluginConfigurationAgainstSchema(entrypointId, ofNullable(configuration).orElse("{}"), this::getSubscriptionSchema);
+        String normalizedConfiguration = LegacySslConfigurationNormalizer.normalizeLegacySslNoneValues(
+            entrypointId,
+            ofNullable(configuration).orElse("{}")
+        );
+        return validatePluginConfigurationAgainstSchema(entrypointId, normalizedConfiguration, this::getSubscriptionSchema);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.v4.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.reactive.api.ApiType;
@@ -52,6 +53,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class EntrypointConnectorPluginServiceImplTest {
 
     private static final String CONNECTOR_ID = "connector-id";
+    private static final String WEBHOOK_ENTRYPOINT_ID = "webhook";
 
     private EntrypointConnectorPluginService cut;
 
@@ -157,6 +159,39 @@ public class EntrypointConnectorPluginServiceImplTest {
 
         final String result = cut.validateEntrypointSubscriptionConfiguration(CONNECTOR_ID, configuration);
         assertThat(result).isEqualTo(expectedConfiguration);
+    }
+
+    @Test
+    public void should_normalize_legacy_ssl_none_values_before_validating_webhook_subscription_configuration() throws IOException {
+        final String legacyConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"},\"keyStore\":{\"type\":\"\"}}}";
+        final String normalizedConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"NONE\"},\"keyStore\":{\"type\":\"NONE\"}}}";
+        final String expectedConfiguration = "validated_and_sanitized";
+
+        when(pluginManager.get(WEBHOOK_ENTRYPOINT_ID, true)).thenReturn(new FakePlugin());
+        when(pluginManager.getFactoryById(CONNECTOR_ID, true)).thenReturn(new FakeConnectorFactory());
+        when(pluginManager.getSubscriptionSchema(WEBHOOK_ENTRYPOINT_ID, true)).thenReturn("subscriptionConfiguration");
+        when(jsonSchemaService.validate("subscriptionConfiguration", normalizedConfiguration)).thenReturn(expectedConfiguration);
+
+        final String result = cut.validateEntrypointSubscriptionConfiguration(WEBHOOK_ENTRYPOINT_ID, legacyConfiguration);
+
+        assertThat(result).isEqualTo(expectedConfiguration);
+        verify(jsonSchemaService).validate("subscriptionConfiguration", normalizedConfiguration);
+    }
+
+    @Test
+    public void should_not_normalize_subscription_configuration_of_an_entrypoint_without_the_shared_ssl_schema() throws IOException {
+        final String legacyConfiguration = "{\"ssl\":{\"trustStore\":{\"type\":\"\"},\"keyStore\":{\"type\":\"\"}}}";
+        final String expectedConfiguration = "validated_and_sanitized";
+
+        when(pluginManager.get(CONNECTOR_ID, true)).thenReturn(new FakePlugin());
+        when(pluginManager.getFactoryById(CONNECTOR_ID, true)).thenReturn(new FakeConnectorFactory());
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID, true)).thenReturn("subscriptionConfiguration");
+        when(jsonSchemaService.validate("subscriptionConfiguration", legacyConfiguration)).thenReturn(expectedConfiguration);
+
+        final String result = cut.validateEntrypointSubscriptionConfiguration(CONNECTOR_ID, legacyConfiguration);
+
+        assertThat(result).isEqualTo(expectedConfiguration);
+        verify(jsonSchemaService).validate("subscriptionConfiguration", legacyConfiguration);
     }
 
     private static class FakePlugin implements EntrypointConnectorPlugin {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15002

## Description

Subscribing to a PUSH plan with the Webhook entrypoint failed with `400 errors.data.invalid` when the SSL key store and trust store were left on "None".

The Webhook plugin ships two subscription schemas that no longer agree since version 8.0.2: the one used to **validate** pins the "None" branch on `const: "NONE"`, while the one served to the **classic Developer Portal** still offers `""`. The portal therefore submits a value its own backend rejects.

`LegacySslConfigurationNormalizer` already maps that legacy `""` to `"NONE"` for API definitions (APIM-14599, APIM-14701), but the subscription validation path never used it. This adds `webhook` to the normalizer's allow list and normalizes the configuration in `EntrypointConnectorPluginServiceImpl.validateEntrypointSubscriptionConfiguration()` — the lowest point shared by subscription create, update and configuration update, so subscriptions already stored with `""` are repaired on their next update.
