### PR TITLE
fix(GKO-3217,GKO-2442): application certificate dryrun validation and fingerprint matching

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
@@ -81,7 +81,22 @@ public interface ClientCertificateRepository extends CrudRepository<ClientCertif
      * @return true if such a certificate exists, false otherwise
      * @throws TechnicalException if an error occurs
      */
-    boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) throws TechnicalException;
+    default boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) throws TechnicalException {
+        return existsByFingerprintAndActiveApplication(fingerprint, environmentId, null);
+    }
+
+    /**
+     * Check if a client certificate with the given fingerprint exists for an active application,
+     * excluding certificates with REVOKED status and optionally excluding a specific application.
+     *
+     * @param fingerprint the certificate fingerprint to check
+     * @param environmentId the environment ID
+     * @param excludeApplicationId application ID to exclude from the lookup, or null to check all applications
+     * @return true if such a certificate exists, false otherwise
+     * @throws TechnicalException if an error occurs
+     */
+    boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId)
+        throws TechnicalException;
 
     /**
      * Delete all client certificates for a given application.

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
@@ -179,8 +179,14 @@ public class JdbcClientCertificateRepository
     }
 
     @Override
-    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) throws TechnicalException {
-        log.debug("JdbcClientCertificateRepository.existsByFingerprintAndActiveApplication({}, {})", fingerprint, environmentId);
+    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId)
+        throws TechnicalException {
+        log.debug(
+            "JdbcClientCertificateRepository.existsByFingerprintAndActiveApplication({}, {}, {})",
+            fingerprint,
+            environmentId,
+            excludeApplicationId
+        );
 
         try {
             String sql =
@@ -191,14 +197,21 @@ public class JdbcClientCertificateRepository
                 " a ON cc.application_id = a.id " +
                 "WHERE cc.fingerprint = ? AND cc.environment_id = ? AND cc.status != ? AND a.status = ?";
 
-            List<Integer> results = jdbcTemplate.queryForList(
-                sql,
-                Integer.class,
-                fingerprint,
-                environmentId,
-                ClientCertificateStatus.REVOKED.name(),
-                ApplicationStatus.ACTIVE.name()
-            );
+            if (excludeApplicationId != null) {
+                sql += " AND cc.application_id != ?";
+            }
+
+            Object[] args = excludeApplicationId != null
+                ? new Object[] {
+                    fingerprint,
+                    environmentId,
+                    ClientCertificateStatus.REVOKED.name(),
+                    ApplicationStatus.ACTIVE.name(),
+                    excludeApplicationId,
+                }
+                : new Object[] { fingerprint, environmentId, ClientCertificateStatus.REVOKED.name(), ApplicationStatus.ACTIVE.name() };
+
+            List<Integer> results = jdbcTemplate.queryForList(sql, Integer.class, args);
 
             return !results.isEmpty();
         } catch (Exception ex) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
@@ -183,11 +183,13 @@ public class MongoClientCertificateRepository implements ClientCertificateReposi
     }
 
     @Override
-    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) throws TechnicalException {
+    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId)
+        throws TechnicalException {
         log.debug(
-            "Check if client certificate with fingerprint [{}] exists for an active application in environment [{}]",
+            "Check if client certificate with fingerprint [{}] exists for an active application in environment [{}], excluding application [{}]",
             fingerprint,
-            environmentId
+            environmentId,
+            excludeApplicationId
         );
 
         try {
@@ -195,6 +197,9 @@ public class MongoClientCertificateRepository implements ClientCertificateReposi
             query.addCriteria(Criteria.where("fingerprint").is(fingerprint));
             query.addCriteria(Criteria.where("environmentId").is(environmentId));
             query.addCriteria(Criteria.where("status").ne(ClientCertificateStatus.REVOKED.name()));
+            if (excludeApplicationId != null) {
+                query.addCriteria(Criteria.where("applicationId").ne(excludeApplicationId));
+            }
 
             List<ClientCertificateMongo> certificates = mongoTemplate.find(query, ClientCertificateMongo.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
@@ -375,6 +375,13 @@ public class ClientCertificateRepositoryTest extends AbstractManagementRepositor
     }
 
     @Test
+    public void should_return_false_when_fingerprint_exists_only_on_excluded_application() throws Exception {
+        boolean exists = clientCertificateRepository.existsByFingerprintAndActiveApplication("ABC123", "env-1", "app-1");
+
+        assertThat(exists).isFalse();
+    }
+
+    @Test
     public void should_delete_by_application_id() throws Exception {
         // app-1 has 2 certificates: cert-1 and cert-2
         Page<ClientCertificate> beforeDelete = clientCertificateRepository.findByApplicationId(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -25,6 +25,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.EventLatestCrudInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
@@ -79,6 +80,7 @@ import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application.use_case.ImportApplicationCRDUseCase;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
@@ -225,6 +227,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImpl;
@@ -774,9 +777,17 @@ public class ResourceContextConfiguration {
     public ValidateApplicationSettingsDomainService validateApplicationSettingsDomainService(
         ApplicationRepository applicationRepository,
         ApplicationTypeService applicationTypeService,
-        ParameterService parameterService
+        ParameterService parameterService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService,
+        ClientCertificateCrudService clientCertificateCrudService
     ) {
-        return new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, applicationTypeService, parameterService);
+        return new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            applicationTypeService,
+            parameterService,
+            clientCertificateValidationDomainService,
+            clientCertificateCrudService
+        );
     }
 
     @Bean
@@ -1320,8 +1331,15 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ClientCertificateValidationDomainService clientCertificateValidationDomainService() {
-        return mock(ClientCertificateValidationDomainService.class);
+    public ClientCertificateCrudService clientCertificateCrudService() {
+        return new ClientCertificateCrudServiceInMemory();
+    }
+
+    @Bean
+    public ClientCertificateValidationDomainService clientCertificateValidationDomainService(
+        ClientCertificateCrudService clientCertificateCrudService
+    ) {
+        return new ClientCertificateValidationDomainServiceImpl(clientCertificateCrudService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -112,6 +112,7 @@ import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application.use_case.ValidateApplicationCRDUseCase;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
@@ -915,9 +916,17 @@ public class ResourceContextConfiguration {
     public ValidateApplicationSettingsDomainService validateApplicationSettingsDomainService(
         ApplicationRepository applicationRepository,
         ApplicationTypeService applicationTypeService,
-        ParameterService parameterService
+        ParameterService parameterService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService,
+        ClientCertificateCrudService clientCertificateCrudService
     ) {
-        return new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, applicationTypeService, parameterService);
+        return new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            applicationTypeService,
+            parameterService,
+            clientCertificateValidationDomainService,
+            clientCertificateCrudService
+        );
     }
 
     @Bean
@@ -1740,6 +1749,11 @@ public class ResourceContextConfiguration {
     @Bean
     ClientCertificateDomainService clientCertificateDomainService() {
         return mock(ClientCertificateDomainService.class);
+    }
+
+    @Bean
+    public ClientCertificateCrudService clientCertificateCrudService() {
+        return mock(ClientCertificateCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -1044,9 +1044,17 @@ public class ResourceContextConfiguration {
     public ValidateApplicationSettingsDomainService validateApplicationSettingsDomainService(
         ApplicationRepository applicationRepository,
         ApplicationTypeService applicationTypeService,
-        ParameterService parameterService
+        ParameterService parameterService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService,
+        ClientCertificateCrudService clientCertificateCrudService
     ) {
-        return new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, applicationTypeService, parameterService);
+        return new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            applicationTypeService,
+            parameterService,
+            clientCertificateValidationDomainService,
+            clientCertificateCrudService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -1005,9 +1005,17 @@ public class ResourceContextConfiguration {
     public ValidateApplicationSettingsDomainService validateApplicationSettingsDomainService(
         ApplicationRepository applicationRepository,
         ApplicationTypeService applicationTypeService,
-        ParameterService parameterService
+        ParameterService parameterService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService,
+        ClientCertificateCrudService clientCertificateCrudService
     ) {
-        return new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, applicationTypeService, parameterService);
+        return new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            applicationTypeService,
+            parameterService,
+            clientCertificateValidationDomainService,
+            clientCertificateCrudService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
@@ -121,5 +121,18 @@ public interface ClientCertificateCrudService {
      * @param environmentId the environment ID
      * @return true if such a certificate exists
      */
