### PR TITLE
feat(portal): migrate legacy subscription forms into portal navigation items

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
@@ -93,30 +93,37 @@ public class SubscriptionFormsToPortalNavigationItemsUpgrader implements Upgrade
         int migrated = 0;
 
         for (var form : forms) {
-            var environmentId = form.getEnvironmentId();
-            var alreadyMigrated = !portalNavigationItemsQueryService
-                .findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, PortalArea.SUBSCRIPTION_FORM)
-                .isEmpty();
-            if (alreadyMigrated) {
-                continue;
-            }
-
-            var organizationId = environmentRepository.findById(environmentId).map(Environment::getOrganizationId).orElse(null);
-            if (organizationId == null) {
-                log.warn("Skipping subscription form migration: environment [{}] no longer exists", environmentId);
-                continue;
-            }
-
-            try {
-                migrate(form, organizationId, environmentId);
+            if (migrateIfNeeded(form)) {
                 migrated++;
-            } catch (Exception e) {
-                log.error("Failed to migrate subscription form for environment [{}]", environmentId, e);
             }
         }
 
         log.info("Subscription form to portal navigation item upgrader completed. Migrated {}/{} forms.", migrated, forms.size());
         return true;
+    }
+
+    private boolean migrateIfNeeded(SubscriptionForm form) throws TechnicalException {
+        var environmentId = form.getEnvironmentId();
+        var alreadyMigrated = !portalNavigationItemsQueryService
+            .findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, PortalArea.SUBSCRIPTION_FORM)
+            .isEmpty();
+        if (alreadyMigrated) {
+            return false;
+        }
+
+        var organizationId = environmentRepository.findById(environmentId).map(Environment::getOrganizationId).orElse(null);
+        if (organizationId == null) {
+            log.warn("Skipping subscription form migration: environment [{}] no longer exists", environmentId);
+            return false;
+        }
+
+        try {
+            migrate(form, organizationId, environmentId);
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to migrate subscription form for environment [{}]", environmentId, e);
+            return false;
+        }
     }
 
     private void migrate(SubscriptionForm form, String organizationId, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.SUBSCRIPTION_FORM_TO_PORTAL_NAVIGATION_ITEM_UPGRADER;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.infra.adapter.SubscriptionFormAdapter;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.SubscriptionFormRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.SubscriptionForm;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Migrates each legacy {@code subscription_forms} row into a {@code PortalPageContent}
+ * (GRAVITEE_MARKDOWN) plus a {@code portal_navigation_items} row (area SUBSCRIPTION_FORM), so
+ * the environment-default subscription form is served through the same nav-item machinery as
+ * every other portal concept. The legacy table is left untouched here — nothing reads from the
+ * new rows until the cutover that retires the legacy aggregate.
+ *
+ * <p>Idempotent per environment: an environment that already has a SUBSCRIPTION_FORM-area item
+ * is skipped, so re-running after a partial failure only migrates what is still missing.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Component
+@CustomLog
+public class SubscriptionFormsToPortalNavigationItemsUpgrader implements Upgrader {
+
+    private final SubscriptionFormRepository subscriptionFormRepository;
+    private final EnvironmentRepository environmentRepository;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalPageContentCrudService pageContentCrudService;
+    private final PortalNavigationItemDomainService portalNavigationItemDomainService;
+
+    public SubscriptionFormsToPortalNavigationItemsUpgrader(
+        @Lazy SubscriptionFormRepository subscriptionFormRepository,
+        @Lazy EnvironmentRepository environmentRepository,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalPageContentCrudService pageContentCrudService,
+        PortalNavigationItemDomainService portalNavigationItemDomainService
+    ) {
+        this.subscriptionFormRepository = subscriptionFormRepository;
+        this.environmentRepository = environmentRepository;
+        this.portalNavigationItemsQueryService = portalNavigationItemsQueryService;
+        this.pageContentCrudService = pageContentCrudService;
+        this.portalNavigationItemDomainService = portalNavigationItemDomainService;
+    }
+
+    @Override
+    public int getOrder() {
+        return SUBSCRIPTION_FORM_TO_PORTAL_NAVIGATION_ITEM_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        var forms = subscriptionFormRepository.findAll();
+        int migrated = 0;
+
+        for (var form : forms) {
+            var environmentId = form.getEnvironmentId();
+            var alreadyMigrated = !portalNavigationItemsQueryService
+                .findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, PortalArea.SUBSCRIPTION_FORM)
+                .isEmpty();
+            if (alreadyMigrated) {
+                continue;
+            }
+
+            var organizationId = environmentRepository.findById(environmentId).map(Environment::getOrganizationId).orElse(null);
+            if (organizationId == null) {
+                log.warn("Skipping subscription form migration: environment [{}] no longer exists", environmentId);
+                continue;
+            }
+
+            try {
+                migrate(form, organizationId, environmentId);
+                migrated++;
+            } catch (Exception e) {
+                log.error("Failed to migrate subscription form for environment [{}]", environmentId, e);
+            }
+        }
+
+        log.info("Subscription form to portal navigation item upgrader completed. Migrated {}/{} forms.", migrated, forms.size());
+        return true;
+    }
+
+    private void migrate(SubscriptionForm form, String organizationId, String environmentId) {
+        var content = pageContentCrudService.create(
+            new GraviteeMarkdownPageContent(
+                PortalPageContentId.random(),
+                organizationId,
+                environmentId,
+                GraviteeMarkdown.of(form.getGmdContent())
+            )
+        );
+
+        var auditInfo = AuditInfo.builder().organizationId(organizationId).environmentId(environmentId).build();
+        var createItem = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.forSubscriptionFormDefault(auditInfo))
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .title("Subscription Form")
+            .area(PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .portalPageContentId(content.getId())
+            .validationConstraints(SubscriptionFormAdapter.parseFieldConstraintsJson(form.getValidationConstraints()))
+            .published(form.isEnabled())
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+
+        portalNavigationItemDomainService.create(organizationId, environmentId, createItem);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgrader.java
@@ -118,7 +118,7 @@ public class SubscriptionFormsToPortalNavigationItemsUpgrader implements Upgrade
         }
 
         try {
-            migrate(form, organizationId, environmentId);
+            createPageContentAndNavigationItem(form, organizationId, environmentId);
             return true;
         } catch (Exception e) {
             log.error("Failed to migrate subscription form for environment [{}]", environmentId, e);
@@ -126,7 +126,7 @@ public class SubscriptionFormsToPortalNavigationItemsUpgrader implements Upgrade
         }
     }
 
