### PR TITLE
fix: API promotion multi env not working

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIdsCalculatorDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIdsCalculatorDomainService.java
@@ -56,12 +56,31 @@ public class ApiIdsCalculatorDomainService {
     }
 
     public ImportDefinition recalculateApiDefinitionIds(String environmentId, ImportDefinition toRecalculate) {
+        return recalculateApiDefinitionIds(environmentId, toRecalculate, null);
+    }
+
+    /**
+     * Recalculate the ids of the imported definition.
+     *
+     * When {@code targetApi} is provided, it is the API the definition is going to be applied to and ids are
+     * recalculated against it directly, without looking the API up by crossId. This is what a promotion needs
+     * when the target API was resolved through another mean than crossId (e.g. promotion history): otherwise the
+     * crossId lookup misses again, random ids are generated and the update is applied to a non-existing API.
+     */
+    public ImportDefinition recalculateApiDefinitionIds(String environmentId, ImportDefinition toRecalculate, Api targetApi) {
         Objects.requireNonNull(toRecalculate.getApiExport(), "Api is mandatory");
         if (toRecalculate.getApiExport().getId() == null || toRecalculate.getApiExport().getId().isEmpty()) {
-            findApiByEnvironmentAndCrossId(environmentId, toRecalculate.getApiExport().getCrossId()).ifPresentOrElse(
-                api -> recalculateIdsFromCrossId(toRecalculate, api),
-                () -> recalculateIdsFromDefinitionIds(environmentId, toRecalculate)
-            );
+            Optional.ofNullable(targetApi)
+                .or(() -> findApiByEnvironmentAndCrossId(environmentId, toRecalculate.getApiExport().getCrossId()))
+                .ifPresentOrElse(
+                    api -> recalculateIdsFromCrossId(toRecalculate, api),
+                    () -> recalculateIdsFromDefinitionIds(environmentId, toRecalculate)
+                );
+        } else if (targetApi != null && targetApi.getId() != null && !targetApi.getId().equals(toRecalculate.getApiExport().getId())) {
+            // The definition carries an id but we are updating another API: never let the definition id win.
+            // Page and plan ids are left untouched, they are matched by crossId/id by the import layer.
+            log.debug("Import definition id [{}] replaced by target api id [{}]", toRecalculate.getApiExport().getId(), targetApi.getId());
+            toRecalculate.getApiExport().setId(targetApi.getId());
         }
         return generateEmptyIdsForPlansAndPages(toRecalculate);
     }
