### PR TITLE
fix(security): strip IdP access_token from browser Web Storage

### DIFF
--- a/gravitee-apim-console-webui/src/auth/access-token-filtering-state-store.spec.ts
+++ b/gravitee-apim-console-webui/src/auth/access-token-filtering-state-store.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AccessTokenFilteringStateStore } from './auth.service';
+
+describe('AccessTokenFilteringStateStore', () => {
+  let backingStore: Record<string, string>;
+  let store: AccessTokenFilteringStateStore;
+
+  beforeEach(() => {
+    backingStore = {};
+    const fakeStorage: Storage = {
+      length: 0,
+      clear: () => undefined,
+      key: () => null,
+      getItem: (key: string) => backingStore[key] ?? null,
+      setItem: (key: string, value: string) => {
+        backingStore[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete backingStore[key];
+      },
+    };
+    store = new AccessTokenFilteringStateStore({ store: fakeStorage });
+  });
+
+  it('strips access_token from a serialised User object before persisting it', async () => {
+    const user = JSON.stringify({
+      access_token: 'super-secret-idp-token',
+      id_token: 'some-id-token',
+      expires_at: 123456789,
+      token_type: 'Bearer',
+    });
+
+    await store.set('user:authority:client', user);
+
+    const stored = JSON.parse(backingStore['oidc.user:authority:client']);
+    expect(stored.access_token).toBe('');
+    expect(stored.id_token).toBe('some-id-token');
+    expect(stored.expires_at).toBe(123456789);
+  });
+
+  it('stores non-JSON values (e.g. OIDC state entries) unchanged', async () => {
+    await store.set('state:abc123', 'not-json');
+
+    expect(backingStore['oidc.state:abc123']).toBe('not-json');
+  });
+});

--- a/gravitee-apim-console-webui/src/auth/auth.service.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Inject, Injectable } from '@angular/core';
+import angular from 'angular';
 import { HttpClient } from '@angular/common/http';
 import { UserManager, WebStorageStateStore, Log } from 'oidc-client-ts';
 import { Router } from '@angular/router';
@@ -29,6 +30,30 @@ import { CustomUserFields } from '../entities/customUserFields';
 import { environment } from '../environments/environment';
 
 const USER_PROVIDER_ID_SELECTED = 'user-provider-id-selected';
