### PR TITLE
ci(gamma): check graphene versions across the bundled gamma modules

### DIFF
--- a/.circleci/ci/package-lock.json
+++ b/.circleci/ci/package-lock.json
@@ -10,6 +10,7 @@
             "devDependencies": {
                 "@sucrase/jest-plugin": "3.0.0",
                 "@types/jest": "29.5.14",
+                "@types/semver": "7.7.0",
                 "eslint": "9.39.4",
                 "eslint-config-prettier": "10.1.8",
                 "eslint-plugin-import": "2.32.0",
@@ -18,6 +19,7 @@
                 "jest": "29.7.0",
                 "license-check-and-add": "4.0.5",
                 "prettier": "3.5.3",
+                "semver": "7.7.1",
                 "sucrase": "3.35.0",
                 "ts-node": "10.9.2",
                 "typescript": "5.7.3",
@@ -1519,6 +1521,13 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
             "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
             "dev": true
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+            "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.1",
@@ -8464,6 +8473,12 @@
             "version": "20.5.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
             "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+            "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
             "dev": true
         },
         "@types/stack-utils": {

--- a/.circleci/ci/package.json
+++ b/.circleci/ci/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@sucrase/jest-plugin": "3.0.0",
         "@types/jest": "29.5.14",
+        "@types/semver": "7.7.0",
         "typescript-eslint": "8.26.1",
         "eslint": "9.39.4",
         "eslint-config-prettier": "10.1.8",
@@ -34,6 +35,7 @@
         "jest": "29.7.0",
         "license-check-and-add": "4.0.5",
         "prettier": "3.5.3",
+        "semver": "7.7.1",
         "sucrase": "3.35.0",
         "ts-node": "10.9.2",
         "typescript": "5.7.3",

--- a/.circleci/ci/src/graphene-versions/apim-pins.ts
+++ b/.circleci/ci/src/graphene-versions/apim-pins.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse } from 'yaml';
+import { ApimPins, GRAPHENE_CHARTS, GRAPHENE_CORE, GRAPHENE_POLICY_STUDIO, OBSERVABILITY, WorkspacePins } from './rules';
+
+const TRACKED_PACKAGES = [GRAPHENE_CHARTS, GRAPHENE_CORE, GRAPHENE_POLICY_STUDIO, OBSERVABILITY];
+
+export function readApimPins(repoRoot: string): ApimPins {
+  const packages = readPinnedPackages(path.join(repoRoot, 'package.json'));
+
+  // Only the package the host shares as a singleton is load-bearing. Dropping any of the others is
+  // a legitimate cleanup once no module registers it, and must not red-line every backend PR — the
+  // rules below already skip a package APIM does not pin.
+  if (packages[GRAPHENE_CORE] === undefined) {
+    throw new Error(`The root package.json no longer pins ${GRAPHENE_CORE}. This check has nothing left to compare against.`);
+  }
+
+  const observabilityVersion = packages[OBSERVABILITY];
+
+  return {
+    packages,
+    // Nothing to look up when observability is unpinned; asking would build an '@npm:undefined'
+    // descriptor and fail on a lockfile that is perfectly correct.
+    observabilityGraphenePeers:
+      observabilityVersion === undefined ? {} : readObservabilityGraphenePeers(path.join(repoRoot, 'yarn.lock'), observabilityVersion),
+    workspacePins: readWorkspacePins(repoRoot),
+  };
+}
+
+function readPinnedPackages(packageJsonFile: string): Record<string, string> {
+  const manifest = JSON.parse(fs.readFileSync(packageJsonFile, 'utf-8'));
+  const declared: Record<string, string> = { ...manifest.dependencies, ...manifest.devDependencies };
+
+  return Object.fromEntries(TRACKED_PACKAGES.filter((name) => declared[name] !== undefined).map((name) => [name, declared[name]]));
+}
+
+/**
+ * Observability declares graphene as a peer and ships none of its own, so the range it needs is
+ * only recorded in the lockfile entry for the version APIM pins.
+ */
+function readObservabilityGraphenePeers(lockFile: string, observabilityVersion: string): Record<string, string> {
+  const descriptor = `${OBSERVABILITY}@npm:${observabilityVersion}`;
+  const lock = parse(fs.readFileSync(lockFile, 'utf-8'));
+
+  const entry = Object.entries(lock as Record<string, { peerDependencies?: Record<string, string> }>).find(([descriptors]) =>
+    descriptors.split(', ').includes(descriptor),
+  );
+  if (!entry) {
+    throw new Error(`yarn.lock has no entry for ${descriptor}. Run 'yarn install' so the lockfile matches the root package.json.`);
+  }
+
+  const peers = entry[1].peerDependencies ?? {};
+  return Object.fromEntries(Object.entries(peers).filter(([name]) => TRACKED_PACKAGES.includes(name)));
+}
+
+/**
+ * Every in-repo Gamma project that pins one of the tracked packages. The Gamma console host has no
+ * package.json of its own, so these are the only in-repo pins besides the root.
+ */
+function readWorkspacePins(repoRoot: string): WorkspacePins[] {
+  const gammaRoot = path.join(repoRoot, 'gravitee-gamma');
+  if (!fs.existsSync(gammaRoot)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(gammaRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join('gravitee-gamma', entry.name, 'package.json'))
+    .filter((file) => fs.existsSync(path.join(repoRoot, file)))
+    .map((file) => ({ file, packages: readPinnedPackages(path.join(repoRoot, file)) }))
+    .filter((workspace) => Object.keys(workspace.packages).length > 0);
+}

--- a/.circleci/ci/src/graphene-versions/bundled-modules.ts
+++ b/.circleci/ci/src/graphene-versions/bundled-modules.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ModuleRegistrations, UnreadableModule } from './rules';
+
+const MODULE_ZIP = /^gravitee-gamma-module-.*\.zip$/;
+const UI_DIRECTORY = 'ui/';
+const MANIFEST_ENTRY = 'ui/mf-manifest.json';
+
+/**
+ * The seam between the zips on disk and the comparison. `unzip` streams a single entry out of an
+ * archive that runs to tens of megabytes, so nothing is ever extracted.
+ */
+export interface ZipEntries {
+  /** The entry's content, or undefined when the archive does not carry it. */
+  read(zipFile: string, entry: string): string | undefined;
+  contains(zipFile: string, directory: string): boolean;
+}
+
+const unzipEntries: ZipEntries = {
+  read(zipFile: string, entry: string): string | undefined {
+    return runUnzip(['-p', zipFile, entry]);
+  },
+  contains(zipFile: string, directory: string): boolean {
+    return runUnzip(['-l', zipFile, `${directory}*`]) !== undefined;
+  },
+};
+
+/** unzip's exit code for 'no files matched' — the only failure that means the entry is absent. */
+const UNZIP_NOTHING_MATCHED = 11;
+
+function runUnzip(args: string[]): string | undefined {
+  try {
+    return execFileSync('unzip', args, { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & { status?: number | null };
+
+    // Without unzip every module would look like it ships no UI, and the run would fail as 'no
+    // modules found' instead of naming the real cause.
+    if (failure.code === 'ENOENT') {
+      throw new Error('unzip is not on the PATH. This check reads each module manifest out of its plugin zip.');
+    }
+
+    if (failure.status === UNZIP_NOTHING_MATCHED) {
+      return undefined;
+    }
+
+    // Anything else means the archive could not be read rather than that it lacks the entry: exit 9
+    // for a corrupt or truncated zip, ENOBUFS when an entry outgrows maxBuffer. Reading those as
+    // 'ships no UI' is how a damaged artifact passes the check clean.
+    const cause = failure.status === undefined || failure.status === null ? failure.code : `exit ${failure.status}`;
+    throw new Error(`unzip could not read ${path.basename(args[1])} (${cause})`);
+  }
+}
+
+export interface BundledModules {
+  pluginsDir: string;
+  /** Every gamma module zip the distribution bundles, whether or not it carries a UI. */
+  artifacts: string[];
+  modules: ModuleRegistrations[];
+  /** Zips that ship a UI whose manifest could not be read — see the rule of the same name. */
+  unreadable: UnreadableModule[];
+}
+
+/**
+ * Reads what each bundled Gamma module registers into the Module Federation shared scope, straight
+ * out of the zips the distribution ships. Each module's `plugin-assembly.xml` maps its built
+ * `target/classes/ui` to `ui/`, so the manifest travels inside the plugin zip.
+ */
+export function readBundledModules(distributionDir: string, entries: ZipEntries = unzipEntries): BundledModules {
+  const pluginsDir = path.join(distributionDir, 'plugins');
+  if (!fs.existsSync(pluginsDir)) {
+    throw new Error(
+      `No plugins directory at ${pluginsDir}. This check reads the distribution built by 'Build backend'; ` +
+        'attach its workspace, or point --distribution at the built distribution.',
+    );
+  }
+
+  const artifacts = fs
+    .readdirSync(pluginsDir)
+    .filter((file) => MODULE_ZIP.test(file))
+    .sort();
+
+  const modules: ModuleRegistrations[] = [];
+  const unreadable: UnreadableModule[] = [];
+
+  artifacts.forEach((artifact) => {
+    const outcome = readModule(path.join(pluginsDir, artifact), artifact, entries);
+    if (outcome === undefined) {
+      return;
+    }
+    if ('reason' in outcome) {
+      unreadable.push(outcome);
+    } else {
+      modules.push(outcome);
+    }
+  });
+
+  return { pluginsDir, artifacts, modules, unreadable };
+}
+
+/**
+ * One artifact's outcome: its registrations, why it could not be read, or undefined when it ships
+ * no UI at all and so registers nothing to compare.
+ */
+function readModule(zipFile: string, artifact: string, entries: ZipEntries): ModuleRegistrations | UnreadableModule | undefined {
+  let manifest: string | undefined;
+  try {
+    manifest = entries.read(zipFile, MANIFEST_ENTRY);
+  } catch (error) {
+    return { artifact, reason: (error as Error).message };
+  }
+
+  if (manifest === undefined) {
+    // A module shipping no UI registers nothing. One shipping a UI whose manifest moved is a
+    // different animal: it registers versions this check cannot see, and staying quiet about it is
+    // how a too-new module slips through.
+    try {
+      return entries.contains(zipFile, UI_DIRECTORY)
+        ? { artifact, reason: `it ships a ${UI_DIRECTORY} directory but no ${MANIFEST_ENTRY}` }
+        : undefined;
+    } catch (error) {
+      return { artifact, reason: (error as Error).message };
+    }
+  }
+
+  try {
+    return parseManifest(manifest, artifact);
+  } catch (error) {
+    return { artifact, reason: `its ${MANIFEST_ENTRY} could not be parsed (${(error as Error).message})` };
+  }
+}
+
+function parseManifest(manifest: string, artifact: string): ModuleRegistrations {
+  const parsed = JSON.parse(manifest) as { name?: string; shared?: { name: string; version: string; requiredVersion?: string }[] };
+  const shared = parsed.shared ?? [];
+
+  return {
+    module: parsed.name ?? artifact,
+    artifact,
+    registered: Object.fromEntries(shared.map((entry) => [entry.name, entry.version])),
+    // The range Module Federation evaluates at load. `strictVersion` is not in the manifest — it
+    // lives in each module's own config — so this is as far as the shipped artifact describes the
+    // module's constraint.
+    required: Object.fromEntries(shared.filter((entry) => entry.requiredVersion !== undefined).map((e) => [e.name, e.requiredVersion!])),
+  };
+}

--- a/.circleci/ci/src/graphene-versions/check.ts
+++ b/.circleci/ci/src/graphene-versions/check.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as path from 'path';
+import { config } from '../config';
+import { readApimPins } from './apim-pins';
+import { readBundledModules } from './bundled-modules';
+import { formatReport, hasErrors } from './report';
+import { checkGrapheneVersions } from './rules';
+
+/**
+ * Where 'Build backend' leaves the assembled distribution, and persists it to the workspace. The
+ * config constant is the module directory; the assembly lands under its target/distribution.
+ */
+const DEFAULT_DISTRIBUTION = path.join(config.components.managementApi.distribution, 'target', 'distribution');
+
+function optionOr(name: string, fallback: string): string {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return fallback;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined) {
+    throw new Error(`--${name} needs a value.`);
+  }
+  return value;
+}
+
+function main(): number {
+  const repoRoot = path.resolve(optionOr('repo-root', path.join(__dirname, '..', '..', '..', '..')));
+  const distributionDir = path.resolve(repoRoot, optionOr('distribution', DEFAULT_DISTRIBUTION));
+
+  const pins = readApimPins(repoRoot);
+  const bundled = readBundledModules(distributionDir);
+  const findings = checkGrapheneVersions(pins, bundled.modules, bundled.unreadable);
+
+  console.log(formatReport({ pluginsDir: bundled.pluginsDir, artifacts: bundled.artifacts, pins, modules: bundled.modules }, findings));
+
+  return hasErrors(findings) ? 1 : 0;
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  console.error(`Graphene version consistency check could not run: ${error instanceof Error ? error.message : error}`);
+  process.exitCode = 1;
+}

--- a/.circleci/ci/src/graphene-versions/report.ts
+++ b/.circleci/ci/src/graphene-versions/report.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as semver from 'semver';
+import { ApimPins, Finding, ModuleRegistrations, Severity } from './rules';
+
+const PREAMBLE = [
+  'The Gamma console and every bundled Gamma module register @gravitee/graphene-core into the Module',
+  'Federation shared scope as a singleton, so one copy serves them all at runtime. This job reads what',
+  'each bundled module registers and compares it to the versions APIM pins in its root package.json.',
+  '',
+  'It FAILS only when it could not do that reading, or when the pinned gamma-lib-observability needs a',
+  'graphene the pin does not provide. A version gap either way is a warning rather than a failure: the',
+  'modules share graphene with strictVersion false, so they accept whichever copy the scope hands them',
+  'and the console still renders. What a gap costs is a module executing against a graphene it was not',
+  'compiled against, which surfaces later as a missing export. See the rule text when it fires.',
+];
+
+const SEVERITY_ORDER: Severity[] = ['error', 'warning', 'info'];
+const SEVERITY_LABEL: Record<Severity, string> = { error: 'ERROR', warning: 'WARNING', info: 'NOTE' };
+
+export interface ReportContext {
+  pluginsDir: string;
+  artifacts: string[];
+  pins: ApimPins;
+  modules: ModuleRegistrations[];
+}
+
+export function hasErrors(findings: Finding[]): boolean {
+  return findings.some((finding) => finding.severity === 'error');
+}
+
+export function formatReport(context: ReportContext, findings: Finding[]): string {
+  return [
+    'Graphene version consistency',
+    '============================',
+    '',
+    ...PREAMBLE,
+    '',
+    ...inputSection(context),
+    '',
+    ...findingsSection(findings),
+    '',
+    summary(findings),
+  ].join('\n');
+}
+
+function inputSection(context: ReportContext): string[] {
+  const lines = [
+    `Read from ${context.pluginsDir}: ${count(context.artifacts.length, 'gamma module zip')}, ` +
+      `${context.modules.length} carrying a ui/mf-manifest.json.`,
+    '',
+    'APIM pins (root package.json):',
+    ...Object.entries(context.pins.packages).map(([name, version]) => `  ${name.padEnd(34)} ${version}`),
+  ];
+
+  context.pins.workspacePins.forEach((workspace) => {
+    lines.push('', `${workspace.file}:`, ...Object.entries(workspace.packages).map(([name, version]) => `  ${name.padEnd(34)} ${version}`));
+  });
+
+  context.modules.forEach((module) => {
+    const graphene = Object.entries(module.registered).filter(([name]) => name.startsWith('@gravitee/graphene-'));
+    lines.push(
+      '',
+      `${module.artifact} registers:`,
+      ...(graphene.length > 0
+        ? graphene.map(([name, version]) => `  ${name.padEnd(34)} ${version}${requiredSuffix(module.required[name])}`)
+        : ['  no graphene package in its shared scope']),
+    );
+  });
+
+  return lines;
+}
+
+/**
+ * The range the module requires, shown only when it is one Module Federation cannot satisfy.
+ * `^undefined` is what the inference writes when it cannot resolve the package version — see
+ * gravitee-io/gravitee-ui-graphene#457 — and no version satisfies it.
+ */
+function requiredSuffix(required: string | undefined): string {
+  if (required === undefined || semver.validRange(required) !== null) {
+    return '';
+  }
+  return `   (requires '${required}', which nothing satisfies)`;
+}
+
+function findingsSection(findings: Finding[]): string[] {
+  if (findings.length === 0) {
+    return ['Every bundled module is at or behind the pins. Nothing to report.'];
+  }
+
+  return SEVERITY_ORDER.flatMap((severity) =>
+    findings
+      .filter((finding) => finding.severity === severity)
+      .flatMap((finding) => [`${SEVERITY_LABEL[severity]} [${finding.rule}]${subject(finding)}`, ...wrap(finding.message), '']),
+  );
+}
+
+function subject(finding: Finding): string {
+  const parts = [finding.module, finding.package].filter((part) => part !== undefined);
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function summary(findings: Finding[]): string {
+  const counted = SEVERITY_ORDER.map((severity) => findings.filter((finding) => finding.severity === severity).length);
+  return `Result: ${count(counted[0], 'error')}, ${count(counted[1], 'warning')}, ${count(counted[2], 'note')}`;
+}
+
+function count(quantity: number, noun: string): string {
+  return `${quantity} ${noun}${quantity === 1 ? '' : 's'}`;
+}
+
+function wrap(message: string, width = 116): string[] {
+  const lines: string[] = [];
+  for (const word of message.split(' ')) {
+    const current = lines[lines.length - 1];
+    if (current !== undefined && `${current} ${word}`.length <= width) {
+      lines[lines.length - 1] = `${current} ${word}`;
+    } else {
+      lines.push(`  ${word}`);
+    }
+  }
+  return lines;
+}

--- a/.circleci/ci/src/graphene-versions/rules.ts
+++ b/.circleci/ci/src/graphene-versions/rules.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as semver from 'semver';
+
+export const GRAPHENE_CORE = '@gravitee/graphene-core';
+export const GRAPHENE_CHARTS = '@gravitee/graphene-charts';
+export const GRAPHENE_POLICY_STUDIO = '@gravitee/graphene-policy-studio';
+export const OBSERVABILITY = '@gravitee/gamma-lib-observability';
+
+/**
+ * The package the host shares as a singleton, and the one this job is really about.
+ *
+ * The host shares react, react-dom, react-router-dom and zustand on identical terms; they are not
+ * checked here, because every bundled module already registers them above the pin.
+ */
+const HOST_SINGLETON_PACKAGE = GRAPHENE_CORE;
+
+/** How far a module may lag APIM's graphene-core pin before the lag is worth reporting. */
+export const MINORS_BEHIND_BEFORE_WARNING = 2;
+
+export interface WorkspacePins {
+  file: string;
+  packages: Record<string, string>;
+}
+
+export interface ApimPins {
+  /** Exact versions APIM pins, from the root package.json. */
+  packages: Record<string, string>;
+  /** The graphene peer ranges the pinned observability release declares, from the lockfile. */
+  observabilityGraphenePeers: Record<string, string>;
+  /** The same packages as pinned by in-repo Gamma projects, which must agree with the root. */
+  workspacePins: WorkspacePins[];
+}
+
+export type Severity = 'error' | 'warning' | 'info';
+
+export type RuleId =
+  | 'module-registers-newer-graphene'
+  | 'module-graphene-behind-host'
+  | 'module-version-unparsable'
+  | 'observability-peer-unsatisfied'
+  | 'workspace-pin-differs-from-root'
+  | 'pin-is-not-exact'
+  | 'module-manifest-unreadable'
+  | 'no-modules-found';
+
+export interface Finding {
+  severity: Severity;
+  rule: RuleId;
+  message: string;
+  /** The Module Federation name a module declares, so findings group by one identity. */
+  module?: string;
+  /** The zip a finding came from, for the cases where no manifest was readable to name the module. */
+  artifact?: string;
+  package?: string;
+  registered?: string;
+  pinned?: string;
+}
+
+/** A bundled zip that ships a UI this check could not read the shared scope out of. */
+export interface UnreadableModule {
+  artifact: string;
+  reason: string;
+}
+
+/** What one bundled Gamma module declares in the `shared` array of its `ui/mf-manifest.json`. */
+export interface ModuleRegistrations {
+  module: string;
+  artifact: string;
+  /** Package name to the version the module registers into the shared scope. */
+  registered: Record<string, string>;
+  /** Package name to the range the module requires of it, where the manifest records one. */
+  required: Record<string, string>;
+}
+
+export function checkGrapheneVersions(pins: ApimPins, modules: ModuleRegistrations[], unreadable: UnreadableModule[] = []): Finding[] {
+  const findings: Finding[] = [];
+
+  // A module whose registrations cannot be read is not a module that registers nothing. Passing on
+  // one is how a too-new graphene slips through while the run still shows green.
+  unreadable.forEach((module) =>
+    findings.push({
+      severity: 'error',
+      rule: 'module-manifest-unreadable',
+      artifact: module.artifact,
+      message:
+        `${module.artifact} could not be read: ${module.reason}. This check cannot tell what it registers into the ` +
+        'shared scope, so it fails rather than skip the module quietly. If the module build moved the manifest, ' +
+        'point MANIFEST_ENTRY at its new home.',
+    }),
+  );
+
+  if (modules.length === 0 && unreadable.length === 0) {
+    findings.push({
+      severity: 'error',
+      rule: 'no-modules-found',
+      message:
+        'No bundled Gamma module was found to check. This check only means anything when it reads the modules the ' +
+        'distribution actually ships, so it fails rather than pass on an empty input.',
+    });
+  }
+
+  findings.push(...checkPinsAreExact(pins));
+  modules.forEach((module) => findings.push(...checkModule(pins, module)));
+  findings.push(...checkObservabilityPeers(pins));
+  findings.push(...checkWorkspacePins(pins));
+
+  return findings;
+}
+
+/**
+ * The strict rule below reads the pin as the exact version the host demands. A range would mean the
+ * host accepts a window, which this check does not model — so it refuses to guess.
+ */
+function checkPinsAreExact(pins: ApimPins): Finding[] {
+  return [HOST_SINGLETON_PACKAGE]
+    .filter((name) => pins.packages[name] !== undefined && semver.valid(pins.packages[name]) === null)
+    .map((name) => ({
+      severity: 'warning' as const,
+      rule: 'pin-is-not-exact' as const,
+      package: name,
+      pinned: pins.packages[name],
+      message:
+        `APIM pins ${name} as '${pins.packages[name]}', which is a range rather than an exact version. ` +
+        'This check compares module versions against an exact pin; pin an exact version, or teach this check to model ranges.',
+    }));
+}
+
+/**
+ * These severities hold only while every module shares graphene with `strictVersion: false`.
+ * Module Federation evaluates that flag on behalf of the consumer asking for the module, and one
+ * branch does both outcomes: an unsatisfied singleton calls `error()` — which throws — when the
+ * flag is set, and `warn()` when it is not. A module setting `strictVersion: true` in its own
+ * `module-federation.config.ts` therefore turns every finding below into a console that does not
+ * render. That file lives in the module's repository, which this check never reads.
+ */
+function checkModule(pins: ApimPins, module: ModuleRegistrations): Finding[] {
+  const findings: Finding[] = [];
+
+  const core = module.registered[HOST_SINGLETON_PACKAGE];
+  const corePin = pins.packages[HOST_SINGLETON_PACKAGE];
+  const comparable = core !== undefined && semver.valid(core) !== null && corePin !== undefined && semver.valid(corePin) !== null;
+
+  // Every rule below needs two exact versions. Without this the module would drop out of all of
+  // them and the run would report nothing at all for it.
+  if (core !== undefined && semver.valid(core) === null) {
+    findings.push({
+      severity: 'info',
+      rule: 'module-version-unparsable',
+      module: module.module,
+      artifact: module.artifact,
+      package: HOST_SINGLETON_PACKAGE,
+      registered: core,
+      message:
+        `${module.artifact} registers ${HOST_SINGLETON_PACKAGE} as '${core}', which is not an exact version. ` +
+        'Module Federation writes the resolved version into the manifest, so this should not happen; this check ' +
+        'cannot compare it and is saying so rather than passing the module over in silence.',
+    });
+  }
+
+  if (comparable && semver.gt(core, corePin)) {
+    findings.push({
+      severity: 'warning',
+      rule: 'module-registers-newer-graphene',
+      module: module.module,
+      package: HOST_SINGLETON_PACKAGE,
+      registered: core,
+      pinned: corePin,
+      message:
+        `${module.artifact} registers ${HOST_SINGLETON_PACKAGE} ${core}, newer than APIM's pin of ${corePin}. ` +
+        'Module Federation asks the consumer whether the resolved copy satisfies it, and every module sets ' +
+        "strictVersion: false — so the module accepts the host's older copy and the console still renders. The cost " +
+        `is that ${module.artifact} was compiled against ${core} and executes against ${corePin}: any export added ` +
+        'after that pin is missing at runtime, surfacing as a TypeError on the first call rather than here. Raise ' +
+        `${HOST_SINGLETON_PACKAGE} to ${core} in the root package.json, or release the module against ${corePin}.`,
+    });
+  }
+
+  if (comparable && isFarBehind(core, corePin)) {
+    findings.push({
+      severity: 'warning',
+      rule: 'module-graphene-behind-host',
+      module: module.module,
+      package: HOST_SINGLETON_PACKAGE,
+      registered: core,
+      pinned: corePin,
+      message:
+        `${module.artifact} was built against ${HOST_SINGLETON_PACKAGE} ${core} but will execute on APIM's ${corePin}: the host's ` +
+        'copy wins the singleton. That is allowed, but the gap is wide enough to be worth a release of the module.',
+    });
+  }
+
+  return findings;
+}
+
+function isFarBehind(registered: string, pinned: string): boolean {
+  if (semver.major(registered) < semver.major(pinned)) {
+    return true;
+  }
+  return (
+    semver.major(registered) === semver.major(pinned) && semver.minor(pinned) - semver.minor(registered) > MINORS_BEHIND_BEFORE_WARNING
+  );
+}
+
+/**
+ * `@gravitee/gamma-lib-observability` ships no graphene of its own — it declares graphene as a peer
+ * and runs against whatever copy the shared scope hands it. Nothing installs a graphene on its
+ * behalf, so a peer range APIM's pin does not satisfy is the one dependency that can go silently
+ * unsatisfiable.
+ */
+function checkObservabilityPeers(pins: ApimPins): Finding[] {
+  return Object.entries(pins.observabilityGraphenePeers).flatMap(([name, range]) => {
+    const pinned = pins.packages[name];
+    if (!pinned || !semver.valid(pinned) || semver.satisfies(pinned, range)) {
+      return [];
+    }
+
+    return [
+      {
+        severity: 'error' as const,
+        rule: 'observability-peer-unsatisfied' as const,
+        package: name,
+        pinned,
+        message:
+          `${OBSERVABILITY} ${pins.packages[OBSERVABILITY]} needs ${name} ${range}, but APIM ` +
+          `pins ${pinned}. Observability bundles no graphene of its own, so it will run against a copy it does not support. ` +
+          'Move the observability pin and the graphene pin together in the root package.json.',
+      },
+    ];
+  });
+}
+
+/**
+ * The Gamma console host has no package.json of its own and resolves from the workspace root, so
+ * root is the pin that reaches the browser.
+ *
+ * A warning rather than a failure: the root package.json declares no `workspaces`, these in-repo
+ * files are Nx project markers whose dependencies are never installed, and they already disagree
+ * with the root on react, react-dom and react-router-dom. Failing here would block PRs on files the
+ * repo has always let drift.
+ */
+function checkWorkspacePins(pins: ApimPins): Finding[] {
+  return pins.workspacePins.flatMap((workspace) =>
+    Object.entries(workspace.packages)
+      .filter(([name, version]) => pins.packages[name] !== undefined && pins.packages[name] !== version)
+      .map(([name, version]) => ({
+        severity: 'warning' as const,
+        rule: 'workspace-pin-differs-from-root' as const,
+        package: name,
+        registered: version,
+        pinned: pins.packages[name],
+        message:
+          `${workspace.file} pins ${name} ${version} while the root package.json pins ${pins.packages[name]}. Nothing ` +
+          'installs this file, so the build is unaffected — but the two drifting apart is how the in-repo module ends ' +
+          'up documented against a version the host does not ship.',
+      })),
+  );
+}

--- a/.circleci/ci/src/graphene-versions/tests/bundled-modules.spec.ts
+++ b/.circleci/ci/src/graphene-versions/tests/bundled-modules.spec.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readBundledModules, ZipEntries } from '../bundled-modules';
+
+const MANIFEST = JSON.stringify({
+  name: 'esm',
+  shared: [{ name: '@gravitee/graphene-core', version: '3.13.0', requiredVersion: '^undefined' }],
+});
+
+/** Stands in for the zips on disk: what each archive holds, keyed by entry path. */
+function zipsHolding(archives: Record<string, Record<string, string>>): ZipEntries {
+  const entriesOf = (zipFile: string) => archives[path.basename(zipFile)] ?? {};
+  return {
+    read: (zipFile, entry) => entriesOf(zipFile)[entry],
+    contains: (zipFile, directory) => Object.keys(entriesOf(zipFile)).some((entry) => entry.startsWith(directory)),
+  };
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  tempDirs.splice(0).forEach((dir) => fs.rmSync(dir, { recursive: true, force: true }));
+});
+
+function pluginsDirHolding(artifacts: string[]): string {
+  const distribution = fs.mkdtempSync(path.join(os.tmpdir(), 'graphene-check-'));
+  tempDirs.push(distribution);
+  fs.mkdirSync(path.join(distribution, 'plugins'));
+  artifacts.forEach((artifact) => fs.writeFileSync(path.join(distribution, 'plugins', artifact), ''));
+  return distribution;
+}
+
+describe('readBundledModules', () => {
+  it('reads what a module registers out of its ui/mf-manifest.json', () => {
+    const distribution = pluginsDirHolding(['gravitee-gamma-module-esm-1.5.0.zip']);
+
+    const bundled = readBundledModules(
+      distribution,
+      zipsHolding({ 'gravitee-gamma-module-esm-1.5.0.zip': { 'ui/mf-manifest.json': MANIFEST } }),
+    );
+
+    expect(bundled.modules).toEqual([
+      {
+        module: 'esm',
+        artifact: 'gravitee-gamma-module-esm-1.5.0.zip',
+        registered: { '@gravitee/graphene-core': '3.13.0' },
+        // Kept verbatim, unusable range included: it is what Module Federation evaluates at load.
+        required: { '@gravitee/graphene-core': '^undefined' },
+      },
+    ]);
+    expect(bundled.unreadable).toEqual([]);
+  });
+
+  // The defect this replaced: any unreadable manifest was treated as "ships no UI", so a module
+  // registering a graphene far above the pin passed as clean.
+  it('reports a module that ships a ui/ directory but no manifest at the expected path', () => {
+    const distribution = pluginsDirHolding(['gravitee-gamma-module-esm-1.5.0.zip']);
+
+    const bundled = readBundledModules(
+      distribution,
+      zipsHolding({ 'gravitee-gamma-module-esm-1.5.0.zip': { 'ui/browser/mf-manifest.json': MANIFEST } }),
+    );
+
+    expect(bundled.modules).toEqual([]);
+    expect(bundled.unreadable).toEqual([
+      { artifact: 'gravitee-gamma-module-esm-1.5.0.zip', reason: 'it ships a ui/ directory but no ui/mf-manifest.json' },
+    ]);
+  });
+
+  it('reports a manifest that is not valid JSON', () => {
+    const distribution = pluginsDirHolding(['gravitee-gamma-module-esm-1.5.0.zip']);
+
+    const bundled = readBundledModules(
+      distribution,
+      zipsHolding({ 'gravitee-gamma-module-esm-1.5.0.zip': { 'ui/mf-manifest.json': 'not json' } }),
+    );
+
+    expect(bundled.modules).toEqual([]);
+    expect(bundled.unreadable).toHaveLength(1);
+  });
+
+  it('passes over a module that ships no UI at all, which registers nothing', () => {
+    const distribution = pluginsDirHolding(['gravitee-gamma-module-headless-1.0.0.zip']);
+
+    const bundled = readBundledModules(distribution, zipsHolding({ 'gravitee-gamma-module-headless-1.0.0.zip': { 'lib/module.jar': '' } }));
+
+    expect(bundled.modules).toEqual([]);
+    expect(bundled.unreadable).toEqual([]);
+    expect(bundled.artifacts).toEqual(['gravitee-gamma-module-headless-1.0.0.zip']);
+  });
+
+  it('counts every gamma module zip, so a module that lost its UI stays visible', () => {
+    const distribution = pluginsDirHolding([
+      'gravitee-gamma-module-aim-4.3.0.zip',
+      'gravitee-gamma-module-esm-1.5.0.zip',
+      'gravitee-apim-policy-unrelated-1.0.0.zip',
+    ]);
+
+    const bundled = readBundledModules(
+      distribution,
+      zipsHolding({
+        'gravitee-gamma-module-aim-4.3.0.zip': { 'ui/mf-manifest.json': MANIFEST },
+        'gravitee-gamma-module-esm-1.5.0.zip': { 'ui/browser/mf-manifest.json': MANIFEST },
+      }),
+    );
+
+    expect(bundled.artifacts).toHaveLength(2);
+    expect(bundled.modules).toHaveLength(1);
+    expect(bundled.unreadable).toHaveLength(1);
+  });
+
+  it('fails loudly when there is no distribution to read', () => {
+    expect(() => readBundledModules('/nowhere/at/all')).toThrow(/No plugins directory/);
+  });
+});

