### PR TITLE
test(reporter-elasticsearch): share one Elasticsearch container across test contexts

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/IntegrationTestConfiguration.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/IntegrationTestConfiguration.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.reporter.elasticsearch;
 import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
 import io.gravitee.elasticsearch.config.Endpoint;
 import java.util.Collections;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -37,8 +36,19 @@ public class IntegrationTestConfiguration {
     public static final String ELASTICSEARCH_DEFAULT_VERSION = "9.2.1";
     public static final String CLUSTER_NAME = "gravitee_test";
 
-    @Value("${elasticsearch.version:" + ELASTICSEARCH_DEFAULT_VERSION + "}")
-    private String elasticsearchVersion;
+    /**
+     * One Elasticsearch node for the whole JVM, shared by every Spring context importing this configuration.
+     *
+     * <p>The Spring TestContext cache never closes a context between test classes, so a container declared
+     * as a plain bean stays up until the JVM exits. Two contexts import this class — this one and the
+     * {@code TestConfig} of {@code ElasticsearchReporterTest} — and each would keep its own node running,
+     * alongside the OpenSearch node of {@code IndexPreparerIntegrationTest}. Three of them is more than the
+     * CI machine holds, and the third one never finishes starting.
+     *
+     * <p>The bean below therefore declares no destroy method: closing the container with the first context
+     * to be discarded would take it away from the other. Ryuk removes it when the JVM exits.
+     */
+    private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = startContainer();
 
     @Bean
     public ReporterConfiguration configuration(ElasticsearchContainer elasticSearchContainer) {
@@ -49,13 +59,18 @@ public class IntegrationTestConfiguration {
         return elasticConfiguration;
     }
 
-    @Bean(destroyMethod = "close")
+    @Bean
     public ElasticsearchContainer elasticSearchContainer() {
+        return ELASTICSEARCH_CONTAINER;
+    }
+
+    private static ElasticsearchContainer startContainer() {
+        final String version = System.getProperty("elasticsearch.version", ELASTICSEARCH_DEFAULT_VERSION);
         final ElasticsearchContainer elasticsearchContainer = new ElasticsearchContainer(
-            "docker.elastic.co/elasticsearch/elasticsearch:" + elasticsearchVersion
+            "docker.elastic.co/elasticsearch/elasticsearch:" + version
         );
         elasticsearchContainer.withEnv("cluster.name", CLUSTER_NAME);
-        if (!elasticsearchVersion.startsWith("7")) {
+        if (!version.startsWith("7")) {
             elasticsearchContainer.withEnv("xpack.security.enabled", "false");
         }
         elasticsearchContainer.start();

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/IntegrationTestConfiguration.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/IntegrationTestConfiguration.java
@@ -70,6 +70,9 @@ public class IntegrationTestConfiguration {
             "docker.elastic.co/elasticsearch/elasticsearch:" + version
         );
         elasticsearchContainer.withEnv("cluster.name", CLUSTER_NAME);
+        // Left alone, the node sizes its heap at half the memory it can see — 3.7GB of the CI machine, for
+        // the handful of documents these tests index.
+        elasticsearchContainer.withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
         if (!version.startsWith("7")) {
             elasticsearchContainer.withEnv("xpack.security.enabled", "false");
         }

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexPreparerIntegrationTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexPreparerIntegrationTest.java
@@ -142,6 +142,9 @@ class IndexPreparerIntegrationTest {
                 .withEnv("discovery.type", "single-node")
                 .withEnv("DISABLE_SECURITY_PLUGIN", "true")
                 .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+                // Left alone, the node sizes its heap at half the memory it can see, and it shares the CI
+                // machine with the Elasticsearch node the other integration tests keep running.
+                .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
                 .waitingFor(Wait.forHttp("/").forStatusCode(200));
             container.start();
             return container;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13313

## Description

The `Test reporters` job has been failing on `master` and `4.12.x` since APIM-13313 landed. CircleCI reports `infrastructure_fail`, the `Run reporter tests` step is cancelled after ~8 minutes, and the last thing in the log is an Elasticsearch container that starts and never becomes ready.

Nothing is wrong with the code under test — it all passes locally. `LogBodyIndexingIntegrationTest` brought a **third** Elasticsearch/OpenSearch node into the module's surefire JVM, and a `medium` machine executor cannot hold three:

- `LogBodyIndexingIntegrationTest` uses `@SpringJUnitConfig(IntegrationTestConfiguration.class)`;
- `ElasticsearchReporterTest` uses `@ContextConfiguration(classes = TestConfig.class)`, which `@Import`s that same configuration.

Different TestContext cache keys, therefore two contexts, therefore two Elasticsearch nodes. And the cache never closes a context between test classes, so the first node is still running when the second starts, alongside the OpenSearch node of `IndexPreparerIntegrationTest`. On top of that no container bounds its heap, so every node sizes it at half the memory it can see — about 3.7GB each on the CI machine.

Two commits:

1. **One container shared across contexts.** The container bean becomes a JVM singleton. It declares no destroy method on purpose: closing it with the first context to be discarded would take it away from the other, and Ryuk removes it at JVM exit. Each context keeps its own `ReporterConfiguration`, so the `indexName` / `indexBody` mutations `LogBodyIndexingIntegrationTest` makes do not leak into `ElasticsearchReporterTest`. Sharing one cluster is safe for the index templates: `generateIndexTemplate` suffixes the index name with the type, so the patterns are `gravitee-v4-log*` against `gravitee-body-indexed-v4-log*` — disjoint, no same-priority overlap for Elasticsearch to reject.

   The `@Value("${elasticsearch.version:…}")` field goes away with it: an instance field cannot feed a static initialiser. `System.getProperty` replaces it, and nothing in the repository overrides that property.

2. **Both containers cap their heap at 512MB**, which is ample for the handful of documents these tests index.

The simultaneous peak goes from three nodes back to two, as it was before APIM-13313.

## Additional context

`Test reporters` history on `4.12.x`, from the CircleCI API:

| build | commit | status | step |
| --- | --- | --- | --- |
| [2037647](https://circleci.com/gh/gravitee-io/gravitee-api-management/2037647) | the one before | success | 140s |
| [2038072](https://circleci.com/gh/gravitee-io/gravitee-api-management/2038072) | `98512db` (APIM-13313) | infrastructure_fail | cancelled after 503s |
| [2038452](https://circleci.com/gh/gravitee-io/gravitee-api-management/2038452) | next | infrastructure_fail | cancelled after 488s |
| [2038770](https://circleci.com/gh/gravitee-io/gravitee-api-management/2038770) | next | infrastructure_fail | cancelled after 467s |
| [2038858](https://circleci.com/gh/gravitee-io/gravitee-api-management/2038858) | next | infrastructure_fail | cancelled after 490s |
| [2039544](https://circleci.com/gh/gravitee-io/gravitee-api-management/2039544) | next | success | 177s — the third node took 36s to start, against 30s for the first |
| [2039931](https://circleci.com/gh/gravitee-io/gravitee-api-management/2039931) | next | failed | 366s |

`master` shows the same signature — [2040372](https://circleci.com/gh/gravitee-io/gravitee-api-management/2040372), `infrastructure_fail`, step cancelled.

Verified on this branch with the job's own command (`mvn test -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C`):

| | before | after |
| --- | --- | --- |
| Elasticsearch containers | 2 | 1 |
| simultaneous peak, OpenSearch included | 3 | 2 |
| `ElasticsearchReporterTest` | 17.9s | 0.3s |
| reporter-elasticsearch module | 57.5s | 33.1s |
| tests | green | green |

Needs a backport to `4.12.x`, where the job is failing too.
