### PR TITLE
fix(gateway): key debug handlers by event id

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV2.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV2.java
@@ -19,6 +19,7 @@ import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.definition.model.HttpResponse;
 import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -54,6 +55,30 @@ public class DebugApiV2 extends Api implements ReactableDebugApi<io.gravitee.def
                 .getVirtualHosts()
                 .forEach(virtualHost -> virtualHost.setPath(PathTransformer.computePathWithEventId(this.eventId, virtualHost.getPath())));
         }
+    }
+
+    /**
+     * A debug API is identified by the event that requested it, not only by the API it debugs.
+     *
+     * <p>Reactables are keyed by equality in the handler registry, and the inherited equality
+     * compares API ids alone: two debug runs of the same API would collide and the second one would
+     * look like an already deployed duplicate. Entrypoint paths are already unique per event (see
+     * {@link #setEventId(String)}), so both runs can safely be registered side by side.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ReactableDebugApi<?> that)) {
+            return false;
+        }
+        return Objects.equals(getId(), that.getId()) && Objects.equals(eventId, that.getEventId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), eventId);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV2.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV2.java
@@ -47,6 +47,12 @@ public class DebugApiV2 extends Api implements ReactableDebugApi<io.gravitee.def
     public void setEventId(String eventId) {
         this.eventId = eventId;
 
+        // Secret discovery keys its registry by the definition descriptor, whose discriminator is the
+        // revision (see ApiV4DefinitionSecretRefsFinder#toDefinitionDescriptor). A debug reactable has no
+        // deployment number, so without this both runs of an API would share one descriptor and the first
+        // run to finish would revoke the other run's secret contexts. The event is that per-run identity.
+        this.setRevision(eventId);
+
         // Instead of doing it here, we could implement a custom DebugHandlerEntrypointFactory which allows to override
         // path(), create a new virtual host with this new path to accept an overridden request targeting this path.
         if (definition.getProxy() != null && definition.getProxy().getVirtualHosts() != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
@@ -21,6 +21,7 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -60,6 +61,30 @@ public class DebugApiV4 extends Api implements ReactableDebugApi<io.gravitee.def
                         .forEach(path -> path.setPath(PathTransformer.computePathWithEventId(this.eventId, path.getPath())));
                 });
         }
+    }
+
+    /**
+     * A debug API is identified by the event that requested it, not only by the API it debugs.
+     *
+     * <p>Reactables are keyed by equality in the handler registry, and the inherited equality
+     * compares API ids alone: two debug runs of the same API would collide and the second one would
+     * look like an already deployed duplicate. Entrypoint paths are already unique per event (see
+     * {@link #setEventId(String)}), so both runs can safely be registered side by side.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ReactableDebugApi<?> that)) {
+            return false;
+        }
+        return Objects.equals(getId(), that.getId()) && Objects.equals(eventId, that.getEventId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), eventId);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApiV4.java
@@ -49,6 +49,12 @@ public class DebugApiV4 extends Api implements ReactableDebugApi<io.gravitee.def
     public void setEventId(String eventId) {
         this.eventId = eventId;
 
+        // Secret discovery keys its registry by the definition descriptor, whose discriminator is the
+        // revision (see ApiV4DefinitionSecretRefsFinder#toDefinitionDescriptor). A debug reactable has no
+        // deployment number, so without this both runs of an API would share one descriptor and the first
+        // run to finish would revoke the other run's secret contexts. The event is that per-run identity.
+        this.setRevision(eventId);
+
         if (definition.getListeners() != null) {
             definition
                 .getListeners()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -51,6 +51,7 @@ public class VertxDebugConfiguration {
             .alpn(options.isAlpn())
             .connectTimeout(environment.getProperty("debug.timeout.connect", Integer.class, 5000))
             .requestTimeout(environment.getProperty("debug.timeout.request", Integer.class, 30000))
+            .globalTimeout(environment.getProperty("debug.timeout.global", Integer.class, 0))
             .build();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugHttpClientConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugHttpClientConfiguration.java
@@ -27,6 +27,12 @@ public class VertxDebugHttpClientConfiguration {
     public static final int MAX_CONNECTION_TIMEOUT = 5000;
     public static final int MAX_REQUEST_TIMEOUT = 30000;
 
+    /**
+     * Extra time granted, on top of the connect and request timeouts, to the whole debug sequence:
+     * updating the event, sending the request and reading back the response body.
+     */
+    public static final int GLOBAL_TIMEOUT_MARGIN = 5000;
+
     private boolean compressionSupported;
 
     private boolean alpn;