--- a/.circleci/ci/src/graphene-versions/tests/report.spec.ts
+++ b/.circleci/ci/src/graphene-versions/tests/report.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatReport, hasErrors, ReportContext } from '../report';
+import { Finding } from '../rules';
+
+const context: ReportContext = {
+  pluginsDir: '/dist/plugins',
+  artifacts: ['gravitee-gamma-module-aim-4.3.0-alpha.20.zip'],
+  pins: {
+    packages: { '@gravitee/graphene-core': '3.14.0' },
+    observabilityGraphenePeers: { '@gravitee/graphene-core': '^3.7.0' },
+    workspacePins: [],
+  },
+  modules: [
+    {
+      module: 'aim',
+      artifact: 'gravitee-gamma-module-aim-4.3.0-alpha.20.zip',
+      registered: { '@gravitee/graphene-core': '3.15.0' },
+      required: {},
+    },
+  ],
+};
+
+const failure: Finding = {
+  severity: 'error',
+  rule: 'observability-peer-unsatisfied',
+  package: '@gravitee/graphene-core',
+  pinned: '3.14.0',
+  message: '@gravitee/gamma-lib-observability 1.39.2 needs @gravitee/graphene-core ^3.16.0, but APIM pins 3.14.0.',
+};
+
+describe('formatReport', () => {
+  it('names the package, the pin and the rule that fired', () => {
+    // Rendered against an empty context, so nothing here can be satisfied by the input section.
+    const report = formatReport({ ...context, modules: [] }, [failure]);
+
+    expect(report).toContain('@gravitee/graphene-core');
+    expect(report).toContain('3.14.0');
+    expect(report).toContain('observability-peer-unsatisfied');
+    expect(report).toContain(failure.message);
+  });
+
+  it('names the offending module and the version it registers, for a finding that carries them', () => {
+    const behind: Finding = {
+      severity: 'warning',
+      rule: 'module-graphene-behind-host',
+      module: 'aim',
+      package: '@gravitee/graphene-core',
+      registered: '3.8.0',
+      pinned: '3.14.0',
+      message: 'aim was built against 3.8.0 but will execute on 3.14.0.',
+    };
+
+    const report = formatReport({ ...context, modules: [] }, [behind]);
+
+    expect(report).toContain('aim');
+    expect(report).toContain('3.8.0');
+    expect(report).toContain('3.14.0');
+  });
+
+  it('shows what every module registers, so a passing run is still readable', () => {
+    const report = formatReport(context, []);
+
+    expect(report).toContain('gravitee-gamma-module-aim-4.3.0-alpha.20.zip');
+    expect(report).toContain('@gravitee/graphene-core');
+  });
+
+  it('counts each severity in the summary', () => {
+    const report = formatReport(context, [failure, { ...failure, severity: 'warning' }, { ...failure, severity: 'info' }]);
+
+    expect(report).toContain('1 error, 1 warning, 1 note');
+  });
+
+  it('says so when nothing fired', () => {
+    expect(formatReport(context, [])).toContain('0 errors, 0 warnings, 0 notes');
+  });
+
+  it('lists errors before warnings', () => {
+    const report = formatReport(context, [{ ...failure, severity: 'warning' }, failure]);
+
+    expect(report.indexOf('ERROR')).toBeLessThan(report.indexOf('WARNING'));
+  });
+});
+
+describe('hasErrors', () => {
+  it('is true when any finding is an error', () => {
+    expect(hasErrors([{ ...failure, severity: 'warning' }, failure])).toBe(true);
+  });
+
+  it('is false when only warnings and notes fired', () => {
+    expect(
+      hasErrors([
+        { ...failure, severity: 'warning' },
+        { ...failure, severity: 'info' },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/.circleci/ci/src/graphene-versions/tests/rules.spec.ts
+++ b/.circleci/ci/src/graphene-versions/tests/rules.spec.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApimPins, checkGrapheneVersions, Finding, MINORS_BEHIND_BEFORE_WARNING, ModuleRegistrations, RuleId } from '../rules';
+
+const pins: ApimPins = {
+  packages: {
+    '@gravitee/graphene-charts': '3.14.0',
+    '@gravitee/graphene-core': '3.14.0',
+    '@gravitee/graphene-policy-studio': '3.14.0',
+    '@gravitee/gamma-lib-observability': '1.39.2',
+  },
+  observabilityGraphenePeers: {
+    '@gravitee/graphene-charts': '^3.7.0',
+    '@gravitee/graphene-core': '^3.7.0',
+  },
+  workspacePins: [],
+};
+
+function module(name: string, shared: Record<string, string>): ModuleRegistrations {
+  return { module: name, artifact: `gravitee-gamma-module-${name}-1.0.0.zip`, registered: shared, required: {} };
+}
+
+function rulesFired(findings: { rule: RuleId }[]): RuleId[] {
+  return findings.map((finding) => finding.rule);
+}
+
+function errorsIn(findings: Finding[]): Finding[] {
+  return findings.filter((finding) => finding.severity === 'error');
+}
+
+describe('checkGrapheneVersions', () => {
+  describe('a module registering graphene newer than the host pin', () => {
+    it('reports it against graphene-core, the package the host shares with strictVersion', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.15.0' })]);
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity: 'warning',
+          rule: 'module-registers-newer-graphene',
+          module: 'aim',
+          package: '@gravitee/graphene-core',
+          registered: '3.15.0',
+          pinned: '3.14.0',
+        }),
+      );
+    });
+
+    // The host loads its own copy before it registers any remote, and MF only prefers a higher
+    // version while none is loaded, so this is not known to break anything.
+    it('does not fail the run, since the breakage it describes is unconfirmed', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.15.0' })]);
+
+      expect(errorsIn(findings)).toEqual([]);
+    });
+
+    it('passes when the module registers exactly the pinned version', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(rulesFired(findings)).not.toContain('module-registers-newer-graphene');
+    });
+
+    it('compares as semver, not as strings', () => {
+      // '3.9.0' > '3.14.0' lexicographically, but 3.9.0 is behind.
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.9.0' })]);
+
+      expect(rulesFired(findings)).not.toContain('module-registers-newer-graphene');
+    });
+  });
+
+  describe('a module lagging the host pin', () => {
+    it(`warns past ${MINORS_BEHIND_BEFORE_WARNING} minors behind`, () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.8.0' })]);
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity: 'warning',
+          rule: 'module-graphene-behind-host',
+          module: 'aim',
+          registered: '3.8.0',
+          pinned: '3.14.0',
+        }),
+      );
+    });
+
+    it('stays quiet within the tolerated lag', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.12.0' })]);
+
+      expect(rulesFired(findings)).not.toContain('module-graphene-behind-host');
+    });
+
+    it('warns when the module is a whole major behind', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '2.20.0' })]);
+
+      expect(rulesFired(findings)).toContain('module-graphene-behind-host');
+    });
+  });
+
+  describe('packages the host does not share', () => {
+    it.each([['@gravitee/graphene-charts'], ['@gravitee/graphene-policy-studio']])(
+      'stays silent about %s, which the host does not share',
+      (name) => {
+        const findings = checkGrapheneVersions(pins, [module('aim', { [name]: '4.0.0' })]);
+
+        expect(findings).toEqual([]);
+      },
+    );
+
+    it('accepts modules registering different majors of them, since each carries its own copy', () => {
+      const findings = checkGrapheneVersions(pins, [
+        module('aim', { '@gravitee/graphene-charts': '3.8.0', '@gravitee/graphene-policy-studio': '3.8.0' }),
+        module('esm', { '@gravitee/graphene-charts': '4.1.0', '@gravitee/graphene-policy-studio': '4.1.0' }),
+      ]);
+
+      expect(errorsIn(findings)).toEqual([]);
+    });
+  });
+
+  describe('observability peer ranges', () => {
+    it('fails when the pinned graphene does not satisfy the peer range', () => {
+      const stalePeers: ApimPins = { ...pins, observabilityGraphenePeers: { '@gravitee/graphene-core': '^4.0.0' } };
+
+      const findings = checkGrapheneVersions(stalePeers, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity: 'error',
+          rule: 'observability-peer-unsatisfied',
+          package: '@gravitee/graphene-core',
+          pinned: '3.14.0',
+        }),
+      );
+    });
+
+    it('passes when the pin satisfies every peer range', () => {
+      const findings = checkGrapheneVersions(pins, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(rulesFired(findings)).not.toContain('observability-peer-unsatisfied');
+    });
+  });
+
+  describe('in-repo workspace pins', () => {
+    it('reports an in-repo module pinning a graphene version other than the root one', () => {
+      const drifted: ApimPins = {
+        ...pins,
+        workspacePins: [
+          { file: 'gravitee-gamma/gravitee-gamma-module-apim/package.json', packages: { '@gravitee/graphene-core': '3.13.0' } },
+        ],
+      };
+
+      const findings = checkGrapheneVersions(drifted, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity: 'warning',
+          rule: 'workspace-pin-differs-from-root',
+          package: '@gravitee/graphene-core',
+          registered: '3.13.0',
+          pinned: '3.14.0',
+        }),
+      );
+    });
+
+    it('passes when the in-repo pins agree with root', () => {
+      const agreeing: ApimPins = {
+        ...pins,
+        workspacePins: [
+          { file: 'gravitee-gamma/gravitee-gamma-module-apim/package.json', packages: { '@gravitee/graphene-core': '3.14.0' } },
+        ],
+      };
+
+      const findings = checkGrapheneVersions(agreeing, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(rulesFired(findings)).not.toContain('workspace-pin-differs-from-root');
+    });
+  });
+
+  describe('a module whose manifest could not be read', () => {
+    it('fails, rather than let a module it could not inspect pass as clean', () => {
+      const findings = checkGrapheneVersions(
+        pins,
+        [module('aim', { '@gravitee/graphene-core': '3.14.0' })],
+        [{ artifact: 'gravitee-gamma-module-esm-1.5.0.zip', reason: 'it ships a ui/ directory but no ui/mf-manifest.json' }],
+      );
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          severity: 'error',
+          rule: 'module-manifest-unreadable',
+          artifact: 'gravitee-gamma-module-esm-1.5.0.zip',
+        }),
+      );
+    });
+
+    it('fails even when every module it could read is clean', () => {
+      const findings = checkGrapheneVersions(
+        pins,
+        [module('aim', { '@gravitee/graphene-core': '3.14.0' })],
+        [{ artifact: 'gravitee-gamma-module-esm-1.5.0.zip', reason: 'it ships a ui/ directory but no ui/mf-manifest.json' }],
+      );
+
+      expect(errorsIn(findings)).toHaveLength(1);
+    });
+  });
+
+  describe('inputs the check cannot evaluate', () => {
+    it('fails loudly when no module registered anything, rather than passing silently', () => {
+      const findings = checkGrapheneVersions(pins, []);
+
+      expect(findings).toContainEqual(expect.objectContaining({ severity: 'error', rule: 'no-modules-found' }));
+    });
+
+    it('reports a root pin that is a range instead of an exact version', () => {
+      const ranged: ApimPins = { ...pins, packages: { ...pins.packages, '@gravitee/graphene-core': '^3.14.0' } };
+
+      const findings = checkGrapheneVersions(ranged, [module('aim', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({ severity: 'warning', rule: 'pin-is-not-exact', package: '@gravitee/graphene-core' }),
+      );
+    });
+
+    it('accepts a module that registers only a subset of the graphene packages', () => {
+      const findings = checkGrapheneVersions(pins, [module('edge', { '@gravitee/graphene-core': '3.14.0' })]);
+
+      expect(errorsIn(findings)).toEqual([]);
+    });
+
+    it('accepts a module that registers no graphene package at all', () => {
+      const findings = checkGrapheneVersions(pins, [module('authz', { '@gravitee/gamma-modules-sdk': '1.2.0' })]);
+
+      expect(errorsIn(findings)).toEqual([]);
+    });
+  });
+
+  it('passes on the versions master ships today', () => {
+    const today = [
+      module('aim', {
+        '@gravitee/graphene-core': '3.8.0',
+        '@gravitee/graphene-charts': '3.8.0',
+        '@gravitee/graphene-policy-studio': '3.8.0',
+      }),
+      module('authz', { '@gravitee/graphene-core': '3.8.0' }),
+      module('edge', { '@gravitee/graphene-core': '3.8.0' }),
+      module('esm', { '@gravitee/graphene-core': '3.8.0', '@gravitee/graphene-policy-studio': '3.8.0' }),
+    ];
+
+    const findings = checkGrapheneVersions(pins, today);
+
+    expect(findings.filter((finding) => finding.severity === 'error')).toEqual([]);
+    expect(rulesFired(findings)).toContain('module-graphene-behind-host');
+  });
+});

