### PR TITLE
fix(gamma): count mcp and mcp-studio traffic in analytics and logs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -37,6 +37,8 @@ public class FilterAdapter {
     static final String HTTP_PROXY_ENTRYPOINT_ID = "http-proxy";
     static final String LLM_PROXY_ENTRYPOINT_ID = "llm-proxy";
     static final String MCP_PROXY_ENTRYPOINT_ID = "mcp-proxy";
+    static final String MCP_ENTRYPOINT_ID = "mcp";
+    static final String MCP_STUDIO_ENTRYPOINT_ID = "mcp-studio";
     static final String A2A_PROXY_ENTRYPOINT_ID = "a2a-proxy";
     static final String EDGE_ENTRYPOINT_ID = "edge";
 
@@ -273,7 +275,9 @@ public class FilterAdapter {
                     HTTP_PROXY_ENTRYPOINT_ID,
                     LLM_PROXY_ENTRYPOINT_ID,
                     MCP_PROXY_ENTRYPOINT_ID,
-                    A2A_PROXY_ENTRYPOINT_ID
+                    A2A_PROXY_ENTRYPOINT_ID,
+                    MCP_ENTRYPOINT_ID,
+                    MCP_STUDIO_ENTRYPOINT_ID
                 )
             )
         );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -493,7 +493,9 @@ class FilterAdapterTest {
                 HTTP_PROXY_ENTRYPOINT_ID,
                 LLM_PROXY_ENTRYPOINT_ID,
                 MCP_PROXY_ENTRYPOINT_ID,
-                A2A_PROXY_ENTRYPOINT_ID
+                A2A_PROXY_ENTRYPOINT_ID,
+                MCP_ENTRYPOINT_ID,
+                MCP_STUDIO_ENTRYPOINT_ID
             );
         }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