@@ -38,6 +44,8 @@ public class VertxDebugHttpClientConfiguration {
     private int connectTimeout;
 
     private int requestTimeout;
+
+    private int globalTimeout;
 
     private int port;
 
@@ -81,5 +89,18 @@ public class VertxDebugHttpClientConfiguration {
 
     public void setRequestTimeout(int requestTimeout) {
         this.requestTimeout = requestTimeout;
+    }
+
+    /**
+     * Upper bound for a whole debug run, after which the deployed handler is torn down. Defaults to
+     * the sum of the connect and request timeouts plus a margin, so it can only fire once the
+     * per-request timeouts had their chance.
+     */
+    public int getGlobalTimeout() {
+        return globalTimeout > 0 ? globalTimeout : getConnectTimeout() + getRequestTimeout() + GLOBAL_TIMEOUT_MARGIN;
+    }
+
+    public void setGlobalTimeout(int globalTimeout) {
+        this.globalTimeout = globalTimeout;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -52,6 +52,7 @@ import io.vertx.rxjava3.core.http.HttpClient;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,9 @@ public class DebugReactorEventListener extends ReactorEventListener {
                                 .ignoreElement();
                         })
                     )
+                    // Neither the event update nor the response body read is bounded on its own: without
+                    // this, a stalled run never reaches a terminal callback and leaks its handler forever.
+                    .timeout(debugHttpClientConfiguration.getGlobalTimeout(), TimeUnit.MILLISECONDS)
                     .subscribeOn(Schedulers.io())
                     .subscribe(
                         () -> {
@@ -155,7 +159,7 @@ public class DebugReactorEventListener extends ReactorEventListener {
                             logger.error("Debugging API has failed for API [{}], removing the handler.", debugApi.getId(), throwable);
                             eventManager.publishEvent(SecretDiscoveryEventType.REVOKE, secretDiscoveryEvent);
                             reactorHandlerRegistry.remove(debugApi);
-                            failEvent(debugEvent);
+                            failEventIfNotCompleted(debugEvent);
                         }
                     );
             }
@@ -284,6 +288,36 @@ public class DebugReactorEventListener extends ReactorEventListener {
             headers.forEach(headersMultiMap::set);
         }
         return headersMultiMap;
+    }
+
+    /**
+     * Marks the debug event as failed, unless the debug already succeeded.
+     *
+     * <p>The in-memory event still carries the payload as it was submitted, while the debug
+     * completion processor stores the debug result on that very same event. Writing the in-memory
+     * copy back would erase that result, so reload the event and leave it alone once it reached
+     * {@link ApiDebugStatus#SUCCESS}. An event that can no longer be read is failed from the copy at
+     * hand, as it was before.
+     */
+    private void failEventIfNotCompleted(io.gravitee.repository.management.model.Event debugEvent) {
+        if (debugEvent == null) {
+            return;
+        }
+        Completable.defer(() -> {
+            var latest = eventRepository.findById(debugEvent.getId());
+            if (latest.isEmpty()) {
+                return updateEvent(debugEvent, ApiDebugStatus.ERROR);
+            }
+            return isSuccessful(latest.get()) ? Completable.complete() : updateEvent(latest.get(), ApiDebugStatus.ERROR);
+        })
+            .subscribeOn(Schedulers.io())
+            .subscribe(() -> {}, throwable -> logger.error("Failed to update event {} to ERROR status", debugEvent.getId(), throwable));
+    }
+
+    private boolean isSuccessful(io.gravitee.repository.management.model.Event event) {
+        return ApiDebugStatus.SUCCESS.name().equals(
+            event.getProperties().get(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue())
+        );
     }
 
     private void failEvent(io.gravitee.repository.management.model.Event debugEvent) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -50,6 +50,7 @@ import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.security.GeneralSecurityException;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -293,11 +294,15 @@ public class DebugReactorEventListener extends ReactorEventListener {
     /**
      * Marks the debug event as failed, unless the debug already succeeded.
      *
-     * <p>The in-memory event still carries the payload as it was submitted, while the debug
-     * completion processor stores the debug result on that very same event. Writing the in-memory
-     * copy back would erase that result, so reload the event and leave it alone once it reached
-     * {@link ApiDebugStatus#SUCCESS}. An event that can no longer be read is failed from the copy at
-     * hand, as it was before.
+     * <p>The debug completion processor stores the debug result on that very same event, so two
+     * precautions are taken. The status is written as a patch carrying nothing but
+     * {@code API_DEBUG_STATUS}: a full update built from a copy read earlier would erase the result.
+     * And an event that already reached {@link ApiDebugStatus#SUCCESS} is left alone, so a run that
+     * completed just as the timeout fired is not reported as failed.
+     *
+     * <p>That read is best effort — a completion landing between it and the patch still flips the
+     * status to {@code ERROR}. There is no conditional write on {@code EventRepository} to close that
+     * window; what the patch guarantees is that the debug result itself survives it.
      */
     private void failEventIfNotCompleted(io.gravitee.repository.management.model.Event debugEvent) {
         if (debugEvent == null) {
@@ -305,13 +310,31 @@ public class DebugReactorEventListener extends ReactorEventListener {
         }
         Completable.defer(() -> {
             var latest = eventRepository.findById(debugEvent.getId());
-            if (latest.isEmpty()) {
-                return updateEvent(debugEvent, ApiDebugStatus.ERROR);
+            if (latest.isPresent() && isSuccessful(latest.get())) {
+                return Completable.complete();
             }
-            return isSuccessful(latest.get()) ? Completable.complete() : updateEvent(latest.get(), ApiDebugStatus.ERROR);
+            return patchEventStatus(debugEvent, ApiDebugStatus.ERROR);
         })
             .subscribeOn(Schedulers.io())
             .subscribe(() -> {}, throwable -> logger.error("Failed to update event {} to ERROR status", debugEvent.getId(), throwable));
+    }
+
+    /**
+     * Writes a single property on the event, leaving every other field — the debug payload above all —
+     * untouched. Both the Mongo and JDBC repositories implement {@code createOrPatch} as a per-property
+     * merge.
+     */
+    private Completable patchEventStatus(io.gravitee.repository.management.model.Event debugEvent, ApiDebugStatus apiDebugStatus) {
+        return Completable.fromAction(() -> {
+            var patch = new io.gravitee.repository.management.model.Event();
+            patch.setId(debugEvent.getId());
+            patch.setType(debugEvent.getType());
+            patch.setProperties(
+                Map.of(io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS.getValue(), apiDebugStatus.name())
+            );
+            patch.setUpdatedAt(new Date());
+            eventRepository.createOrPatch(patch);
+        });
     }
 
     private boolean isSuccessful(io.gravitee.repository.management.model.Event event) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV2V2Test.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV2V2Test.java
@@ -40,4 +40,28 @@ public class DebugApiV2V2Test {
             .anyMatch(item -> item.getPath().equals("/" + EVENT_ID + "-path2"))
             .anyMatch(item -> item.getPath().equals("/" + EVENT_ID + "-path3"));
     }
+
+    @Test
+    public void should_not_be_equal_when_debugging_the_same_api_from_another_event() {
+        final DebugApiV2 first = new DebugApiV2("evt-1", anApiDefinition());
+        final DebugApiV2 second = new DebugApiV2("evt-2", anApiDefinition());
+
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first.hashCode()).isNotEqualTo(second.hashCode());
+    }
+
+    @Test
+    public void should_be_equal_when_debugging_the_same_api_from_the_same_event() {
+        final DebugApiV2 first = new DebugApiV2(EVENT_ID, anApiDefinition());
+        final DebugApiV2 second = new DebugApiV2(EVENT_ID, anApiDefinition());
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+    }
+
+    private static io.gravitee.definition.model.debug.DebugApiV2 anApiDefinition() {
+        final io.gravitee.definition.model.debug.DebugApiV2 debugApi = Stubs.getADebugApiDefinition();
+        debugApi.setId("api-id");
+        return debugApi;
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV2V2Test.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV2V2Test.java
@@ -59,6 +59,17 @@ public class DebugApiV2V2Test {
         assertThat(first.hashCode()).isEqualTo(second.hashCode());
     }
 
+    @Test
+    public void should_carry_the_event_as_revision_so_two_runs_get_distinct_secret_descriptors() {
+        final DebugApiV2 first = new DebugApiV2("evt-1", anApiDefinition());
+        final DebugApiV2 second = new DebugApiV2("evt-2", anApiDefinition());
+
+        // The revision is the only per-run discriminator the secret discovery descriptor carries; left
+        // null, the first run to finish would revoke the contexts of the one still running.
+        assertThat(first.getRevision()).isEqualTo("evt-1");
+        assertThat(second.getRevision()).isEqualTo("evt-2");
+    }
+
     private static io.gravitee.definition.model.debug.DebugApiV2 anApiDefinition() {
         final io.gravitee.definition.model.debug.DebugApiV2 debugApi = Stubs.getADebugApiDefinition();
         debugApi.setId("api-id");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV4Test.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV4Test.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.HttpRequest;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DebugApiV4Test {
+
+    private static final String EVENT_ID = "evt-id";
+
+    @Test
+    void should_construct_and_compute_new_path() {
+        final DebugApiV4 result = new DebugApiV4(EVENT_ID, anApiDefinition());
+
+        assertThat(((HttpListener) result.getDefinition().getListeners().getFirst()).getPaths())
+            .hasSize(2)
+            .anyMatch(path -> path.getPath().equals("/" + EVENT_ID + "-path1"))
+            .anyMatch(path -> path.getPath().equals("/" + EVENT_ID + "-path2"));
+    }
+
+    @Test
+    void should_not_be_equal_when_debugging_the_same_api_from_another_event() {
+        final DebugApiV4 first = new DebugApiV4("evt-1", anApiDefinition());
+        final DebugApiV4 second = new DebugApiV4("evt-2", anApiDefinition());
+
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first.hashCode()).isNotEqualTo(second.hashCode());
+    }
+
+    @Test
+    void should_be_equal_when_debugging_the_same_api_from_the_same_event() {
+        final DebugApiV4 first = new DebugApiV4(EVENT_ID, anApiDefinition());
+        final DebugApiV4 second = new DebugApiV4(EVENT_ID, anApiDefinition());
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+    }
+
+    private static io.gravitee.definition.model.debug.DebugApiV4 anApiDefinition() {
+        final Api api = Api.builder()
+            .id("api-id")
+            .name("api")
+            .listeners(List.of(HttpListener.builder().paths(List.of(new Path("/path1"), new Path("/path2"))).build()))
+            .build();
+
+        return new io.gravitee.definition.model.debug.DebugApiV4(api, new HttpRequest("/path", "GET"));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV4Test.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/definition/DebugApiV4Test.java
@@ -59,6 +59,17 @@ class DebugApiV4Test {
         assertThat(first.hashCode()).isEqualTo(second.hashCode());
     }
 
+    @Test
+    void should_carry_the_event_as_revision_so_two_runs_get_distinct_secret_descriptors() {
+        final DebugApiV4 first = new DebugApiV4("evt-1", anApiDefinition());
+        final DebugApiV4 second = new DebugApiV4("evt-2", anApiDefinition());
+
+        // The revision is the only per-run discriminator the secret discovery descriptor carries; left
+        // null, the first run to finish would revoke the contexts of the one still running.
+        assertThat(first.getRevision()).isEqualTo("evt-1");
+        assertThat(second.getRevision()).isEqualTo("evt-2");
+    }
+
     private static io.gravitee.definition.model.debug.DebugApiV4 anApiDefinition() {
         final Api api = Api.builder()
             .id("api-id")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -52,9 +52,12 @@ import io.gravitee.gateway.debug.definition.DebugApiV2;
 import io.gravitee.gateway.debug.definition.ReactableDebugApi;
 import io.gravitee.gateway.debug.vertx.VertxDebugHttpClientConfiguration;
 import io.gravitee.gateway.handlers.accesspoint.manager.AccessPointManager;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.accesspoint.ReactableAccessPoint;
+import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
+import io.gravitee.gateway.reactor.handler.impl.DefaultReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.impl.ReactableEvent;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
@@ -74,6 +77,7 @@ import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -788,6 +792,135 @@ class DebugReactorEventListenerTest {
             debugApiModel.setRequest(httpRequest);
             final MultiMap result = debugReactorEventListener.buildHeaders(new DebugApiV2("eventId", debugApiModel), httpRequest);
             assertThat(result.get("host")).isNull();
+        }
+    }
+
+    /**
+     * These tests exercise a real {@link DefaultReactorHandlerRegistry} instead of a mock: the
+     * defect they cover lives in how a debug API is keyed in that registry, so a stubbed
+     * {@code contains()} would hide it.
+     */
+    @Nested
+    class HandlerLifecycle {
+
+        private static final String OTHER_EVENT_ID = "evt-id-2";
+
+        private ReactorHandlerRegistry registry;
+
+        @BeforeEach
+        void beforeEach() throws Exception {
+            final ReactorHandler reactorHandler = mock(ReactorHandler.class);
+            when(reactorHandler.acceptors()).thenReturn(List.of());
+            final ReactorFactoryManager reactorFactoryManager = mock(ReactorFactoryManager.class);
+            when(reactorFactoryManager.create(any())).thenReturn(List.of(reactorHandler));
+            registry = spy(new DefaultReactorHandlerRegistry(reactorFactoryManager));
+        }
+
+        @Test
+        void should_deploy_a_second_debug_of_the_same_api_while_a_previous_one_is_still_running() throws JsonProcessingException {
+            givenAStalledDebugRequest();
+            final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(60000));
+
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+            awaitTheRequestToBeSent();
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(OTHER_EVENT_ID)));
+
+            verify(registry, times(2)).create(any(DebugApiV2.class));
+        }
+
+        @Test
+        void should_skip_a_debug_event_dispatched_twice() throws JsonProcessingException {
+            givenAStalledDebugRequest();
+            final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(60000));
+
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+            awaitTheRequestToBeSent();
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+
+            verify(registry, times(1)).create(any(DebugApiV2.class));
+        }
+
+        @Test
+        void should_remove_the_handler_and_fail_the_event_when_the_debug_never_completes() throws Exception {
+            givenAStalledDebugRequest();
+            when(eventRepository.findById(EVENT_ID)).thenReturn(Optional.of(getAnEvent(EVENT_ID, PAYLOAD)));
+            final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(200));
+
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+
+            await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    verify(registry).remove(any(DebugApiV2.class));
+                    verify(eventRepository, times(2)).update(eventCaptor.capture());
+                });
+            assertThat(eventCaptor.getAllValues().getLast().getProperties()).containsEntry(
+                API_DEBUG_STATUS.getValue(),
+                ApiDebugStatus.ERROR.name()
+            );
+        }
+
+        @Test
+        void should_not_fail_an_event_already_completed_when_the_debug_times_out() throws Exception {
+            givenAStalledDebugRequest();
+            when(eventRepository.findById(EVENT_ID)).thenReturn(
+                Optional.of(getAnEvent(EVENT_ID, PAYLOAD, new HashMap<>(Map.of(API_DEBUG_STATUS.getValue(), "SUCCESS"))))
+            );
+            final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(200));
+
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+
+            await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(registry).remove(any(DebugApiV2.class)));
+            verify(eventRepository, times(1)).update(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.DEBUGGING.name());
+        }
+
+        /**
+         * The debug chain runs on its own scheduler: waiting for the stalled request to be sent is
+         * what makes the first run observably in flight before the second event is dispatched.
+         */
+        private void awaitTheRequestToBeSent() {
+            await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(vertx).createHttpClient(any(HttpClientOptions.class)));
+        }
+
+        private void givenAStalledDebugRequest() throws JsonProcessingException {
+            when(objectMapper.readValue(anyString(), any(DebugApiV2.class.getClass()))).thenAnswer(invocation -> anApiDefinition());
+            final HttpClient httpClient = mock(HttpClient.class);
+            when(vertx.createHttpClient(any(HttpClientOptions.class))).thenReturn(httpClient);
+            when(httpClient.rxRequest(any())).thenReturn(Single.never());
+        }
+
+        private io.gravitee.definition.model.debug.DebugApiV2 anApiDefinition() {
+            final io.gravitee.definition.model.debug.DebugApiV2 debugApiModel = getADebugApiDefinition();
+            debugApiModel.setId("api-id");
+            debugApiModel.setRequest(new HttpRequest("/path1", "GET", "request body"));
+            return debugApiModel;
+        }
+
+        private ReactableEvent<Event> aReactableEvent(String eventId) {
+            final Event event = getAnEvent(eventId, PAYLOAD);
+            return new ReactableEvent<>(event.getId(), event);
+        }
+
+        private VertxDebugHttpClientConfiguration aConfiguration(int globalTimeout) {
+            return VertxDebugHttpClientConfiguration.builder().globalTimeout(globalTimeout).build();
+        }
+
+        private DebugReactorEventListener listenerWith(ReactorHandlerRegistry registry, VertxDebugHttpClientConfiguration configuration) {
+            return new DebugReactorEventListener(
+                vertx,
+                eventManager,
+                eventRepository,
+                objectMapper,
+                configuration,
+                registry,
+                accessPointManager,
+                dataEncryptor
+            );
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -315,10 +316,9 @@ class DebugReactorEventListenerTest {
             verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
             verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApiV2.class));
 