--- a/.circleci/ci/src/jobs/backend/index.ts
+++ b/.circleci/ci/src/jobs/backend/index.ts
@@ -15,6 +15,7 @@
  */
 export * from './job-backend-build-and-publish-on-download-website';
 export * from './job-build-backend';
+export * from './job-check-graphene-versions';
 export * from './job-community-build-backend';
 export * from './job-nexus-staging';
 export * from './job-publish';

--- a/.circleci/ci/src/jobs/backend/job-check-graphene-versions.ts
+++ b/.circleci/ci/src/jobs/backend/job-check-graphene-versions.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command, Job, commands } from '../../circleci-config';
+import { config } from '../../config';
+import { NodeLtsExecutor } from '../../executors';
+
+/**
+ * Compares the graphene versions the bundled Gamma modules register into the Module Federation
+ * shared scope against the versions APIM pins. Nothing else in the pipeline loads the console host
+ * and a remote together, so nothing else sees this drift at all.
+ *
+ * Reads the module zips out of the distribution 'Build backend' assembled and persisted, so it
+ * needs no download, credential or registry access of its own — hence the `requires` on that job.
+ */
+export class CheckGrapheneVersionsJob {
+  public static create(): Job {
+    const steps: Command[] = [
+      new commands.Checkout(),
+      new commands.workspace.Attach({ at: '.' }),
+      // The workspace carries the built distribution, not .circleci/ci/node_modules, so this job
+      // installs its own. Cached on the lockfile so only a dependency change pays for it.
+      new commands.cache.Restore({
+        keys: [`${config.cache.prefix}-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}`],
+      }),
+      new commands.Run({
+        name: 'Install CI project dependencies',
+        command: 'npm ci --prefer-offline --no-audit --no-fund',
+        working_directory: '.circleci/ci',
+      }),
+      new commands.cache.Save({
+        paths: ['.circleci/ci/node_modules'],
+        key: `${config.cache.prefix}-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}`,
+      }),
+      new commands.Run({
+        name: 'Check graphene versions across bundled Gamma modules',
+        command: 'npx ts-node src/graphene-versions/check.ts',
+        working_directory: '.circleci/ci',
+      }),
+    ];
+    return new Job('job-check-graphene-versions', NodeLtsExecutor.create('small'), steps);
+  }
+}

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -246,6 +246,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-integration:
     machine:
       image: ubuntu-2204:current