-    boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId);
+    default boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) {
+        return existsByFingerprintAndActiveApplication(fingerprint, environmentId, null);
+    }
+
+    /**
+     * Check whether a non-revoked certificate with the given fingerprint already exists
+     * for an active application in the specified environment, optionally excluding one application.
+     *
+     * @param fingerprint the SHA-256 certificate fingerprint
+     * @param environmentId the environment ID
+     * @param excludeApplicationId application ID to exclude from the lookup, or null to check all applications
+     * @return true if such a certificate exists
+     */
+    boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateValidationDomainService.java
@@ -40,7 +40,19 @@ public interface ClientCertificateValidationDomainService {
      * @param environmentId the environment ID for duplicate fingerprint lookup
      * @return extracted certificate information
      */
-    CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId);
+    default CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId) {
+        return validateForCreation(clientCertificate, environmentId, null);
+    }
+
+    /**
+     * Validates a certificate for creation: PEM validation, duplicate fingerprint check, and date bounds.
+     *
+     * @param clientCertificate the certificate to validate
+     * @param environmentId the environment ID for duplicate fingerprint lookup
+     * @param excludeApplicationId application ID to exclude from duplicate fingerprint lookup, or null
+     * @return extracted certificate information
+     */
+    CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId, String excludeApplicationId);
 
     record CertificateInfo(Date certificateExpiration, String subject, String issuer, String fingerprint) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -234,9 +234,9 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     }
 
     @Override
