### PR TITLE
feat(portal): rewire Portal Next onto the generic nav-item/content abstraction

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
@@ -1241,12 +1241,22 @@ describe('SubscribeToApiComponent', () => {
   }
 
   function expectGetSubscriptionForm(subscriptionForm: SubscriptionForm | null) {
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/${API_ID}/subscription-form`);
-    if (subscriptionForm) {
-      req.flush(subscriptionForm);
-    } else {
-      req.flush(null, { status: 404, statusText: 'Not Found' });
+    const navigationItemId = 'subscription-form-nav-item-id';
+    const listReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/portal-navigation-items?area=SUBSCRIPTION_FORM`);
+
+    if (!subscriptionForm) {
+      listReq.flush([]);
+      return;
     }
+    listReq.flush([{ id: navigationItemId }]);
+
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/portal-navigation-items/${navigationItemId}/content`)
+      .flush({ type: 'GRAVITEE_MARKDOWN', content: subscriptionForm.gmdContent });
+
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/apis/${API_ID}/subscription-form`)
+      .flush({ resolvedOptions: subscriptionForm.resolvedOptions });
   }
 
   function expectPostCreateSubscription(expectedCreateSubscription: CreateSubscription, response: Subscription = fakeSubscription()) {

--- a/gravitee-apim-portal-webui-next/src/entities/portal/portal-navigation-item.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal/portal-navigation-item.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Portal navigation item, as listed by `GET /portal-navigation-items`.
+ * Only the fields the portal frontend consumes are modeled.
+ */
+export interface PortalNavigationItem {
+  id: string;
+}
+
+/**
+ * Portal navigation item content, as returned by `GET /portal-navigation-items/{id}/content`.
+ */
+export interface PortalNavigationItemContent {
+  content: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/portal/subscription-form.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal/subscription-form.ts
@@ -15,11 +15,21 @@
  */
 
 /**
- * Subscription form from Portal API.
- * Returned only when the form exists and is enabled (404 otherwise).
- * Portal does not expose id or enabled flag to consumers.
+ * Subscription form, composed client-side from the generic portal navigation item content
+ * endpoint (gmdContent) and the API-scoped subscription-form endpoint (resolvedOptions). See
+ * `PortalService.getSubscriptionForm`. Portal does not expose id or enabled flag to consumers.
  */
 export interface SubscriptionForm {
   gmdContent: string;
+  resolvedOptions?: Record<string, string[]>;
+}
+
+/**
+ * Response of `GET /apis/{apiId}/subscription-form`: the subscription form's resolved dynamic
+ * options for a specific API, and the visibility check for that API. Content is fetched
+ * separately via the generic portal navigation item content endpoint.
+ * Returned only when the form exists, is enabled, and the API is visible (404 otherwise).
+ */
+export interface ResolvedSubscriptionFormOptions {
   resolvedOptions?: Record<string, string[]>;
 }

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
@@ -20,7 +20,6 @@ import { ConfigService } from './config.service';
 import { PortalService } from './portal.service';
 import { ApiInformation } from '../entities/api/api-information';
 import { PortalPage } from '../entities/portal/portal-page';
-import { SubscriptionForm } from '../entities/portal/subscription-form';
 
 describe('PortalService', () => {
   let service: PortalService;
@@ -95,33 +94,67 @@ describe('PortalService', () => {
     req.flush({ pages: mockPages });
   });
 
-  it('should GET subscription form for an API id', () => {
+  it('should compose subscription form from navigation item content and resolved options', () => {
     const apiId = 'api-123';
-    const mockForm: SubscriptionForm = {
-      gmdContent: '<gmd-select fieldkey="country" options="France,Spain"></gmd-select>',
-      resolvedOptions: {
-        country: ['France', 'Spain'],
-      },
-    };
+    const navigationItemId = 'nav-item-1';
+    const gmdContent = '<gmd-select fieldkey="country" options="France,Spain"></gmd-select>';
+    const resolvedOptions = { country: ['France', 'Spain'] };
 
     service.getSubscriptionForm(apiId).subscribe(form => {
-      expect(form).toEqual(mockForm);
+      expect(form).toEqual({ gmdContent, resolvedOptions });
     });
 
-    const req = httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`);
-    expect(req.request.method).toBe('GET');
-    req.flush(mockForm);
+    const listReq = httpMock.expectOne(`${baseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`);
+    expect(listReq.request.method).toBe('GET');
+    listReq.flush([{ id: navigationItemId }]);
+
+    const contentReq = httpMock.expectOne(`${baseURL}/portal-navigation-items/${navigationItemId}/content`);
+    expect(contentReq.request.method).toBe('GET');
+    contentReq.flush({ type: 'GRAVITEE_MARKDOWN', content: gmdContent });
+
+    const optionsReq = httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`);
+    expect(optionsReq.request.method).toBe('GET');
+    optionsReq.flush({ resolvedOptions });
   });
 
-  it('should return null when subscription form endpoint responds 404', () => {
-    const apiId = 'api-404';
+  it('should return null when no SUBSCRIPTION_FORM navigation item exists', () => {
+    const apiId = 'api-no-form';
 
     service.getSubscriptionForm(apiId).subscribe(form => {
       expect(form).toBeNull();
     });
 
-    const req = httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`);
-    expect(req.request.method).toBe('GET');
-    req.flush(null, { status: 404, statusText: 'Not Found' });
+    const listReq = httpMock.expectOne(`${baseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`);
+    listReq.flush([]);
+  });
+
+  it('should return null when the navigation item content call responds 404', () => {
+    const apiId = 'api-123';
+    const navigationItemId = 'nav-item-1';
+
+    service.getSubscriptionForm(apiId).subscribe(form => {
+      expect(form).toBeNull();
+    });
+
+    httpMock.expectOne(`${baseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`).flush([{ id: navigationItemId }]);
+    httpMock
+      .expectOne(`${baseURL}/portal-navigation-items/${navigationItemId}/content`)
+      .flush(null, { status: 404, statusText: 'Not Found' });
+    httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`).flush({ resolvedOptions: {} });
+  });
+
+  it('should return null when the resolved-options call responds 404', () => {
+    const apiId = 'api-404';
+    const navigationItemId = 'nav-item-1';
+
+    service.getSubscriptionForm(apiId).subscribe(form => {
+      expect(form).toBeNull();
+    });
+
+    httpMock.expectOne(`${baseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`).flush([{ id: navigationItemId }]);
+    httpMock
+      .expectOne(`${baseURL}/portal-navigation-items/${navigationItemId}/content`)
+      .flush({ type: 'GRAVITEE_MARKDOWN', content: 'hello' });
+    httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`).flush(null, { status: 404, statusText: 'Not Found' });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.ts
@@ -80,9 +80,16 @@ export class PortalService {
           content: this.getPortalNavigationItemContent(navigationItemId),
           resolvedOptions: this.getSubscriptionFormResolvedOptions(apiId),
         }).pipe(
-          map(({ content, resolvedOptions }) =>
-            content && resolvedOptions ? { gmdContent: content.content, resolvedOptions: resolvedOptions.resolvedOptions } : null,
-          ),
+          map(({ content, resolvedOptions }) => {
+            if (!content || !resolvedOptions) {
+              return null;
+            }
+
+            return {
+              gmdContent: content.content,
+              resolvedOptions: resolvedOptions.resolvedOptions,
+            };
+          }),
         );
       }),
     );

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.ts
@@ -27,12 +27,13 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, catchError, map, of } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import { ApiInformation } from '../entities/api/api-information';
+import { PortalNavigationItem, PortalNavigationItemContent } from '../entities/portal/portal-navigation-item';
 import { PortalPage } from '../entities/portal/portal-page';
-import { SubscriptionForm } from '../entities/portal/subscription-form';
+import { ResolvedSubscriptionFormOptions, SubscriptionForm } from '../entities/portal/subscription-form';
 
 @Injectable({
   providedIn: 'root',
@@ -59,8 +60,56 @@ export class PortalService {
       .pipe(map(resp => resp?.pages ?? []));
   }
 
+  /**
+   * Composes the subscription form from two independent calls:
+   * - form content, via the generic portal navigation item content endpoint (area SUBSCRIPTION_FORM),
+   *   shared with the Console navigation-item editor;
+   * - resolved dynamic options for `apiId`, via the API-scoped subscription-form endpoint, which also
+   *   enforces that `apiId` is visible to the caller.
+   * Emits `null` when the environment has no subscription form, or when either call is unavailable
+   * (404) — matching this method's pre-existing single-endpoint 404 semantics.
+   */
   public getSubscriptionForm(apiId: string): Observable<SubscriptionForm | null> {
-    return this.http.get<SubscriptionForm>(`${this.configService.baseURL}/apis/${apiId}/subscription-form`).pipe(
+    return this.getSubscriptionFormNavigationItemId().pipe(
+      switchMap(navigationItemId => {
+        if (!navigationItemId) {
+          return of(null);
+        }
+
+        return forkJoin({
+          content: this.getPortalNavigationItemContent(navigationItemId),
+          resolvedOptions: this.getSubscriptionFormResolvedOptions(apiId),
+        }).pipe(
+          map(({ content, resolvedOptions }) =>
+            content && resolvedOptions ? { gmdContent: content.content, resolvedOptions: resolvedOptions.resolvedOptions } : null,
+          ),
+        );
+      }),
+    );
+  }
+
+  private getSubscriptionFormNavigationItemId(): Observable<string | null> {
+    const params = new HttpParams().set('area', 'SUBSCRIPTION_FORM');
+    return this.http
+      .get<PortalNavigationItem[]>(`${this.configService.baseURL}/portal-navigation-items`, { params })
+      .pipe(map(items => items[0]?.id ?? null));
+  }
+
+  private getPortalNavigationItemContent(navigationItemId: string): Observable<PortalNavigationItemContent | null> {
+    return this.http
+      .get<PortalNavigationItemContent>(`${this.configService.baseURL}/portal-navigation-items/${navigationItemId}/content`)
+      .pipe(
+        catchError(err => {
+          if (err.status === 404) {
+            return of(null);
+          }
+          throw err;
+        }),
+      );
+  }
+
+  private getSubscriptionFormResolvedOptions(apiId: string): Observable<ResolvedSubscriptionFormOptions | null> {
+    return this.http.get<ResolvedSubscriptionFormOptions>(`${this.configService.baseURL}/apis/${apiId}/subscription-form`).pipe(
       catchError(err => {
         if (err.status === 404) {
           return of(null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -43,8 +43,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -53,13 +51,6 @@ public interface PortalNavigationItemMapper {
 
     PortalArea map(io.gravitee.rest.api.portal.rest.model.PortalArea area);
 
-    /**
-     * SUBSCRIPTION_FORM is never browsable through this listing (a distinct, single, management-only
-     * area, not part of the HOMEPAGE/TOP_NAVBAR navigation tree this portal-rest surface serves) - a
-     * value here would mean a caller queried the wrong area, so this fails loudly instead of silently
-     * producing an unmappable REST value.
-     */
-    @ValueMapping(source = "SUBSCRIPTION_FORM", target = MappingConstants.THROW_EXCEPTION)
     io.gravitee.rest.api.portal.rest.model.PortalArea map(PortalArea area);
 
     default List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> map(@Nonnull List<PortalNavigationItem> items) {
@@ -73,9 +64,7 @@ public interface PortalNavigationItemMapper {
             case PortalNavigationPage page -> map(page);
             case PortalNavigationApi api -> map(api);
             case PortalNavigationApiProduct apiProduct -> map(apiProduct);
-            case PortalNavigationSubscriptionForm subscriptionForm -> throw new IllegalStateException(
-                "SUBSCRIPTION_FORM navigation items are never exposed through the portal navigation listing"
-            );
+            case PortalNavigationSubscriptionForm subscriptionForm -> map(subscriptionForm);
         };
         var wrappedItem = new io.gravitee.rest.api.portal.rest.model.PortalNavigationItem();
         wrappedItem.setActualInstance(baseItem);
@@ -87,6 +76,7 @@ public interface PortalNavigationItemMapper {
     io.gravitee.rest.api.portal.rest.model.PortalNavigationPage map(PortalNavigationPage page);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationApi map(PortalNavigationApi api);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationApiProduct map(PortalNavigationApiProduct apiProduct);
+    io.gravitee.rest.api.portal.rest.model.PortalNavigationSubscriptionForm map(PortalNavigationSubscriptionForm subscriptionForm);
 
     @Mapping(source = "value", target = "content")
     default String extractContent(PortalPageContent<?> content) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionFormMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionFormMapper.java
@@ -15,15 +15,10 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
-import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.use_case.GetSubscriptionFormForApiPortalUseCase;
 import io.gravitee.apim.core.subscription_form.use_case.GetSubscriptionFormForEnvironmentUseCase;
-import java.util.List;
-import java.util.Map;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -33,8 +28,6 @@ import org.mapstruct.factory.Mappers;
 public interface SubscriptionFormMapper {
     SubscriptionFormMapper INSTANCE = Mappers.getMapper(SubscriptionFormMapper.class);
 
-    @Mapping(target = "gmdContent", source = "gmdContent", qualifiedByName = "graviteeMarkdownToString")
-    @Mapping(target = "resolvedOptions", ignore = true)
     io.gravitee.rest.api.portal.rest.model.SubscriptionForm map(SubscriptionForm subscriptionForm);
 
     default io.gravitee.rest.api.portal.rest.model.SubscriptionForm map(GetSubscriptionFormForEnvironmentUseCase.Output output) {
@@ -47,10 +40,5 @@ public interface SubscriptionFormMapper {
         var model = map(output.subscriptionForm());
         model.setResolvedOptions(output.resolvedOptions().isEmpty() ? null : output.resolvedOptions());
         return model;
-    }
-
-    @Named("graviteeMarkdownToString")
-    default String graviteeMarkdownToString(GraviteeMarkdown gmd) {
-        return gmd != null ? gmd.value() : null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscriptionFormResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscriptionFormResource.java
@@ -29,8 +29,9 @@ import jakarta.ws.rs.core.Response;
 import org.springframework.stereotype.Component;
 
 /**
- * Portal endpoint to retrieve the subscription form for a specific API, with EL options resolved
- * against the API's metadata.
+ * Portal endpoint to retrieve the subscription form's resolved dynamic options for a specific API,
+ * with EL options resolved against the API's metadata. Form content itself is fetched separately
+ * via the generic portal navigation item content endpoint (area {@code SUBSCRIPTION_FORM}).
  *
  * <p>Path: {@code GET /apis/{apiId}/subscription-form}</p>
  *

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -797,19 +797,22 @@ paths:
         get:
             tags:
                 - Portal
-            summary: Get the subscription form for an API.
+            summary: Get the resolved dynamic options for an API's subscription form.
             description: |
-              Returns the subscription form content when the form exists and is enabled for the environment.
+              Returns the subscription form's resolved dynamic option lists when the form exists and
+              is enabled for the environment. The form content itself is fetched separately via the
+              generic portal navigation item content endpoint (area 'SUBSCRIPTION_FORM').
               EL expressions in option-bearing fields are resolved against the API's metadata.
               If resolution fails, fallback values are returned instead.
-              Returns 404 when no subscription form exists for the environment or when the form is disabled.
+              Returns 404 when no subscription form exists for the environment, when the form is
+              disabled, or when the API is not visible to the caller.
             operationId: getApiSubscriptionForm
             security:
                 - BasicAuth: []
                 - CookieAuth: []
             responses:
                 200:
-                    description: The subscription form content with resolved options.
+                    description: The subscription form's resolved dynamic options.
                     content:
                         application/json:
                             schema:
@@ -4107,7 +4110,7 @@ paths:
             operationId: getPortalNavigationItemContentById
             description: |
                 Get a specific portal navigation item's content by its ID.
-                Only portal navigation items of type 'PAGE' have content.
+                Only portal navigation items of type 'PAGE' or 'SUBSCRIPTION_FORM' have content.
             security:
                 - {}
                 - BasicAuth: []
@@ -4116,7 +4119,7 @@ paths:
                 200:
                     $ref: "#/components/responses/PortalNavigationItemContentSuccess"
                 400:
-                    description: The portal navigation item is not of type 'PAGE'.
+                    description: The portal navigation item is not of type 'PAGE' or 'SUBSCRIPTION_FORM'.
                     content:
                         application/json:
                             schema:
@@ -4803,21 +4806,11 @@ components:
                     $ref: "#/components/schemas/Links"
         SubscriptionForm:
             type: object
-            description: Subscription form returned to API consumers when the form is enabled.
-            required:
-                - gmdContent
+            description: |-
+              Resolved dynamic options for the subscription form, returned to API consumers when the
+              form is enabled. Form content itself is fetched separately via the generic portal
+              navigation item content endpoint (area 'SUBSCRIPTION_FORM').
             properties:
-                gmdContent:
-                    type: string
-                    description: |-
-                      Gravitee Markdown (GMD) content defining the form.
-                      Supports form components like gmd-input, gmd-textarea, gmd-select, gmd-checkbox, gmd-radio.
-                      Option-bearing fields may contain Gravitee EL expressions (e.g. {#api.metadata['key']}:fallback1,fallback2).
-                    example: |-
-                      # Subscription Information
-
-                      <gmd-input name="consumer_company_name" label="Company Name" required="true"/>
-                      <gmd-textarea name="consumer_use_case" label="Use Case" required="true"/>
                 resolvedOptions:
                     type: object
                     description: |-
@@ -8615,6 +8608,7 @@ components:
                     LINK: "#/components/schemas/PortalNavigationLink"
                     API: "#/components/schemas/PortalNavigationApi"
                     API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
+                    SUBSCRIPTION_FORM: "#/components/schemas/PortalNavigationSubscriptionForm"
         PortalNavigationPage:
             allOf:
                 - $ref: "#/components/schemas/BasePortalNavigationItem"
@@ -8663,6 +8657,15 @@ components:
                     type: string
                     format: uuid
               required: [ apiProductId ]
+        PortalNavigationSubscriptionForm:
+            description: Portal navigation item of type SUBSCRIPTION_FORM
+            allOf:
+                - $ref: "#/components/schemas/BasePortalNavigationItem"
+                - properties:
+                      portalPageContentId:
+                          type: string
+                          description: The UUID of the portal page content backing this subscription form. Always GRAVITEE_MARKDOWN.
+                  required: [portalPageContentId]
         PortalNavigationItem:
             oneOf:
                 - $ref: "#/components/schemas/PortalNavigationPage"
@@ -8670,6 +8673,7 @@ components:
                 - $ref: "#/components/schemas/PortalNavigationLink"
                 - $ref: "#/components/schemas/PortalNavigationApi"
                 - $ref: "#/components/schemas/PortalNavigationApiProduct"
+                - $ref: "#/components/schemas/PortalNavigationSubscriptionForm"
             discriminator:
                 propertyName: type
                 mapping:
@@ -8678,6 +8682,7 @@ components:
                     LINK: "#/components/schemas/PortalNavigationLink"
                     API: "#/components/schemas/PortalNavigationApi"
                     API_PRODUCT: "#/components/schemas/PortalNavigationApiProduct"
+                    SUBSCRIPTION_FORM: "#/components/schemas/PortalNavigationSubscriptionForm"
 
         PortalPageContent:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
 import io.gravitee.apim.core.portal_category.model.PortalCategoryId;
@@ -136,7 +135,8 @@ class PortalNavigationItemMapperTest {
     }
 
     @Test
-    void should_throw_when_mapping_a_subscription_form_item() {
+    void should_map_subscription_form_item() {
+        var contentId = PortalNavigationFixtures.randomPageId();
         var subscriptionForm = PortalNavigationSubscriptionForm.builder()
             .id(PortalNavigationFixtures.randomNavigationId())
             .organizationId("org")
@@ -145,14 +145,17 @@ class PortalNavigationItemMapperTest {
             .segment("subscription-form")
             .area(PortalArea.SUBSCRIPTION_FORM)
             .order(0)
-            .portalPageContentId(PortalNavigationFixtures.randomPageId())
+            .portalPageContentId(contentId)
             .validationConstraints(io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints.empty())
             .published(true)
             .visibility(PortalVisibility.PUBLIC)
             .build();
 
-        assertThatThrownBy(() -> PortalNavigationItemMapper.INSTANCE.getBasePortalNavigationItem(subscriptionForm)).isInstanceOf(
-            IllegalStateException.class
-        );
+        var mapped = PortalNavigationItemMapper.INSTANCE.getBasePortalNavigationItem(subscriptionForm);
+
+        assertThat(mapped.getActualInstance()).isInstanceOf(io.gravitee.rest.api.portal.rest.model.PortalNavigationSubscriptionForm.class);
+        var mappedForm = (io.gravitee.rest.api.portal.rest.model.PortalNavigationSubscriptionForm) mapped.getActualInstance();
+        assertThat(mappedForm.getTitle()).isEqualTo("Subscription Form");
+        assertThat(mappedForm.getPortalPageContentId()).isEqualTo(contentId.json());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscriptionFormResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscriptionFormResourceTest.java
@@ -89,7 +89,7 @@ class ApiSubscriptionFormResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void should_return_200_with_subscription_form_and_resolved_options() {
+    void should_return_200_with_resolved_options_only_no_content() {
         var form = SubscriptionFormFixtures.aSubscriptionFormBuilder()
             .environmentId(ENV_ID)
             .enabled(true)
@@ -103,7 +103,6 @@ class ApiSubscriptionFormResourceTest extends AbstractResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
         var result = response.readEntity(SubscriptionForm.class);
         assertThat(result).isNotNull();
-        assertThat(result.getGmdContent()).isEqualTo(form.getGmdContent().value());
         assertThat(result.getResolvedOptions()).containsEntry("env", List.of("Dev", "Staging", "Prod"));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -23,11 +23,14 @@ import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDa
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.RendererException;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
@@ -64,7 +67,12 @@ public class GetPortalPageContentByNavigationIdUseCase {
             throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
         }
 
-        if (!(portalNavigationItem instanceof PortalNavigationPage page)) {
+        PortalPageContentId portalPageContentId;
+        if (portalNavigationItem instanceof PortalNavigationPage page) {
+            portalPageContentId = page.getPortalPageContentId();
+        } else if (portalNavigationItem instanceof PortalNavigationSubscriptionForm subscriptionForm) {
+            portalPageContentId = subscriptionForm.getPortalPageContentId();
+        } else {
             throw InvalidPortalNavigationItemDataException.typeMismatch(
                 PortalNavigationItemType.PAGE.name(),
                 portalNavigationItem.getType().name()
@@ -72,15 +80,25 @@ public class GetPortalPageContentByNavigationIdUseCase {
         }
 
         var portalPageContent = portalPageContentQueryService
-            .findById(page.getPortalPageContentId())
-            .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
+            .findById(portalPageContentId)
+            .orElseThrow(() -> new PageContentNotFoundException(portalPageContentId.toString()));
 
-        var rendered = contentRenderers
-            .stream()
-            .filter(r -> r.appliesTo(portalPageContent))
-            .findFirst()
-            .orElseThrow(() -> new RendererException("No renderer found for content type: " + portalPageContent.getType()))
-            .render(page, portalPageContent);
+        RenderedPageContent rendered;
+        if (portalNavigationItem instanceof PortalNavigationSubscriptionForm) {
+            // Subscription form content is served raw, with EL placeholders left unresolved: dynamic
+            // option resolution against a specific API is handled separately (there is no "enclosing
+            // API" for an unparented subscription-form item), matching this content's existing
+            // pre-Phase-7 behavior of never being templated at the content-serving layer.
+            var markdownContent = (GraviteeMarkdownPageContent) portalPageContent;
+            rendered = RenderedPageContent.of(markdownContent.getContent().value(), markdownContent.getType());
+        } else {
+            rendered = contentRenderers
+                .stream()
+                .filter(r -> r.appliesTo(portalPageContent))
+                .findFirst()
+                .orElseThrow(() -> new RendererException("No renderer found for content type: " + portalPageContent.getType()))
+                .render(portalNavigationItem, portalPageContent);
+        }
 
         return new Output(rendered, portalNavigationItem);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
@@ -56,6 +57,7 @@ import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateExce
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
@@ -374,6 +376,32 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");
+    }
+
+    @Test
+    void should_return_raw_content_for_subscription_form_without_templating() {
+        var contentId = PortalPageContentId.random();
+        var formId = "00000000-0000-0000-0000-000000000095";
+        var rawContent = "<gmd-select fieldkey=\"env\" options=\"{#api.metadata['envs']}:Prod,Test\"/>";
+        var form = PortalNavigationItemFixtures.aSubscriptionForm(formId, contentId);
+        var formContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(contentId, ORGANIZATION_ID, ENVIRONMENT_ID, rawContent);
+
+        pageContentQueryService.initWith(List.of(formContent));
+        navigationItemsQueryService.initWith(List.of(form));
+
+        var output = useCase.execute(
+            new GetPortalPageContentByNavigationIdUseCase.Input(
+                formId,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                PortalNavigationItemViewerContext.forPortal(true)
+            )
+        );
+
+        assertThat(output.renderedContent().type()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        assertThat(output.renderedContent().value()).isEqualTo(rawContent);
+        assertThat(output.portalNavigationItem()).isInstanceOf(PortalNavigationSubscriptionForm.class);
+        verifyNoInteractions(portalNavigationTemplatingService);
     }
 
     @Test


### PR DESCRIPTION
Follow-up to PORTAL-164 (§7 was verification-only — Portal Next kept its dedicated endpoint since the migration was designed to be invisible to it). Stacked on #19576 (§5-6 REST + Console).

Explicit scope expansion, requested after the original story shipped: rewire Portal Next so **both** web UIs consume the same generic `PortalNavigationItem`/`PortalPageContent` abstraction Console now uses, rather than leaving Portal Next on a bespoke endpoint.

Two concerns in the old dedicated endpoint don't fit the generic, API-agnostic nav-item model: an apiId-scoped authorization check, and EL-resolved dynamic options for a specific API. Presented with this fork, kept both as a separate, slimmer call rather than folding them into the generic endpoint.

## Changes

- Widened portal-rest's own `PortalArea` enum and `PortalNavigationItem` oneOf with a `SUBSCRIPTION_FORM` variant, reversing the two "fail loudly" guards the previous PR in this stack deliberately added (that value is no longer unreachable through this surface).
- Trimmed the `SubscriptionForm` REST schema (`GET /apis/{apiId}/subscription-form`) to drop `gmdContent` — it now returns `resolvedOptions` only; content comes from the generic content endpoint.
- Widened `GetPortalPageContentByNavigationIdUseCase` (shared by Console and Portal Next) to accept `PortalNavigationSubscriptionForm`. Deliberately does **not** route it through `contentRenderers`/`GraviteeMarkdownContentRenderer`: confirmed the pre-existing dedicated endpoint never templated `gmdContent` (only `resolvedOptions` was EL-aware), so templating it now would be an observable behavior change on a template-rendering path.
- `PortalService.getSubscriptionForm(apiId)` (Portal Next) keeps its exact signature but now composes three calls — find the nav item, fetch its raw content, fetch resolved options via the trimmed endpoint — nulling out on any 404 to preserve the old single-endpoint 404 semantics. `subscribe-to-api.component.ts` and its `applyResolvedOptions()` merge logic needed zero changes.

## Compatibility

**Public REST API (OpenAPI contract, portal-rest)**: `SubscriptionForm` schema trimmed (breaking for any other consumer of `GET /apis/{apiId}/subscription-form`, though Portal Next is its only known consumer and is updated in this same PR); new `SUBSCRIPTION_FORM` nav-item type exposed.

**Security-sensitive**: no new authorization logic — the apiId-scoped `isApiVisibleToUser` check stays exactly where it was, in its own call; the generic endpoint's existing nav-item-level visibility checks apply to `SUBSCRIPTION_FORM` unchanged, with no widening of what they check.