-    private void migrate(SubscriptionForm form, String organizationId, String environmentId) {
+    private void createPageContentAndNavigationItem(SubscriptionForm form, String organizationId, String environmentId) {
         var content = pageContentCrudService.create(
             new GraviteeMarkdownPageContent(
                 PortalPageContentId.random(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -71,6 +71,7 @@ public class UpgraderOrder {
     public static final int CLASSIC_CATEGORIES_MIGRATION_UPGRADER = 722;
     public static final int PORTAL_NAVIGATION_STRUCTURE_UPGRADER = 723;
     public static final int PORTAL_NAVIGATION_ITEM_AUTOMATION_METADATA_UPGRADER = 724;
+    public static final int SUBSCRIPTION_FORM_TO_PORTAL_NAVIGATION_ITEM_UPGRADER = 725;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormsToPortalNavigationItemsUpgraderTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.SubscriptionFormRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.SubscriptionForm;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionFormsToPortalNavigationItemsUpgraderTest {
+
+    private static final Environment DEFAULT_ENVIRONMENT = Environment.builder()
+        .id("env-1")
+        .hrids(List.of("default"))
+        .name("Default")
+        .organizationId("org-1")
+        .build();
+
+    @Mock
+    SubscriptionFormRepository subscriptionFormRepository;
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+
+    @Mock
+    PortalPageContentCrudService pageContentCrudService;
+
+    @Mock
+    PortalNavigationItemDomainService portalNavigationItemDomainService;
+
+    private SubscriptionFormsToPortalNavigationItemsUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        upgrader = new SubscriptionFormsToPortalNavigationItemsUpgrader(
+            subscriptionFormRepository,
+            environmentRepository,
+            portalNavigationItemsQueryService,
+            pageContentCrudService,
+            portalNavigationItemDomainService
+        );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_do_nothing_when_there_are_no_forms() {
+        when(subscriptionFormRepository.findAll()).thenReturn(Collections.emptySet());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(pageContentCrudService, never()).create(any());
+        verify(portalNavigationItemDomainService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_throw_upgrader_exception_when_something_wrong_happens() {
+        when(subscriptionFormRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
+
+        Executable throwing = () -> upgrader.upgrade();
+
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("this is a test exception");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_migrate_a_legacy_form_into_page_content_and_a_subscription_form_navigation_item() {
+        var legacyForm = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("# Subscribe\n\n<gmd-input fieldkey=\"email\" />")
+            .enabled(true)
+            .validationConstraints("{}")
+            .build();
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(legacyForm));
+        when(environmentRepository.findById("env-1")).thenReturn(java.util.Optional.of(DEFAULT_ENVIRONMENT));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea("env-1", PortalArea.SUBSCRIPTION_FORM)
+        ).thenReturn(List.of());
+        var createdContent = new GraviteeMarkdownPageContent(
+            PortalPageContentId.random(),
+            "org-1",
+            "env-1",
+            GraviteeMarkdown.of(legacyForm.getGmdContent())
+        );
+        doReturn(createdContent).when(pageContentCrudService).create(any());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<GraviteeMarkdownPageContent> contentCaptor = ArgumentCaptor.forClass(GraviteeMarkdownPageContent.class);
+        verify(pageContentCrudService).create(contentCaptor.capture());
+        assertThat(contentCaptor.getValue().getOrganizationId()).isEqualTo("org-1");
+        assertThat(contentCaptor.getValue().getEnvironmentId()).isEqualTo("env-1");
+        assertThat(contentCaptor.getValue().getContent().value()).isEqualTo(legacyForm.getGmdContent());
+
+        ArgumentCaptor<CreatePortalNavigationItem> itemCaptor = ArgumentCaptor.forClass(CreatePortalNavigationItem.class);
+        verify(portalNavigationItemDomainService).create(eq("org-1"), eq("env-1"), itemCaptor.capture());
+        var createdItem = itemCaptor.getValue();
+        assertThat(createdItem.getType()).isEqualTo(PortalNavigationItemType.SUBSCRIPTION_FORM);
+        assertThat(createdItem.getArea()).isEqualTo(PortalArea.SUBSCRIPTION_FORM);
+        assertThat(createdItem.getPortalPageContentId()).isEqualTo(createdContent.getId());
+        assertThat(createdItem.getPublished()).isTrue();
+        assertThat(createdItem.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+        assertThat(createdItem.getParentId()).isNull();
+        assertThat(createdItem.getId()).isNotNull();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_carry_over_the_legacy_enabled_flag_as_published() {
+        var disabledForm = SubscriptionForm.builder()
+            .id("form-2")
+            .environmentId("env-1")
+            .gmdContent("# Subscribe")
+            .enabled(false)
+            .validationConstraints("{}")
+            .build();
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(disabledForm));
+        when(environmentRepository.findById("env-1")).thenReturn(java.util.Optional.of(DEFAULT_ENVIRONMENT));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea("env-1", PortalArea.SUBSCRIPTION_FORM)
+        ).thenReturn(List.of());
+        doReturn(new GraviteeMarkdownPageContent(PortalPageContentId.random(), "org-1", "env-1", GraviteeMarkdown.of("# Subscribe")))
+            .when(pageContentCrudService)
+            .create(any());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<CreatePortalNavigationItem> itemCaptor = ArgumentCaptor.forClass(CreatePortalNavigationItem.class);
+        verify(portalNavigationItemDomainService).create(any(), any(), itemCaptor.capture());
+        assertThat(itemCaptor.getValue().getPublished()).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_carry_over_legacy_validation_constraints_unchanged() {
+        var formWithConstraints = SubscriptionForm.builder()
+            .id("form-3")
+            .environmentId("env-1")
+            .gmdContent("# Subscribe")
+            .enabled(true)
+            .validationConstraints("{\"email\":[{\"type\":\"required\"}]}")
+            .build();
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(formWithConstraints));
+        when(environmentRepository.findById("env-1")).thenReturn(java.util.Optional.of(DEFAULT_ENVIRONMENT));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea("env-1", PortalArea.SUBSCRIPTION_FORM)
+        ).thenReturn(List.of());
+        doReturn(new GraviteeMarkdownPageContent(PortalPageContentId.random(), "org-1", "env-1", GraviteeMarkdown.of("# Subscribe")))
+            .when(pageContentCrudService)
+            .create(any());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<CreatePortalNavigationItem> itemCaptor = ArgumentCaptor.forClass(CreatePortalNavigationItem.class);
+        verify(portalNavigationItemDomainService).create(any(), any(), itemCaptor.capture());
+        assertThat(itemCaptor.getValue().getValidationConstraints()).isEqualTo(
+            new SubscriptionFormFieldConstraints(Map.of("email", List.of(new Constraint.Required())))
+        );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_skip_environment_that_already_has_a_subscription_form_navigation_item() {
+        var legacyForm = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("# Subscribe")
+            .enabled(true)
+            .validationConstraints("{}")
+            .build();
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(legacyForm));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea("env-1", PortalArea.SUBSCRIPTION_FORM)
+        ).thenReturn(
+            List.of(
+                fixtures.core.model.PortalNavigationItemFixtures.aSubscriptionForm(
+                    "00000000-0000-0000-0000-000000000999",
+                    PortalPageContentId.random()
+                )
+            )
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(pageContentCrudService, never()).create(any());
+        verify(portalNavigationItemDomainService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_skip_a_form_whose_environment_no_longer_exists() {
+        var orphanedForm = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("deleted-env")
+            .gmdContent("# Subscribe")
+            .enabled(true)
+            .validationConstraints("{}")
+            .build();
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(orphanedForm));
+        when(
+            portalNavigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalArea("deleted-env", PortalArea.SUBSCRIPTION_FORM)
+        ).thenReturn(List.of());
+        when(environmentRepository.findById("deleted-env")).thenReturn(java.util.Optional.empty());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(pageContentCrudService, never()).create(any());
+        verify(portalNavigationItemDomainService, never()).create(any(), any(), any());
+    }
+}


### PR DESCRIPTION
PORTAL-164 §3: data migration. Stacked on #19573 (§1-2 domain model).

## Changes

- `SubscriptionFormsToPortalNavigationItemsUpgrader` — one backend-agnostic `Upgrader`, reading every legacy `subscription_forms` row and writing a `PortalPageContent` + `PortalNavigationSubscriptionForm` pair through the domain use-case/validator path (so the §1-2 validation rules apply), rather than a raw repository insert.
  - Deliberate deviation from the story's literal wording (separate Liquibase/JDBC + Mongo-specific upgraders): this codebase's actual convention for this migration shape is a single Java class working through repository/use-case abstractions for both backends. Confirmed with the requester before implementing.
- Idempotent per environment (skips environments that already have a `SUBSCRIPTION_FORM`-area item).
- Legacy `subscription_forms` table/collection is left untouched — nothing reads from the new rows yet (that's §4, next in the stack).

## Compatibility

Persistence-adjacent (new upgrader, runs on boot) but no schema change and no behavior change to any existing read/write path — the legacy table remains the source of truth until §4 lands.