@@ -326,6 +349,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-integration:
           name: Integration tests
           context:
@@ -336,6 +365,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Integration tests
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -190,6 +190,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-gateway:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -290,6 +313,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-gateway:
           name: Test gateway
           context:
@@ -308,6 +337,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test gateway
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -246,6 +246,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-integration:
     machine:
       image: ubuntu-2204:current
@@ -326,6 +349,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-integration:
           name: Integration tests
           context:
@@ -336,6 +365,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Integration tests
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -261,6 +261,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-definition:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -616,6 +639,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-definition:
           name: Test definition
           context:
@@ -720,6 +749,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -246,6 +246,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-plugin:
     machine:
       image: ubuntu-2204:current
@@ -348,6 +371,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-plugin:
           name: Test plugins
           context:
@@ -366,6 +395,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test plugins
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -246,6 +246,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-reporter:
     machine:
       image: ubuntu-2204:current
@@ -348,6 +371,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-reporter:
           name: Test reporters
           context:
@@ -366,6 +395,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test reporters
 orbs:
   keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -261,6 +261,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-rest-api:
     machine:
       image: ubuntu-2204:current
@@ -455,6 +478,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-rest-api:
           name: Test rest-api
           context:
@@ -489,6 +518,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test rest-api
             - Test kafka-explorer
             - Test gamma

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -205,6 +205,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-gamma:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -372,6 +395,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-gamma:
           name: Test gamma
           context:
