### PR TITLE
chore(master): bump gravitee-policy-transform-avro-json from 5.2.2 to 5.2.3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -164,7 +164,7 @@
     <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
     <gravitee-policy-ssl-enforcement.version>1.7.0</gravitee-policy-ssl-enforcement.version>
     <gravitee-policy-traffic-shadowing.version>3.0.3</gravitee-policy-traffic-shadowing.version>
-    <gravitee-policy-transform-avro-json.version>5.2.2</gravitee-policy-transform-avro-json.version>
+    <gravitee-policy-transform-avro-json.version>5.2.3</gravitee-policy-transform-avro-json.version>
     <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
     <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
     <gravitee-policy-transformheaders.version>5.2.0</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-transform-avro-json](https://github.com/gravitee-io/gravitee-policy-transform-avro-json)** from `5.2.2` to `5.2.3` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-transform-avro-json/releases) page.

## Jira

[APIM-15023](https://gravitee.atlassian.net/browse/APIM-15023)

## Backport

- `apply-on-4-12-x`
- `apply-on-4-11-x`
- `apply-on-4-10-x`


[APIM-15023]: https://gravitee.atlassian.net/browse/APIM-15023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