### PR TITLE
feat(portal): add SUBSCRIPTION_FORM nav-item area and domain model

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalNavigationItem.java
@@ -40,11 +40,13 @@ public class PortalNavigationItem {
         LINK,
         API,
         API_PRODUCT,
+        SUBSCRIPTION_FORM,
     }
 
     public enum Area {
         HOMEPAGE,
         TOP_NAVBAR,
+        SUBSCRIPTION_FORM,
     }
 
     public enum Visibility {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -2399,7 +2399,7 @@ components:
     PortalArea:
       type: string
       description: The portal area (used by portal navigation items)
-      enum: [ HOMEPAGE, TOP_NAVBAR ]
+      enum: [ HOMEPAGE, TOP_NAVBAR, SUBSCRIPTION_FORM ]
       example: TOP_NAVBAR
       default: TOP_NAVBAR
     PortalVisibility:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -105,6 +105,9 @@ public interface PortalNavigationItemsMapper {
             case io.gravitee.apim.core.portal_page.model.PortalNavigationLink link -> new PortalNavigationItem(map(link));
             case io.gravitee.apim.core.portal_page.model.PortalNavigationApi api -> new PortalNavigationItem(map(api));
             case io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct apiProduct -> new PortalNavigationItem(map(apiProduct));
+            case io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm subscriptionForm -> throw new UnsupportedOperationException(
+                "SUBSCRIPTION_FORM navigation items are not yet exposed through the management-v2 REST contract"
+            );
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
@@ -42,6 +43,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -49,6 +52,15 @@ public interface PortalNavigationItemMapper {
     PortalNavigationItemMapper INSTANCE = Mappers.getMapper(PortalNavigationItemMapper.class);
 
     PortalArea map(io.gravitee.rest.api.portal.rest.model.PortalArea area);
+
+    /**
+     * SUBSCRIPTION_FORM is never browsable through this listing (a distinct, single, management-only
+     * area, not part of the HOMEPAGE/TOP_NAVBAR navigation tree this portal-rest surface serves) - a
+     * value here would mean a caller queried the wrong area, so this fails loudly instead of silently
+     * producing an unmappable REST value.
+     */
+    @ValueMapping(source = "SUBSCRIPTION_FORM", target = MappingConstants.THROW_EXCEPTION)
+    io.gravitee.rest.api.portal.rest.model.PortalArea map(PortalArea area);
 
     default List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> map(@Nonnull List<PortalNavigationItem> items) {
         return items.stream().map(this::getBasePortalNavigationItem).toList();
@@ -61,6 +73,9 @@ public interface PortalNavigationItemMapper {
             case PortalNavigationPage page -> map(page);
             case PortalNavigationApi api -> map(api);
             case PortalNavigationApiProduct apiProduct -> map(apiProduct);
+            case PortalNavigationSubscriptionForm subscriptionForm -> throw new IllegalStateException(
+                "SUBSCRIPTION_FORM navigation items are never exposed through the portal navigation listing"
+            );
         };
         var wrappedItem = new io.gravitee.rest.api.portal.rest.model.PortalNavigationItem();
         wrappedItem.setActualInstance(baseItem);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -8576,7 +8576,7 @@ components:
         PortalArea:
             type: string
             description: The portal area (used by portal navigation items)
-            enum: [HOMEPAGE, TOP_NAVBAR]
+            enum: [HOMEPAGE, TOP_NAVBAR, SUBSCRIPTION_FORM]
         PortalNavigationSearchInclude:
             type: string
             enum:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import jakarta.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
@@ -87,6 +88,7 @@ public final class PortalNavigationTreeWalker {
             case PortalNavigationApi a -> visitor.visitApi(a, parentPath);
             case PortalNavigationApiProduct p -> visitor.visitApiProduct(p, parentPath);
             case PortalNavigationLink l -> visitor.visitLink(l, parentPath);
+            case PortalNavigationSubscriptionForm s -> visitor.visitSubscriptionForm(s, parentPath);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationApiProduct;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 
 /** Override only the node kinds you care about; defaults are no-ops. */
 public interface PortalNavigationVisitor {
@@ -33,4 +34,6 @@ public interface PortalNavigationVisitor {
     default void visitApiProduct(PortalNavigationApiProduct apiProduct, NavigationPath parentPath) {}
 
     default void visitLink(PortalNavigationLink link, NavigationPath parentPath) {}
+
+    default void visitSubscriptionForm(PortalNavigationSubscriptionForm subscriptionForm, NavigationPath parentPath) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -40,6 +40,9 @@ import io.gravitee.apim.core.portal_page.domain_service.validation.SourceAutomat
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourceConfigurationRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedAncestorFinder;
 import io.gravitee.apim.core.portal_page.domain_service.validation.SourcedItemReadOnlyRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SubscriptionFormContentTypeRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SubscriptionFormNoParentRule;
+import io.gravitee.apim.core.portal_page.domain_service.validation.SubscriptionFormUniquenessRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.TitleRequiredRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.TypeConsistencyRule;
 import io.gravitee.apim.core.portal_page.domain_service.validation.UniqueItemIdRule;
@@ -87,17 +90,21 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
         var sourceAutomationExclusivityRule = new SourceAutomationExclusivityRule(navigationItemsQueryService, pageContentQueryService);
         var sourcedItemReadOnlyRule = new SourcedItemReadOnlyRule(new SourcedAncestorFinder(navigationItemsQueryService));
         var fileListingSourceOnFolderRule = new FileListingSourceOnFolderRule(portalNavigationItemSourceDomainService::supportsFileListing);
+        var subscriptionFormNoParentRule = new SubscriptionFormNoParentRule();
 
         this.createRules = List.of(
             new UniqueItemIdRule(navigationItemsQueryService),
             new HomepageUniquenessRule(navigationItemsQueryService),
+            new SubscriptionFormUniquenessRule(navigationItemsQueryService),
             new PageContentExistsRule(pageContentQueryService),
+            new SubscriptionFormContentTypeRule(pageContentQueryService),
             titleRequiredRule,
             new ApiItemCreateRule(apiProductQueryService),
             new ApiProductItemCreateRule(apiProductQueryService),
             new ApiDocumentationAreaRule(),
             linkUrlRule,
             parentRule,
+            subscriptionFormNoParentRule,
             segmentConflictRule,
             externalSourceItemTypeRule,
             sourceConfigurationRule,
@@ -110,6 +117,7 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
             new ApiItemUpdateRule(apiProductQueryService),
             new ApiProductItemUpdateRule(),
             parentRule,
+            subscriptionFormNoParentRule,
             segmentConflictRule,
             linkUrlRule,
             externalSourceItemTypeRule,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormContentTypeRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormContentTypeRule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * For SUBSCRIPTION_FORM area, ensures the referenced page content is GRAVITEE_MARKDOWN — mirrors
+ * the existing type-gated pattern used to restrict a page content type to its consumer
+ * ({@code DefaultGraviteeMarkdownProvider.appliesTo()}).
+ */
+@RequiredArgsConstructor
+public class SubscriptionFormContentTypeRule implements CreatePortalNavigationItemValidationRule {
+
+    private final PortalPageContentQueryService pageContentQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getArea() == PortalArea.SUBSCRIPTION_FORM && item.getPortalPageContentId() != null;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var content = pageContentQueryService
+            .findById(item.getPortalPageContentId())
+            .orElseThrow(() -> new PageContentNotFoundException(item.getPortalPageContentId().toString()));
+        if (content.getType() != PortalPageContentType.GRAVITEE_MARKDOWN) {
+            throw InvalidPortalNavigationItemDataException.subscriptionFormContentMustBeGraviteeMarkdown();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormNoParentRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormNoParentRule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+
+/**
+ * SUBSCRIPTION_FORM-area items never carry a parent: this area's items have no children of their
+ * own, so the only correct rule is "no parent, ever" (create and update).
+ */
+public class SubscriptionFormNoParentRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getArea() == PortalArea.SUBSCRIPTION_FORM;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        if (item.getParentId() != null) {
+            throw InvalidPortalNavigationItemDataException.subscriptionFormMustNotHaveParent();
+        }
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem.getArea() == PortalArea.SUBSCRIPTION_FORM;
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        if (toUpdate.getParentId() != null) {
+            throw InvalidPortalNavigationItemDataException.subscriptionFormMustNotHaveParent();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * For SUBSCRIPTION_FORM area, ensures no item already exists in that area — there is exactly one
+ * subscription form per environment.
+ */
+@RequiredArgsConstructor
+public class SubscriptionFormUniquenessRule implements CreatePortalNavigationItemValidationRule {
+
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    @Override
+    public boolean appliesTo(CreatePortalNavigationItem item) {
+        return item.getArea() == PortalArea.SUBSCRIPTION_FORM;
+    }
+
+    @Override
+    public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
+        var existing = navigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(
+            environmentId,
+            PortalArea.SUBSCRIPTION_FORM,
+            item.getReference()
+        );
+        if (!existing.isEmpty()) {
+            throw new SubscriptionFormAlreadyExistsException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/TypeConsistencyRule.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 
 /**
@@ -43,6 +44,7 @@ public class TypeConsistencyRule implements UpdatePortalNavigationItemValidation
             case PortalNavigationLink ignored -> PortalNavigationItemType.LINK;
             case PortalNavigationApi ignored -> PortalNavigationItemType.API;
             case PortalNavigationApiProduct ignored -> PortalNavigationItemType.API_PRODUCT;
+            case PortalNavigationSubscriptionForm ignored -> PortalNavigationItemType.SUBSCRIPTION_FORM;
         };
         if (existingType != toUpdate.getType()) {
             throw InvalidPortalNavigationItemDataException.typeMismatch(toUpdate.getType().toString(), existingType.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalNavigationItemDataException.java
@@ -45,6 +45,16 @@ public class InvalidPortalNavigationItemDataException extends ValidationDomainEx
         return new InvalidPortalNavigationItemDataException("API-attached documentation can only be added to TOP_NAVBAR area.");
     }
 
+    public static InvalidPortalNavigationItemDataException subscriptionFormMustNotHaveParent() {
+        return new InvalidPortalNavigationItemDataException("A SUBSCRIPTION_FORM navigation item can never have a parent.");
+    }
+
+    public static InvalidPortalNavigationItemDataException subscriptionFormContentMustBeGraviteeMarkdown() {
+        return new InvalidPortalNavigationItemDataException(
+            "A SUBSCRIPTION_FORM navigation item must reference GRAVITEE_MARKDOWN content."
+        );
+    }
+
     public static InvalidPortalNavigationItemDataException sourceNotAllowedForType(String type) {
         return new InvalidPortalNavigationItemDataException(
             "An external source can only be configured on PAGE and FOLDER navigation items (got %s).".formatted(type)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/SubscriptionFormAlreadyExistsException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/SubscriptionFormAlreadyExistsException.java
@@ -13,20 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal.model;
+package io.gravitee.apim.core.portal_page.exception;
 
-public enum PortalArea {
-    HOMEPAGE("homepage"),
-    TOP_NAVBAR("topNavbar"),
-    SUBSCRIPTION_FORM("subscriptionForm");
+import io.gravitee.apim.core.exception.ConflictDomainException;
 
-    private final String wireName;
+public class SubscriptionFormAlreadyExistsException extends ConflictDomainException {
 
-    PortalArea(String wireName) {
-        this.wireName = wireName;
-    }
-
-    public String wireName() {
-        return wireName;
+    public SubscriptionFormAlreadyExistsException() {
+        super("Subscription form already exists for this environment");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/CreatePortalNavigationItem.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -45,6 +46,8 @@ public final class CreatePortalNavigationItem {
 
     @NotNull
     private PortalPageContentType contentType;
+
+    private SubscriptionFormFieldConstraints validationConstraints;
 
     private String url;
     private String apiId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItem.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.slug.model.Slug;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.Objects;
@@ -29,7 +30,13 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder(toBuilder = true)
 public abstract sealed class PortalNavigationItem
-    permits PortalNavigationPage, PortalNavigationLink, PortalNavigationFolder, PortalNavigationApi, PortalNavigationApiProduct {
+    permits
+        PortalNavigationPage,
+        PortalNavigationLink,
+        PortalNavigationFolder,
+        PortalNavigationApi,
+        PortalNavigationApiProduct,
+        PortalNavigationSubscriptionForm {
 
     @Nonnull
     private final PortalNavigationItemId id;
@@ -169,6 +176,10 @@ public abstract sealed class PortalNavigationItem
         final var title = item.getTitle();
         final var area = item.getArea();
         final var contentId = item.getPortalPageContentId();
+        final var validationConstraints = Objects.requireNonNullElseGet(
+            item.getValidationConstraints(),
+            SubscriptionFormFieldConstraints::empty
+        );
         final var url = item.getUrl();
         final var apiId = item.getApiId();
         final var apiProductId = item.getApiProductId();
@@ -204,6 +215,18 @@ public abstract sealed class PortalNavigationItem
                 published,
                 visibility,
                 categoryIds
+            );
+            case SUBSCRIPTION_FORM -> new PortalNavigationSubscriptionForm(
+                id,
+                organizationId,
+                environmentId,
+                title,
+                area,
+                order,
+                contentId,
+                validationConstraints,
+                published,
+                visibility
             );
         };
         newItem.setSegment(segmentFor(item));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemId.java
@@ -65,6 +65,14 @@ public class PortalNavigationItemId implements Comparable<PortalNavigationItemId
     }
 
     /**
+     * Identifies the one environment-default subscription-form item without needing a separate
+     * uniqueness query — there is exactly one per environment.
+     */
+    public static PortalNavigationItemId forSubscriptionFormDefault(AuditInfo auditInfo) {
+        return of(HRIDToUUID.navigation().context(auditInfo).subscriptionFormDefault().id());
+    }
+
+    /**
      * A link has no separate content object (unlike Documentation/Listing), so this id doubles as
      * both the nav item id and the automation resource's own id — the single source of truth shared
      * by {@code PortalLinkSyncDomainService} (materialize/dematerialize) and {@code GetPortalLinkUseCase}.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemType.java
@@ -20,7 +20,8 @@ public enum PortalNavigationItemType {
     FOLDER,
     LINK,
     API,
-    API_PRODUCT;
+    API_PRODUCT,
+    SUBSCRIPTION_FORM;
 
     public boolean isContainer() {
         return this == FOLDER || this == API || this == API_PRODUCT;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSubscriptionForm.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSubscriptionForm.java
@@ -19,7 +19,6 @@ import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import jakarta.annotation.Nonnull;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -28,11 +27,9 @@ public final class PortalNavigationSubscriptionForm extends PortalNavigationItem
 
     private static final PortalNavigationItemType TYPE = PortalNavigationItemType.SUBSCRIPTION_FORM;
 
-    @Setter
     @Nonnull
-    private PortalPageContentId portalPageContentId;
+    private final PortalPageContentId portalPageContentId;
 
-    @Setter
     @Nonnull
     private SubscriptionFormFieldConstraints validationConstraints;
 
@@ -56,5 +53,9 @@ public final class PortalNavigationSubscriptionForm extends PortalNavigationItem
     @Override
     public PortalNavigationItemType getType() {
         return TYPE;
+    }
+
+    public void updateValidationConstraints(@Nonnull SubscriptionFormFieldConstraints validationConstraints) {
+        this.validationConstraints = validationConstraints;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSubscriptionForm.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSubscriptionForm.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+public final class PortalNavigationSubscriptionForm extends PortalNavigationItem {
+
+    private static final PortalNavigationItemType TYPE = PortalNavigationItemType.SUBSCRIPTION_FORM;
+
+    @Setter
+    @Nonnull
+    private PortalPageContentId portalPageContentId;
+
+    @Setter
+    @Nonnull
+    private SubscriptionFormFieldConstraints validationConstraints;
+
+    PortalNavigationSubscriptionForm(
+        @Nonnull PortalNavigationItemId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull String title,
+        @Nonnull PortalArea area,
+        @Nonnull Integer order,
+        @Nonnull PortalPageContentId portalPageContentId,
+        @Nonnull SubscriptionFormFieldConstraints validationConstraints,
+        @Nonnull Boolean published,
+        @Nonnull PortalVisibility visibility
+    ) {
+        super(id, organizationId, environmentId, title, area, order, published, visibility);
+        this.portalPageContentId = portalPageContentId;
+        this.validationConstraints = validationConstraints;
+    }
+
+    @Override
+    public PortalNavigationItemType getType() {
+        return TYPE;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.adapter;
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
 import io.gravitee.apim.core.portal_page.model.*;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ public interface PortalNavigationItemAdapter {
 
     com.fasterxml.jackson.databind.ObjectMapper OBJECT_MAPPER = new com.fasterxml.jackson.databind.ObjectMapper();
     String PORTAL_PAGE_CONTENT_ID = "portalPageContentId";
+    String VALIDATION_CONSTRAINTS = "validationConstraints";
     String URL = "url";
     String SOURCE = "source";
     String SOURCE_TYPE = "type";
@@ -52,6 +54,7 @@ public interface PortalNavigationItemAdapter {
             case LINK -> portalNavigationLinkFromRepository(portalNavigationItem);
             case API -> portalNavigationApiFromRepository(portalNavigationItem);
             case API_PRODUCT -> portalNavigationApiProductFromRepository(portalNavigationItem);
+            case SUBSCRIPTION_FORM -> portalNavigationSubscriptionFormFromRepository(portalNavigationItem);
         };
     }
 
@@ -59,6 +62,7 @@ public interface PortalNavigationItemAdapter {
         return switch (area) {
             case HOMEPAGE -> PortalArea.HOMEPAGE;
             case TOP_NAVBAR -> PortalArea.TOP_NAVBAR;
+            case SUBSCRIPTION_FORM -> PortalArea.SUBSCRIPTION_FORM;
         };
     }
 
@@ -66,6 +70,7 @@ public interface PortalNavigationItemAdapter {
         return switch (area) {
             case HOMEPAGE -> io.gravitee.repository.management.model.PortalNavigationItem.Area.HOMEPAGE;
             case TOP_NAVBAR -> io.gravitee.repository.management.model.PortalNavigationItem.Area.TOP_NAVBAR;
+            case SUBSCRIPTION_FORM -> io.gravitee.repository.management.model.PortalNavigationItem.Area.SUBSCRIPTION_FORM;
         };
     }
 
@@ -116,6 +121,19 @@ public interface PortalNavigationItemAdapter {
         io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem
     );
 
+    @Mapping(target = "portalPageContentId", expression = "java(parsePortalPageContentId(portalNavigationItem.getConfiguration()))")
+    @Mapping(target = "validationConstraints", expression = "java(parseValidationConstraints(portalNavigationItem.getConfiguration()))")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "repositoryRootIdToDomain")
+    @Mapping(target = "visibility", expression = "java(repositoryVisibilityToDomain(portalNavigationItem))")
+    @Mapping(target = "reference", expression = "java(referenceFromRepository(portalNavigationItem))")
+    @Mapping(
+        target = "automationMetadata",
+        expression = "java(automationMetadataFromRepository(portalNavigationItem.getAutomationMetadata()))"
+    )
+    PortalNavigationSubscriptionForm portalNavigationSubscriptionFormFromRepository(
+        io.gravitee.repository.management.model.PortalNavigationItem portalNavigationItem
+    );
+
     /**
      * Core-facing copy of the repository's {@code automationMetadata}, trimmed the same way
      * {@link io.gravitee.apim.core.portal_page.model.AutomationMetadata#trimmedForNavItem()} does:
@@ -154,6 +172,7 @@ public interface PortalNavigationItemAdapter {
             case PortalNavigationPage page -> toRepository(page);
             case PortalNavigationLink link -> toRepository(link);
             case PortalNavigationFolder folder -> toRepository(folder);
+            case PortalNavigationSubscriptionForm subscriptionForm -> toRepository(subscriptionForm);
         };
     }
 
@@ -209,6 +228,16 @@ public interface PortalNavigationItemAdapter {
     )
     io.gravitee.repository.management.model.PortalNavigationItem toRepository(PortalNavigationApiProduct portalNavigationItem);
 
+    @Mapping(target = "type", expression = "java(mapType(portalNavigationItem))")
+    @Mapping(target = "configuration", expression = "java(configurationOf(portalNavigationItem))")
+    @Mapping(target = "referenceType", expression = "java(referenceTypeToRepository(portalNavigationItem.getReference()))")
+    @Mapping(target = "referenceId", expression = "java(referenceIdToRepository(portalNavigationItem.getReference()))")
+    @Mapping(
+        target = "automationMetadata",
+        expression = "java(automationMetadataToRepository(portalNavigationItem.getAutomationMetadata()))"
+    )
+    io.gravitee.repository.management.model.PortalNavigationItem toRepository(PortalNavigationSubscriptionForm portalNavigationItem);
+
     default io.gravitee.repository.management.model.PortalNavigationItem.Type mapType(PortalNavigationItem portalNavigationItem) {
         return switch (portalNavigationItem) {
             case PortalNavigationFolder ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.FOLDER;
@@ -216,6 +245,7 @@ public interface PortalNavigationItemAdapter {
             case PortalNavigationLink ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.LINK;
             case PortalNavigationApi ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.API;
             case PortalNavigationApiProduct ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.API_PRODUCT;
+            case PortalNavigationSubscriptionForm ignored -> io.gravitee.repository.management.model.PortalNavigationItem.Type.SUBSCRIPTION_FORM;
         };
     }
 
@@ -231,6 +261,15 @@ public interface PortalNavigationItemAdapter {
                 case PortalNavigationFolder folder -> writeSource(config, folder.getSource());
                 case PortalNavigationApi ignored -> {}
                 case PortalNavigationApiProduct ignored -> {}
+                case PortalNavigationSubscriptionForm subscriptionForm -> {
+                    config.put(PORTAL_PAGE_CONTENT_ID, subscriptionForm.getPortalPageContentId().json());
+                    config.set(
+                        VALIDATION_CONSTRAINTS,
+                        SubscriptionFormAdapter.FIELD_CONSTRAINTS_JSON.readTree(
+                            SubscriptionFormAdapter.writeFieldConstraintsJson(subscriptionForm.getValidationConstraints())
+                        )
+                    );
+                }
             }
             return OBJECT_MAPPER.writeValueAsString(config);
         } catch (Exception e) {
@@ -272,6 +311,19 @@ public interface PortalNavigationItemAdapter {
             return PortalPageContentId.of(node.get(PORTAL_PAGE_CONTENT_ID).asText());
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid configuration for PortalNavigationItem PAGE type", e);
+        }
+    }
+
+    @Named("parseValidationConstraints")
+    default SubscriptionFormFieldConstraints parseValidationConstraints(String configuration) {
+        if (configuration == null || configuration.isEmpty()) {
+            throw new IllegalArgumentException("PortalNavigationItem configuration is missing for SUBSCRIPTION_FORM type");
+        }
+        try {
+            var node = OBJECT_MAPPER.readTree(configuration).get(VALIDATION_CONSTRAINTS);
+            return SubscriptionFormAdapter.parseFieldConstraintsJson(node == null ? null : node.toString());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid configuration for PortalNavigationItem SUBSCRIPTION_FORM type", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -202,6 +202,10 @@ public final class HRIDToUUID {
         public NavigationInApi api(String apiId) {
             return new NavigationInApi(organizationId, environmentId, apiId);
         }
+
+        public EnvironmentNavigationItemResult subscriptionFormDefault() {
+            return new EnvironmentNavigationItemResult(organizationId, environmentId, "subscription-form-default");
+        }
     }
 
     public record NavigationInPortal(String organizationId, String environmentId, String portalId) {
@@ -237,6 +241,16 @@ public final class HRIDToUUID {
     public record ApiNavigationItemResult(String organizationId, String environmentId, String apiId, String kind, String identifier) {
         public String id() {
             return UuidString.generateFrom(organizationId, environmentId, apiId, kind, identifier);
+        }
+    }
+
+    /**
+     * Scoped to the environment alone (no portal or API parent) — for navigation items that are a
+     * singleton per environment, such as the default subscription form.
+     */
+    public record EnvironmentNavigationItemResult(String organizationId, String environmentId, String kind) {
+        public String id() {
+            return UuidString.generateFrom(organizationId, environmentId, kind);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalNavigationItemFixtures.java
@@ -27,10 +27,12 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import java.util.List;
 
 public class PortalNavigationItemFixtures {
@@ -162,6 +164,22 @@ public class PortalNavigationItemFixtures {
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .parentId(parentId)
+            .build();
+    }
+
+    public static PortalNavigationSubscriptionForm aSubscriptionForm(String id, PortalPageContentId contentId) {
+        return PortalNavigationSubscriptionForm.builder()
+            .id(PortalNavigationItemId.of(id))
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Subscription Form")
+            .segment(PortalNavigationItem.slugify("Subscription Form").value())
+            .area(PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .portalPageContentId(contentId)
+            .validationConstraints(SubscriptionFormFieldConstraints.empty())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalNavigationItemsRepositoryFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalNavigationItemsRepositoryFixtures.java
@@ -81,6 +81,24 @@ public class PortalNavigationItemsRepositoryFixtures {
             .build();
     }
 
+    public static PortalNavigationItem aSubscriptionForm(String id, String portalPageContentId) {
+        var configuration = String.format("{\"portalPageContentId\":\"%s\",\"validationConstraints\":{}}", portalPageContentId);
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Subscription Form")
+            .segment("subscription-form")
+            .type(Type.SUBSCRIPTION_FORM)
+            .area(Area.SUBSCRIPTION_FORM)
+            .order(0)
+            .rootId(id)
+            .configuration(configuration)
+            .published(true)
+            .visibility(Visibility.PUBLIC)
+            .build();
+    }
+
     public static PortalNavigationItem aLink(String id, String title, String url, String parentId) {
         return aLink(id, title, url, parentId, parentId == null ? id : parentId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormContentTypeRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormContentTypeRuleTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionFormContentTypeRuleTest {
+
+    private PortalPageContentQueryServiceInMemory pageContentQueryService;
+    private SubscriptionFormContentTypeRule rule;
+
+    @BeforeEach
+    void setUp() {
+        pageContentQueryService = new PortalPageContentQueryServiceInMemory();
+        rule = new SubscriptionFormContentTypeRule(pageContentQueryService);
+    }
+
+    @Test
+    void applies_only_to_subscription_form_area_with_a_content_id() {
+        assertThat(rule.appliesTo(createItem(PortalArea.SUBSCRIPTION_FORM, PortalPageContentId.random()))).isTrue();
+        assertThat(rule.appliesTo(createItem(PortalArea.SUBSCRIPTION_FORM, null))).isFalse();
+        assertThat(rule.appliesTo(createItem(PortalArea.TOP_NAVBAR, PortalPageContentId.random()))).isFalse();
+    }
+
+    @Test
+    void accepts_gravitee_markdown_content() {
+        var content = PortalPageContentFixtures.aGraviteeMarkdownPageContent();
+        pageContentQueryService.initWith(List.of(content));
+
+        assertThatCode(() ->
+            rule.validate(createItem(PortalArea.SUBSCRIPTION_FORM, content.getId()), "env-1", null)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejects_non_gravitee_markdown_content() {
+        var content = PortalPageContentFixtures.anAsyncApiPageContent();
+        pageContentQueryService.initWith(List.of(content));
+
+        assertThatThrownBy(() -> rule.validate(createItem(PortalArea.SUBSCRIPTION_FORM, content.getId()), "env-1", null))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("GRAVITEE_MARKDOWN");
+    }
+
+    @Test
+    void rejects_a_missing_content_id() {
+        var missingId = PortalPageContentId.random();
+
+        assertThatThrownBy(() -> rule.validate(createItem(PortalArea.SUBSCRIPTION_FORM, missingId), "env-1", null)).isInstanceOf(
+            PageContentNotFoundException.class
+        );
+    }
+
+    private static CreatePortalNavigationItem createItem(PortalArea area, PortalPageContentId contentId) {
+        return CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .title("Subscription Form")
+            .segment("subscription-form")
+            .area(area)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .portalPageContentId(contentId)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormNoParentRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormNoParentRuleTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionFormNoParentRuleTest {
+
+    private final SubscriptionFormNoParentRule rule = new SubscriptionFormNoParentRule();
+
+    @Test
+    void applies_only_to_subscription_form_area_on_create() {
+        assertThat(rule.appliesTo(createItem(PortalArea.SUBSCRIPTION_FORM, null))).isTrue();
+        assertThat(rule.appliesTo(createItem(PortalArea.TOP_NAVBAR, null))).isFalse();
+    }
+
+    @Test
+    void accepts_subscription_form_without_parent_on_create() {
+        assertThatCode(() -> rule.validate(createItem(PortalArea.SUBSCRIPTION_FORM, null), "env-1", null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejects_subscription_form_with_parent_on_create() {
+        var parentId = PortalNavigationItemId.random();
+
+        assertThatThrownBy(() -> rule.validate(createItem(PortalArea.SUBSCRIPTION_FORM, parentId), "env-1", null))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("never have a parent");
+    }
+
+    @Test
+    void applies_only_to_subscription_form_area_on_update() {
+        var existingSubscriptionForm = PortalNavigationItemFixtures.aSubscriptionForm(
+            "00000000-0000-0000-0000-000000000020",
+            PortalPageContentId.random()
+        );
+        var existingPage = PortalNavigationItemFixtures.aPage("00000000-0000-0000-0000-000000000021", "Support", null);
+
+        assertThat(rule.appliesTo(UpdatePortalNavigationItem.builder().build(), existingSubscriptionForm)).isTrue();
+        assertThat(rule.appliesTo(UpdatePortalNavigationItem.builder().build(), existingPage)).isFalse();
+    }
+
+    @Test
+    void rejects_subscription_form_with_parent_on_update() {
+        var existingSubscriptionForm = PortalNavigationItemFixtures.aSubscriptionForm(
+            "00000000-0000-0000-0000-000000000020",
+            PortalPageContentId.random()
+        );
+        var update = UpdatePortalNavigationItem.builder().parentId(PortalNavigationItemId.random()).build();
+
+        assertThatThrownBy(() -> rule.validate(update, existingSubscriptionForm, UpdateValidationContext.empty()))
+            .isInstanceOf(InvalidPortalNavigationItemDataException.class)
+            .hasMessageContaining("never have a parent");
+    }
+
+    private static CreatePortalNavigationItem createItem(PortalArea area, PortalNavigationItemId parentId) {
+        return CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .title("Subscription Form")
+            .segment("subscription-form")
+            .area(area)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .parentId(parentId)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRuleTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionFormUniquenessRuleTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String ORG_ID = "org-1";
+
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private SubscriptionFormUniquenessRule rule;
+
+    @BeforeEach
+    void setUp() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        rule = new SubscriptionFormUniquenessRule(navigationItemsQueryService);
+    }
+
+    @Test
+    void applies_only_to_subscription_form_area() {
+        assertThat(rule.appliesTo(subscriptionFormCreateItem())).isTrue();
+        assertThat(
+            rule.appliesTo(
+                CreatePortalNavigationItem.builder()
+                    .type(PortalNavigationItemType.FOLDER)
+                    .title("Navbar")
+                    .segment("navbar")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                    .build()
+            )
+        ).isFalse();
+    }
+
+    @Test
+    void rejects_a_second_subscription_form_for_the_same_environment() {
+        navigationItemsQueryService.storage().add(PortalNavigationItem.from(subscriptionFormCreateItem(), ORG_ID, ENV_ID, null));
+
+        assertThatThrownBy(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).isInstanceOf(
+            SubscriptionFormAlreadyExistsException.class
+        );
+    }
+
+    @Test
+    void allows_the_first_subscription_form_for_an_environment() {
+        assertThatCode(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void existing_subscription_form_in_a_different_environment_does_not_conflict() {
+        navigationItemsQueryService.storage().add(PortalNavigationItem.from(subscriptionFormCreateItem(), ORG_ID, "env-other", null));
+
+        assertThatCode(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).doesNotThrowAnyException();
+    }
+
+    private static CreatePortalNavigationItem subscriptionFormCreateItem() {
+        return CreatePortalNavigationItem.builder()
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .title("Subscription Form")
+            .segment("subscription-form")
+            .area(PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .portalPageContentId(PortalPageContentId.random())
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemIdTest.java
@@ -68,4 +68,21 @@ class PortalNavigationItemIdTest {
             PortalNavigationItemId.forApiDocumentation(AUDIT_INFO, "other-api-id", contentId)
         );
     }
+
+    @Test
+    void forSubscriptionFormDefault_is_deterministic_for_the_same_environment() {
+        var first = PortalNavigationItemId.forSubscriptionFormDefault(AUDIT_INFO);
+        var second = PortalNavigationItemId.forSubscriptionFormDefault(AUDIT_INFO);
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void forSubscriptionFormDefault_differs_per_environment() {
+        var otherEnvAudit = AuditInfo.builder().organizationId("organization-id").environmentId("other-environment-id").build();
+
+        assertThat(PortalNavigationItemId.forSubscriptionFormDefault(AUDIT_INFO)).isNotEqualTo(
+            PortalNavigationItemId.forSubscriptionFormDefault(otherEnvAudit)
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalNavigationItemAdapterTest.java
@@ -337,6 +337,28 @@ class PortalNavigationItemAdapterTest {
         }
 
         @Test
+        void should_map_subscription_form_to_entity() {
+            // Given
+            var repositoryItem = PortalNavigationItemsRepositoryFixtures.aSubscriptionForm(
+                "550e8400-e29b-41d4-a716-446655440060",
+                "550e8400-e29b-41d4-a716-446655440061"
+            );
+
+            // When
+            var entity = adapter.toEntity(repositoryItem);
+
+            // Then
+            assertThat(entity).isInstanceOf(PortalNavigationSubscriptionForm.class);
+            var subscriptionForm = (PortalNavigationSubscriptionForm) entity;
+            assertThat(subscriptionForm.getId()).isEqualTo(PortalNavigationItemId.of("550e8400-e29b-41d4-a716-446655440060"));
+            assertThat(subscriptionForm.getArea()).isEqualTo(PortalArea.SUBSCRIPTION_FORM);
+            assertThat(subscriptionForm.getPortalPageContentId()).isEqualTo(PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440061"));
+            assertThat(subscriptionForm.getValidationConstraints()).isEqualTo(
+                io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints.empty()
+            );
+        }
+
+        @Test
         void should_throw_when_link_configuration_is_missing() {
             // Given
             var repositoryItem = PortalNavigationItemsRepositoryFixtures.aLink("550e8400-e29b-41d4-a716-446655440008", "link", null, null);
@@ -495,6 +517,57 @@ class PortalNavigationItemAdapterTest {
 
             // Then
             assertThat(repositoryItem.getCategoryIds()).containsExactly(categoryId.toString());
+        }
+
+        @Test
+        void should_map_subscription_form_to_repository() {
+            // Given
+            var entity = PortalNavigationItemFixtures.aSubscriptionForm(
+                "550e8400-e29b-41d4-a716-446655440062",
+                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440063")
+            );
+
+            // When
+            var repositoryItem = adapter.toRepository((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) entity);
+
+            // Then
+            assertThat(repositoryItem.getId()).isEqualTo("550e8400-e29b-41d4-a716-446655440062");
+            assertThat(repositoryItem.getType()).isEqualTo(PortalNavigationItem.Type.SUBSCRIPTION_FORM);
+            assertThat(repositoryItem.getArea()).isEqualTo(PortalNavigationItem.Area.SUBSCRIPTION_FORM);
+            assertThat(repositoryItem.getConfiguration()).isEqualTo(
+                "{\"portalPageContentId\":\"550e8400-e29b-41d4-a716-446655440063\",\"validationConstraints\":{}}"
+            );
+            assertThat(repositoryItem.isPublished()).isTrue();
+            assertThat(repositoryItem.getVisibility()).isEqualTo(PortalNavigationItem.Visibility.PUBLIC);
+        }
+
+        @Test
+        void should_round_trip_subscription_form_validation_constraints_through_repository() {
+            // Given
+            var constraints = new io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints(
+                java.util.Map.of(
+                    "email",
+                    java.util.List.of(
+                        new io.gravitee.apim.core.subscription_form.model.Constraint.Required(),
+                        new io.gravitee.apim.core.subscription_form.model.Constraint.MinLength(3)
+                    )
+                )
+            );
+            var entity = PortalNavigationItemFixtures.aSubscriptionForm(
+                "550e8400-e29b-41d4-a716-446655440064",
+                PortalPageContentId.random()
+            )
+                .toBuilder()
+                .validationConstraints(constraints)
+                .build();
+
+            // When
+            var roundTripped = adapter.toEntity(
+                adapter.toRepository((io.gravitee.apim.core.portal_page.model.PortalNavigationItem) entity)
+            );
+
+            // Then
+            assertThat(((PortalNavigationSubscriptionForm) roundTripped).getValidationConstraints()).isEqualTo(constraints);
         }
 
         @Test


### PR DESCRIPTION
PORTAL-164 §1-2: groundwork for migrating the environment-default subscription form onto the same `PortalNavigationItem`/`PortalPageContent` machinery every other portal concept already uses (homepage, top navbar, pages). **Zero observable behavior change** to Console or Portal Next — this PR is domain model + persistence only, nothing reads from it yet.

**Stack**: 1st of 5 PRs. This is the base of the stack; the rest build on top of it in order.

## Changes

- New `PortalArea.SUBSCRIPTION_FORM` and a new sealed subtype `PortalNavigationSubscriptionForm` (`portalPageContentId` + `validationConstraints`), added to the `PortalNavigationItem` sealed hierarchy.
- `PortalNavigationItemId.forSubscriptionFormDefault(...)` — deterministic id for this environment-singleton item, mirroring the existing HOMEPAGE/TOP_NAVBAR default-item pattern.
- Three new domain validation rules (no-parent, uniqueness, content-type-must-be-GRAVITEE_MARKDOWN), wired into the existing validator pipeline.
- `PortalNavigationItemAdapter` — mapper-only persistence change (no schema change; `configuration` is already a generic column on both Mongo and JDBC).
- Fixed two other exhaustive switches the new sealed subtype broke at compile time (`TypeConsistencyRule`, `PortalNavigationTreeWalker`/Visitor) — Java's sealed-switch exhaustiveness checking is what surfaced every call site needing this.

Combined into one commit/PR because the domain model doesn't compile without the mapper update.

## Compatibility

Not compatibility-sensitive on its own: new enum value + new sealed subtype, no schema change, nothing yet reads or writes through this path in a user-visible way.