@@ -69,8 +88,11 @@ public class ApiIdsCalculatorDomainService {
     private void recalculateIdsFromCrossId(ImportDefinition toRecalculate, Api api) {
         log.debug("Recalculating page and plans ids from cross id {} for api {}", api.getCrossId(), api.getId());
         toRecalculate.getApiExport().setId(api.getId());
-        Map<String, String> newPageIdsByOldPageIds = recalculatePageIdsFromCrossIds(api, toRecalculate.getPages());
-        recalculatePlanIdsFromCrossIds(api, toRecalculate.getPlans(), newPageIdsByOldPageIds);
+        Map<String, String> newPageIdsByOldPageIds = recalculatePageIdsFromCrossIds(
+            api,
+            Objects.requireNonNullElse(toRecalculate.getPages(), List.of())
+        );
+        recalculatePlanIdsFromCrossIds(api, Objects.requireNonNullElse(toRecalculate.getPlans(), Set.of()), newPageIdsByOldPageIds);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainService.java
@@ -83,8 +83,15 @@ public class ImportDefinitionUpdateDomainService {
     }
 
     public Api update(ImportDefinition importDefinition, Api existingPromotedApi, AuditInfo auditInfo) {
+        Objects.requireNonNull(existingPromotedApi, "An existing API is required to update from an import definition");
         var apiId = existingPromotedApi.getId();
-        var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(auditInfo.environmentId(), importDefinition);
+        // Ids are recalculated against the API we are updating (not against a crossId lookup) so that the update always
+        // targets this API even when the imported definition crossId differs from the existing one.
+        var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(
+            auditInfo.environmentId(),
+            importDefinition,
+            existingPromotedApi
+        );
         var apiExport = apiWithIds.getApiExport();
 
         if (

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/domain_service/PromotionContextDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/domain_service/PromotionContextDomainService.java
@@ -17,30 +17,54 @@ package io.gravitee.apim.core.promotion.domain_service;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiPathExtractor;
+import io.gravitee.apim.core.api.domain_service.ApiPathIndex;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.model.Path;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
 import io.gravitee.apim.core.promotion.crud_service.PromotionCrudService;
 import io.gravitee.apim.core.promotion.model.Promotion;
+import io.gravitee.apim.core.promotion.model.PromotionStatus;
+import io.gravitee.apim.core.promotion.query_service.PromotionQueryService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.CustomLog;
 
+@CustomLog
 @DomainService
 public class PromotionContextDomainService {
 
     private final PromotionCrudService promotionCrudService;
+    private final PromotionQueryService promotionQueryService;
     private final ApiQueryService apiQueryService;
+    private final ApiCrudService apiCrudService;
     private final EnvironmentCrudService environmentCrudService;
     private final JsonMapper jsonMapper;
 
     public PromotionContextDomainService(
         PromotionCrudService promotionCrudService,
+        PromotionQueryService promotionQueryService,
         ApiQueryService apiQueryService,
+        ApiCrudService apiCrudService,
         EnvironmentCrudService environmentCrudService,
         JsonMapper jsonMapper
     ) {
         this.promotionCrudService = promotionCrudService;
+        this.promotionQueryService = promotionQueryService;
         this.apiQueryService = apiQueryService;
+        this.apiCrudService = apiCrudService;
         this.environmentCrudService = environmentCrudService;
         this.jsonMapper = jsonMapper;
     }
@@ -65,18 +89,253 @@ public class PromotionContextDomainService {
         var promotion = promotionCrudService.getById(promotionId);
         var crossId = extractCrossIdFromDefinition(promotion);
         var environment = environmentCrudService.getByCockpitId(promotion.getTargetEnvCockpitId());
-        var targetApiOpt = apiQueryService.findByEnvironmentIdAndCrossId(environment.getId(), crossId);
+        var targetEnvId = environment.getId();
         var expectedDefinitionVersion = getPromotionDefinitionVersion(promotion);
+        var resolved = resolveTargetApi(promotion, crossId, targetEnvId, expectedDefinitionVersion, isAccepted);
 
-        if (isAccepted && targetApiOpt.isPresent()) {
-            if (targetApiOpt.get().getDefinitionVersion() != expectedDefinitionVersion) {
-                throw new IllegalStateException(
-                    "An API with the same crossId already exists with a different definition version in the target environment"
-                );
+        if (isAccepted && resolved.isPresent()) {
+            var targetApi = resolved.get().api();
+            if (targetApi.getDefinitionVersion() != expectedDefinitionVersion) {
+                throw new IllegalStateException(resolved.get().strategy().definitionVersionMismatch(targetApi));
             }
         }
 
-        return new PromotionContext(promotion, expectedDefinitionVersion, targetApiOpt.orElse(null), environment.getId());
+        return new PromotionContext(promotion, expectedDefinitionVersion, resolved.map(ResolvedApi::api).orElse(null), targetEnvId);
+    }
+
+    /** How the API already living in the target environment was identified. */
+    private enum Resolution {
+        CROSS_ID("An API with the same crossId already exists with a different definition version (API %s)"),
+        PROMOTION_HISTORY("The API previously promoted to this environment (%s) has a different definition version"),
+        CONTEXT_PATH("The API already serving this context path (%s) has a different definition version");
+
+        private final String mismatchMessage;
+
+        Resolution(String mismatchMessage) {
+            this.mismatchMessage = mismatchMessage;
+        }
+
+        String definitionVersionMismatch(Api targetApi) {
+            return mismatchMessage.formatted(targetApi.getId());
+        }
+    }
+
+    private record ResolvedApi(Api api, Resolution strategy) {}
+
+    /**
+     * Identifies the API in the target environment that this promotion must update, rather than duplicate.
+     *
+     * <p>crossId is the intended identity but it is not guaranteed to stay aligned across environments: it can be
+     * changed on either side, and before the promotion pipeline persisted {@code targetApiId} nothing repaired the
+     * link. When it diverges, the promotion has to fall back on evidence that the two APIs are the same one:
+     * the {@code targetApiId} recorded by a previous accepted promotion, then the context path, which the gateway
+     * already guarantees to be unique within an environment.
+     *
+     * <p>Scoped to V4: V2 promotions resolve their own target inside {@code PromotionServiceImpl} and only use this
+     * result for the definition version guard, so widening it there would reject promotions that used to succeed.
+     */
+    private Optional<ResolvedApi> resolveTargetApi(
+        Promotion promotion,
+        String crossId,
+        String targetEnvId,
+        DefinitionVersion expectedDefinitionVersion,
+        boolean isAccepted
+    ) {
+        var byCrossId = apiQueryService.findByEnvironmentIdAndCrossId(targetEnvId, crossId);
+        if (byCrossId.isPresent()) {
+            return byCrossId.map(api -> new ResolvedApi(api, Resolution.CROSS_ID));
+        }
+
+        if (expectedDefinitionVersion != DefinitionVersion.V4) {
+            return Optional.empty();
+        }
+
+        var previousPromotions = findPreviousAcceptedPromotions(promotion);
+        if (previousPromotions.isEmpty()) {
+            // This source API was never promoted into this environment, so nothing in it belongs to this promotion.
+            return Optional.empty();
+        }
+
+        return findApiPromotedInPreviousPromotion(previousPromotions, targetEnvId)
+            .map(api -> new ResolvedApi(api, Resolution.PROMOTION_HISTORY))
+            // Context-path scan walks every V2/V4 API in the environment. Reject does not use the resolved
+            // API, so skip it — every upgrading environment is in this state until each API is re-promoted.
+            .or(() ->
+                isAccepted
+                    ? findApiOwningTheContextPath(promotion, targetEnvId).map(api -> new ResolvedApi(api, Resolution.CONTEXT_PATH))
+                    : Optional.empty()
+            )
+            .map(resolvedApi -> {
+                log.info(
+                    "Promotion [{}]: no API with crossId [{}] in environment [{}], updating API [{}] (crossId [{}]) resolved by {}",
+                    promotion.getId(),
+                    crossId,
+                    targetEnvId,
+                    resolvedApi.api().getId(),
+                    resolvedApi.api().getCrossId(),
+                    resolvedApi.strategy()
+                );
+                return resolvedApi;
+            });
+    }
+
+    /** Accepted promotions of the same source API into the same target environment, excluding the one being processed. */
+    private List<Promotion> findPreviousAcceptedPromotions(Promotion promotion) {
+        if (promotion.getApiId() == null || promotion.getTargetEnvCockpitId() == null) {
+            return List.of();
+        }
+
+        var previousPromotions = promotionQueryService
+            .search(
+                new PromotionQueryService.PromotionQuery(
+                    promotion.getApiId(),
+                    Set.of(promotion.getTargetEnvCockpitId()),
+                    Set.of(PromotionStatus.ACCEPTED),
+                    // Include accepted rows with a null target_api_id — those are the upgrade-path history.
+                    null
+                )
+            )
+            .getContent();
+
+        return previousPromotions
+            .stream()
+            // The query cannot exclude the promotion being processed.
+            .filter(previous -> !Objects.equals(previous.getId(), promotion.getId()))
+            .toList();
+    }
+
+    private Optional<Api> findApiPromotedInPreviousPromotion(List<Promotion> previousPromotions, String targetEnvId) {
+        return previousPromotions
+            .stream()
+            .filter(previous -> previous.getTargetApiId() != null && !previous.getTargetApiId().isBlank())
+            .max(Comparator.comparing(Promotion::getCreatedAt, Comparator.nullsFirst(Comparator.naturalOrder())))
+            .map(Promotion::getTargetApiId)
+            .flatMap(apiCrudService::findById)
+            // A targetApiId must never make us update an API we cannot prove lives in the target environment.
+            .filter(api -> targetEnvId.equals(api.getEnvironmentId()));
+    }
+
+    /**
+     * Last resort, for environments promoted before {@code targetApiId} was recorded: the API serving the context
+     * path this promotion is about is the one a previous promotion created. Only used once the promotion history has
+     * confirmed this source API was already promoted here, so an unrelated API that merely happens to own the path
+     * is never overwritten.
+     *
+     * <p>{@link ApiPathIndex#scanPaths} reports overlapping (contained) paths, which is the right ambiguity check
+     * but the wrong identity check — {@code /orders} overlaps {@code /orders/v2}. After a unique overlap, the
+     * candidate must own every promoted path exactly (host + path). An ambiguous or inexact match is treated as
+     * no match — the promotion fails on the path conflict instead of guessing which API to overwrite.
+     */
+    private Optional<Api> findApiOwningTheContextPath(Promotion promotion, String targetEnvId) {
+        var candidatePaths = extractPathsFromDefinition(promotion);
+        if (candidatePaths.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var pathsByApiId = new HashMap<String, List<Path>>();
+        try (var apis = searchPathBearingApis(targetEnvId)) {
+            apis.forEach(api -> {
+                var paths = ApiPathExtractor.extractPaths(api);
+                if (!paths.isEmpty()) {
+                    pathsByApiId.put(api.getId(), paths);
+                }
+            });
+        }
+
+        var conflictingApiIds = ApiPathIndex.scanPaths(pathsByApiId, null, candidatePaths)
+            .stream()
+            .map(ApiPathIndex.Conflict::apiId)
+            .distinct()
+            .toList();
+
+        if (conflictingApiIds.size() != 1) {
+            if (conflictingApiIds.size() > 1) {
+                log.warn(
+                    "Promotion [{}]: {} APIs of environment [{}] conflict with the promoted context paths {}, not resolving a target",
+                    promotion.getId(),
+                    conflictingApiIds.size(),
+                    targetEnvId,
+                    candidatePaths
+                );
+            }
+            return Optional.empty();
+        }
+
+        var apiId = conflictingApiIds.getFirst();
+        if (!ownsEveryPromotedPathExactly(pathsByApiId.getOrDefault(apiId, List.of()), candidatePaths)) {
+            log.warn(
+                "Promotion [{}]: API [{}] overlaps the promoted context paths {} but does not own them exactly, not resolving a target",
+                promotion.getId(),
+                apiId,
+                candidatePaths
+            );
+            return Optional.empty();
+        }
+
+        return apiCrudService.findById(apiId);
+    }
+
+    /** Host + path only; {@code overrideAccess} is not part of identity. */
+    private static boolean ownsEveryPromotedPathExactly(List<Path> existingPaths, List<Path> promotedPaths) {
+        return promotedPaths
+            .stream()
+            .allMatch(promoted ->
+                existingPaths
+                    .stream()
+                    .anyMatch(
+                        existing ->
+                            Objects.equals(existing.getHost(), promoted.getHost()) && Objects.equals(existing.getPath(), promoted.getPath())
+                    )
+            );
+    }
+
+    private Stream<Api> searchPathBearingApis(String targetEnvId) {
+        return apiQueryService.search(
+            ApiSearchCriteria.builder()
+                .environmentId(targetEnvId)
+                .definitionVersion(List.of(DefinitionVersion.V2, DefinitionVersion.V4))
+                .build(),
+            null,
+            ApiFieldFilter.builder().pictureExcluded(true).build()
+        );
+    }
+
+    /**
+     * Reads the HTTP listener paths out of the V4 definition JSON stored on the promotion. A definition we cannot
+     * read paths from simply disables the context path resolution.
+     */
+    private List<Path> extractPathsFromDefinition(Promotion promotion) {
+        try {
+            var apiNode = jsonMapper.readTree(promotion.getApiDefinition()).get("api");
+            if (apiNode == null || apiNode.isNull()) {
+                return List.of();
+            }
+
+            var paths = new ArrayList<Path>();
+            apiNode
+                .path("listeners")
+                .forEach(listener ->
+                    listener
+                        .path("paths")
+                        .forEach(path -> {
+                            var pathValue = path.path("path");
+                            if (!pathValue.isMissingNode() && !pathValue.isNull()) {
+                                var host = path.path("host");
+                                paths.add(
+                                    Path.builder()
+                                        .host(host.isMissingNode() || host.isNull() ? null : host.asText())
+                                        .path(pathValue.asText())
+                                        .build()
+                                        .sanitize()
+                                );
+                            }
+                        })
+                );
+            return paths;
+        } catch (Exception e) {
+            log.warn("Could not extract context paths from promotion [{}] definition", promotion.getId(), e);
+            return List.of();
+        }
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
@@ -137,9 +137,29 @@ public class ProcessPromotionUseCase {
         }
 
         if (existingPromotedApi != null) {
-            importDefinitionUpdateDomainService.update(importDefinition, existingPromotedApi, auditInfo);
+            // Resolution is already env-scoped. This is the use-case contract: Input.existingPromotedApi is
+            // supplied by the caller, so a null or foreign environmentId must still be rejected here.
+            if (
+                existingPromotedApi.getEnvironmentId() == null || !existingPromotedApi.getEnvironmentId().equals(auditInfo.environmentId())
+            ) {
+                throw new IllegalStateException(
+                    "Promotion " +
+                        promotion.getId() +
+                        " failed. Target API " +
+                        existingPromotedApi.getId() +
+                        " does not belong to the target environment " +
+                        auditInfo.environmentId()
+                );
+            }
+            var updatedApi = importDefinitionUpdateDomainService.update(importDefinition, existingPromotedApi, auditInfo);
+            // The target must stay the API we resolved, whatever the import layer returns.
+            promotion.setTargetApiId(updatedApi != null && updatedApi.getId() != null ? updatedApi.getId() : existingPromotedApi.getId());
         } else {
-            importDefinitionCreateDomainService.create(auditInfo, importDefinition);
+            var createdApi = importDefinitionCreateDomainService.create(auditInfo, importDefinition);
+            if (createdApi == null || createdApi.getId() == null) {
+                throw new IllegalStateException("Promotion " + promotion.getId() + " failed. The promoted API could not be created");
+            }
+            promotion.setTargetApiId(createdApi.getId());
         }
         promotion.setStatus(PromotionStatus.ACCEPTED);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -235,6 +235,12 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             if (existingPromotion.isPresent()) {
                 log.debug("Updating existing promotion: {}", promotion.getId());
+                // The Cockpit round-trip may echo a promotion without its targetApiId (e.g. the source environment
+                // replaying a promotion request). Never lose the link to the API already promoted: it is what lets
+                // the next promotion update that API in place when the crossId lookup misses.
+                if (promotion.getTargetApiId() == null && existingPromotion.get().getTargetApiId() != null) {
+                    promotion.setTargetApiId(existingPromotion.get().getTargetApiId());
+                }
                 createdOrUpdatedPromotion = promotionRepository.update(promotion);
             } else {
                 log.debug("Creating promotion: {}", promotion.getId());
@@ -433,6 +439,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         promotion.setApiDefinition(promotionEntity.getApiDefinition());
         promotion.setStatus(convert(promotionEntity.getStatus()));
         promotion.setAuthor(promotionAuthor);
+        promotion.setTargetApiId(promotionEntity.getTargetApiId());
 
         return promotion;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
@@ -134,7 +134,7 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) {
         return storage
             .stream()
-            .filter(api -> api.getEnvironmentId().equals(environmentId) && api.getCrossId().equals(crossId))
+            .filter(api -> environmentId.equals(api.getEnvironmentId()) && Objects.equals(api.getCrossId(), crossId))
             .findFirst();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PromotionQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PromotionQueryServiceInMemory.java
@@ -25,7 +25,15 @@ import java.util.List;
 
 public class PromotionQueryServiceInMemory implements PromotionQueryService, InMemoryAlternative<Promotion> {
 
-    final List<Promotion> storage = new ArrayList<>();
+    final List<Promotion> storage;
+
+    public PromotionQueryServiceInMemory() {
+        this.storage = new ArrayList<>();
+    }
+
+    public PromotionQueryServiceInMemory(PromotionCrudServiceInMemory promotionCrudService) {
+        this.storage = promotionCrudService.storage;
+    }
 
     @Override
     public void initWith(List<Promotion> items) {
@@ -51,13 +59,16 @@ public class PromotionQueryServiceInMemory implements PromotionQueryService, InM
         List<Promotion> matches = storage
             .stream()
             .filter(promotion -> {
-                boolean matchesApiId = promotionQuery.apiId() == null || promotion.getApiId().equals(promotionQuery.apiId());
+                boolean matchesApiId = promotionQuery.apiId() == null || promotionQuery.apiId().equals(promotion.getApiId());
 
-                boolean matchesStatuses = promotionQuery.statuses() == null || promotionQuery.statuses().contains(promotion.getStatus());
+                boolean matchesStatuses =
+                    promotionQuery.statuses() == null ||
+                    (promotion.getStatus() != null && promotionQuery.statuses().contains(promotion.getStatus()));
 
                 boolean matchesTargetEnvCockpitIds =
                     promotionQuery.targetEnvCockpitIds() == null ||
-                    promotionQuery.targetEnvCockpitIds().contains(promotion.getTargetEnvCockpitId());
+                    (promotion.getTargetEnvCockpitId() != null &&
+                        promotionQuery.targetEnvCockpitIds().contains(promotion.getTargetEnvCockpitId()));
 
                 boolean matchesTargetApiExists =
                     promotionQuery.targetApiExists() == null || (promotionQuery.targetApiExists() == (promotion.getTargetApiId() != null));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIdsCalculatorDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIdsCalculatorDomainServiceTest.java
@@ -282,6 +282,143 @@ class ApiIdsCalculatorDomainServiceTest {
     }
 
     @Nested
+    class KnownTargetApi {
+
+        private static final String TARGET_API_ID = "target-api-id";
+        private final Api targetApi = Api.builder()
+            .id(TARGET_API_ID)
+            .crossId("target-cross-id-that-does-not-match")
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+
+        @BeforeEach
+        void setUp() {
+            // The target API is NOT resolvable by the definition crossId (e.g. resolved through promotion history).
+            apiQueryService.initWith(List.of(targetApi));
+            pageQueryServiceInMemory.initWith(
+                List.of(
+                    buildPage("existing-page-id", "a-page-cross-id")
+                        .toBuilder()
+                        .referenceId(TARGET_API_ID)
+                        .referenceType(Page.ReferenceType.API)
+                        .build()
+                )
+            );
+            planQueryServiceInMemory.initWith(
+                List.of(buildPlanWithFlows("existing-plan-id", "a-plan-cross-id").toBuilder().referenceId(TARGET_API_ID).build())
+            );
+        }
+
+        @Test
+        void should_recalculate_ids_against_target_api_when_definition_has_no_id_and_cross_id_does_not_match() {
+            final Set<PlanWithFlows> plans = Set.of(
+                buildPlanWithFlows("", "a-plan-cross-id"),
+                buildPlanWithFlows("", "brand-new-plan-cross-id")
+            );
+            final List<Page> pages = List.of(buildPage("", "a-page-cross-id"), buildPage("", "brand-new-page-cross-id"));
+            final ImportDefinition toRecalculate = buildImportDefinition("", plans, pages);
+            toRecalculate.getApiExport().setCrossId(API_CROSS_ID);
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, targetApi);
+
+            assertThat(result.getApiExport().getId()).isEqualTo(TARGET_API_ID);
+            assertThat(result.getPlans())
+                .filteredOn(plan -> "a-plan-cross-id".equals(plan.getCrossId()))
+                .extracting(PlanWithFlows::getId)
+                .containsExactly("existing-plan-id");
+            assertThat(result.getPlans())
+                .filteredOn(plan -> "brand-new-plan-cross-id".equals(plan.getCrossId()))
+                .allSatisfy(plan -> assertIsUuid(plan.getId()));
+            assertThat(result.getPages())
+                .filteredOn(page -> "a-page-cross-id".equals(page.getCrossId()))
+                .extracting(Page::getId)
+                .containsExactly("existing-page-id");
+            assertThat(result.getPages())
+                .filteredOn(page -> "brand-new-page-cross-id".equals(page.getCrossId()))
+                .allSatisfy(page -> assertIsUuid(page.getId()));
+        }
+
+        @Test
+        void should_keep_page_and_plan_ids_that_have_no_cross_id_when_recalculating_against_a_known_target() {
+            final Set<PlanWithFlows> plans = Set.of(buildPlanWithFlows("plan-id-from-file", ""));
+            final List<Page> pages = List.of(buildPage("page-id-from-file", ""));
+            final ImportDefinition toRecalculate = buildImportDefinition("", plans, pages);
+            toRecalculate.getApiExport().setCrossId(API_CROSS_ID);
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, targetApi);
+
+            assertThat(result.getApiExport().getId()).isEqualTo(TARGET_API_ID);
+            assertThat(result.getPlans()).extracting(PlanWithFlows::getId).containsExactly("plan-id-from-file");
+            assertThat(result.getPages()).extracting(Page::getId).containsExactly("page-id-from-file");
+        }
+
+        @Test
+        void should_prefer_target_api_over_cross_id_lookup() {
+            final Api apiMatchingCrossId = Api.builder()
+                .id("api-matching-cross-id")
+                .crossId(API_CROSS_ID)
+                .environmentId(ENVIRONMENT_ID)
+                .build();
+            apiQueryService.initWith(List.of(targetApi, apiMatchingCrossId));
+            final ImportDefinition toRecalculate = buildImportDefinition("", Set.of(), List.of());
+            toRecalculate.getApiExport().setCrossId(API_CROSS_ID);
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, targetApi);
+
+            assertThat(result.getApiExport().getId()).isEqualTo(TARGET_API_ID);
+        }
+
+        @Test
+        void should_replace_definition_id_by_target_api_id_when_they_differ() {
+            final Set<PlanWithFlows> plans = Set.of(buildPlanWithFlows("plan-id-from-definition", "a-plan-cross-id"));
+            final ImportDefinition toRecalculate = buildImportDefinition("api-id-from-definition", plans, List.of());
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, targetApi);
+
+            assertThat(result.getApiExport().getId()).isEqualTo(TARGET_API_ID);
+            // Sub-entity ids from the definition are left as-is, the import layer matches them by crossId then id.
+            assertThat(result.getPlans()).extracting(PlanWithFlows::getId).containsExactly("plan-id-from-definition");
+        }
+
+        @Test
+        void should_leave_definition_id_when_target_api_id_is_null() {
+            final ImportDefinition toRecalculate = buildImportDefinition("api-id-from-definition", Set.of(), List.of());
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(
+                ENVIRONMENT_ID,
+                toRecalculate,
+                Api.builder().id(null).crossId("target-cross-id").environmentId(ENVIRONMENT_ID).build()
+            );
+
+            assertThat(result.getApiExport().getId()).isEqualTo("api-id-from-definition");
+        }
+
+        @Test
+        void should_not_fail_when_definition_has_no_plans_nor_pages() {
+            final ImportDefinition toRecalculate = buildImportDefinition("", null, null);
+            toRecalculate.getApiExport().setCrossId(API_CROSS_ID);
+
+            final ImportDefinition result = assertDoesNotThrow(() ->
+                cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, targetApi)
+            );
+
+            assertThat(result.getApiExport().getId()).isEqualTo(TARGET_API_ID);
+        }
+
+        @Test
+        void should_behave_as_before_when_target_api_is_null() {
+            final ImportDefinition toRecalculate = buildImportDefinition("", Set.of(), List.of());
+            toRecalculate.getApiExport().setCrossId(API_CROSS_ID);
+
+            final ImportDefinition result = cut.recalculateApiDefinitionIds(ENVIRONMENT_ID, toRecalculate, null);
+
+            // No API matches the crossId and no target is known: a brand-new id is generated.
+            assertThat(result.getApiExport().getId()).isNotEqualTo(TARGET_API_ID);
+            assertIsUuid(result.getApiExport().getId());
+        }
+    }
+
+    @Nested
     class NoApiForCrossId {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
@@ -18,8 +18,10 @@ package io.gravitee.apim.core.api.domain_service.import_definition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -153,6 +155,71 @@ class ImportDefinitionUpdateDomainServiceTest {
         );
         assertThat(apiImagesService.apiPictures.get(PROMOTED_API_ID)).isEqualTo(picture);
         assertThat(apiImagesService.apiBackgrounds.get(PROMOTED_API_ID)).isEqualTo(background);
+    }
+
+    @Test
+    public void should_update_the_given_api_when_definition_has_no_id_and_cross_id_does_not_match() {
+        // Promotion case: definition exported without ids, target API resolved by another mean than crossId.
+        var existingApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id(PROMOTED_API_ID)
+            .crossId("cross-id-of-the-existing-api")
+            .environmentId(TARGET_ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(existingApi));
+        apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().crossId(PROMOTED_API_CROSS_ID).name("updated name").build())
+            .build();
+
+        var updated = service.update(importDefinition, existingApi, AUDIT_INFO);
+
+        assertThat(updated).isNotNull();
+        assertThat(updated.getId()).isEqualTo(PROMOTED_API_ID);
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(1);
+        verify(apiService).update(
+            eq(new ExecutionContext(ORGANIZATION_ID, TARGET_ENVIRONMENT_ID)),
+            eq(PROMOTED_API_ID),
+            // The crossId of the definition is applied so that the next promotion is resolved by crossId again.
+            argThat(update -> "updated name".equals(update.getName()) && PROMOTED_API_CROSS_ID.equals(update.getCrossId())),
+            eq(false),
+            eq(USER)
+        );
+    }
+
+    @Test
+    public void should_update_the_given_api_when_definition_carries_the_id_of_another_api() {
+        var existingApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id(PROMOTED_API_ID)
+            .crossId(PROMOTED_API_CROSS_ID)
+            .environmentId(TARGET_ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(existingApi));
+        apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().id("source-api-id").crossId(PROMOTED_API_CROSS_ID).name("updated name").build())
+            .build();
+
+        var updated = service.update(importDefinition, existingApi, AUDIT_INFO);
+
+        assertThat(updated.getId()).isEqualTo(PROMOTED_API_ID);
+        verify(apiService).update(any(), eq(PROMOTED_API_ID), any(), eq(false), eq(USER));
+        verify(apiService, never()).update(any(), eq("source-api-id"), any(), anyBoolean(), any());
+    }
+
+    @Test
+    public void should_fail_fast_when_no_existing_api_is_given() {
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().crossId(PROMOTED_API_CROSS_ID).name("updated name").build())
+            .build();
+
+        var throwable = catchThrowable(() -> service.update(importDefinition, null, AUDIT_INFO));
+
+        assertThat(throwable).isInstanceOf(NullPointerException.class);
+        verify(apiService, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
@@ -18,20 +18,25 @@ package io.gravitee.apim.core.promotion.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.PromotionFixtures;
 import initializers.ImportDefinitionCreateDomainServiceTestInitializer;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PromotionCrudServiceInMemory;
+import inmemory.PromotionQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionUpdateDomainServiceTestInitializer;
 import io.gravitee.apim.core.api.exception.ApiImportedWithErrorException;
@@ -47,6 +52,7 @@ import io.gravitee.apim.core.cockpit.model.CockpitReplyStatus;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.environment.model.Environment;
 import io.gravitee.apim.core.plan.model.PlanWithFlows;
+import io.gravitee.apim.core.promotion.domain_service.PromotionContextDomainService;
 import io.gravitee.apim.core.promotion.model.Promotion;
 import io.gravitee.apim.core.promotion.model.PromotionStatus;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
@@ -59,6 +65,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -107,6 +114,9 @@ class ProcessPromotionUseCaseTest {
     private final ImportDefinitionUpdateDomainServiceTestInitializer importDefinitionUpdateDomainService =
         new ImportDefinitionUpdateDomainServiceTestInitializer(apiCrudServiceInMemory);
     private final EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    private final PromotionQueryServiceInMemory promotionQueryService = new PromotionQueryServiceInMemory(promotionCrudService);
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudServiceInMemory);
+    private PromotionContextDomainService promotionContextDomainService;
     private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
     private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     private AuditDomainService auditService;
@@ -124,6 +134,15 @@ class ProcessPromotionUseCaseTest {
             importDefinitionCreateDomainService.initialize(),
             importDefinitionUpdateDomainService.initialize(ENVIRONMENT_ID),
             auditService
+        );
+
+        promotionContextDomainService = new PromotionContextDomainService(
+            promotionCrudService,
+            promotionQueryService,
+            apiQueryService,
+            apiCrudServiceInMemory,
+            environmentCrudService,
+            new JsonMapper()
         );
 
         UuidString.overrideGenerator(() -> UUID);
@@ -248,6 +267,8 @@ class ProcessPromotionUseCaseTest {
             )
         );
         assertThat(result).isNotNull();
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo("already-promoted-api");
     }
 
     @Test
@@ -291,6 +312,7 @@ class ProcessPromotionUseCaseTest {
         assertThat(result).isNotNull();
         assertThat(result.promotion()).isNotNull();
         assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo(UUID);
         assertThat(apiCrudServiceInMemory.storage()).hasSize(2);
         assertThat(apiCrudServiceInMemory.get(UUID))
             .isNotNull()
@@ -299,6 +321,266 @@ class ProcessPromotionUseCaseTest {
                 assertThat(api.getApiLifecycleState()).isEqualTo(Api.ApiLifecycleState.CREATED);
                 assertThat(api.getLifecycleState()).isEqualTo(Api.LifecycleState.STOPPED);
             });
+    }
+
+    @Test
+    void should_create_a_new_api_instead_of_updating_when_existing_promoted_api_was_not_resolved() {
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyInTarget = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId("different-cross-id")
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyInTarget));
+
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+        importDefinitionCreateDomainService.parametersQueryService.initWith(
+            List.of(
+                new Parameter(
+                    Key.API_PRIMARY_OWNER_MODE.key(),
+                    ENVIRONMENT_ID,
+                    ParameterReferenceType.ENVIRONMENT,
+                    ApiPrimaryOwnerMode.USER.name()
+                ),
+                new Parameter(Key.PLAN_SECURITY_KEYLESS_ENABLED.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, "true")
+            )
+        );
+        importDefinitionCreateDomainService.userCrudService.initWith(List.of(BASE_USER_ENTITY));
+        when(
+            importDefinitionCreateDomainService.validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any())
+        ).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = useCase.execute(
+            new ProcessPromotionUseCase.Input(
+                PROMOTION,
+                DefinitionVersion.V4,
+                true,
+                null,
+                ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                AUDIT
+            )
+        );
+
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo(UUID);
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(2);
+        assertThat(apiCrudServiceInMemory.get("already-promoted-api").getCrossId()).isEqualTo("different-cross-id");
+        assertThat(apiCrudServiceInMemory.get(UUID)).isNotNull();
+    }
+
+    @Test
+    void should_update_existing_target_api_when_resolved_even_if_crossId_differs() {
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyInTarget = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId("different-cross-id")
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyInTarget));
+
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+
+        var result = useCase.execute(
+            new ProcessPromotionUseCase.Input(
+                PROMOTION,
+                DefinitionVersion.V4,
+                true,
+                alreadyInTarget,
+                ImportDefinition.builder().apiExport(ApiExport.builder().id(API_ID).crossId(CROSS_ID).build()).build(),
+                AUDIT
+            )
+        );
+
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo("already-promoted-api");
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(1);
+        assertThat(apiCrudServiceInMemory.get("already-promoted-api")).isNotNull();
+        verify(cockpitPromotionServiceProvider).processPromotion(any(), any(), any());
+    }
+
+    @Test
+    void should_update_resolved_target_api_in_place_when_export_has_no_id_and_crossId_differs() {
+        // Real promotions export the definition without ids (Excludable.IDS). When the target API was resolved through
+        // the promotion history, its crossId differs from the definition one: the update must still hit that API.
+        promotionCrudService.initWith(List.of(PROMOTION));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyInTarget = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId("different-cross-id")
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyInTarget));
+
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+
+        var result = useCase.execute(
+            new ProcessPromotionUseCase.Input(
+                PROMOTION,
+                DefinitionVersion.V4,
+                true,
+                alreadyInTarget,
+                ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).name("promoted name").build()).build(),
+                AUDIT
+            )
+        );
+
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo("already-promoted-api");
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(1);
+        verify(importDefinitionUpdateDomainService.apiService).update(
+            any(),
+            eq("already-promoted-api"),
+            argThat(update -> CROSS_ID.equals(update.getCrossId()) && "promoted name".equals(update.getName())),
+            eq(false),
+            eq(USER_NAME)
+        );
+    }
+
+    @Test
+    void should_refuse_to_update_a_target_api_that_belongs_to_another_environment() {
+        var promotion = aPendingPromotion();
+        promotionCrudService.initWith(List.of(promotion));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var apiInAnotherEnv = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("api-in-another-env")
+            .crossId(CROSS_ID)
+            .environmentId("ANOTHER-ENV-ID")
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(apiInAnotherEnv));
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(
+                new ProcessPromotionUseCase.Input(
+                    promotion,
+                    DefinitionVersion.V4,
+                    true,
+                    apiInAnotherEnv,
+                    ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                    AUDIT
+                )
+            )
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("api-in-another-env")
+            .hasMessageContaining(ENVIRONMENT_ID);
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(1);
+        verify(importDefinitionUpdateDomainService.apiService, never()).update(any(), any(), any(), anyBoolean(), any());
+        verify(cockpitPromotionServiceProvider, never()).processPromotion(any(), any(), any());
+        assertThat(promotionCrudService.storage().getFirst().getStatus()).isEqualTo(PromotionStatus.TO_BE_VALIDATED);
+    }
+
+    @Test
+    void should_refuse_to_update_a_target_api_with_no_environment_id() {
+        var promotion = aPendingPromotion();
+        promotionCrudService.initWith(List.of(promotion));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var apiWithNoEnv = ApiFixtures.aProxyApiV4().toBuilder().id("api-with-no-env").crossId(CROSS_ID).environmentId(null).build();
+        apiCrudServiceInMemory.initWith(List.of(apiWithNoEnv));
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(
+                new ProcessPromotionUseCase.Input(
+                    promotion,
+                    DefinitionVersion.V4,
+                    true,
+                    apiWithNoEnv,
+                    ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                    AUDIT
+                )
+            )
+        );
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("api-with-no-env")
+            .hasMessageContaining(ENVIRONMENT_ID);
+        verify(importDefinitionUpdateDomainService.apiService, never()).update(any(), any(), any(), anyBoolean(), any());
+        verify(cockpitPromotionServiceProvider, never()).processPromotion(any(), any(), any());
+        assertThat(promotionCrudService.storage().getFirst().getStatus()).isEqualTo(PromotionStatus.TO_BE_VALIDATED);
+    }
+
+    @Test
+    void should_not_accept_nor_notify_cockpit_when_the_target_api_update_fails() {
+        var promotion = aPendingPromotion();
+        promotionCrudService.initWith(List.of(promotion));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyInTarget = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId(CROSS_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyInTarget));
+        when(importDefinitionUpdateDomainService.apiService.update(any(), any(), any(), anyBoolean(), any())).thenThrow(
+            new IllegalStateException("update failed")
+        );
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(
+                new ProcessPromotionUseCase.Input(
+                    promotion,
+                    DefinitionVersion.V4,
+                    true,
+                    alreadyInTarget,
+                    ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                    AUDIT
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(IllegalStateException.class).hasMessage("update failed");
+        verify(cockpitPromotionServiceProvider, never()).processPromotion(any(), any(), any());
+        assertThat(promotionCrudService.storage().getFirst().getStatus()).isEqualTo(PromotionStatus.TO_BE_VALIDATED);
+        assertThat(promotionCrudService.storage().getFirst().getTargetApiId()).isNull();
+    }
+
+    @Test
+    void should_not_persist_promotion_when_cockpit_rejects_the_processed_promotion() {
+        var stored = aPendingPromotion();
+        var input = aPendingPromotion();
+        promotionCrudService.initWith(List.of(stored));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyInTarget = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId(CROSS_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyInTarget));
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.ERROR);
+
+        Throwable throwable = catchThrowable(() ->
+            useCase.execute(
+                new ProcessPromotionUseCase.Input(
+                    input,
+                    DefinitionVersion.V4,
+                    true,
+                    alreadyInTarget,
+                    ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                    AUDIT
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        // The stored promotion is untouched: no ACCEPTED status and no targetApiId without a successful Cockpit reply.
+        assertThat(promotionCrudService.storage().getFirst().getStatus()).isEqualTo(PromotionStatus.TO_BE_VALIDATED);
+        assertThat(promotionCrudService.storage().getFirst().getTargetApiId()).isNull();
     }
 
     @Test
@@ -414,4 +696,100 @@ class ProcessPromotionUseCaseTest {
                 "(Plans) Cannot invoke \"io.gravitee.definition.model.DefinitionVersion.ordinal()\""
             );
     }
+
+    /**
+     * The scenario an environment upgrading from an affected version is in: the API was promoted before the pipeline
+     * persisted {@code targetApiId}, so every accepted promotion row has {@code target_api_id = NULL}, and the crossId
+     * has since diverged. Resolution runs for real here (through {@link PromotionContextDomainService}) rather than
+     * being handed in, because the whole question is whether the target gets resolved at all on that path.
+     */
+    @Test
+    void should_update_the_already_promoted_api_in_place_when_upgrading_from_a_version_that_never_stored_target_api_id() {
+        var promotion = aPendingPromotion().toBuilder().apiDefinition(A_V4_DEFINITION_SERVING_HTTP_PROXY).build();
+        var legacyAccepted = promotion
+            .toBuilder()
+            .id("legacy-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId(null)
+            .createdAt(Instant.parse("2026-01-01T00:00:00Z"))
+            .build();
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+
+        var alreadyPromotedApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId("diverged-cross-id")
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(alreadyPromotedApi));
+
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+
+        var context = promotionContextDomainService.getPromotionContext(promotion.getId(), true);
+
+        assertThat(context.existingPromotedApi())
+            .as("the API already serving the promoted context path must be resolved as the promotion target")
+            .isNotNull()
+            .extracting(Api::getId)
+            .isEqualTo("already-promoted-api");
+
+        var result = useCase.execute(
+            new ProcessPromotionUseCase.Input(
+                context.promotion(),
+                context.expectedDefinitionVersion(),
+                true,
+                context.existingPromotedApi(),
+                ImportDefinition.builder().apiExport(ApiExport.builder().crossId(CROSS_ID).build()).build(),
+                AUDIT
+            )
+        );
+
+        assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.ACCEPTED);
+        assertThat(result.promotion().getTargetApiId()).isEqualTo("already-promoted-api");
+        // No second API, so no entrypoint conflict — and the next promotion resolves by targetApiId.
+        assertThat(apiCrudServiceInMemory.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_create_the_api_rather_than_take_over_an_unrelated_api_serving_the_same_path() {
+        // Same shape as above but with no accepted promotion of this API into the environment: the API owning the
+        // path is a stranger and must not be overwritten.
+        var promotion = aPendingPromotion().toBuilder().apiDefinition(A_V4_DEFINITION_SERVING_HTTP_PROXY).build();
+        promotionCrudService.initWith(List.of(promotion));
+        environmentCrudService.initWith(List.of(ENVIRONMENT));
+        apiCrudServiceInMemory.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV4()
+                    .toBuilder()
+                    .id("unrelated-api")
+                    .crossId("unrelated-cross-id")
+                    .environmentId(ENVIRONMENT_ID)
+                    .build()
+            )
+        );
+
+        var context = promotionContextDomainService.getPromotionContext(promotion.getId(), true);
+
+        assertThat(context.existingPromotedApi()).isNull();
+    }
+
+    /**
+     * The use case mutates the promotion it receives; {@link #PROMOTION} is shared by all tests so tests asserting on
+     * the "not accepted" state need their own instance with a known initial status.
+     */
+    private static Promotion aPendingPromotion() {
+        return PROMOTION.toBuilder().status(PromotionStatus.TO_BE_VALIDATED).targetApiId(null).build();
+    }
+
+    private static final String A_V4_DEFINITION_SERVING_HTTP_PROXY = """
+        {
+            "api": {
+                "crossId": "%s",
+                "definitionVersion": "V4",
+                "name": "My Api",
+                "listeners": [ { "type": "HTTP", "paths": [ { "path": "/http_proxy" } ] } ]
+            }
+        }
+        """.formatted(CROSS_ID);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/PromotionContextDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/PromotionContextDomainServiceTest.java
@@ -20,17 +20,21 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import fixtures.core.model.ApiFixtures;
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PromotionCrudServiceInMemory;
+import inmemory.PromotionQueryServiceInMemory;
 import io.gravitee.apim.core.environment.model.Environment;
 import io.gravitee.apim.core.promotion.domain_service.PromotionContextDomainService;
 import io.gravitee.apim.core.promotion.model.Promotion;
