### PR TITLE
chore(deps): update gravitee-policy-transform-avro-json to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <gravitee-policy-role-based-access-control.version>1.4.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.2</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>4.0.0</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>4.0.1</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.0.2</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Issue

_No ticket — follow-up to the Confluent repository declaration added in gravitee-io/gravitee-policy-transform-avro-json#98._

## Description

Bumps `gravitee-policy-transform-avro-json` from `4.0.0` to `4.0.1` so this branch picks up the version whose POM declares the Confluent repository.

`io.confluent:kafka-avro-serializer` and three of its transitive dependencies (`kafka-schema-serializer`, `kafka-schema-registry-client`, `common-utils`) are not published to Maven Central. Until now the policy's POM declared no repository for them, so `gravitee-apim-distribution-integration-tests` — which depends on the policy in `test` scope and therefore inherits those artifacts — could only resolve them through the internal Artifactory mirror.

With this bump, the repository declaration comes along with the dependency and the resolution no longer depends on that mirror.

## Additional context

`4.0.1` was cut from a dedicated `4.0.x` branch so this support branch receives the build fix and nothing else.

The obvious alternative, `4.1.1`, would have dragged in the *unwrapped JSON encoding* feature: 19 files, three new codec classes and 53 lines of `schema-form.json`, surfacing new options in Policy Studio. That line was never shipped by any distribution — it existed for a single day, between the `4.0.0` release on 2026-05-12 and `5.0.0` on 2026-05-14 — so a support branch is not the place to introduce it.

The other active branches (`4.10.x`, `4.11.x`, `4.12.x`, `master`) move from `5.2.1` to `5.2.2`, which carries the same fix and nothing else.