-            verify(eventRepository, times(2)).update(eventCaptor.capture());
-
-            final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
-            assertThat(events.get(1).getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+            verify(eventRepository, times(1)).update(any());
+            verify(eventRepository, timeout(10000)).createOrPatch(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
 
             verify(eventManager, timeout(10000)).publishEvent(eq(SecretDiscoveryEventType.REVOKE), secretDiscoveryEventCaptor.capture());
 
@@ -358,10 +358,12 @@ class DebugReactorEventListenerTest {
                     verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
                     verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApiV2.class));
 
-                    verify(eventRepository, times(2)).update(eventCaptor.capture());
-
-                    final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
-                    assertThat(events.get(1).getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+                    verify(eventRepository, times(1)).update(any());
+                    verify(eventRepository).createOrPatch(eventCaptor.capture());
+                    assertThat(eventCaptor.getValue().getProperties()).containsEntry(
+                        API_DEBUG_STATUS.getValue(),
+                        ApiDebugStatus.ERROR.name()
+                    );
 
                     verify(eventManager, timeout(10000)).publishEvent(
                         eq(SecretDiscoveryEventType.REVOKE),
@@ -404,12 +406,12 @@ class DebugReactorEventListenerTest {
                     verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
                     verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApiV2.class));
 
-                    verify(eventRepository, times(2)).update(eventCaptor.capture());
-
-                    final List<Event> events = eventCaptor.getAllValues();
-                    assertThat(events.get(1).getProperties())
-                        .containsKey(API_DEBUG_STATUS.getValue())
-                        .containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+                    verify(eventRepository, times(1)).update(any());
+                    verify(eventRepository).createOrPatch(eventCaptor.capture());
+                    assertThat(eventCaptor.getValue().getProperties()).containsEntry(
+                        API_DEBUG_STATUS.getValue(),
+                        ApiDebugStatus.ERROR.name()
+                    );
 
                     verify(eventManager, timeout(10000)).publishEvent(
                         eq(SecretDiscoveryEventType.REVOKE),
@@ -447,12 +449,12 @@ class DebugReactorEventListenerTest {
                     verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
                     verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApiV2.class));
 
-                    verify(eventRepository, times(2)).update(eventCaptor.capture());
-
-                    final List<Event> events = eventCaptor.getAllValues();
-                    assertThat(events.get(1).getProperties())
-                        .containsKey(API_DEBUG_STATUS.getValue())
-                        .containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+                    verify(eventRepository, times(1)).update(any());
+                    verify(eventRepository).createOrPatch(eventCaptor.capture());
+                    assertThat(eventCaptor.getValue().getProperties()).containsEntry(
+                        API_DEBUG_STATUS.getValue(),
+                        ApiDebugStatus.ERROR.name()
+                    );
                 });
         }
 