-    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) {
+    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId) {
         try {
-            return clientCertificateRepository.existsByFingerprintAndActiveApplication(fingerprint, environmentId);
+            return clientCertificateRepository.existsByFingerprintAndActiveApplication(fingerprint, environmentId, excludeApplicationId);
         } catch (TechnicalException e) {
             throw new TechnicalManagementException(
                 "An error occurs while checking if client certificate with fingerprint " + fingerprint + " already exists",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -19,6 +19,10 @@ import static io.gravitee.repository.management.model.Application.METADATA_CLIEN
 import static io.gravitee.repository.management.model.ApplicationStatus.*;
 
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.utils.CollectionUtils;
@@ -38,6 +42,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.security.cert.Certificate;
@@ -63,15 +68,21 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
     private final ApplicationRepository applicationRepository;
     private final ApplicationTypeService applicationTypeService;
     private final ParameterService parameterService;
+    private final ClientCertificateValidationDomainService clientCertificateValidationDomainService;
+    private final ClientCertificateCrudService clientCertificateCrudService;
 
     public ValidateApplicationSettingsDomainServiceImpl(
         @Lazy ApplicationRepository applicationRepository,
         ApplicationTypeService applicationTypeService,
-        ParameterService parameterService
+        ParameterService parameterService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService,
+        ClientCertificateCrudService clientCertificateCrudService
     ) {
         this.applicationRepository = applicationRepository;
         this.applicationTypeService = applicationTypeService;
         this.parameterService = parameterService;
+        this.clientCertificateValidationDomainService = clientCertificateValidationDomainService;
+        this.clientCertificateCrudService = clientCertificateCrudService;
     }
 
     @Override
@@ -91,7 +102,7 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
         }
 
         if (input.settings().getTls() != null) {
-            errors.addAll(validateTlsSettings(input.settings().getTls()));
+            errors.addAll(validateTlsSettings(input, input.settings().getTls()));
         }
 
         return Result.ofBoth(input.sanitized(sanitizedBuilder.build()), errors);
@@ -126,7 +137,7 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
         sanitizedBuilder.oauth(oauthSettings);
     }
 
-    private List<Error> validateTlsSettings(TlsSettings tls) {
+    private List<Error> validateTlsSettings(Input input, TlsSettings tls) {
         var errors = new ArrayList<Error>();
         boolean hasSingle = StringUtils.isNotEmpty(tls.getClientCertificate());
         boolean hasList = CollectionUtils.isNotEmpty(tls.getClientCertificates());
@@ -138,7 +149,9 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
 
         if (hasSingle) {
             errors.add(Error.warning("clientCertificate is deprecated, use clientCertificates instead"));
-            errors.addAll(validateCertificatePem(tls.getClientCertificate()).errors());
+            errors.addAll(
+                validateCertificateCreation(input, new CreateClientCertificate("certificate", null, null, tls.getClientCertificate()))
+            );
         } else if (hasList) {
             Set<String> certs = tls.getClientCertificates().stream().map(CreateClientCertificate::certificate).collect(Collectors.toSet());
             if (certs.size() != tls.getClientCertificates().size()) {
@@ -146,11 +159,45 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
                 return errors;
             }
             for (var cert : tls.getClientCertificates()) {
-                errors.addAll(validateCertificateEntry(cert));
+                errors.addAll(validateCertificateCreation(input, cert));
             }
         }
 
         return errors;
+    }
+
+    private List<Error> validateCertificateCreation(Input input, CreateClientCertificate cert) {
+        var errors = new ArrayList<>(validateCertificateEntry(cert));
+        if (errors.stream().anyMatch(Error::isSevere)) {
+            return errors;
+        }
+        if (!requiresCreationValidation(input, cert.certificate())) {
+            return errors;
+        }
+        try {
+            clientCertificateValidationDomainService.validateForCreation(
+                new ClientCertificate(cert.name(), cert.certificate(), cert.startsAt(), cert.endsAt()),
+                input.auditInfo().environmentId()
+            );
+        } catch (AbstractManagementException e) {
+            errors.add(Error.severe(e.getMessage()));
+        }
+        return errors;
+    }
+
+    private boolean requiresCreationValidation(Input input, String certificatePem) {
+        if (input.applicationId() == null) {
+            return true;
+        }
+        var existingCerts = clientCertificateCrudService.findByApplicationIdAndStatuses(
+            input.applicationId(),
+            ClientCertificateStatus.ACTIVE,
+            ClientCertificateStatus.ACTIVE_WITH_END
+        );
+        if (CollectionUtils.isEmpty(existingCerts)) {
+            return true;
+        }
+        return existingCerts.stream().noneMatch(cert -> certificatePem.equals(cert.certificate()));
     }
 
     private List<Error> validateCertificateEntry(CreateClientCertificate cert) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImpl.java
@@ -147,37 +147,65 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
             return errors;
         }
 
+        if (!hasSingle && !hasList) {
+            return errors;
+        }
+
+        var existingCerts = loadExistingCertificates(input);
+
         if (hasSingle) {
             errors.add(Error.warning("clientCertificate is deprecated, use clientCertificates instead"));
             errors.addAll(
-                validateCertificateCreation(input, new CreateClientCertificate("certificate", null, null, tls.getClientCertificate()))
+                validateCertificateCreation(
+                    input,
+                    new CreateClientCertificate("certificate", null, null, tls.getClientCertificate()),
+                    existingCerts
+                )
             );
-        } else if (hasList) {
-            Set<String> certs = tls.getClientCertificates().stream().map(CreateClientCertificate::certificate).collect(Collectors.toSet());
-            if (certs.size() != tls.getClientCertificates().size()) {
-                errors.add(Error.severe("client certificate content must be unique"));
-                return errors;
+        } else {
+            Set<String> fingerprints = new java.util.HashSet<>();
+            for (var cert : tls.getClientCertificates()) {
+                var parsed = validateCertificatePem(cert.certificate());
+                if (parsed.errors().stream().anyMatch(Error::isSevere)) {
+                    continue;
+                }
+                if (!fingerprints.add(fingerprint(cert.certificate()))) {
+                    errors.add(Error.severe("client certificate content must be unique"));
+                    return errors;
+                }
             }
             for (var cert : tls.getClientCertificates()) {
-                errors.addAll(validateCertificateCreation(input, cert));
+                errors.addAll(validateCertificateCreation(input, cert, existingCerts));
             }
         }
 
         return errors;
     }
 
-    private List<Error> validateCertificateCreation(Input input, CreateClientCertificate cert) {
+    private List<ClientCertificate> loadExistingCertificates(Input input) {
+        if (input.applicationId() == null) {
+            return List.of();
+        }
+        return clientCertificateCrudService.findByApplicationIdAndStatuses(
+            input.applicationId(),
+            ClientCertificateStatus.ACTIVE,
+            ClientCertificateStatus.ACTIVE_WITH_END
+        );
+    }
+
+    private List<Error> validateCertificateCreation(Input input, CreateClientCertificate cert, List<ClientCertificate> existingCerts) {
         var errors = new ArrayList<>(validateCertificateEntry(cert));
         if (errors.stream().anyMatch(Error::isSevere)) {
             return errors;
         }
-        if (!requiresCreationValidation(input, cert.certificate())) {
+        if (!requiresCreationValidation(cert.certificate(), existingCerts)) {
             return errors;
         }
         try {
             clientCertificateValidationDomainService.validateForCreation(
                 new ClientCertificate(cert.name(), cert.certificate(), cert.startsAt(), cert.endsAt()),
-                input.auditInfo().environmentId()
+                input.auditInfo().environmentId(),
+                input.applicationId()
             );
         } catch (AbstractManagementException e) {
             errors.add(Error.severe(e.getMessage()));
@@ -185,19 +213,23 @@ public class ValidateApplicationSettingsDomainServiceImpl implements ValidateApp
         return errors;
     }
 
-    private boolean requiresCreationValidation(Input input, String certificatePem) {
-        if (input.applicationId() == null) {
-            return true;
-        }
-        var existingCerts = clientCertificateCrudService.findByApplicationIdAndStatuses(
-            input.applicationId(),
-            ClientCertificateStatus.ACTIVE,
-            ClientCertificateStatus.ACTIVE_WITH_END
-        );
+    private boolean requiresCreationValidation(String certificatePem, List<ClientCertificate> existingCerts) {
         if (CollectionUtils.isEmpty(existingCerts)) {
             return true;
         }
-        return existingCerts.stream().noneMatch(cert -> certificatePem.equals(cert.certificate()));
+        var incomingFingerprint = fingerprint(certificatePem);
+        return existingCerts.stream().noneMatch(cert -> incomingFingerprint.equals(fingerprintOf(cert)));
+    }
+
+    private String fingerprintOf(ClientCertificate certificate) {
+        if (StringUtils.isNotEmpty(certificate.fingerprint())) {
+            return certificate.fingerprint();
+        }
+        return fingerprint(certificate.certificate());
+    }
+
+    private String fingerprint(String certificatePem) {
+        return clientCertificateValidationDomainService.validate(certificatePem).fingerprint();
     }
 
     private List<Error> validateCertificateEntry(CreateClientCertificate cert) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImpl.java
@@ -63,10 +63,10 @@ public class ClientCertificateValidationDomainServiceImpl implements ClientCerti
     }
 
     @Override
-    public CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId) {
+    public CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId, String excludeApplicationId) {
         CertificateInfo info = validate(clientCertificate.certificate());
 
-        if (clientCertificateCrudService.existsByFingerprintAndActiveApplication(info.fingerprint(), environmentId)) {
+        if (clientCertificateCrudService.existsByFingerprintAndActiveApplication(info.fingerprint(), environmentId, excludeApplicationId)) {
             throw new ClientCertificateAlreadyUsedException(info.fingerprint());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -548,7 +548,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     cert.startsAt(),
                     cert.endsAt()
                 );
-                clientCertificateCrudService.create(application.getId(), validateAndEnrich(certToCreate, executionContext));
+                clientCertificateCrudService.create(application.getId(), validateAndEnrich(certToCreate, executionContext, null));
             }
 
             Application createdApplication = applicationRepository.create(application);
@@ -730,16 +730,17 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             .sorted(Comparator.comparing(ClientCertificate::createdAt))
             .toList();
 
-        // Build a map of existing certificates by their certificate content for matching
-        Map<String, ClientCertificate> existingByCertificate = existing
+        Map<String, ClientCertificate> existingByFingerprint = existing
             .stream()
-            .collect(Collectors.toMap(ClientCertificate::certificate, c -> c, (a, b) -> a));
+            .collect(Collectors.toMap(this::fingerprintOf, c -> c, (a, b) -> a));
 
-        Set<String> incomingCertificates = incoming.stream().map(CreateClientCertificate::certificate).collect(toSet());
-
-        // Create new certificates (incoming certificates not in existing) or update existing ones
+        Map<CreateClientCertificate, String> incomingFingerprints = incoming
+            .stream()
+            .collect(Collectors.toMap(cert -> cert, cert -> fingerprint(cert.certificate())));
+        // Create new certificates (incoming fingerprints not in existing) or update existing ones
         for (CreateClientCertificate incomingCert : incoming) {
-            ClientCertificate existingCert = existingByCertificate.get(incomingCert.certificate());
+            String incomingFingerprint = incomingFingerprints.get(incomingCert);
+            ClientCertificate existingCert = existingByFingerprint.get(incomingFingerprint);
             if (existingCert == null) {
                 // Create new certificate
                 var certToCreate = new ClientCertificate(
@@ -748,7 +749,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     incomingCert.startsAt(),
                     incomingCert.endsAt()
                 );
-                clientCertificateCrudService.create(applicationId, validateAndEnrich(certToCreate, executionContext));
+                clientCertificateCrudService.create(applicationId, validateAndEnrich(certToCreate, executionContext, applicationId));
             } else if (hasChanges(incomingCert, existingCert)) {
                 // Update existing certificate only if there are changes (name, startsAt, endsAt)
                 clientCertificateCrudService.update(
@@ -759,17 +760,28 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
 
         // Delete certificates that are no longer in the incoming list
-        for (ClientCertificate existingCert : existing) {
-            if (!incomingCertificates.contains(existingCert.certificate())) {
-                clientCertificateCrudService.delete(existingCert.id());
+        var newFingerprints = new HashSet<>(incomingFingerprints.values());
+        for (var entry : existingByFingerprint.entrySet()) {
+            var fingerprint = entry.getKey();
+            var clientCertificate = entry.getValue();
+            if (!newFingerprints.contains(fingerprint)) {
+                clientCertificateCrudService.delete(clientCertificate.id());
             }
         }
 
         applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(applicationId);
     }
 
-    private ClientCertificate validateAndEnrich(ClientCertificate certToCreate, ExecutionContext executionContext) {
-        var certInfo = clientCertificateValidationDomainService.validateForCreation(certToCreate, executionContext.getEnvironmentId());
+    private ClientCertificate validateAndEnrich(
+        ClientCertificate certToCreate,
+        ExecutionContext executionContext,
+        String excludeApplicationId
+    ) {
+        var certInfo = clientCertificateValidationDomainService.validateForCreation(
+            certToCreate,
+            executionContext.getEnvironmentId(),
+            excludeApplicationId
+        );
         return new ClientCertificate(
             null,
             null,
@@ -795,6 +807,17 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             !Objects.equals(incoming.startsAt(), existing.startsAt()) ||
             !Objects.equals(incoming.endsAt(), existing.endsAt())
         );
+    }
+
+    private String fingerprint(String certificatePem) {
+        return clientCertificateValidationDomainService.validate(certificatePem).fingerprint();
+    }
+
+    private String fingerprintOf(ClientCertificate certificate) {
+        if (StringUtils.isNotBlank(certificate.fingerprint())) {
+            return certificate.fingerprint();
+        }
+        return fingerprint(certificate.certificate());
     }
 
     private void createAuditLog(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
@@ -194,14 +194,15 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
     }
 
     @Override
-    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId) {
+    public boolean existsByFingerprintAndActiveApplication(String fingerprint, String environmentId, String excludeApplicationId) {
         return storage
             .stream()
             .anyMatch(
                 cert ->
                     fingerprint.equals(cert.fingerprint()) &&
                     environmentId.equals(cert.environmentId()) &&
-                    cert.status() != ClientCertificateStatus.REVOKED
+                    cert.status() != ClientCertificateStatus.REVOKED &&
+                    (excludeApplicationId == null || !excludeApplicationId.equals(cert.applicationId()))
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -24,6 +24,7 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ApplicationMetadataCrudServiceInMemory;
 import inmemory.ApplicationMetadataQueryServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.ImportApplicationCRDDomainServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
@@ -41,6 +42,7 @@ import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.Origin;
 import io.gravitee.repository.management.api.ApplicationRepository;
@@ -113,7 +115,13 @@ class ImportApplicationCRDUseCaseTest {
     private final ValidateApplicationCRDDomainService crdValidator = new ValidateApplicationCRDDomainService(
         new ValidateGroupsDomainService(groupQueryService),
         new ValidateCRDMembersDomainService(userDomainService, roleQueryService),
-        new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, new ApplicationTypeServiceImpl(), parameterService)
+        new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            new ApplicationTypeServiceImpl(),
+            parameterService,
+            new ClientCertificateValidationDomainServiceImpl(new ClientCertificateCrudServiceInMemory()),
+            new ClientCertificateCrudServiceInMemory()
+        )
     );
 
     ImportApplicationCRDUseCase useCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
@@ -212,14 +212,25 @@ class ClientCertificateCrudServiceImplTest {
 
     @Test
     void should_delegate_exists_by_fingerprint_check_to_repository() throws TechnicalException {
-        when(clientCertificateRepository.existsByFingerprintAndActiveApplication("fp-123", ENVIRONMENT_ID)).thenReturn(true);
+        when(clientCertificateRepository.existsByFingerprintAndActiveApplication("fp-123", ENVIRONMENT_ID, null)).thenReturn(true);
 
         assertThat(clientCertificateCrudService.existsByFingerprintAndActiveApplication("fp-123", ENVIRONMENT_ID)).isTrue();
     }
 
     @Test
+    void should_delegate_exists_by_fingerprint_check_with_excluded_application_to_repository() throws TechnicalException {
+        when(clientCertificateRepository.existsByFingerprintAndActiveApplication("fp-123", ENVIRONMENT_ID, APPLICATION_ID)).thenReturn(
+            false
+        );
+
+        assertThat(
+            clientCertificateCrudService.existsByFingerprintAndActiveApplication("fp-123", ENVIRONMENT_ID, APPLICATION_ID)
+        ).isFalse();
+    }
+
+    @Test
     void should_throw_technical_management_exception_when_exists_by_fingerprint_fails() throws TechnicalException {
-        when(clientCertificateRepository.existsByFingerprintAndActiveApplication(any(), any())).thenThrow(
+        when(clientCertificateRepository.existsByFingerprintAndActiveApplication(any(), any(), any())).thenThrow(
             new TechnicalException("Database error")
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -20,9 +20,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
+import inmemory.ClientCertificateCrudServiceInMemory;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
@@ -53,12 +59,24 @@ class ValidateApplicationSettingsDomainServiceImplTest {
 
     private final ApplicationTypeService applicationTypeService = new ApplicationTypeServiceImpl();
 
+    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
+
+    private final ClientCertificateValidationDomainService clientCertificateValidationDomainService =
+        new ClientCertificateValidationDomainServiceImpl(clientCertificateCrudService);
+
     private ValidateApplicationSettingsDomainServiceImpl cut;
 
     @BeforeEach
     void setUp() {
         reset(applicationRepository, parameterService);
-        cut = new ValidateApplicationSettingsDomainServiceImpl(applicationRepository, applicationTypeService, parameterService);
+        clientCertificateCrudService.reset();
+        cut = new ValidateApplicationSettingsDomainServiceImpl(
+            applicationRepository,
+            applicationTypeService,
+            parameterService,
+            clientCertificateValidationDomainService,
+            clientCertificateCrudService
+        );
     }
 
     @Test
@@ -236,6 +254,75 @@ class ValidateApplicationSettingsDomainServiceImplTest {
                 .get()
                 .asInstanceOf(LIST)
                 .anyMatch(e -> ((Validator.Error) e).getMessage().contains("client certificate content must be unique"));
+        }
+
+        @Test
+        void should_reject_certificate_already_used_by_another_application() {
+            var info = clientCertificateValidationDomainService.validate(VALID_PEM);
+            clientCertificateCrudService.initWith(
+                List.of(
+                    new ClientCertificate(
+                        "existing-id",
+                        "cross-id",
+                        "other-app-id",
+                        "Existing",
+                        null,
+                        null,
+                        new Date(),
+                        new Date(),
+                        VALID_PEM,
+                        null,
+                        null,
+                        null,
+                        info.fingerprint(),
+                        "test",
+                        ClientCertificateStatus.ACTIVE
+                    )
+                )
+            );
+
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("cert1", null, null, VALID_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("already used by another active application"));
+        }
+
+        @Test
+        void should_accept_certificate_already_present_on_same_application() {
+            var info = clientCertificateValidationDomainService.validate(VALID_PEM);
+            clientCertificateCrudService.initWith(
+                List.of(
+                    new ClientCertificate(
+                        "existing-id",
+                        "cross-id",
+                        "app-id",
+                        "Existing",
+                        null,
+                        null,
+                        new Date(),
+                        new Date(),
+                        VALID_PEM,
+                        null,
+                        null,
+                        null,
+                        info.fingerprint(),
+                        "test",
+                        ClientCertificateStatus.ACTIVE
+                    )
+                )
+            );
+
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("cert1", null, null, VALID_PEM)))
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isEmpty();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ValidateApplicationSettingsDomainServiceImplTest.java
@@ -17,8 +17,12 @@ package io.gravitee.apim.infra.domain_service.application;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -257,6 +261,24 @@ class ValidateApplicationSettingsDomainServiceImplTest {
         }
 
         @Test
+        void should_reject_duplicated_certificate_with_different_pem_formatting() {
+            var reformattedPem = VALID_PEM.replace("-----BEGIN CERTIFICATE-----\n", "-----BEGIN CERTIFICATE-----\r\n");
+            var tls = TlsSettings.builder()
+                .clientCertificates(
+                    List.of(
+                        new CreateClientCertificate("cert1", null, null, VALID_PEM),
+                        new CreateClientCertificate("cert2", null, null, reformattedPem)
+                    )
+                )
+                .build();
+
+            var result = cut.validateAndSanitize(inputWithTls(tls));
+
+            assertThat(result.severe()).isPresent();
+            assertThat(result.severe().get()).anyMatch(e -> e.getMessage().contains("client certificate content must be unique"));
+        }
+
+        @Test
         void should_reject_certificate_already_used_by_another_application() {
             var info = clientCertificateValidationDomainService.validate(VALID_PEM);
             clientCertificateCrudService.initWith(
@@ -323,6 +345,48 @@ class ValidateApplicationSettingsDomainServiceImplTest {
             var result = cut.validateAndSanitize(inputWithTls(tls));
 
             assertThat(result.severe()).isEmpty();
+        }
+
+        @Test
+        void should_pass_application_id_as_exclude_when_validating_certificate_on_update() {
+            var validationSpy = spy(clientCertificateValidationDomainService);
+            cut = new ValidateApplicationSettingsDomainServiceImpl(
+                applicationRepository,
+                applicationTypeService,
+                parameterService,
+                validationSpy,
+                clientCertificateCrudService
+            );
+
+            clientCertificateCrudService.initWith(
+                List.of(
+                    new ClientCertificate(
+                        "existing-id",
+                        "cross-id",
+                        "app-id",
+                        "Existing",
+                        null,
+                        null,
+                        new Date(),
+                        new Date(),
+                        VALID_PEM,
+                        null,
+                        null,
+                        null,
+                        "stale-fingerprint",
+                        "test",
+                        ClientCertificateStatus.ACTIVE
+                    )
+                )
+            );
+
+            var tls = TlsSettings.builder()
+                .clientCertificates(List.of(new CreateClientCertificate("cert1", null, null, VALID_PEM)))
+                .build();
+
+            cut.validateAndSanitize(inputWithTls(tls));
+
+            verify(validationSpy).validateForCreation(any(ClientCertificate.class), eq("test"), eq("app-id"));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImplTest.java
@@ -190,6 +190,70 @@ class ClientCertificateValidationDomainServiceImplTest {
         }
 
         @Test
+        void should_allow_fingerprint_when_it_belongs_to_excluded_application_on_update() {
+            var info = service.validate(PEM_CERTIFICATE);
+            clientCertificateCrudService.initWith(
+                List.of(
+                    new ClientCertificate(
+                        "existing-id",
+                        "cross-id",
+                        "app-1",
+                        "Existing",
+                        null,
+                        null,
+                        new Date(),
+                        new Date(),
+                        PEM_CERTIFICATE,
+                        null,
+                        null,
+                        null,
+                        info.fingerprint(),
+                        "env-1",
+                        ClientCertificateStatus.ACTIVE
+                    )
+                )
+            );
+
+            var cert = new ClientCertificate("Renamed Cert", PEM_CERTIFICATE, null, null);
+
+            var result = service.validateForCreation(cert, "env-1", "app-1");
+
+            assertThat(result.fingerprint()).isEqualTo(info.fingerprint());
+        }
+
+        @Test
+        void should_still_reject_fingerprint_used_by_another_application_when_excluding_different_application() {
+            var info = service.validate(PEM_CERTIFICATE);
+            clientCertificateCrudService.initWith(
+                List.of(
+                    new ClientCertificate(
+                        "existing-id",
+                        "cross-id",
+                        "app-1",
+                        "Existing",
+                        null,
+                        null,
+                        new Date(),
+                        new Date(),
+                        PEM_CERTIFICATE,
+                        null,
+                        null,
+                        null,
+                        info.fingerprint(),
+                        "env-1",
+                        ClientCertificateStatus.ACTIVE
+                    )
+                )
+            );
+
+            var cert = new ClientCertificate("New Cert", PEM_CERTIFICATE, null, null);
+
+            assertThatThrownBy(() -> service.validateForCreation(cert, "env-1", "app-2")).isInstanceOf(
+                ClientCertificateAlreadyUsedException.class
+            );
+        }
+
+        @Test
         void should_throw_when_starts_at_is_after_ends_at() {
             var startsAt = Date.from(Instant.now().plus(2, ChronoUnit.DAYS));
             var endsAt = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -147,7 +147,7 @@ public class ApplicationService_CreateTest {
     @BeforeEach
     public void setup() {
         GraviteeContext.cleanContext();
-        when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenReturn(VALID_CERT_INFO);
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenReturn(VALID_CERT_INFO);
     }
 
     @Test
@@ -478,7 +478,9 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
         when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
-        when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenThrow(new ClientCertificateInvalidException());
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenThrow(
+            new ClientCertificateInvalidException()
+        );
 
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         Assertions.assertThatThrownBy(() -> applicationService.create(executionContext, newApplication, USER_NAME))
@@ -505,7 +507,9 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
         when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
-        when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenThrow(new ClientCertificateEmptyException());
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenThrow(
+            new ClientCertificateEmptyException()
+        );
 
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         Assertions.assertThatThrownBy(() -> applicationService.create(executionContext, newApplication, USER_NAME))
@@ -524,7 +528,7 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
         when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
-        when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenThrow(
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenThrow(
             ClientCertificateAlreadyUsedException.class
         );
 
@@ -545,7 +549,7 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
         when(applicationConverter.toApplication(any(NewApplicationEntity.class))).thenCallRealMethod();
         when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
-        when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenThrow(
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenThrow(
             new ClientCertificateAuthorityException()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -32,9 +32,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import inmemory.ClientCertificateCrudServiceInMemory;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService.CertificateInfo;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.exceptions.DuplicateKeyException;
@@ -191,7 +193,10 @@ public class ApplicationService_UpdateTest {
 
     @BeforeEach
     public void setUp() {
-        lenient().when(clientCertificateValidationDomainService.validateForCreation(any(), any())).thenReturn(VALID_CERT_INFO);
+        lenient().when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenReturn(VALID_CERT_INFO);
+        lenient()
+            .when(clientCertificateValidationDomainService.validate(any()))
+            .thenAnswer(invocation -> new CertificateInfo(new Date(), "CN=test", "CN=issuer", "fp:" + invocation.getArgument(0)));
     }
 
     @Test
@@ -779,6 +784,132 @@ public class ApplicationService_UpdateTest {
         subscriptionModifierCaptor.getValue().accept(fakeSubscription);
         Assertions.assertThat(fakeSubscription.getClientId()).isEqualTo(CLIENT_ID);
         Assertions.assertThat(fakeSubscription.getApplicationName()).isEqualTo(NEW_APPLICATION_NAME);
+    }
+
+    @Test
+    public void should_allow_certificate_rename_when_fingerprint_already_belongs_to_same_application() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setApp(new SimpleApplicationSettings());
+        settings.setTls(
+            TlsSettings.builder()
+                .clientCertificates(
+                    java.util.List.of(
+                        new io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate("new-name", null, null, VALID_PEM_1)
+                    )
+                )
+                .build()
+        );
+
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+
+        io.gravitee.apim.core.application_certificate.model.ClientCertificate existingCert =
+            new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                "existing-cert-id",
+                null,
+                APPLICATION_ID,
+                "old-name",
+                null,
+                null,
+                new java.util.Date(),
+                new java.util.Date(),
+                VALID_PEM_1,
+                null,
+                null,
+                null,
+                "fp:" + VALID_PEM_1,
+                null,
+                io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.ACTIVE
+            );
+        when(
+            clientCertificateCrudService.findByApplicationIdAndStatuses(
+                any(),
+                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class),
+                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class)
+            )
+        ).thenReturn(java.util.List.of(existingCert));
+
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+
+        verify(clientCertificateCrudService).update(eq("existing-cert-id"), any());
+        verify(clientCertificateCrudService, never()).create(any(), any());
+        verify(clientCertificateValidationDomainService, never()).validateForCreation(any(), any(), any());
+    }
+
+    @Test
+    public void should_create_certificate_during_sync_when_exclude_ignores_same_application_fingerprint() throws TechnicalException {
+        ClientCertificateCrudServiceInMemory backingStore = new ClientCertificateCrudServiceInMemory();
+        ClientCertificateValidationDomainServiceImpl realValidation = new ClientCertificateValidationDomainServiceImpl(backingStore);
+        var certInfo = realValidation.validate(VALID_PEM_1);
+
+        backingStore.initWith(
+            List.of(
+                new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                    "stored-cert-id",
+                    null,
+                    APPLICATION_ID,
+                    "existing",
+                    null,
+                    null,
+                    new java.util.Date(),
+                    new java.util.Date(),
+                    VALID_PEM_1,
+                    null,
+                    null,
+                    null,
+                    certInfo.fingerprint(),
+                    GraviteeContext.getExecutionContext().getEnvironmentId(),
+                    io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.ACTIVE
+                )
+            )
+        );
+
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setApp(new SimpleApplicationSettings());
+        settings.setTls(TlsSettings.builder().clientCertificate(VALID_PEM_1).build());
+
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+
+        io.gravitee.apim.core.application_certificate.model.ClientCertificate staleExisting =
+            new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
+                "stored-cert-id",
+                null,
+                APPLICATION_ID,
+                "existing",
+                null,
+                null,
+                new java.util.Date(),
+                new java.util.Date(),
+                VALID_PEM_1,
+                null,
+                null,
+                null,
+                "stale-fingerprint",
+                null,
+                io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.ACTIVE
+            );
+        when(
+            clientCertificateCrudService.findByApplicationIdAndStatuses(
+                any(),
+                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class),
+                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class)
+            )
+        ).thenReturn(java.util.List.of(staleExisting));
+        when(clientCertificateCrudService.create(eq(APPLICATION_ID), any())).thenAnswer(invocation ->
+            backingStore.create(invocation.getArgument(0), invocation.getArgument(1))
+        );
+        when(clientCertificateValidationDomainService.validate(any())).thenAnswer(invocation ->
+            realValidation.validate(invocation.getArgument(0))
+        );
+        when(clientCertificateValidationDomainService.validateForCreation(any(), any(), any())).thenAnswer(invocation ->
+            realValidation.validateForCreation(invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2))
+        );
+
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+
+        verify(clientCertificateCrudService).create(eq(APPLICATION_ID), any());
+        verify(clientCertificateValidationDomainService).validateForCreation(any(), any(), eq(APPLICATION_ID));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-3217
https://gravitee.atlassian.net/browse/GKO-2442

## Summary

- **GKO-3217** — Application PUT `dryRun` did not reject client certificates already used by another active application. Wired `ClientCertificateValidationDomainService` into `ValidateApplicationSettingsDomainService` so CRD dryrun matches `ApplicationService` import behaviour.
- **GKO-2442** — Certificate sync and CRD validation compared raw PEM strings. Switched to SHA-256 fingerprint matching in `syncClientCertificates` and application settings validation (in-spec duplicates, update skip).

## Test plan

- [x] `ValidateApplicationSettingsDomainServiceImplTest`
- [x] `ImportApplicationCRDUseCaseTest`
- [x] `ApplicationService_UpdateTest` (syncClientCertificates)
- [x] `ApplicationsResourceTest`