### PR TITLE
chore(deps): update gravitee-policy-transform-avro-json to 5.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <gravitee-policy-role-based-access-control.version>2.0.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.2</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>5.2.1</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>5.2.2</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.1.0</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Issue

_No ticket — follow-up to the Confluent repository declaration added in gravitee-io/gravitee-policy-transform-avro-json#96 and #97._

## Description

Bumps `gravitee-policy-transform-avro-json` so this branch picks up the version whose POM declares the Confluent repository.

`io.confluent:kafka-avro-serializer` and three of its transitive dependencies (`kafka-schema-serializer`, `kafka-schema-registry-client`, `common-utils`) are not published to Maven Central. Until now the policy's POM declared no repository for them, so `gravitee-apim-distribution-integration-tests` — which depends on the policy in `test` scope and therefore inherits those artifacts — could only resolve them through the internal Artifactory mirror.

With this bump, the repository declaration comes along with the dependency and the resolution no longer depends on that mirror.

## Additional context

This is the APIM half of the change; the policy side is already merged and released. Same bump is being applied to the other active branches.