+
+/**
+ * A StateStore that delegates to the given store, but strips the IdP `access_token` before it is ever
+ * persisted to Web Storage.
+ *
+ * Rationale (APIM-14822): the `access_token` is a live bearer credential at the IdP and must not be
+ * readable from `localStorage`/`sessionStorage` by an XSS running after login. `id_token` and `expires_at`
+ * are kept: they are needed for single logout (`signoutRedirect({ id_token_hint })`) and for the
+ * `user.expired` check in `checkAuth()`.
+ */
+export class AccessTokenFilteringStateStore extends WebStorageStateStore {
+  override set(key: string, value: string): Promise<void> {
+    try {
+      const parsed = JSON.parse(value);
+      if (angular.isObject(parsed) && 'access_token' in parsed) {
+        parsed.access_token = '';
+        value = JSON.stringify(parsed);
+      }
+    } catch {
+      // Not a JSON-serialised User object (e.g. OIDC state entries) - store as-is.
+    }
+    return super.set(key, value);
+  }
+}
 
 @Injectable({
   providedIn: 'root',
@@ -69,7 +94,7 @@ export class AuthService {
         scope: idp.scopes?.join(idp.scopeDelimiter ?? ' '),
         response_type: 'code',
         post_logout_redirect_uri: `${(window.location.origin + window.location.pathname).replace(/\/$/, '') + this.locationStrategy.prepareExternalUrl('/_login')}`,
-        userStore: new WebStorageStateStore({ store: window.localStorage }),
+        userStore: new AccessTokenFilteringStateStore({ store: window.localStorage }),
         loadUserInfo: false,
         extraHeaders: {
           // Needed for Gravitee APIM POST method

--- a/gravitee-apim-portal-webui-next/src/app/app.config.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.config.ts
@@ -21,7 +21,7 @@ import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, withComponentInputBinding, withRouterConfig } from '@angular/router';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
-import { provideOAuthClient } from 'angular-oauth2-oidc';
+import { MemoryStorage, OAuthStorage, provideOAuthClient } from 'angular-oauth2-oidc';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { catchError, combineLatest, Observable, switchMap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
@@ -29,6 +29,7 @@ import { of } from 'rxjs/internal/observable/of';
 import { routes } from './app.routes';
 import { csrfInterceptor } from '../interceptors/csrf.interceptor';
 import { httpRequestInterceptor } from '../interceptors/http-request.interceptor';
+import { AccessTokenFilteringOAuthStorage } from '../services/access-token-filtering-oauth-storage';
 import { AuthService } from '../services/auth.service';
 import { ConfigService } from '../services/config.service';
 import { CurrentUserService } from '../services/current-user.service';
@@ -66,6 +67,11 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withInterceptors([httpRequestInterceptor, csrfInterceptor])),
     provideAnimations(),
     provideOAuthClient(),
+    // APIM-14822: prevent the IdP access_token from ever reaching Web Storage.
+    {
+      provide: OAuthStorage,
+      useFactory: () => new AccessTokenFilteringOAuthStorage(typeof sessionStorage !== 'undefined' ? sessionStorage : new MemoryStorage()),
+    },
     importProvidersFrom(GioIconsModule),
     provideAppInitializer(() => {
       const initializerFn = initApp(

--- a/gravitee-apim-portal-webui-next/src/services/access-token-filtering-oauth-storage.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/access-token-filtering-oauth-storage.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MemoryStorage } from 'angular-oauth2-oidc';
+
+import { AccessTokenFilteringOAuthStorage } from './access-token-filtering-oauth-storage';
+
+describe('AccessTokenFilteringOAuthStorage', () => {
+  it('ignores writes to the access_token key', () => {
+    const delegate = new MemoryStorage();
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.setItem('access_token', 'super-secret-idp-token');
+
+    expect(storage.getItem('access_token')).toBeUndefined();
+    expect(delegate.getItem('access_token')).toBeUndefined();
+  });
+
+  it('still writes and reads every other key, e.g. id_token, unaffected', () => {
+    const delegate = new MemoryStorage();
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.setItem('id_token', 'some-id-token');
+    storage.setItem('expires_at', '123456789');
+
+    expect(storage.getItem('id_token')).toBe('some-id-token');
+    expect(storage.getItem('expires_at')).toBe('123456789');
+  });
+
+  it('delegates removeItem for every key, including access_token', () => {
+    const delegate = new MemoryStorage();
+    delegate.setItem('id_token', 'some-id-token');
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.removeItem('id_token');
+
+    expect(storage.getItem('id_token')).toBeUndefined();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/access-token-filtering-oauth-storage.ts
+++ b/gravitee-apim-portal-webui-next/src/services/access-token-filtering-oauth-storage.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OAuthStorage } from 'angular-oauth2-oidc';
+
+/**
+ * An OAuthStorage that ignores writes to the `access_token` key, so the IdP access token - a live bearer
+ * credential at the IdP - never reaches Web Storage.
+ *
+ * `id_token` and the other OIDC bookkeeping keys are left untouched: they are needed for single logout
+ * and session-expiry checks.
+ *
+ * See APIM-14822.
+ */
+export class AccessTokenFilteringOAuthStorage implements OAuthStorage {
+  private static readonly FILTERED_KEY = 'access_token';
+
+  constructor(private readonly delegate: OAuthStorage) {}
+
+  getItem(key: string): string | null {
+    return this.delegate.getItem(key);
+  }
+
+  removeItem(key: string): void {
+    this.delegate.removeItem(key);
+  }
+
+  setItem(key: string, data: string): void {
+    if (key === AccessTokenFilteringOAuthStorage.FILTERED_KEY) {
+      return;
+    }
+    this.delegate.setItem(key, data);
+  }
+}

--- a/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MemoryStorage } from 'angular-oauth2-oidc';
+
+import { AccessTokenFilteringOAuthStorage } from './access-token-filtering-oauth-storage';
+
+describe('AccessTokenFilteringOAuthStorage', () => {
+  it('ignores writes to the access_token key', () => {
+    const delegate = new MemoryStorage();
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.setItem('access_token', 'super-secret-idp-token');
+
+    expect(storage.getItem('access_token')).toBeUndefined();
+    expect(delegate.getItem('access_token')).toBeUndefined();
+  });
+
+  it('still writes and reads every other key, e.g. id_token, unaffected', () => {
+    const delegate = new MemoryStorage();
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.setItem('id_token', 'some-id-token');
+    storage.setItem('expires_at', '123456789');
+
+    expect(storage.getItem('id_token')).toBe('some-id-token');
+    expect(storage.getItem('expires_at')).toBe('123456789');
+  });
+
+  it('delegates removeItem for every key, including access_token', () => {
+    const delegate = new MemoryStorage();
+    delegate.setItem('id_token', 'some-id-token');
+    const storage = new AccessTokenFilteringOAuthStorage(delegate);
+
+    storage.removeItem('id_token');
+
+    expect(storage.getItem('id_token')).toBeUndefined();
+  });
+});

--- a/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.ts
+++ b/gravitee-apim-portal-webui/src/app/shared/access-token-filtering-oauth-storage.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OAuthStorage } from 'angular-oauth2-oidc';
+
+/**
+ * An OAuthStorage that ignores writes to the `access_token` key, so the IdP access token - a live bearer
+ * credential at the IdP - never reaches Web Storage.
+ *
+ * `id_token` and the other OIDC bookkeeping keys are left untouched: they are needed for single logout
+ * and session-expiry checks.
+ *
+ * See APIM-14822.
+ */
+export class AccessTokenFilteringOAuthStorage implements OAuthStorage {
+  private static readonly FILTERED_KEY = 'access_token';
+
+  constructor(private readonly delegate: OAuthStorage) {}
+
+  getItem(key: string): string | null {
+    return this.delegate.getItem(key);
+  }
+
+  removeItem(key: string): void {
+    this.delegate.removeItem(key);
+  }
+
+  setItem(key: string, data: string): void {
+    if (key === AccessTokenFilteringOAuthStorage.FILTERED_KEY) {
+      return;
+    }
+    this.delegate.setItem(key, data);
+  }
+}

--- a/gravitee-apim-portal-webui/src/app/shared/shared.module.ts
+++ b/gravitee-apim-portal-webui/src/app/shared/shared.module.ts
@@ -19,7 +19,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateCompiler, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { OAuthModule } from 'angular-oauth2-oidc';
+import { MemoryStorage, OAuthModule, OAuthStorage } from 'angular-oauth2-oidc';
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler';
 
 import { GvCheckboxControlValueAccessorDirective } from '../directives/gv-checkbox-control-value-accessor.directive';
@@ -37,6 +37,8 @@ import { MarkdownDescriptionPipe } from '../pipes/markdown-description.pipe';
 import { ApiStatesPipe } from '../pipes/api-states.pipe';
 import { SafePipe } from '../pipes/safe.pipe';
 import { ApiLabelsPipe } from '../pipes/api-labels.pipe';
+
+import { AccessTokenFilteringOAuthStorage } from './access-token-filtering-oauth-storage';
 
 @NgModule({
   declarations: [
@@ -84,6 +86,17 @@ import { ApiLabelsPipe } from '../pipes/api-labels.pipe';
       },
     }),
   ],
-  providers: [ApiLabelsPipe, ApiStatesPipe, MarkdownDescriptionPipe, LocalizedDatePipe, provideHttpClient(withInterceptorsFromDi())],
+  providers: [
+    ApiLabelsPipe,
+    ApiStatesPipe,
+    MarkdownDescriptionPipe,
+    LocalizedDatePipe,
+    provideHttpClient(withInterceptorsFromDi()),
+    // APIM-14822: prevent the IdP access_token from ever reaching Web Storage.
+    {
+      provide: OAuthStorage,
+      useFactory: () => new AccessTokenFilteringOAuthStorage(typeof sessionStorage !== 'undefined' ? sessionStorage : new MemoryStorage()),
+    },
+  ],
 })
 export class SharedModule {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14822

## Description
After SSO login, the IdP `access_token` was being persisted in the browser's Web Storage (`localStorage` in Console, `sessionStorage` in Portal/Portal-next). If the app ever has an XSS vulnerability, a script running after login could read that token straight out of storage.

## What we're protecting against

A pre-existing XSS running in the page, reading Web Storage. This is hardening (defense-in-depth per RFC 9700 / OWASP), not an active exploit — there's no vulnerability today, but leaving a live IdP bearer credential sitting in storage widens the blast radius if one is ever found.

## What this is *not* about

The `/auth/oauth2/{idp}` response body itself. A network response isn't something a post-login XSS can read — it only has access to storage. `/auth/oauth2/{idp}` is also a documented, standards-based OAuth `token_endpoint` (RFC 6749 §5.1 requires `access_token` there, and it's published in `portal-openapi.yaml`), so changing that response is a breaking API change with a real deprecation cost — for close to zero additional security benefit once storage is fixed. **No API contract change was made.**

## Fix implemented

Frontend-only, no server-side state, no API contract change:

- **Console** — `AccessTokenFilteringStateStore` wraps the OIDC `userStore` and strips `access_token` from the serialized `User` object before it's written to `localStorage`.
- **Portal & Portal-next** — `AccessTokenFilteringOAuthStorage` decorates