@@ -630,10 +632,12 @@ class DebugReactorEventListenerTest {
                         any(io.gravitee.gateway.debug.definition.DebugApiV4.class)
                     );
 
-                    verify(eventRepository, times(2)).update(eventCaptor.capture());
-
-                    final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
-                    assertThat(events.get(1).getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+                    verify(eventRepository, times(1)).update(any());
+                    verify(eventRepository).createOrPatch(eventCaptor.capture());
+                    assertThat(eventCaptor.getValue().getProperties()).containsEntry(
+                        API_DEBUG_STATUS.getValue(),
+                        ApiDebugStatus.ERROR.name()
+                    );
 
                     verify(eventManager, timeout(10000)).publishEvent(
                         eq(SecretDiscoveryEventType.REVOKE),
@@ -829,6 +833,25 @@ class DebugReactorEventListenerTest {
         }
 
         @Test
+        void should_scope_secret_discovery_to_each_debug_run() throws JsonProcessingException {
+            givenAStalledDebugRequest();
+            final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(60000));
+
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(EVENT_ID)));
+            awaitTheRequestToBeSent();
+            listener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, aReactableEvent(OTHER_EVENT_ID)));
+
+            verify(eventManager, times(2)).publishEvent(eq(SecretDiscoveryEventType.DISCOVER), secretDiscoveryEventCaptor.capture());
+
+            // Both runs debug the same definition, so the descriptor derived from these events tells them
+            // apart by the revision alone. Sharing one descriptor would let the REVOKE of whichever run
+            // finishes first drop the secret contexts of the one still executing.
+            assertThat(secretDiscoveryEventCaptor.getAllValues())
+                .extracting(event -> event.metadata().revision())
+                .containsExactly(EVENT_ID, OTHER_EVENT_ID);
+        }
+
+        @Test
         void should_skip_a_debug_event_dispatched_twice() throws JsonProcessingException {
             givenAStalledDebugRequest();
             final DebugReactorEventListener listener = listenerWith(registry, aConfiguration(60000));
@@ -852,12 +875,10 @@ class DebugReactorEventListenerTest {
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     verify(registry).remove(any(DebugApiV2.class));
-                    verify(eventRepository, times(2)).update(eventCaptor.capture());
+                    verify(eventRepository, times(1)).update(any());
+                    verify(eventRepository).createOrPatch(eventCaptor.capture());
                 });