@@ -402,6 +431,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Build backend
+            - Check graphene versions
             - Test gamma
             - Test gamma UI
             - Check prettier formatting for nx projects

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -320,6 +320,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-definition:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -905,6 +928,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-definition:
           name: Test definition
           context:
@@ -1084,6 +1113,7 @@ workflows:
           requires:
             - Helm Chart - Lint & Test
             - Build backend
+            - Check graphene versions
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -320,6 +320,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-definition:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -905,6 +928,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-definition:
           name: Test definition
           context:
@@ -1084,6 +1113,7 @@ workflows:
           requires:
             - Helm Chart - Lint & Test
             - Build backend
+            - Check graphene versions
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -345,6 +345,29 @@ jobs:
             - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/target/distribution
             - ./gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/target/distribution
+  job-check-graphene-versions:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Install CI project dependencies
+          command: npm ci --prefer-offline --no-audit --no-fund
+          working_directory: .circleci/ci
+      - save_cache:
+          paths:
+            - .circleci/ci/node_modules
+          key: gravitee-api-management-v15-check-graphene-versions-{{ checksum ".circleci/ci/package-lock.json" }}
+      - run:
+          name: Check graphene versions across bundled Gamma modules
+          command: npx ts-node src/graphene-versions/check.ts
+          working_directory: .circleci/ci
   job-test-definition:
     docker:
       - image: cimg/openjdk:25.0.3
