### PR TITLE
fix(console): allow read-only access to v2 endpoint group details

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.spec.ts
@@ -20,7 +20,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatIconHarness, MatIconTestingModule } from '@angular/material/icon/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiProxyEndpointListComponent } from './api-proxy-endpoint-list.component';
 import { ApiProxyEndpointListHarness } from './api-proxy-endpoint-list.harness';
@@ -38,13 +38,13 @@ describe('ApiProxyEndpointListComponent', () => {
   let httpTestingController: HttpTestingController;
   let endpointsGroupHarness: ApiProxyEndpointListHarness;
 
-  const initComponent = async (api: ApiV2) => {
+  const initComponent = async (api: ApiV2, permissions: string[] = ['api-definition-u', 'api-definition-r']) => {
     TestBed.configureTestingModule({
       declarations: [ApiProxyEndpointListComponent],
       imports: [NoopAnimationsModule, GioTestingModule, ApiEndpointsModule, MatIconTestingModule],
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
-        { provide: GioTestingPermissionProvider, useValue: ['api-definition-u', 'api-definition-r'] },
+        { provide: GioTestingPermissionProvider, useValue: permissions },
       ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {
@@ -195,6 +195,40 @@ describe('ApiProxyEndpointListComponent', () => {
               '(_MatIconHarness with host element matching selector: ".mat-icon" satisfying the constraints: host matches selector "[mattooltip="Health check is enabled"]")',
           ),
         );
+    });
+  });
+
+  describe('read-only mode', () => {
+    it('should allow viewing endpoint groups and endpoints without allowing updates if user can only read', async () => {
+      await initComponent(fakeApiV2({ id: API_ID }), ['api-definition-r']);
+
+      expect(await endpointsGroupHarness.isAddEndpointGroupButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isAddEndpointButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isEditEndpointGroupButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isDeleteEndpointGroupButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isOpenEndpointGroupDetailButtonVisible()).toEqual(true);
+
+      const navigateByUrl = jest.spyOn(TestBed.inject(Router), 'navigateByUrl').mockResolvedValue(true);
+      await endpointsGroupHarness.clickOpenEndpointGroupDetail(0);
+      expect(navigateByUrl).toHaveBeenCalled();
+
+      expect(await endpointsGroupHarness.isEditEndpointButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isDeleteEndpointButtonVisible()).toEqual(false);
+      expect(await endpointsGroupHarness.isOpenEndpointDetailButtonVisible()).toEqual(true);
+    });
+
+    it('should keep update actions available if user can update', async () => {
+      await initComponent(fakeApiV2({ id: API_ID }));
+
+      expect(await endpointsGroupHarness.isAddEndpointGroupButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isAddEndpointButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isEditEndpointGroupButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isDeleteEndpointGroupButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isOpenEndpointGroupDetailButtonVisible()).toEqual(false);
+
+      expect(await endpointsGroupHarness.isEditEndpointButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isDeleteEndpointButtonVisible()).toEqual(true);
+      expect(await endpointsGroupHarness.isOpenEndpointDetailButtonVisible()).toEqual(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.component.ts
@@ -123,6 +123,6 @@ export class ApiProxyEndpointListComponent implements OnInit {
 
   private initData(api: ApiV2): void {
     this.endpointGroupsTableData = toEndpoints(api);
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-r']) || api.definitionContext?.origin === 'KUBERNETES';
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/list/api-proxy-endpoint-list.harness.ts
@@ -23,9 +23,20 @@ export class ApiProxyEndpointListHarness extends ComponentHarness {
   static hostSelector = 'api-proxy-endpoint-list';
 
   private getAddEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ text: /Add new endpoint group/ }));
+  private getAddEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ text: /Add new endpoint group/ }));
+  private getAddEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add new endpoint"]' }));
   private getEditEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ selector: '[mattooltip="Edit group"]' }));
+  private getEditEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit group"]' }));
   private getDeleteEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Delete group"]' }));
+  private getDeleteEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete group"]' }));
+  private getOpenEndpointGroupDetailButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[aria-label="Button to open group detail"]' }),
+  );
+  private getEditEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Button to edit an endpoint"]' }));
   private getDeleteEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
+  private getOpenEndpointDetailButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[aria-label="Button to open endpoint detail"]' }),
+  );
 
   public async getTable(index: number) {
     const table = this.locatorFor(MatTableHarness.with({ selector: `#endpointGroupsTable-${index}` }));
@@ -57,9 +68,46 @@ export class ApiProxyEndpointListHarness extends ComponentHarness {
     return button.click();
   }
 
+  public async isAddEndpointGroupButtonVisible(): Promise<boolean> {
+    return this.getAddEndpointGroupButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async isAddEndpointButtonVisible(): Promise<boolean> {
+    return this.getAddEndpointButtons().then(buttons => buttons.length > 0);
+  }
+
   public async editEndpointGroup() {
     const button = await this.getEditEndpointGroupButton();
     return await button.click();
+  }
+
+  public async isEditEndpointGroupButtonVisible(): Promise<boolean> {
+    return this.getEditEndpointGroupButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async isDeleteEndpointGroupButtonVisible(): Promise<boolean> {
+    return this.getDeleteEndpointGroupButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async isOpenEndpointGroupDetailButtonVisible(): Promise<boolean> {
+    return this.getOpenEndpointGroupDetailButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async clickOpenEndpointGroupDetail(index: number): Promise<void> {
+    const buttons = await this.getOpenEndpointGroupDetailButtons();
+    return buttons[index].click();
+  }
+
+  public async isEditEndpointButtonVisible(): Promise<boolean> {
+    return this.getEditEndpointButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async isDeleteEndpointButtonVisible(): Promise<boolean> {
+    return this.getDeleteEndpointButtons().then(buttons => buttons.length > 0);
+  }
+
+  public async isOpenEndpointDetailButtonVisible(): Promise<boolean> {
+    return this.getOpenEndpointDetailButtons().then(buttons => buttons.length > 0);
   }
 
   public async deleteEndpointGroup(rootLoader: HarnessLoader) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15026

## Description

Completes the API V2 flow described in [APIM-15026](https://gravitee.atlassian.net/browse/APIM-15026).

Previously, the V2 endpoint group list derived its read-only state from the absence of `api-definition-r`. A user with READ permission but without UPDATE permission was therefore placed in the editable UI branch, while the permission directives hid all group actions. As a result, there was no way to open the endpoint group details from the UI.

The read-only state is now derived from the absence of `api-definition-u`. Read-only users see the existing view actions, while all mutation actions remain unavailable.

## Changes

- Display `Open group detail` for users with `api-definition-r` but without `api-definition-u`.
- Display the read-only endpoint detail action for the same users.
- Keep add, edit, and delete actions hidden in read-only mode.
- Preserve the existing edit actions for users with UPDATE permission.
- Preserve read-only behavior for APIs originating from Kubernetes.
- Add regression coverage for both read-only and update-capable users.



https://github.com/user-attachments/assets/603fbd00-1f16-4ae3-8a17-91e582d31f38




[APIM-15026]: https://gravitee.atlassian.net/browse/APIM-15026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