+import io.gravitee.apim.core.promotion.model.PromotionStatus;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
@@ -51,11 +55,15 @@ class PromotionContextDomainServiceTest {
     private static final String TARGET_ENV_ID = "TARGET-ENV-ID";
     private static final String TARGET_ENV_COCKPIT_ID = "TARGET-ENV-COCKPIT-ID";
     private final PromotionCrudServiceInMemory promotionCrudService = new PromotionCrudServiceInMemory();
-    private final ApiQueryServiceInMemory apiQueryServiceInMemory = new ApiQueryServiceInMemory();
+    private final PromotionQueryServiceInMemory promotionQueryService = new PromotionQueryServiceInMemory(promotionCrudService);
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryServiceInMemory = new ApiQueryServiceInMemory(apiCrudService);
     private final EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
     private final PromotionContextDomainService service = new PromotionContextDomainService(
         promotionCrudService,
+        promotionQueryService,
         apiQueryServiceInMemory,
+        apiCrudService,
         environmentCrudService,
         new JsonMapper()
     );
@@ -72,7 +80,9 @@ class PromotionContextDomainServiceTest {
 
     @AfterEach
     void tearDown() {
-        Stream.of(promotionCrudService, apiQueryServiceInMemory, environmentCrudService).forEach(InMemoryAlternative::reset);
+        Stream.of(promotionCrudService, apiQueryServiceInMemory, environmentCrudService, apiCrudService).forEach(
+            InMemoryAlternative::reset
+        );
     }
 
     @Test
@@ -102,6 +112,594 @@ class PromotionContextDomainServiceTest {
         assertThat(result.expectedDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
         assertThat(result.existingPromotedApi()).isNull();
         assertThat(result.targetEnvId()).isEqualTo(TARGET_ENV_ID);
+    }
+
+    @Test
+    void should_return_existing_target_api_when_crossId_matches() {
+        Promotion promotion = aV4Promotion();
+        promotionCrudService.initWith(List.of(promotion));
+        var targetApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId(CROSS_ID)
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        apiQueryServiceInMemory.initWith(List.of(targetApi));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(targetApi);
+    }
+
+    @Test
+    void should_not_resolve_target_api_when_crossId_does_not_match_and_there_is_no_last_accepted_promotion() {
+        Promotion promotion = aV4Promotion();
+        promotionCrudService.initWith(List.of(promotion));
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV4()
+                    .toBuilder()
+                    .id("already-promoted-api")
+                    .crossId("different-cross-id")
+                    .environmentId(TARGET_ENV_ID)
+                    .build()
+            )
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_resolve_target_api_from_last_accepted_promotion_when_crossId_does_not_match() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = aV4Promotion()
+            .toBuilder()
+            .id("last-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId("already-promoted-api")
+            .createdAt(Instant.parse("2026-01-01T00:00:00Z"))
+            .build();
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        var targetApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("already-promoted-api")
+            .crossId("different-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        apiQueryServiceInMemory.initWith(List.of(targetApi));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(targetApi);
+    }
+
+    @Test
+    void should_prefer_crossId_match_over_last_accepted_promotion() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = aV4Promotion()
+            .toBuilder()
+            .id("last-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId("api-from-last-promotion")
+            .createdAt(Instant.parse("2026-01-01T00:00:00Z"))
+            .build();
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        var apiMatchingCrossId = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("api-matching-cross-id")
+            .crossId(CROSS_ID)
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        var apiFromLastPromotion = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("api-from-last-promotion")
+            .crossId("different-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        apiQueryServiceInMemory.initWith(List.of(apiMatchingCrossId, apiFromLastPromotion));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(apiMatchingCrossId);
+    }
+
+    @Test
+    void should_resolve_most_recent_accepted_promotion_when_multiple_exist() {
+        Promotion promotion = aV4Promotion();
+        Promotion olderAccepted = aV4Promotion()
+            .toBuilder()
+            .id("older-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId("older-promoted-api")
+            .createdAt(Instant.parse("2025-01-01T00:00:00Z"))
+            .build();
+        Promotion newerAccepted = aV4Promotion()
+            .toBuilder()
+            .id("newer-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId("newer-promoted-api")
+            .createdAt(Instant.parse("2026-01-01T00:00:00Z"))
+            .build();
+        promotionCrudService.initWith(List.of(promotion, olderAccepted, newerAccepted));
+        var olderApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("older-promoted-api")
+            .crossId("older-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        var newerApi = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id("newer-promoted-api")
+            .crossId("newer-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        apiQueryServiceInMemory.initWith(List.of(olderApi, newerApi));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(newerApi);
+    }
+
+    @Test
+    void should_not_resolve_target_api_when_last_accepted_promotion_points_to_missing_api() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = aV4Promotion()
+            .toBuilder()
+            .id("last-accepted-promotion")
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId("deleted-promoted-api")
+            .createdAt(Instant.parse("2026-01-01T00:00:00Z"))
+            .build();
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_from_history_when_it_lives_in_another_environment() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "api-in-other-env", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV4()
+                    .toBuilder()
+                    .id("api-in-other-env")
+                    .crossId("different-cross-id")
+                    .environmentId(DEFAULT_ENV_ID)
+                    .build()
+            )
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_from_history_when_it_has_no_environment_id() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "api-with-no-env", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        apiQueryServiceInMemory.initWith(
+            List.of(ApiFixtures.aProxyApiV4().toBuilder().id("api-with-no-env").crossId("different-cross-id").environmentId(null).build())
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_from_promotions_that_are_not_accepted() {
+        Promotion promotion = aV4Promotion();
+        Promotion rejected = anAcceptedPromotion("rejected-promotion", "rejected-target-api", "2026-01-01T00:00:00Z")
+            .toBuilder()
+            .status(PromotionStatus.REJECTED)
+            .build();
+        Promotion pending = anAcceptedPromotion("pending-promotion", "pending-target-api", "2026-02-01T00:00:00Z")
+            .toBuilder()
+            .status(PromotionStatus.TO_BE_VALIDATED)
+            .build();
+        Promotion inError = anAcceptedPromotion("error-promotion", "error-target-api", "2026-03-01T00:00:00Z")
+            .toBuilder()
+            .status(PromotionStatus.ERROR)
+            .build();
+        promotionCrudService.initWith(List.of(promotion, rejected, pending, inError));
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                aTargetApi("rejected-target-api", "cross-1"),
+                aTargetApi("pending-target-api", "cross-2"),
+                aTargetApi("error-target-api", "cross-3")
+            )
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_from_accepted_promotions_of_another_source_api() {
+        Promotion promotion = aV4Promotion();
+        Promotion otherApiPromotion = anAcceptedPromotion("other-api-promotion", "other-api-target", "2026-01-01T00:00:00Z")
+            .toBuilder()
+            .apiId("another-source-api")
+            .build();
+        promotionCrudService.initWith(List.of(promotion, otherApiPromotion));
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("other-api-target", "different-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_from_accepted_promotions_to_another_target_environment() {
+        Promotion promotion = aV4Promotion();
+        Promotion otherEnvPromotion = anAcceptedPromotion("other-env-promotion", "other-env-target", "2026-01-01T00:00:00Z")
+            .toBuilder()
+            .targetEnvCockpitId("ANOTHER-ENV-COCKPIT-ID")
+            .build();
+        promotionCrudService.initWith(List.of(promotion, otherEnvPromotion));
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("other-env-target", "different-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_when_history_has_no_target_api_id_and_the_definition_declares_no_path() {
+        Promotion promotion = aV4Promotion();
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        // aV4Promotion() declares no listener, so the context path fallback has nothing to match on either.
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("already-promoted-api", "different-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_use_the_promotion_being_processed_as_history() {
+        Promotion promotion = aV4Promotion().toBuilder().status(PromotionStatus.ACCEPTED).targetApiId("self-target-api").build();
+        promotionCrudService.initWith(List.of(promotion));
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("self-target-api", "different-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_fall_back_to_older_history_when_newest_target_api_is_missing() {
+        // Newest accepted promotion points to an API that has been deleted since; the older one is still valid.
+        Promotion promotion = aV4Promotion();
+        Promotion olderAccepted = anAcceptedPromotion("older-accepted-promotion", "older-promoted-api", "2025-01-01T00:00:00Z");
+        Promotion newerAccepted = anAcceptedPromotion("newer-accepted-promotion", "deleted-promoted-api", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, olderAccepted, newerAccepted));
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("older-promoted-api", "older-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        // Documented behaviour: the most recent accepted promotion is authoritative. If its API is gone the
+        // promotion creates a new API; we do not silently pick an older API that may have been replaced on purpose.
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_throw_when_api_resolved_from_history_has_a_different_definition_version() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "v2-target-api", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV2().toBuilder().id("v2-target-api").crossId("different-cross-id").environmentId(TARGET_ENV_ID).build()
+            )
+        );
+
+        Throwable throwable = catchThrowable(() -> service.getPromotionContext(promotion.getId(), true));
+
+        assertThat(throwable).isInstanceOf(IllegalStateException.class).hasMessageContaining("different definition version");
+    }
+
+    @Test
+    void should_resolve_target_api_from_history_when_rejecting_without_definition_version_check() {
+        Promotion promotion = aV4Promotion();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "v2-target-api", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        var v2TargetApi = ApiFixtures.aProxyApiV2()
+            .toBuilder()
+            .id("v2-target-api")
+            .crossId("different-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        apiQueryServiceInMemory.initWith(List.of(v2TargetApi));
+
+        var result = service.getPromotionContext(promotion.getId(), false);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(v2TargetApi);
+    }
+
+    @Test
+    void should_resolve_target_api_from_history_when_created_at_is_missing() {
+        Promotion promotion = aV4Promotion();
+        Promotion withoutDate = anAcceptedPromotion("no-date-promotion", "no-date-target-api", null);
+        Promotion withDate = anAcceptedPromotion("dated-promotion", "dated-target-api", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, withoutDate, withDate));
+        var datedApi = aTargetApi("dated-target-api", "cross-dated");
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("no-date-target-api", "cross-no-date"), datedApi));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(datedApi);
+    }
+
+    @Test
+    void should_not_search_history_when_promotion_has_no_source_api_id() {
+        Promotion promotion = aV4Promotion().toBuilder().apiId(null).build();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "already-promoted-api", "2026-01-01T00:00:00Z")
+            .toBuilder()
+            .apiId(null)
+            .build();
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        apiQueryServiceInMemory.initWith(List.of(aTargetApi("already-promoted-api", "different-cross-id")));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Context path resolution: the path an environment upgrading from an affected version takes, where every
+    // accepted promotion row predates targetApiId persistence and therefore has target_api_id = NULL.
+    // ---------------------------------------------------------------------------------------------------------
+
+    @Test
+    void should_resolve_target_api_by_context_path_when_history_predates_target_api_id_persistence() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        // Accepted before the fix: the row proves the API was promoted here, but carries no targetApiId.
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        var apiServingThePath = anApiServingTheContextPath("already-promoted-api", "diverged-cross-id", TARGET_ENV_ID);
+        apiQueryServiceInMemory.initWith(List.of(apiServingThePath));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(apiServingThePath);
+    }
+
+    @Test
+    void should_not_resolve_target_api_by_context_path_when_rejecting() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        apiQueryServiceInMemory.initWith(List.of(anApiServingTheContextPath("already-promoted-api", "diverged-cross-id", TARGET_ENV_ID)));
+
+        var result = service.getPromotionContext(promotion.getId(), false);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_by_context_path_when_the_api_was_never_promoted_to_this_environment() {
+        // No accepted promotion for this source API: an API owning the path is a stranger, never overwrite it.
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        promotionCrudService.initWith(List.of(promotion));
+        apiQueryServiceInMemory.initWith(List.of(anApiServingTheContextPath("unrelated-api", "unrelated-cross-id", TARGET_ENV_ID)));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_by_overlapping_nested_path() {
+        // scanPaths reports containment, so /orders overlaps /orders/v2. That is not identity — updating
+        // the nested API would replace an unrelated definition.
+        Promotion promotion = aV4PromotionServing("/orders");
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        apiQueryServiceInMemory.initWith(
+            List.of(anApiServingTheContextPath("unrelated-nested-api", "unrelated-cross-id", TARGET_ENV_ID, "/orders/v2"))
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_by_context_path_when_several_apis_conflict() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                anApiServingTheContextPath("first-conflicting-api", "cross-1", TARGET_ENV_ID),
+                // A sub-path of the promoted one also conflicts, so the match is ambiguous.
+                anApiServingTheContextPath("second-conflicting-api", "cross-2", TARGET_ENV_ID, CONTEXT_PATH + "/sub")
+            )
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_not_resolve_target_api_by_context_path_in_another_environment() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        apiQueryServiceInMemory.initWith(List.of(anApiServingTheContextPath("api-in-other-env", "diverged-cross-id", DEFAULT_ENV_ID)));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    @Test
+    void should_prefer_promotion_history_over_context_path() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "api-from-history", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        var apiFromHistory = anApiServingTheContextPath("api-from-history", "cross-history", TARGET_ENV_ID, "/another-path");
+        apiQueryServiceInMemory.initWith(
+            List.of(apiFromHistory, anApiServingTheContextPath("api-on-the-path", "cross-path", TARGET_ENV_ID))
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(apiFromHistory);
+    }
+
+    @Test
+    void should_prefer_cross_id_over_context_path() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        var apiWithMatchingCrossId = anApiServingTheContextPath("api-with-cross-id", CROSS_ID, TARGET_ENV_ID, "/another-path");
+        apiQueryServiceInMemory.initWith(
+            List.of(apiWithMatchingCrossId, anApiServingTheContextPath("api-on-the-path", "cross-path", TARGET_ENV_ID))
+        );
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.existingPromotedApi()).isEqualTo(apiWithMatchingCrossId);
+    }
+
+    @Test
+    void should_report_the_context_path_when_the_api_owning_it_has_a_different_definition_version() {
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH);
+        Promotion legacyAccepted = anAcceptedPromotion("legacy-accepted-promotion", null, "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, legacyAccepted));
+        var v2ApiOnThePath = ApiFixtures.aProxyApiV2()
+            .toBuilder()
+            .id("v2-api-on-the-path")
+            .crossId("diverged-cross-id")
+            .environmentId(TARGET_ENV_ID)
+            .build();
+        ((io.gravitee.definition.model.Api) v2ApiOnThePath.getApiDefinitionValue()).getProxy().setVirtualHosts(
+            List.of(new io.gravitee.definition.model.VirtualHost(CONTEXT_PATH))
+        );
+        apiQueryServiceInMemory.initWith(List.of(v2ApiOnThePath));
+
+        Throwable throwable = catchThrowable(() -> service.getPromotionContext(promotion.getId(), true));
+
+        // The operator needs to know the conflict is on the context path, not on the crossId.
+        assertThat(throwable)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("context path")
+            .hasMessageContaining("v2-api-on-the-path");
+    }
+
+    @Test
+    void should_not_apply_any_fallback_for_v2_promotions() {
+        // V2 resolves its own target inside PromotionServiceImpl; widening resolution here would make the definition
+        // version guard reject V2 promotions that used to succeed.
+        Promotion promotion = aV4PromotionServing(CONTEXT_PATH).toBuilder().apiDefinition(aV2Definition(CONTEXT_PATH)).build();
+        Promotion lastAccepted = anAcceptedPromotion("last-accepted-promotion", "already-promoted-api", "2026-01-01T00:00:00Z");
+        promotionCrudService.initWith(List.of(promotion, lastAccepted));
+        apiQueryServiceInMemory.initWith(List.of(anApiServingTheContextPath("already-promoted-api", "diverged-cross-id", TARGET_ENV_ID)));
+
+        var result = service.getPromotionContext(promotion.getId(), true);
+
+        assertThat(result.expectedDefinitionVersion()).isEqualTo(DefinitionVersion.V2);
+        assertThat(result.existingPromotedApi()).isNull();
+    }
+
+    private static final String CONTEXT_PATH = "/http_proxy";
+
+    private static io.gravitee.apim.core.api.model.Api anApiServingTheContextPath(String id, String crossId, String environmentId) {
+        return anApiServingTheContextPath(id, crossId, environmentId, CONTEXT_PATH);
+    }
+
+    private static io.gravitee.apim.core.api.model.Api anApiServingTheContextPath(
+        String id,
+        String crossId,
+        String environmentId,
+        String path
+    ) {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id(id).crossId(crossId).environmentId(environmentId).build();
+        ((io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue()).setListeners(
+            List.of(
+                io.gravitee.definition.model.v4.listener.http.HttpListener.builder()
+                    .paths(List.of(io.gravitee.definition.model.v4.listener.http.Path.builder().path(path).build()))
+                    .build()
+            )
+        );
+        return api;
+    }
+
+    private static Promotion aV4PromotionServing(String path) {
+        return aV4Promotion()
+            .toBuilder()
+            .apiDefinition(
+                """
+                {
+                    "api": {
+                        "crossId": "%s",
+                        "definitionVersion": "V4",
+                        "name": "My Api",
+                        "listeners": [
+                            { "type": "HTTP", "paths": [ { "path": "%s" } ] }
+                        ]
+                    }
+                }
+                """.formatted(CROSS_ID, path)
+            )
+            .build();
+    }
+
+    private static String aV2Definition(String path) {
+        return """
+        {
+            "gravitee": "2.0.0",
+            "crossId": "%s",
+            "name": "My Api",
+            "proxy": { "virtual_hosts": [ { "path": "%s" } ] }
+        }
+        """.formatted(CROSS_ID, path);
+    }
+
+    private static Promotion anAcceptedPromotion(String id, String targetApiId, String createdAt) {
+        return aV4Promotion()
+            .toBuilder()
+            .id(id)
+            .status(PromotionStatus.ACCEPTED)
+            .targetApiId(targetApiId)
+            .createdAt(createdAt == null ? null : Instant.parse(createdAt))
+            .build();
+    }
+
+    private static io.gravitee.apim.core.api.model.Api aTargetApi(String id, String crossId) {
+        return ApiFixtures.aProxyApiV4().toBuilder().id(id).crossId(crossId).environmentId(TARGET_ENV_ID).build();
+    }
+
+    private static Promotion aV4Promotion() {
+        return Promotion.builder()
+            .id(PROMOTION_ID)
+            .apiId(API_ID)
+            .targetEnvCockpitId(TARGET_ENV_COCKPIT_ID)
+            .apiDefinition(
+                """
+                {
+                    "api": {
+                        "crossId": "api-cross-id",
+                        "definitionVersion": "V4",
+                        "name": "My Api"
+                    }
+                }
+                """
+            )
+            .build();
     }
 
     @Test
@@ -194,7 +792,7 @@ class PromotionContextDomainServiceTest {
         Throwable throwable = catchThrowable(() -> service.getPromotionContext(promotion.getId(), true));
         assertThat(throwable).isInstanceOf(IllegalStateException.class);
         assertThat(throwable).hasMessage(
-            "An API with the same crossId already exists with a different definition version in the target environment"
+            "An API with the same crossId already exists with a different definition version (API target-v4-api)"
         );
     }
 
@@ -227,7 +825,7 @@ class PromotionContextDomainServiceTest {
         Throwable throwable = catchThrowable(() -> service.getPromotionContext(promotion.getId(), true));
         assertThat(throwable).isInstanceOf(IllegalStateException.class);
         assertThat(throwable).hasMessage(
-            "An API with the same crossId already exists with a different definition version in the target environment"
+            "An API with the same crossId already exists with a different definition version (API target-v2-api)"
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -202,6 +202,47 @@ public class PromotionServiceTest {
     }
 
     @Test
+    public void shouldKeepTargetApiIdOfTheEntityWhenCreatingOrUpdating() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty());
+        when(promotionRepository.create(any())).thenReturn(getAPromotion());
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+
+        verify(promotionRepository, times(1)).create(argThat(promotion -> "api#1-Promoted".equals(promotion.getTargetApiId())));
+    }
+
+    @Test
+    public void shouldNotLoseExistingTargetApiIdWhenUpdatedEntityHasNone() throws TechnicalException {
+        // Cockpit echoes the promotion to the source environment without the targetApiId set by the target one.
+        Promotion existing = getAPromotion();
+        existing.setTargetApiId("api-already-promoted");
+        when(promotionRepository.findById(any())).thenReturn(Optional.of(existing));
+        when(promotionRepository.update(any())).thenReturn(existing);
+
+        PromotionEntity withoutTargetApiId = getAPromotionEntity();
+        withoutTargetApiId.setTargetApiId(null);
+
+        promotionService.createOrUpdate(withoutTargetApiId);
+
+        verify(promotionRepository, times(1)).update(argThat(promotion -> "api-already-promoted".equals(promotion.getTargetApiId())));
+    }
+
+    @Test
+    public void shouldReplaceExistingTargetApiIdWhenUpdatedEntityHasOne() throws TechnicalException {
+        Promotion existing = getAPromotion();
+        existing.setTargetApiId("old-target-api");
+        when(promotionRepository.findById(any())).thenReturn(Optional.of(existing));
+        when(promotionRepository.update(any())).thenReturn(existing);
+
+        PromotionEntity withNewTargetApiId = getAPromotionEntity();
+        withNewTargetApiId.setTargetApiId("new-target-api");
+
+        promotionService.createOrUpdate(withNewTargetApiId);
+
+        verify(promotionRepository, times(1)).update(argThat(promotion -> "new-target-api".equals(promotion.getTargetApiId())));
+    }
+
+    @Test
     public void shouldNotCreateOrUpdateException() throws TechnicalException {
         assertThrows(TechnicalManagementException.class, () -> {
             when(promotionRepository.findById(any())).thenThrow(new TechnicalException());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15033

## Description

v4 promotion accept only resolved the target API with `environmentId` + `crossId`. When that lookup missed, accept created a second API and failed with `Path [...] already exists` even though the API was already in the target environment.

v2 already had the right behavior: fall back to the last accepted promotion’s `targetApiId`, and persist `targetApiId` after create/update.

v4 accept never wrote `targetApiId`. On an environment that only ever used the v4 path, every accepted row has `target_api_id = NULL`, JDBC `targetApiExists = true` filters those rows out, and a history-only fallback cannot fire. That is the customer / upgrade case: `crossId` has also diverged, so there is nothing recorded to read.

This change makes v4 accept update in place again.

### How the target API is resolved

`PromotionContextDomainService` identifies the API that this promotion must update, rather than duplicate:

1. **`crossId`** in the target environment (nominal).
2. **Promotion history** — the latest accepted promotion of the same source API into the same target environment, using its `targetApiId`. The API must live in the target environment (`environmentId` null is a mismatch).
3. **Context path** — only for **v4 accept**, and only if there is at least one accepted promotion row for this source API + target env (the row may have `targetApiId == null`). `scanPaths` is the ambiguity check (overlap). After a unique overlap, the candidate must own every promoted path exactly (host + path). `/orders` vs only `/orders/v2` is not a match. Ambiguous or inexact matches are not resolved.

Path scan is skipped on reject (reject does not use `existingPromotedApi`). It is the upgrade-path repair for environments that never stored `targetApiId`: it is corroborated by prior promotion into that env plus the uniqueness the gateway already enforces. It does not take over a hand-created API that has never been the target of an accepted promotion. Containment alone is not identity.

V2 promotions still resolve in `PromotionServiceImpl`. This service short-circuits fallbacks when the expected definition version is not v4.

### What makes the resolved API actually get updated

Resolving the target is not enough on its own:

- **`ProcessPromotionUseCase`** persists `targetApiId` on v4 accept (create and update) so later re-promotes can resolve the existing API. Update is refused if the resolved API’s `environmentId` is null or is not the audit environment.
- **`PromotionServiceImpl.convert()`** maps `targetApiId`. Without this, entity→model conversion drops the field and persistence through `createOrUpdate` is a no-op.
- **`createOrUpdate` keep-on-null** — if Cockpit echoes a promotion without `targetApiId`, the stored value is kept instead of wiped.
- **`ApiIdsCalculatorDomainService.recalculateApiDefinitionIds(env, def, Api targetApi)`** plus **`ImportDefinitionUpdateDomainService.update()`** always pass the resolved API into id recalculation. Promotion exports use `Excludable.IDS` (`id == null`); without this, a successful resolve still creates a second API.

`update()` is also used by `UpdateApiDefinitionFromImportUseCase`. Anchoring recalculation to the API being updated is correct for that path as well; this PR does not add import-endpoint coverage.

## Additional context

Re-promote of a v4 proxy used to update the existing target API in place. After a `crossId` mismatch (or a v4 history with no `targetApiId`), accept tried to create again and collided on the entrypoint.

**How to reproduce (before)**

1. Promote a v4 API from env A to env B and accept it.
2. Change the target API `crossId` so it no longer matches the source.
3. Promote again from A to B and accept.
4. Accept fails with `Path [/.../] already exists`.

**After this change**

The same flow updates the existing target API in place. Same path, same target API id, no new API.

On an environment that never stored `targetApiId` (upgrade from an affected v4-only history), accept still updates in place when there is a prior accepted promotion into that env and a unique context-path match.

before fix

https://github.com/user-attachments/assets/0119a9fb-a37d-4b8f-9ca1-37c8dfe99fa4

After the fix

https://github.com/user-attachments/assets/b9f578c9-8266-4a2c-b923-4e72e69f8134

**Out of scope**

- Changing context path as part of promote
- Taking over a hand-created production API with **no** accepted promotion row (ops: copy source API/plan `crossId`s)
- Reusing `ApiPathIndex.snapshotOf` for resolve (a stale snapshot can pick the wrong API; promotion resolve is rare)
- Import-from-definition endpoint tests (`UpdateApiDefinitionFromImportUseCase` inherits the `update()` id-anchor as a side effect)
- The earlier plan-delete / active-subscription error on some promotes (APIM-13936 / unmatched plans with subscriptions)
- Deleting and recreating the production API (that drops prod-only subscriptions)

**Test plan**

- [x] Unit: `PromotionContextDomainServiceTest` — `crossId` hit; history fallback; newest accepted wins; missing / other-env / null-`environmentId` target stays unresolved; path fallback when `targetApiId` is null and the path is unique; nested overlap (`/orders` vs `/orders/v2`) is not a match; no take-over without an accepted row; path scan skipped on reject; version-mismatch messages per resolution strategy
- [x] Unit: `ProcessPromotionUseCaseTest` — create/update persist `targetApiId`; update when resolved even if `crossId` differs; refuse update when the API is in another env or has no `environmentId`; upgrade path updates in place
- [x] Unit: `ApiIdsCalculatorDomainServiceTest` — recalculation against a known target API; pages/plans without a crossId keep file ids when the target is known
- [x] Unit: `PromotionServiceTest` — `convert()` maps `targetApiId`; `createOrUpdate` keeps a stored `targetApiId` when the incoming value is null
- [x] Manual: first v4 promote A → B creates the target API
- [x] Manual: re-promote with matching `crossId` updates in place
- [x] Manual: break target `crossId`, re-promote, accept updates the same target API instead of failing on the path