-            assertThat(eventCaptor.getAllValues().getLast().getProperties()).containsEntry(
-                API_DEBUG_STATUS.getValue(),
-                ApiDebugStatus.ERROR.name()
-            );
+            assertThat(eventCaptor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
         }
 
         @Test
@@ -875,6 +896,8 @@ class DebugReactorEventListenerTest {
                 .untilAsserted(() -> verify(registry).remove(any(DebugApiV2.class)));
             verify(eventRepository, times(1)).update(eventCaptor.capture());
             assertThat(eventCaptor.getValue().getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.DEBUGGING.name());
+            // the reload runs on its own scheduler: leave it a window in which it could have written
+            verify(eventRepository, after(500).never()).createOrPatch(any());
         }
 
         /**


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15030

## Description

Once a debug run failed to finish its listener chain, every later debug of that same API on that
Gateway process was silently dropped: the event stayed in `TO_DEBUG`, the Console warned after 20s
and never resolved, and only a Gateway restart cleared it. Debug on other APIs kept working.

Root cause, in `gravitee-apim-gateway-services-debug`: the handler registry keys a debug run by
`Reactable` equality, which — inherited from `AbstractReactableApi` — compares API ids only. Two
debug runs of the same API therefore shared one key, and the second looked like an already-deployed
duplicate.

Fix: `DebugApiV2` / `DebugApiV4` now include `eventId` in `equals`/`hashCode`, so two runs of the
same API register side by side. A new optional `debug.timeout.global` bounds the whole debug
sequence (defaults to `connect + request + 5000ms`), so a run that never reaches a terminal callback
(e.g. a stalled event-repository write) still gets torn down and its event marked `ERROR` instead of
leaking its handler forever. The error branch reloads the event before failing it, so it never
overwrites a result already written by the debug completion processor.