### PR TITLE
fix(ci): make the @gravitee renovate rule match, and split it by release cycle

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,9 +59,23 @@
             "enabled": false
         },
         {
-            // Update Gravitee NPM packages at any time
-            "matchPackageNames": ["^@gravitee/*"],
+            // Legacy Angular console packages - move together on their own line
+            "matchPackageNames": ["@gravitee/ui-**"],
             "groupName": "@gravitee/ui"
+        },
+        {
+            // Graphene design system - three packages, released in lockstep
+            "matchPackageNames": [
+                "@gravitee/graphene-core",
+                "@gravitee/graphene-charts",
+                "@gravitee/graphene-policy-studio"
+            ],
+            "groupName": "graphene"
+        },
+        {
+            // Separate release cycle from graphene; adoption is a deliberate decision
+            "matchPackageNames": ["@gravitee/gamma-lib-observability"],
+            "groupName": "gamma-lib-observability"
         }
     ]
 }


### PR DESCRIPTION
`"matchPackageNames": ["^@gravitee/*"]` is a regex in a field that takes exact names or globs, so it matches nothing. Renovate has never opened a `@gravitee/*` PR in this repo.

Fixing the matcher alone would group four unrelated families into a single PR, so this splits them by release cycle:

| group | packages | line |
|---|---|---|
| `@gravitee/ui` | `ui-analytics`, `ui-particles-angular`, `ui-policy-studio-angular`, `ui-schematics` | 17.8.0 |
| `graphene` | `graphene-core`, `graphene-charts`, `graphene-policy-studio` | 3.14.0, lockstep |
| `gamma-lib-observability` | `gamma-lib-observability` | 1.39.2, its own cycle |

`@gravitee/gamma-modules-sdk` deliberately falls outside all three — low-churn devDependency on yet another cycle, so it gets its own PRs.

The three matchers are disjoint, so ordering doesn't matter. `rangeStrategy` is unchanged: `config:js-app` pins, which is correct for the host — APIM resolves the single Graphene version every federated module shares.

**Expect a two-major `gamma-lib-observability` PR** (1.39.2 → 3.1.0) on the first run after this merges. That library is peer-only on Graphene and 3.x requires `^3.13.0`, which this repo satisfies at 3.14.0 — but it is an adoption decision, not a routine bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