@@ -1196,6 +1219,12 @@ workflows:
             - cicd-orchestrator
           requires:
             - Validate backend
+      - job-check-graphene-versions:
+          name: Check graphene versions
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build backend
       - job-test-definition:
           name: Test definition
           context:
@@ -1411,6 +1440,7 @@ workflows:
           requires:
             - Helm Chart - Lint & Test
             - Build backend
+            - Check graphene versions
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/workflows/groups/backend-jobs.ts
+++ b/.circleci/ci/src/workflows/groups/backend-jobs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Config, Job, workflow } from '../../circleci-config';
-import { BuildBackendJob, SetupJob, SonarCloudAnalysisJob, ValidateJob } from '../../jobs';
+import { BuildBackendJob, CheckGrapheneVersionsJob, SetupJob, SonarCloudAnalysisJob, ValidateJob } from '../../jobs';
 import { analysisJobFor, BACKEND_SUITES, suiteJobFor } from './analysed-projects';
 import { CircleCIEnvironment } from '../../pipelines';
 import { config } from '../../config';
@@ -48,6 +48,9 @@ export function backendJobs(
   const buildBackendJob = BuildBackendJob.create(dynamicConfig, environment);
   dynamicConfig.addJob(buildBackendJob);
 
+  const checkGrapheneVersionsJob = CheckGrapheneVersionsJob.create();
+  dynamicConfig.addJob(checkGrapheneVersionsJob);
+
   jobs.push(
     new workflow.WorkflowJob(setupJob, { name: 'Setup', context: config.jobContext }),
     new workflow.WorkflowJob(validateBackendJob, {
@@ -60,8 +63,13 @@ export function backendJobs(
       context: config.jobContext,
       requires: ['Validate backend'],
     }),
+    new workflow.WorkflowJob(checkGrapheneVersionsJob, {
+      name: 'Check graphene versions',
+      context: config.jobContext,
+      requires: ['Build backend'],
+    }),
   );
-  requires.push('Build backend');
+  requires.push('Build backend', 'Check graphene versions');
 
   // Created on the first project that survives the predicate: a pipeline that analyses nothing
   // must not emit an analysis job definition no workflow references.


### PR DESCRIPTION
Adds a **`Check graphene versions` job to the PR workflow, requiring `Build backend`** — a normal job in the generated config, wired in `backend-jobs.ts` and gating `Validate workflow status`.

**Live run:** [CircleCI job output](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/94287/details?workflowId=06f199ca-a1f1-4216-a196-68ec7d3d41eb&job=086a6019-ca84-4637-a6bc-eccfd7b533c3&buildNumber=2042322&jobType=build#step-103-) (the job is green; the surrounding workflow was cancelled)

```yaml
- job-check-graphene-versions:
    name: Check graphene versions
    requires:
      - Build backend
```

## Why

The Gamma console and every bundled Gamma module register `@gravitee/graphene-core` into the Module Federation shared scope as a singleton, so one copy serves them all. The modules are built in separate repos and bump independently. Nothing in the pipeline loads the host and a remote together, so this drift is invisible today.

## How

It depends on `Build backend` because it consumes that job's workspace. `attach_workspace` → `unzip -p <module zip> ui/mf-manifest.json` → compare each module's registered version to APIM's pin. No downloads, credentials or registry access.

**Fails** when it could not do its job — a module zip that ships a `ui/` tree with no readable manifest, or no module zips at all — and when the pinned `gamma-lib-observability` needs a graphene the pin does not provide.

**Warns** on version drift: a module registering graphene-core above the pin, a module more than 2 minors behind, an in-repo `package.json` disagreeing with the root.

**Notes** `graphene-charts` / `graphene-policy-studio` drift across modules.

## On the ticket's premise

FOUND-174 assumed a module registering a newer graphene wins the singleton and stops the console rendering. **Reviewing this against `@module-federation/runtime-core` suggests that is not what happens**, so it is a warning here rather than a failure.

`findSingletonVersionOrderByVersion` prefers a higher version only while none is loaded:

```js
const callback = function(prev, cur) {
    return !isLoaded(versions[prev]) && versionLt(prev, cur);
};
```

The host loads its own copy in `bootstrap.tsx` (static imports, lines 18–21) before `runApplicationBootstrap()` registers any remote, and declares `remotes: []` — so its copy should win regardless of what a module registers.

The same shape is already live in production: the host shares `react`, `react-dom` and `react-router-dom` on **identical** `singleton + strictVersion: true` terms, and every bundled module registers above the pin — `authz` ships react 19.2.8 against a 19.2.4 pin — while the console renders fine.

This is static analysis. The settling experiment is loading the console against a module registering a too-new graphene-core; if it does throw, promote the rule to an error with the evidence.

## Baseline

Against the module versions pinned today: **0 errors, 2 warnings, 4 notes** (`authz` and `edge` on graphene 3.8.0 vs the 3.14.0 pin).

Security-sensitive: adds `semver` / `@types/semver` to `.circleci/ci`.