@@ -45,7 +45,23 @@ public class AnalyticsRequestPipeline {
 
     static final Set<ApiType> ANALYTICS_SUPPORTED_API_TYPES = ApiType.ALL;
 
-    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of("http-get", "http-post", "http-proxy", "llm-proxy", "mcp-proxy", "a2a-proxy");
+    /**
+     * Entrypoints whose traffic these screens describe, injected when the caller names none.
+     *
+     * <p>An entrypoint missing from here is invisible rather than unfiltered: the condition is an allowlist,
+     * so its traffic is excluded at every time range, which reads as "nothing happened" rather than as a
+     * scoping choice. Adding an entrypoint kind means adding it here too.
+     */
+    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of(
+        "http-get",
+        "http-post",
+        "http-proxy",
+        "llm-proxy",
+        "mcp",
+        "mcp-proxy",
+        "mcp-studio",
+        "a2a-proxy"
+    );
 
     private final ObservabilityFilterValidator filterValidator;
     private final AccessibleApiScopeDomainService accessibleApiScope;

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -75,13 +75,18 @@ public class SearchObservabilityLogsUseCase {
      * unfiltered logs total includes native connections while dashboard totals do not — aligning
      * the analytics side is a pending decision with the Gamma team. The ES query builder adds a
      * field-missing fallback alongside these terms.
+     *
+     * <p>As in the analytics pipeline, this is an allowlist: an entrypoint absent from it has no logs, at any
+     * time range, rather than merely unfiltered ones.
      */
     static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of(
         "http-get",
         "http-post",
         "http-proxy",
         "llm-proxy",
+        "mcp",
         "mcp-proxy",
+        "mcp-studio",
         "a2a-proxy",
         "native-kafka"
     );

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -41,8 +41,9 @@ tags:
           are RBAC-scoped: the caller only sees logs for APIs they have read access to.
 
           Filter conditions reference the shared filter catalog narrowed to the `LOGS` signal.
-          When no explicit entrypoint filter is supplied, the server injects the canonical HTTP
-          entrypoints so table totals match the analytics dashboard.
+          When no explicit entrypoint filter is supplied, the server scopes the search to the
+          entrypoints observability counts as request traffic, plus native Kafka connections, which
+          the logs signal serves and the analytics dashboard does not.
     - name: Analytics
       description: |
           Environment-wide analytics computation: aggregate measures, faceted breakdowns, and
@@ -50,8 +51,10 @@ tags:
 
           Filter conditions reference the shared filter catalog narrowed to the `ANALYTICS` signal.
           RBAC scoping ensures the caller only sees metrics for APIs they have read access to.
-          When no explicit `ENTRYPOINT` filter is supplied, the server injects the canonical HTTP
-          entrypoints (`http-get`, `http-post`, `http-proxy`, `llm-proxy`, `mcp-proxy`).
+          When no explicit `ENTRYPOINT` filter is supplied, the server scopes the query to the
+          entrypoints observability counts as request traffic. That list is a product decision, not a
+          plugin property, and grows as entrypoints reach the product; query
+          `GET /observability/filters/ENTRYPOINT/values` for the ids present in your own data.
 
           All three endpoints return opaque JSON produced by the APIM analytics engine — the
           response schemas below document the stable structure but additional fields may appear.
@@ -605,9 +608,10 @@ paths:
                 indistinguishable from an unfiltered result.
 
                 **Default entrypoint scoping**: when no explicit `ENTRYPOINT` filter is supplied,
-                the server injects the canonical HTTP entrypoints (`http-get`, `http-post`,
-                `http-proxy`, `llm-proxy`, `mcp-proxy`) so log table totals match the analytics
-                dashboard for the same time range. Skipped for decision rows, which carry no
+                the server scopes the search to the entrypoints observability counts as request
+                traffic, plus native Kafka connections - the logs signal serves those and the
+                analytics dashboard does not, so an unfiltered log total can exceed the dashboard
+                total on an environment that mixes both. Skipped for decision rows, which carry no
                 entrypoint.
 
                 **Enrichment**: each log entry is enriched server-side with display names for API,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
@@ -236,9 +236,51 @@ class AnalyticsRequestPipelineTest {
                 "http-post",
                 "http-proxy",
                 "llm-proxy",
+                "mcp",
                 "mcp-proxy",
+                "mcp-studio",
                 "a2a-proxy"
             );
+        }
+
+        @Test
+        void should_include_mcp_so_tool_server_apis_are_not_silently_invisible() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), null, null, analyticsDataPort);
+
+            // An MCP server on the tool-server entrypoint reports entrypoint-id mcp, which is a different id
+            // from mcp-proxy and mcp-studio. Leaving it out excludes that traffic at every time range.
+            var entrypoint = scope
+                .filters()
+                .stream()
+                .filter(c -> "ENTRYPOINT".equals(c.name()))
+                .findFirst();
+            assertThat(entrypoint).isPresent();
+            assertThat(entrypoint.get().values()).contains("mcp");
+        }
+
+        @Test
+        void should_include_mcp_studio_so_studio_mode_servers_are_not_silently_invisible() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), null, null, analyticsDataPort);
+
+            // An MCP server built in studio mode reports entrypoint-id mcp-studio. Leaving it out of the
+            // allowlist does not widen the query - it excludes that traffic at every time range, so the
+            // screens read as "no traffic" rather than as "filtered out", which is indistinguishable from
+            // a broken gateway to whoever is looking.
+            var entrypoint = scope
+                .filters()
+                .stream()
+                .filter(c -> "ENTRYPOINT".equals(c.name()))
+                .findFirst();
+            assertThat(entrypoint).isPresent();
+            assertThat(entrypoint.get().values()).contains("mcp-studio");
         }
 
         @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -540,7 +540,11 @@ class SearchObservabilityLogsUseCaseTest {
                 "http-post",
                 "http-proxy",
                 "llm-proxy",
+                "mcp",
                 "mcp-proxy",
+                // Studio-mode MCP servers report this entrypoint. Omitting it hides their logs entirely
+                // rather than merely narrowing them.
+                "mcp-studio",
                 "a2a-proxy",
                 "native-kafka"
             );


### PR DESCRIPTION
## Summary

`DEFAULT_ENTRYPOINT_IDS` is the allowlist applied whenever a caller names no entrypoint filter. It listed neither `mcp-studio` nor `mcp`, so servers on those entrypoints were excluded from every analytics and logs query at every time range — which reads as *"no traffic occurred"* rather than *"filtered out"*, and is indistinguishable from a broken gateway to whoever is looking.

## Changes

- `mcp` and `mcp-studio` added to the allowlist in both `AnalyticsRequestPipeline` (analytics) and `SearchObservabilityLogsUseCase` (logs).
- Scope matches what **#19602 (OBS-18)** settles on master: `mcp-proxy`, `mcp`, `mcp-studio` and `a2a-proxy` are request traffic and are counted; `agent-to-agent` is a **different** entrypoint id and stays out until its logs are served too.

## Relationship to #19602

Same bug, same scope decision, different layer — because the layers differ between branches. On `master` this allowlist is derived from the `ObservabilityEntrypoints` registry, which #19602 fixes at the source. **That registry does not exist on `amp_demo`** (introduced on master by `6d5c1ae74a`, after this branch diverged), so here the hardcoded set is the only source of truth and is fixed where it lives.

This change is superseded by the registry when `amp_demo` takes master; it is not intended for `master`.

## Test plan
- [x] `AnalyticsRequestPipelineTest` and `SearchObservabilityLogsUseCaseTest` updated, including a new test for `mcp`
- [x] Each new test verified to fail without the fix
