### PR TITLE
chore(deps): bump gravitee-policy-oas-validation to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <gravitee-policy-mock.version>1.15.0</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>3.0.0</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>5.2.1</gravitee-policy-oauth2.version>
-        <gravitee-policy-oas-validation.version>2.0.2</gravitee-policy-oas-validation.version>
+        <gravitee-policy-oas-validation.version>2.0.3</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
Issue
https://gravitee.atlassian.net/browse/APIM-15021

Description
bump gravitee-policy-oas-validation to 2.0.3

Reference PR : https://github.com/gravitee-io/gravitee-policy-oas-validation/pull/61

