### PR TITLE
feat(rest-api): expose performance targets on management api v2

### DIFF
--- a/gravitee-apim-common/src/main/java/io/gravitee/apim/core/exception/TooManyRequestsDomainException.java
+++ b/gravitee-apim-common/src/main/java/io/gravitee/apim/core/exception/TooManyRequestsDomainException.java
@@ -13,23 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.performance_target.exception;
+package io.gravitee.apim.core.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
-import java.util.Map;
+import java.time.Duration;
+import lombok.Getter;
 
-public class InvalidPerformanceTargetException extends ValidationDomainException {
+/**
+ * The operation was requested again before the delay it enforces between two runs had elapsed.
+ */
+@Getter
+public class TooManyRequestsDomainException extends AbstractDomainException {
 
-    public static final String RULE_INDEX_PARAMETER = "ruleIndex";
+    private final Duration retryAfter;
 
-    public InvalidPerformanceTargetException(String message) {
+    public TooManyRequestsDomainException(String message, Duration retryAfter) {
         super(message);
-    }
-
-    /**
-     * @param ruleIndex the position, in the target's rules, of the rule the message is about
-     */
-    public InvalidPerformanceTargetException(String message, int ruleIndex) {
-        super(message, Map.of(RULE_INDEX_PARAMETER, String.valueOf(ruleIndex)));
+        this.retryAfter = retryAfter;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
@@ -42,6 +42,11 @@ public interface PerformanceTargetEvaluationRepository {
      */
     Page<PerformanceTargetEvaluation> findEnvironmentLatest(String environmentId, Pageable pageable) throws TechnicalException;
 
+    /**
+     * @return the stored evaluations of the target, most recently evaluated first
+     */
+    Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable) throws TechnicalException;
+
     PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId) throws TechnicalException;
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
@@ -150,24 +150,36 @@ public class JdbcPerformanceTargetEvaluationRepository
     public Page<PerformanceTargetEvaluation> findEnvironmentLatest(String environmentId, Pageable pageable) throws TechnicalException {
         log.debug("JdbcPerformanceTargetEvaluationRepository.findEnvironmentLatest({})", environmentId);
         try {
-            var where = " where environment_id = ? and latest = ?";
-            Long total = jdbcTemplate.queryForObject("select count(*) from " + this.tableName + where, Long.class, environmentId, true);
-            if (total == null || total == 0) {
-                return new Page<>(List.of(), pageable.pageNumber(), 0, 0);
-            }
-            var content = jdbcTemplate.query(
-                getOrm().getSelectAllSql() +
-                    where +
-                    " order by evaluated_at desc, id " +
-                    createPagingClause(pageable.pageSize(), pageable.from()),
-                getRowMapper(),
-                environmentId,
-                true
-            );
-            return new Page<>(content, pageable.pageNumber(), content.size(), total);
+            return pageMostRecentFirst(" where environment_id = ? and latest = ?", pageable, environmentId, true);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to find latest performance target evaluations of environment " + environmentId, ex);
         }
+    }
+
+    @Override
+    public Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable) throws TechnicalException {
+        log.debug("JdbcPerformanceTargetEvaluationRepository.findByTargetId({})", targetId);
+        try {
+            return pageMostRecentFirst(" where target_id = ?", pageable, targetId);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find performance target evaluations of target " + targetId, ex);
+        }
+    }
+
+    private Page<PerformanceTargetEvaluation> pageMostRecentFirst(String where, Pageable pageable, Object... args) {
+        Long total = jdbcTemplate.queryForObject("select count(*) from " + this.tableName + where, Long.class, args);
+        if (total == null || total == 0) {
+            return new Page<>(List.of(), pageable.pageNumber(), 0, 0);
+        }
+        var content = jdbcTemplate.query(
+            getOrm().getSelectAllSql() +
+                where +
+                " order by evaluated_at desc, id " +
+                createPagingClause(pageable.pageSize(), pageable.from()),
+            getRowMapper(),
+            args
+        );
+        return new Page<>(content, pageable.pageNumber(), content.size(), total);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
@@ -72,7 +72,16 @@ class MongoPerformanceTargetEvaluationRepository implements PerformanceTargetEva
     @Override
     public Page<PerformanceTargetEvaluation> findEnvironmentLatest(String environmentId, Pageable pageable) throws TechnicalException {
         log.debug("Find latest performance target evaluations of environment [{}]", environmentId);
-        var page = internalRepository.findEnvironmentLatest(environmentId, pageable);
+        return map(internalRepository.findEnvironmentLatest(environmentId, pageable));
+    }
+
+    @Override
+    public Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable) throws TechnicalException {
+        log.debug("Find performance target evaluations of target [{}]", targetId);
+        return map(internalRepository.findByTargetId(targetId, pageable));
+    }
+
+    private Page<PerformanceTargetEvaluation> map(Page<PerformanceTargetEvaluationMongo> page) {
         return new Page<>(
             page.getContent().stream().map(mapper::map).toList(),
             page.getPageNumber(),

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
@@ -25,5 +25,7 @@ public interface PerformanceTargetEvaluationMongoRepositoryCustom {
 
     Page<PerformanceTargetEvaluationMongo> findEnvironmentLatest(String environmentId, Pageable pageable);
 
+    Page<PerformanceTargetEvaluationMongo> findByTargetId(String targetId, Pageable pageable);
+
     PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 
@@ -53,10 +54,18 @@ public class PerformanceTargetEvaluationMongoRepositoryImpl implements Performan
 
     @Override
     public Page<PerformanceTargetEvaluationMongo> findEnvironmentLatest(String environmentId, Pageable pageable) {
-        var latestOfEnvironment = query(where("environmentId").is(environmentId).and("latest").is(true));
-        long total = mongoTemplate.count(latestOfEnvironment, PerformanceTargetEvaluationMongo.class);
+        return pageMostRecentFirst(query(where("environmentId").is(environmentId).and("latest").is(true)), pageable);
+    }
+
+    @Override
+    public Page<PerformanceTargetEvaluationMongo> findByTargetId(String targetId, Pageable pageable) {
+        return pageMostRecentFirst(query(where("targetId").is(targetId)), pageable);
+    }
+
+    private Page<PerformanceTargetEvaluationMongo> pageMostRecentFirst(Query query, Pageable pageable) {
+        long total = mongoTemplate.count(query, PerformanceTargetEvaluationMongo.class);
         var content = mongoTemplate.find(
-            latestOfEnvironment
+            query
                 .with(Sort.by(Sort.Order.desc("evaluatedAt"), Sort.Order.asc("_id")))
                 .skip((long) pageable.pageNumber() * pageable.pageSize())
                 .limit(pageable.pageSize()),

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
@@ -161,6 +161,34 @@ public class PerformanceTargetEvaluationRepositoryTest extends AbstractManagemen
         assertThat(page.getContent()).isEmpty();
     }
 
+    // findByTargetId
+    @Test
+    public void findByTargetId_should_page_history_most_recent_first() throws TechnicalException {
+        var firstPage = performanceTargetEvaluationRepository.findByTargetId(
+            "target1",
+            new PageableBuilder().pageNumber(0).pageSize(1).build()
+        );
+        var secondPage = performanceTargetEvaluationRepository.findByTargetId(
+            "target1",
+            new PageableBuilder().pageNumber(1).pageSize(1).build()
+        );
+
+        assertThat(firstPage.getTotalElements()).isEqualTo(2);
+        assertThat(firstPage.getContent()).extracting(PerformanceTargetEvaluation::getId).containsExactly("eval-1b");
+        assertThat(secondPage.getContent()).extracting(PerformanceTargetEvaluation::getId).containsExactly("eval-1a");
+    }
+
+    @Test
+    public void findByTargetId_should_return_empty_page_for_unknown_target() throws TechnicalException {
+        var page = performanceTargetEvaluationRepository.findByTargetId(
+            "unknown",
+            new PageableBuilder().pageNumber(0).pageSize(10).build()
+        );
+
+        assertThat(page.getTotalElements()).isZero();
+        assertThat(page.getContent()).isEmpty();
+    }
+
     // getEnvironmentSummary
     @Test
     public void getEnvironmentSummary_should_count_latest_evaluations_by_status() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -36,6 +36,11 @@ tags:
     description: Everything about shared policy groups
   - name: Scoring
     description: Everything about APIs scoring
+  - name: Performance Targets
+    description: |-
+      Declared performance expectations (latency, error rate, cost...) evaluated against gateway telemetry.
+      A target applies to a subject: the API ids whose traffic is evaluated, and a reference chosen by the caller
+      (an API id, an agent catalog id) to find its targets again.
   - name: Clusters
     description: Everything about clusters
   - name: Newt Ai
@@ -479,6 +484,215 @@ paths:
       responses:
         "204":
           description: Scoring function deleted
+        default:
+          $ref: "#/components/responses/Error"
+
+  # Performance Targets
+  /performance-targets:
+    post:
+      tags:
+        - Performance Targets
+      summary: Create a performance target
+      description: |-
+        Declares what "good" looks like for a subject. Rules are validated against the analytics definition of the
+        API types listed in the subject: a rule whose metric, measure or filter is not available for those types is
+        refused with a 400 error carrying the index of the failing rule in the `ruleIndex` parameter.
+      operationId: createPerformanceTarget
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePerformanceTarget"
+        required: true
+      responses:
+        "201":
+          description: Performance target created
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URL of the created target
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTarget"
+        default:
+          $ref: "#/components/responses/Error"
+    get:
+      tags:
+        - Performance Targets
+      summary: Get the performance targets of a reference
+      description: Lists the targets created with the given `subject.reference` in this environment.
+      operationId: getPerformanceTargetsByReference
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetReference"
+      responses:
+        "200":
+          $ref: "#/components/responses/PerformanceTargetsResponse"
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/_summary:
+    get:
+      tags:
+        - Performance Targets
+      summary: Count the performance targets of the environment by status
+      description: Counts the latest evaluation of every target of the environment by status.
+      operationId: getPerformanceTargetsSummary
+      responses:
+        "200":
+          description: Counts by status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTargetsSummary"
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/evaluations/_latest:
+    post:
+      tags:
+        - Performance Targets
+      summary: Get the latest evaluation of several references
+      description: |-
+        Returns one entry per requested reference, keyed by reference. The value is the latest evaluation of the
+        reference (the worst one when several targets share the reference), or `null` when the reference has no
+        target or no evaluation yet. Meant for list badges.
+      operationId: getLatestPerformanceTargetEvaluations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LatestPerformanceTargetEvaluationsRequest"
+        required: true
+      responses:
+        "200":
+          description: Latest evaluation per reference
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LatestPerformanceTargetEvaluationsResponse"
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/{targetId}:
+    get:
+      tags:
+        - Performance Targets
+      summary: Get a performance target
+      operationId: getPerformanceTarget
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+      responses:
+        "200":
+          description: Performance target found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTarget"
+        default:
+          $ref: "#/components/responses/Error"
+    put:
+      tags:
+        - Performance Targets
+      summary: Update a performance target
+      description: Replaces the subject, schedule and rules of the target. The same validation as creation applies.
+      operationId: updatePerformanceTarget
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePerformanceTarget"
+        required: true
+      responses:
+        "200":
+          description: Performance target updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTarget"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      tags:
+        - Performance Targets
+      summary: Delete a performance target and its evaluations
+      operationId: deletePerformanceTarget
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+      responses:
+        "204":
+          description: Performance target deleted
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/{targetId}/evaluations:
+    get:
+      tags:
+        - Performance Targets
+      summary: Get the evaluation history of a performance target
+      description: The stored evaluations of the target, most recent first. History is bounded by the evaluator.
+      operationId: getPerformanceTargetEvaluations
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+        - $ref: "#/components/parameters/pageParam"
+        - $ref: "#/components/parameters/perPageParam"
+      responses:
+        "200":
+          $ref: "#/components/responses/PerformanceTargetEvaluationsResponse"
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/{targetId}/evaluations/latest:
+    get:
+      tags:
+        - Performance Targets
+      summary: Get the latest evaluation of a performance target
+      operationId: getLatestPerformanceTargetEvaluation
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+      responses:
+        "200":
+          description: Latest evaluation of the target
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTargetEvaluation"
+        "404":
+          description: The target does not exist or has not been evaluated yet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          $ref: "#/components/responses/Error"
+  /performance-targets/{targetId}/_evaluate:
+    post:
+      tags:
+        - Performance Targets
+      summary: Evaluate a performance target now
+      description: |-
+        Runs the same evaluation as the scheduler, stores the result as the target's latest evaluation and returns
+        it. Refused with a 429 error while the target was evaluated less than 30 seconds ago; the `Retry-After`
+        header says how long to wait.
+      operationId: evaluatePerformanceTarget
+      parameters:
+        - $ref: "#/components/parameters/performanceTargetId"
+      responses:
+        "200":
+          description: The stored evaluation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PerformanceTargetEvaluation"
+        "429":
+          description: The target was evaluated too recently
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before evaluating again
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/Error"
 
@@ -2058,6 +2272,300 @@ components:
       pattern: '^[^/]+\.js$'
       description: The name of ruleset
 
+    # Performance Targets
+    PerformanceTargetSubject:
+      type: object
+      description: What a target applies to.
+      properties:
+        apiIds:
+          type: array
+          description: |-
+            The API ids whose gateway telemetry is evaluated. One id for an API target; the APIs an agent depends on
+            for an agent target. May be empty when the dependencies are not known yet: every rule is then
+            NOT_EVALUABLE.
+          items:
+            type: string
+        reference:
+          type: string
+          minLength: 1
+          description: |-
+            An opaque lookup key chosen by the caller (an API id, an agent catalog id) to find its targets again.
+            Stored and indexed, never interpreted.
+      required:
+        - apiIds
+        - reference
+    PerformanceTargetOperator:
+      type: string
+      description: How the observed value is compared to the threshold; the rule passes when the comparison holds.
+      enum:
+        - LT
+        - LTE
+        - GT
+        - GTE
+    PerformanceTargetFilterOperator:
+      type: string
+      description: Operator of a rule filter, from the analytics engine filter vocabulary.
+      enum:
+        - EQ
+        - IN
+        - LTE
+        - GTE
+        - CONTAINS
+    PerformanceTargetRuleFilter:
+      type: object
+      description: Narrows the measure of a rule using the analytics engine filter vocabulary, e.g. `MCP_PROXY_TOOL EQ search`.
+      properties:
+        name:
+          type: string
+          description: A filter name of the analytics definition, e.g. `MCP_PROXY_TOOL`
+        operator:
+          $ref: "#/components/schemas/PerformanceTargetFilterOperator"
+        value:
+          description: The filter value; a string, a number or an array of strings depending on the operator.
+      required:
+        - name
+        - operator
+        - value
+    PerformanceTargetRule:
+      type: object
+      description: |-
+        One expectation: a measure of a metric of the analytics definition compared to a threshold, e.g.
+        `HTTP_GATEWAY_RESPONSE_TIME P95 LTE 2000`.
+      properties:
+        metric:
+          type: string
+          description: A metric name of the analytics definition, e.g. `HTTP_GATEWAY_RESPONSE_TIME`
+        measure:
+          type: string
+          description: A measure of that metric, e.g. `P95`
+        operator:
+          $ref: "#/components/schemas/PerformanceTargetOperator"
+        threshold:
+          type: number
+          format: double
+          description: The boundary of acceptable behaviour, in the metric's unit
+        apiTypes:
+          type: array
+          description: |-
+            Restricts the rule to the subject ids of these API types, e.g. latency on `A2A_PROXY` only. Empty means
+            the whole subject.
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/ApiType"
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/PerformanceTargetRuleFilter"
+      required:
+        - metric
+        - measure
+        - operator
+        - threshold
+    CreatePerformanceTarget:
+      type: object
+      description: The performance target to create
+      properties:
+        subject:
+          $ref: "#/components/schemas/PerformanceTargetSubject"
+        windowSeconds:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 900
+          description: The rolling window evaluated, in seconds. Must be at least the interval.
+        intervalSeconds:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 300
+          description: How often the target is evaluated, in seconds
+        minSampleSize:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 20
+          description: Below this many samples in the window a rule is NOT_EVALUABLE rather than PASS
+        rules:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/PerformanceTargetRule"
+      required:
+        - subject
+        - rules
+    UpdatePerformanceTarget:
+      type: object
+      description: The new subject, schedule and rules of a performance target
+      properties:
+        subject:
+          $ref: "#/components/schemas/PerformanceTargetSubject"
+        windowSeconds:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 900
+          description: The rolling window evaluated, in seconds. Must be at least the interval.
+        intervalSeconds:
+          type: integer
+          format: int64
+          minimum: 1
+          default: 300
+          description: How often the target is evaluated, in seconds
+        minSampleSize:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 20
+          description: Below this many samples in the window a rule is NOT_EVALUABLE rather than PASS
+        rules:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/PerformanceTargetRule"
+      required:
+        - subject
+        - rules
+    PerformanceTarget:
+      type: object
+      description: A performance target
+      properties:
+        id:
+          type: string
+        subject:
+          $ref: "#/components/schemas/PerformanceTargetSubject"
+        windowSeconds:
+          type: integer
+          format: int64
+          description: The rolling window evaluated, in seconds
+        intervalSeconds:
+          type: integer
+          format: int64
+          description: How often the target is evaluated, in seconds
+        minSampleSize:
+          type: integer
+          format: int32
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/PerformanceTargetRule"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    PerformanceTargetEvaluationStatus:
+      type: string
+      description: |-
+        PASS when the rule holds, BREACH when it does not, NOT_EVALUABLE when the window has fewer samples than
+        the target's minimum or no data at all. A target's status is the worst of its rules.
+      enum:
+        - PASS
+        - BREACH
+        - NOT_EVALUABLE
+    PerformanceTargetDeviation:
+      type: object
+      description: How far the observed value is from the threshold
+      properties:
+        absolute:
+          type: number
+          format: double
+          description: Observed minus threshold, in the metric's unit
+        ratio:
+          type: number
+          format: double
+          description: Absolute deviation relative to the threshold
+    PerformanceTargetRuleResult:
+      type: object
+      description: The outcome of one rule over the evaluated window
+      properties:
+        metric:
+          type: string
+        measure:
+          type: string
+        operator:
+          $ref: "#/components/schemas/PerformanceTargetOperator"
+        threshold:
+          type: number
+          format: double
+        observed:
+          type: number
+          format: double
+          description: The measured value; absent when the rule is NOT_EVALUABLE
+        deviation:
+          $ref: "#/components/schemas/PerformanceTargetDeviation"
+        sampleCount:
+          type: integer
+          format: int64
+          description: How many samples the window held for this rule
+        status:
+          $ref: "#/components/schemas/PerformanceTargetEvaluationStatus"
+    PerformanceTargetEvaluation:
+      type: object
+      description: The outcome of evaluating one target over one window
+      properties:
+        id:
+          type: string
+        targetId:
+          type: string
+        reference:
+          type: string
+          description: The subject reference of the target at evaluation time
+        status:
+          $ref: "#/components/schemas/PerformanceTargetEvaluationStatus"
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/PerformanceTargetRuleResult"
+        windowFrom:
+          type: string
+          format: date-time
+        windowTo:
+          type: string
+          format: date-time
+        coveredApiIds:
+          type: array
+          description: The API ids the evaluation actually covered, so a lagging subject is visible
+          items:
+            type: string
+        evaluatedAt:
+          type: string
+          format: date-time
+    PerformanceTargetsSummary:
+      type: object
+      description: How many targets of the environment currently pass, miss, or cannot be evaluated
+      properties:
+        pass:
+          type: integer
+          format: int64
+        breach:
+          type: integer
+          format: int64
+        notEvaluable:
+          type: integer
+          format: int64
+    LatestPerformanceTargetEvaluationsRequest:
+      type: object
+      properties:
+        references:
+          type: array
+          description: The subject references to look up
+          minItems: 1
+          maxItems: 500
+          uniqueItems: true
+          items:
+            type: string
+      required:
+        - references
+    LatestPerformanceTargetEvaluationsResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: The latest evaluation of each requested reference, `null` when it has none
+          additionalProperties:
+            $ref: "#/components/schemas/PerformanceTargetEvaluation"
+
     ApiType:
       type: string
       description: API's type.
@@ -3357,6 +3865,22 @@ components:
       schema:
         $ref: "#/components/schemas/ScoringFunctionName"
 
+    # Performance Targets
+    performanceTargetId:
+      name: targetId
+      in: path
+      description: The unique ID of the performance target
+      required: true
+      schema:
+        type: string
+    performanceTargetReference:
+      name: reference
+      in: query
+      description: The subject reference the targets were created with
+      required: true
+      schema:
+        type: string
+
     # Cluster
     clusterId:
       name: clusterId
@@ -3730,6 +4254,35 @@ components:
                 type: array
                 items:
                   $ref: "#/components/schemas/ScoringFunction"
+
+    # Performance Targets
+    PerformanceTargetsResponse:
+      description: Performance targets list
+      content:
+        application/json:
+          schema:
+            title: "PerformanceTargetsResponse"
+            properties:
+              data:
+                description: The targets of the reference
+                type: array
+                items:
+                  $ref: "#/components/schemas/PerformanceTarget"
+    PerformanceTargetEvaluationsResponse:
+      description: Page of performance target evaluations, most recent first
+      content:
+        application/json:
+          schema:
+            title: "PerformanceTargetEvaluationsResponse"
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PerformanceTargetEvaluation"
+              pagination:
+                $ref: "#/components/schemas/Pagination"
+              links:
+                $ref: "#/components/schemas/Links"
 
     # NewAI
     GenerateExpressionLanguageResponse:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.ConflictDo
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.NotAllowedDomainExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.NotFoundDomainExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.TechnicalDomainExceptionMapper;
+import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.TooManyRequestsDomainExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain.ValidationDomainExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.provider.ByteArrayOutputStreamWriter;
 import io.gravitee.rest.api.management.v2.rest.provider.CommaSeparatedQueryParamConverterProvider;
@@ -117,6 +118,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(NotAllowedDomainExceptionMapper.class);
         register(NotFoundDomainExceptionMapper.class);
         register(ConflictDomainExceptionMapper.class);
+        register(TooManyRequestsDomainExceptionMapper.class);
 
         register(CommaSeparatedQueryParamConverterProvider.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionmapper/domain/TooManyRequestsDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionmapper/domain/TooManyRequestsDomainExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionmapper.domain;
+
+import io.gravitee.apim.core.exception.TooManyRequestsDomainException;
+import io.gravitee.common.http.HttpStatusCode;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+public class TooManyRequestsDomainExceptionMapper extends AbstractDomainExceptionMapper<TooManyRequestsDomainException> {
+
+    @Override
+    public Response toResponse(TooManyRequestsDomainException exception) {
+        var response = Response.status(HttpStatusCode.TOO_MANY_REQUESTS_429)
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(convert(exception, HttpStatusCode.TOO_MANY_REQUESTS_429));
+        if (exception.getRetryAfter() != null) {
+            response.header(HttpHeaders.RETRY_AFTER, retryAfterSeconds(exception));
+        }
+        return response.build();
+    }
+
+    /**
+     * Retry-After is expressed in whole seconds; round up so that a client honoring it never retries too early.
+     */
+    private static long retryAfterSeconds(TooManyRequestsDomainException exception) {
+        return Math.max(1, (long) Math.ceil(exception.getRetryAfter().toMillis() / 1000.0));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PerformanceTargetMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PerformanceTargetMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.performance_target.exception.InvalidPerformanceTargetException;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEnvironmentSummary;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetDeviation;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetRule;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetRuleResult;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetSubject;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetsSummary;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePerformanceTarget;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = { DateMapper.class })
+public interface PerformanceTargetMapper {
+    PerformanceTargetMapper INSTANCE = Mappers.getMapper(PerformanceTargetMapper.class);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "window", source = "windowSeconds")
+    @Mapping(target = "interval", source = "intervalSeconds")
+    PerformanceTarget map(CreatePerformanceTarget source);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "window", source = "windowSeconds")
+    @Mapping(target = "interval", source = "intervalSeconds")
+    PerformanceTarget map(UpdatePerformanceTarget source);
+
+    @Mapping(target = "windowSeconds", source = "window")
+    @Mapping(target = "intervalSeconds", source = "interval")
+    io.gravitee.rest.api.management.v2.rest.model.PerformanceTarget map(PerformanceTarget source);
+
+    PerformanceTarget.Subject map(PerformanceTargetSubject source);
+
+    PerformanceTargetSubject map(PerformanceTarget.Subject source);
+
+    PerformanceTarget.Rule map(PerformanceTargetRule source);
+
+    PerformanceTargetRule map(PerformanceTarget.Rule source);
+
+    io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation map(PerformanceTargetEvaluation source);
+
+    PerformanceTargetRuleResult map(PerformanceTargetEvaluation.RuleResult source);
+
+    PerformanceTargetDeviation map(PerformanceTargetEvaluation.Deviation source);
+
+    PerformanceTargetsSummary map(PerformanceTargetEnvironmentSummary source);
+
+    /**
+     * Maps rule by rule so that a vocabulary error names the failing rule, as the validation does.
+     */
+    default List<PerformanceTarget.Rule> mapRules(List<PerformanceTargetRule> rules) {
+        var mapped = new ArrayList<PerformanceTarget.Rule>(rules.size());
+        for (int ruleIndex = 0; ruleIndex < rules.size(); ruleIndex++) {
+            try {
+                mapped.add(map(rules.get(ruleIndex)));
+            } catch (InvalidPerformanceTargetException e) {
+                throw new InvalidPerformanceTargetException(e.getMessage(), ruleIndex);
+            }
+        }
+        return mapped;
+    }
+
+    default MetricSpec.Name toMetricName(String metric) {
+        return toName(metric, MetricSpec.Name::valueOf, "metric");
+    }
+
+    default MetricSpec.Measure toMeasure(String measure) {
+        return toName(measure, MetricSpec.Measure::valueOf, "measure");
+    }
+
+    default FilterSpec.Name toFilterName(String filter) {
+        return toName(filter, FilterSpec.Name::valueOf, "filter");
+    }
+
+    private static <T extends Enum<T>> T toName(String value, Function<String, T> valueOf, String kind) {
+        try {
+            return valueOf.apply(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidPerformanceTargetException("Unknown %s %s".formatted(kind, value));
+        }
+    }
+
+    default Duration toDuration(Long seconds) {
+        return seconds == null ? null : Duration.ofSeconds(seconds);
+    }
+
+    default Long toSeconds(Duration duration) {
+        return duration == null ? null : duration.getSeconds();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetResource.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.performance_target.use_case.DeletePerformanceTargetUseCase;
+import io.gravitee.apim.core.performance_target.use_case.EvaluatePerformanceTargetUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetLatestPerformanceTargetEvaluationUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetPerformanceTargetEvaluationHistoryUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetPerformanceTargetUseCase;
+import io.gravitee.apim.core.performance_target.use_case.UpdatePerformanceTargetUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.PerformanceTargetMapper;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluationsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class EnvironmentPerformanceTargetResource extends AbstractResource {
+
+    @PathParam("targetId")
+    private String targetId;
+
+    @Inject
+    private GetPerformanceTargetUseCase getPerformanceTargetUseCase;
+
+    @Inject
+    private UpdatePerformanceTargetUseCase updatePerformanceTargetUseCase;
+
+    @Inject
+    private DeletePerformanceTargetUseCase deletePerformanceTargetUseCase;
+
+    @Inject
+    private GetLatestPerformanceTargetEvaluationUseCase getLatestPerformanceTargetEvaluationUseCase;
+
+    @Inject
+    private GetPerformanceTargetEvaluationHistoryUseCase getPerformanceTargetEvaluationHistoryUseCase;
+
+    @Inject
+    private EvaluatePerformanceTargetUseCase evaluatePerformanceTargetUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public PerformanceTarget getPerformanceTarget() {
+        var target = getPerformanceTargetUseCase.execute(new GetPerformanceTargetUseCase.Input(environmentId(), targetId)).target();
+        return PerformanceTargetMapper.INSTANCE.map(target);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.UPDATE }) })
+    public PerformanceTarget updatePerformanceTarget(@Valid @NotNull UpdatePerformanceTarget request) {
+        var updated = updatePerformanceTargetUseCase
+            .execute(new UpdatePerformanceTargetUseCase.Input(environmentId(), targetId, PerformanceTargetMapper.INSTANCE.map(request)))
+            .target();
+        return PerformanceTargetMapper.INSTANCE.map(updated);
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.DELETE }) })
+    public Response deletePerformanceTarget() {
+        deletePerformanceTargetUseCase.execute(new DeletePerformanceTargetUseCase.Input(environmentId(), targetId));
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("_evaluate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.UPDATE }) })
+    public PerformanceTargetEvaluation evaluatePerformanceTarget() {
+        var evaluation = evaluatePerformanceTargetUseCase
+            .execute(new EvaluatePerformanceTargetUseCase.Input(environmentId(), targetId))
+            .evaluation();
+        return PerformanceTargetMapper.INSTANCE.map(evaluation);
+    }
+
+    @GET
+    @Path("evaluations/latest")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public PerformanceTargetEvaluation getLatestEvaluation() {
+        var latest = getLatestPerformanceTargetEvaluationUseCase
+            .execute(new GetLatestPerformanceTargetEvaluationUseCase.Input(environmentId(), targetId))
+            .evaluation();
+        return PerformanceTargetMapper.INSTANCE.map(latest);
+    }
+
+    @GET
+    @Path("evaluations")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public PerformanceTargetEvaluationsResponse getEvaluations(@BeanParam @Valid PaginationParam paginationParam) {
+        var page = getPerformanceTargetEvaluationHistoryUseCase
+            .execute(
+                new GetPerformanceTargetEvaluationHistoryUseCase.Input(
+                    environmentId(),
+                    targetId,
+                    new PageableImpl(paginationParam.getPage(), paginationParam.getPerPage())
+                )
+            )
+            .evaluations();
+
+        return new PerformanceTargetEvaluationsResponse()
+            .data(page.getContent().stream().map(PerformanceTargetMapper.INSTANCE::map).toList())
+            .pagination(
+                PaginationInfo.computePaginationInfo(page.getTotalElements(), Math.toIntExact(page.getPageElements()), paginationParam)
+            )
+            .links(computePaginationLinks(page.getTotalElements(), paginationParam));
+    }
+
+    private static String environmentId() {
+        return GraviteeContext.getExecutionContext().getEnvironmentId();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetsResource.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.performance_target.use_case.CreatePerformanceTargetUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetLatestPerformanceTargetEvaluationsByReferencesUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetPerformanceTargetsByReferenceUseCase;
+import io.gravitee.apim.core.performance_target.use_case.GetPerformanceTargetsSummaryUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.PerformanceTargetMapper;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.LatestPerformanceTargetEvaluationsRequest;
+import io.gravitee.rest.api.management.v2.rest.model.LatestPerformanceTargetEvaluationsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetsSummary;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashMap;
+
+public class EnvironmentPerformanceTargetsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreatePerformanceTargetUseCase createPerformanceTargetUseCase;
+
+    @Inject
+    private GetPerformanceTargetsByReferenceUseCase getPerformanceTargetsByReferenceUseCase;
+
+    @Inject
+    private GetPerformanceTargetsSummaryUseCase getPerformanceTargetsSummaryUseCase;
+
+    @Inject
+    private GetLatestPerformanceTargetEvaluationsByReferencesUseCase getLatestPerformanceTargetEvaluationsByReferencesUseCase;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.CREATE }) })
+    public Response createPerformanceTarget(@Valid @NotNull CreatePerformanceTarget request) {
+        var created = createPerformanceTargetUseCase
+            .execute(new CreatePerformanceTargetUseCase.Input(PerformanceTargetMapper.INSTANCE.map(request), getAuditInfo()))
+            .target();
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(created.id()).build())
+            .entity(PerformanceTargetMapper.INSTANCE.map(created))
+            .build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public PerformanceTargetsResponse getPerformanceTargetsByReference(@QueryParam("reference") @NotEmpty String reference) {
+        var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+        var targets = getPerformanceTargetsByReferenceUseCase
+            .execute(new GetPerformanceTargetsByReferenceUseCase.Input(environmentId, reference))
+            .targets();
+        return new PerformanceTargetsResponse().data(targets.stream().map(PerformanceTargetMapper.INSTANCE::map).toList());
+    }
+
+    @GET
+    @Path("_summary")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public PerformanceTargetsSummary getPerformanceTargetsSummary() {
+        var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+        var summary = getPerformanceTargetsSummaryUseCase.execute(new GetPerformanceTargetsSummaryUseCase.Input(environmentId)).summary();
+        return PerformanceTargetMapper.INSTANCE.map(summary);
+    }
+
+    @POST
+    @Path("evaluations/_latest")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
+    public LatestPerformanceTargetEvaluationsResponse getLatestEvaluations(
+        @Valid @NotNull LatestPerformanceTargetEvaluationsRequest request
+    ) {
+        var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+        var latestByReference = getLatestPerformanceTargetEvaluationsByReferencesUseCase
+            .execute(new GetLatestPerformanceTargetEvaluationsByReferencesUseCase.Input(environmentId, request.getReferences()))
+            .latestByReference();
+
+        var data = new LinkedHashMap<String, PerformanceTargetEvaluation>();
+        latestByReference.forEach((reference, evaluation) ->
+            data.put(reference, evaluation == null ? null : PerformanceTargetMapper.INSTANCE.map(evaluation))
+        );
+        return new LatestPerformanceTargetEvaluationsResponse().data(data);
+    }
+
+    @Path("{targetId}")
+    public EnvironmentPerformanceTargetResource getEnvironmentPerformanceTargetResource() {
+        return resourceContext.getResource(EnvironmentPerformanceTargetResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.cluster.ClustersResource
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentAnalyticsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentLogsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentNewtAIResource;
+import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentPerformanceTargetsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.EnvironmentScoringResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.PortalCategoriesResource;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.PortalNavigationItemsResource;
@@ -104,6 +105,11 @@ public class EnvironmentResource extends AbstractResource {
     @Path("/scoring")
     public EnvironmentScoringResource getEnvironmentScoringResource() {
         return resourceContext.getResource(EnvironmentScoringResource.class);
+    }
+
+    @Path("/performance-targets")
+    public EnvironmentPerformanceTargetsResource getEnvironmentPerformanceTargetsResource() {
+        return resourceContext.getResource(EnvironmentPerformanceTargetsResource.class);
     }
 
     @Path("/analytics")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetResourceTest.java
@@ -1,0 +1,487 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.PerformanceTargetCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetDeviation;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluationStatus;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluationsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetOperator;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetRule;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetRuleResult;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetSubject;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentPerformanceTargetResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "environment-id";
+    private static final String A2A_API = "a2a-api";
+    private static final String LLM_API = "llm-api";
+    private static final String TARGET_ID = "target-id";
+    private static final Instant NOW = Instant.parse("2021-06-01T10:00:00.00Z");
+    private static final Instant CREATED_AT = Instant.parse("2020-02-03T20:22:02.00Z");
+
+    WebTarget target;
+
+    @Inject
+    PerformanceTargetCrudServiceInMemory performanceTargetCrudService;
+
+    @Inject
+    PerformanceTargetEvaluationCrudServiceInMemory performanceTargetEvaluationCrudService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/performance-targets/" + TARGET_ID;
+    }
+
+    @BeforeEach
+    void setup() {
+        target = rootTarget();
+
+        var environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        apiCrudService.initWith(
+            List.of(
+                ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API).build(),
+                ApiFixtures.aLLMProxyApiV4().toBuilder().id(LLM_API).build()
+            )
+        );
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        UuidString.reset();
+        TimeProvider.reset();
+        GraviteeContext.cleanContext();
+        Stream.of(apiCrudService, performanceTargetCrudService, performanceTargetEvaluationCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_the_target() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+
+            var response = target.request().get();
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(PerformanceTarget.class)
+                .isEqualTo(
+                    new PerformanceTarget()
+                        .id(TARGET_ID)
+                        .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                        .windowSeconds(900L)
+                        .intervalSeconds(300L)
+                        .minSampleSize(20)
+                        .rules(List.of(aLatencyRule()))
+                        .createdAt(CREATED_AT.atOffset(ZoneOffset.UTC))
+                        .updatedAt(CREATED_AT.atOffset(ZoneOffset.UTC))
+                );
+        }
+
+        @Test
+        void should_return_404_when_the_target_does_not_exist() {
+            var response = target.request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_when_the_target_belongs_to_another_environment() {
+            performanceTargetCrudService.initWith(
+                List.of(PerformanceTargetFixtures.aTarget(TARGET_ID).toBuilder().environmentId("other-environment").build())
+            );
+
+            var response = target.request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_without_read_permission() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.READ, () -> target.request().get());
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void should_replace_subject_schedule_and_rules_and_keep_identity() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+            var request = new UpdatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API, LLM_API)).reference("agent-42"))
+                .windowSeconds(3600L)
+                .intervalSeconds(600L)
+                .minSampleSize(5)
+                .rules(List.of(aLatencyRule().threshold(1500.0)));
+
+            var response = target.request().put(json(request));
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(PerformanceTarget.class)
+                .isEqualTo(
+                    new PerformanceTarget()
+                        .id(TARGET_ID)
+                        .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API, LLM_API)).reference("agent-42"))
+                        .windowSeconds(3600L)
+                        .intervalSeconds(600L)
+                        .minSampleSize(5)
+                        .rules(List.of(aLatencyRule().threshold(1500.0)))
+                        .createdAt(CREATED_AT.atOffset(ZoneOffset.UTC))
+                        .updatedAt(NOW.atOffset(ZoneOffset.UTC))
+                );
+            assertThat(performanceTargetCrudService.storage())
+                .singleElement()
+                .satisfies(stored -> {
+                    assertThat(stored.environmentId()).isEqualTo(ENVIRONMENT);
+                    assertThat(stored.subject().reference()).isEqualTo("agent-42");
+                });
+        }
+
+        @Test
+        void should_reject_an_invalid_rule_with_the_failing_rule_index_and_keep_the_target() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+            var request = new UpdatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule().measure("PERCENTAGE")));
+
+            var response = target.request().put(json(request));
+
+            assertThat(response).hasStatus(HttpStatusCode.BAD_REQUEST_400);
+            assertThat(response.readEntity(Error.class).getParameters()).containsEntry("ruleIndex", "0");
+            assertThat(performanceTargetCrudService.storage()).containsExactly(PerformanceTargetFixtures.aTarget(TARGET_ID));
+        }
+
+        @Test
+        void should_return_404_when_the_target_does_not_exist() {
+            var request = new UpdatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule()));
+
+            var response = target.request().put(json(request));
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_without_update_permission() {
+            var request = new UpdatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule()));
+
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.UPDATE, () ->
+                target.request().put(json(request))
+            );
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_the_target_and_its_evaluations() {
+            performanceTargetCrudService.initWith(
+                List.of(PerformanceTargetFixtures.aTarget(TARGET_ID), PerformanceTargetFixtures.aTarget("other-target"))
+            );
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation("eval-1", TARGET_ID, PerformanceTargetEvaluation.Status.PASS),
+                    PerformanceTargetFixtures.anEvaluation("eval-2", TARGET_ID, PerformanceTargetEvaluation.Status.BREACH),
+                    PerformanceTargetFixtures.anEvaluation("eval-other", "other-target", PerformanceTargetEvaluation.Status.PASS)
+                )
+            );
+
+            var response = target.request().delete();
+
+            assertThat(response).hasStatus(HttpStatusCode.NO_CONTENT_204);
+            assertThat(performanceTargetCrudService.storage())
+                .extracting(t -> t.id())
+                .containsExactly("other-target");
+            assertThat(performanceTargetEvaluationCrudService.storage())
+                .extracting(e -> e.id())
+                .containsExactly("eval-other");
+        }
+
+        @Test
+        void should_return_404_when_the_target_does_not_exist() {
+            var response = target.request().delete();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_without_delete_permission() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.DELETE, () -> target.request().delete());
+        }
+    }
+
+    @Nested
+    class Evaluations {
+
+        private static final Instant T1 = Instant.parse("2021-06-01T09:00:00.00Z");
+        private static final Instant T2 = Instant.parse("2021-06-01T09:05:00.00Z");
+        private static final Instant T3 = Instant.parse("2021-06-01T09:10:00.00Z");
+
+        @BeforeEach
+        void givenTargetWithHistory() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation("eval-1", TARGET_ID, PerformanceTargetEvaluation.Status.PASS, T1)
+                        .toBuilder()
+                        .latest(false)
+                        .build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-2", TARGET_ID, PerformanceTargetEvaluation.Status.PASS, T2)
+                        .toBuilder()
+                        .latest(false)
+                        .build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-3", TARGET_ID, PerformanceTargetEvaluation.Status.BREACH, T3),
+                    PerformanceTargetFixtures.anEvaluation("eval-other", "other-target", PerformanceTargetEvaluation.Status.PASS, T3)
+                )
+            );
+        }
+
+        @Test
+        void should_return_the_latest_evaluation_with_its_rule_results() {
+            var response = target.path("evaluations/latest").request().get();
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation.class)
+                .isEqualTo(
+                    new io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation()
+                        .id("eval-3")
+                        .targetId(TARGET_ID)
+                        .reference(A2A_API)
+                        .status(PerformanceTargetEvaluationStatus.BREACH)
+                        .rules(
+                            List.of(
+                                new PerformanceTargetRuleResult()
+                                    .metric("HTTP_GATEWAY_RESPONSE_TIME")
+                                    .measure("P95")
+                                    .operator(PerformanceTargetOperator.LTE)
+                                    .threshold(2000.0)
+                                    .observed(4810.0)
+                                    .deviation(new PerformanceTargetDeviation().absolute(2810.0).ratio(1.405))
+                                    .sampleCount(63L)
+                                    .status(PerformanceTargetEvaluationStatus.BREACH)
+                            )
+                        )
+                        .windowFrom(T3.minus(Duration.ofMinutes(15)).atOffset(ZoneOffset.UTC))
+                        .windowTo(T3.atOffset(ZoneOffset.UTC))
+                        .coveredApiIds(List.of(A2A_API))
+                        .evaluatedAt(T3.atOffset(ZoneOffset.UTC))
+                );
+        }
+
+        @Test
+        void should_return_404_when_the_target_has_not_been_evaluated_yet() {
+            performanceTargetEvaluationCrudService.reset();
+
+            var response = target.path("evaluations/latest").request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_for_the_latest_evaluation_of_an_unknown_target() {
+            performanceTargetCrudService.reset();
+
+            var response = target.path("evaluations/latest").request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_page_the_history_most_recent_first() {
+            var response = target.path("evaluations").queryParam("page", 1).queryParam("perPage", 2).request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.OK_200);
+            var body = response.readEntity(PerformanceTargetEvaluationsResponse.class);
+            assertThat(body.getData())
+                .extracting(io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation::getId)
+                .containsExactly("eval-3", "eval-2");
+            assertThat(body.getPagination().getTotalCount()).isEqualTo(3L);
+            assertThat(body.getPagination().getPage()).isEqualTo(1);
+            assertThat(body.getPagination().getPerPage()).isEqualTo(2);
+            assertThat(body.getPagination().getPageCount()).isEqualTo(2);
+            assertThat(body.getPagination().getPageItemsCount()).isEqualTo(2);
+        }
+
+        @Test
+        void should_return_404_for_the_history_of_an_unknown_target() {
+            performanceTargetCrudService.reset();
+
+            var response = target.path("evaluations").request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_without_read_permission() {
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.READ, () ->
+                target.path("evaluations").request().get()
+            );
+        }
+    }
+
+    @Nested
+    class EvaluateNow {
+
+        @BeforeEach
+        void givenTarget() {
+            performanceTargetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+        }
+
+        @Test
+        void should_evaluate_store_as_latest_and_return_the_evaluation() {
+            UuidString.overrideGenerator(() -> "evaluation-id");
+
+            var response = target.path("_evaluate").request().post(null);
+
+            assertThat(response).hasStatus(HttpStatusCode.OK_200);
+            var evaluation = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetEvaluation.class);
+            assertThat(evaluation.getId()).isEqualTo("evaluation-id");
+            assertThat(evaluation.getTargetId()).isEqualTo(TARGET_ID);
+            assertThat(evaluation.getStatus()).isEqualTo(PerformanceTargetEvaluationStatus.PASS);
+            assertThat(evaluation.getWindowFrom()).isEqualTo(NOW.minus(Duration.ofMinutes(15)).atOffset(ZoneOffset.UTC));
+            assertThat(evaluation.getEvaluatedAt()).isEqualTo(NOW.atOffset(ZoneOffset.UTC));
+            assertThat(performanceTargetEvaluationCrudService.storage())
+                .singleElement()
+                .satisfies(stored -> {
+                    assertThat(stored.id()).isEqualTo("evaluation-id");
+                    assertThat(stored.latest()).isTrue();
+                });
+        }
+
+        @Test
+        void should_refuse_with_429_and_retry_after_when_evaluated_less_than_30_seconds_ago() {
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation(
+                        "recent",
+                        TARGET_ID,
+                        PerformanceTargetEvaluation.Status.PASS,
+                        NOW.minusSeconds(10)
+                    )
+                )
+            );
+
+            var response = target.path("_evaluate").request().post(null);
+
+            assertThat(response).hasStatus(HttpStatusCode.TOO_MANY_REQUESTS_429).hasHeader("Retry-After", "20");
+            assertThat(response.readEntity(Error.class).getMessage()).contains(TARGET_ID);
+            assertThat(performanceTargetEvaluationCrudService.storage())
+                .extracting(e -> e.id())
+                .containsExactly("recent");
+        }
+
+        @Test
+        void should_evaluate_again_once_30_seconds_have_passed_and_replace_the_latest() {
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation(
+                        "previous",
+                        TARGET_ID,
+                        PerformanceTargetEvaluation.Status.BREACH,
+                        NOW.minusSeconds(30)
+                    )
+                )
+            );
+
+            var response = target.path("_evaluate").request().post(null);
+
+            assertThat(response).hasStatus(HttpStatusCode.OK_200);
+            assertThat(performanceTargetEvaluationCrudService.storage())
+                .filteredOn(PerformanceTargetEvaluation::latest)
+                .singleElement()
+                .satisfies(latest -> assertThat(latest.evaluatedAt()).isEqualTo(NOW));
+        }
+
+        @Test
+        void should_return_404_when_the_target_does_not_exist() {
+            performanceTargetCrudService.reset();
+
+            var response = target.path("_evaluate").request().post(null);
+
+            assertThat(response).hasStatus(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_without_update_permission() {
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.UPDATE, () ->
+                target.path("_evaluate").request().post(null)
+            );
+        }
+    }
+
+    private static PerformanceTargetRule aLatencyRule() {
+        return new PerformanceTargetRule()
+            .metric("HTTP_GATEWAY_RESPONSE_TIME")
+            .measure("P95")
+            .operator(PerformanceTargetOperator.LTE)
+            .threshold(2000.0);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentPerformanceTargetsResourceTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.PerformanceTargetCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.LatestPerformanceTargetEvaluationsRequest;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTarget;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetOperator;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetRule;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetSubject;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.PerformanceTargetsSummary;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentPerformanceTargetsResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "environment-id";
+    private static final String A2A_API = "a2a-api";
+    private static final String LLM_API = "llm-api";
+    private static final Instant NOW = Instant.parse("2020-02-03T20:22:02.00Z");
+
+    WebTarget target;
+
+    @Inject
+    PerformanceTargetCrudServiceInMemory performanceTargetCrudService;
+
+    @Inject
+    PerformanceTargetEvaluationCrudServiceInMemory performanceTargetEvaluationCrudService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/performance-targets";
+    }
+
+    @BeforeEach
+    void setup() {
+        target = rootTarget();
+
+        var environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        apiCrudService.initWith(
+            List.of(
+                ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API).build(),
+                ApiFixtures.aLLMProxyApiV4().toBuilder().id(LLM_API).build()
+            )
+        );
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        UuidString.reset();
+        TimeProvider.reset();
+        GraviteeContext.cleanContext();
+        Stream.of(apiCrudService, performanceTargetCrudService, performanceTargetEvaluationCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void should_create_target_and_return_it_with_its_location() {
+            UuidString.overrideGenerator(() -> "generated-id");
+            var request = new CreatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .windowSeconds(900L)
+                .intervalSeconds(300L)
+                .minSampleSize(20)
+                .rules(List.of(aLatencyRule()));
+
+            var response = target.request().post(json(request));
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.CREATED_201)
+                .hasHeader("Location", target.path("generated-id").getUri().toString())
+                .asEntity(PerformanceTarget.class)
+                .isEqualTo(
+                    new PerformanceTarget()
+                        .id("generated-id")
+                        .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                        .windowSeconds(900L)
+                        .intervalSeconds(300L)
+                        .minSampleSize(20)
+                        .rules(List.of(aLatencyRule()))
+                        .createdAt(NOW.atOffset(ZoneOffset.UTC))
+                        .updatedAt(NOW.atOffset(ZoneOffset.UTC))
+                );
+            assertThat(performanceTargetCrudService.storage())
+                .extracting(t -> t.id(), t -> t.environmentId(), t -> t.subject().reference())
+                .containsExactly(tuple("generated-id", ENVIRONMENT, A2A_API));
+        }
+
+        @Test
+        void should_reject_a_rule_the_subject_cannot_be_evaluated_on_with_the_failing_rule_index() {
+            var llmCostRule = new PerformanceTargetRule()
+                .metric("LLM_PROMPT_TOKEN_TOTAL_COST")
+                .measure("AVG")
+                .operator(PerformanceTargetOperator.LTE)
+                .threshold(0.01);
+            var request = new CreatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule(), llmCostRule));
+
+            var response = target.request().post(json(request));
+
+            assertThat(response).hasStatus(HttpStatusCode.BAD_REQUEST_400);
+            var error = response.readEntity(Error.class);
+            assertThat(error.getMessage()).contains("LLM_PROMPT_TOKEN_TOTAL_COST").contains("A2A_PROXY");
+            assertThat(error.getParameters()).containsEntry("ruleIndex", "1");
+            assertThat(performanceTargetCrudService.storage()).isEmpty();
+        }
+
+        @Test
+        void should_reject_an_unknown_metric_with_the_failing_rule_index() {
+            var request = new CreatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule().metric("NOT_A_METRIC")));
+
+            var response = target.request().post(json(request));
+
+            assertThat(response).hasStatus(HttpStatusCode.BAD_REQUEST_400);
+            var error = response.readEntity(Error.class);
+            assertThat(error.getMessage()).contains("NOT_A_METRIC");
+            assertThat(error.getParameters()).containsEntry("ruleIndex", "0");
+        }
+
+        @Test
+        void should_return_403_without_create_permission() {
+            var request = new CreatePerformanceTarget()
+                .subject(new PerformanceTargetSubject().apiIds(List.of(A2A_API)).reference(A2A_API))
+                .rules(List.of(aLatencyRule()));
+
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.CREATE, () ->
+                target.request().post(json(request))
+            );
+        }
+    }
+
+    @Nested
+    class GetByReference {
+
+        @Test
+        void should_return_the_targets_of_the_reference_in_this_environment() {
+            performanceTargetCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.aTarget("target-1"),
+                    PerformanceTargetFixtures.aTarget("target-2"),
+                    PerformanceTargetFixtures.aTarget("other-reference")
+                        .toBuilder()
+                        .subject(new io.gravitee.apim.core.performance_target.model.PerformanceTarget.Subject(List.of(LLM_API), LLM_API))
+                        .build(),
+                    PerformanceTargetFixtures.aTarget("other-environment").toBuilder().environmentId("other-environment").build()
+                )
+            );
+
+            var response = target.queryParam("reference", A2A_API).request().get();
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(PerformanceTargetsResponse.class)
+                .extracting(PerformanceTargetsResponse::getData)
+                .asInstanceOf(InstanceOfAssertFactories.list(PerformanceTarget.class))
+                .extracting(PerformanceTarget::getId)
+                .containsExactlyInAnyOrder("target-1", "target-2");
+        }
+
+        @Test
+        void should_require_a_reference() {
+            var response = target.request().get();
+
+            assertThat(response).hasStatus(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_without_read_permission() {
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.READ, () ->
+                target.queryParam("reference", A2A_API).request().get()
+            );
+        }
+    }
+
+    @Nested
+    class LatestEvaluationsByReferences {
+
+        @Test
+        void should_return_one_entry_per_reference_with_the_worst_latest_evaluation_or_null() throws Exception {
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation("eval-api", "target-api", Status.PASS),
+                    PerformanceTargetFixtures.anEvaluation("eval-agent-pass", "target-agent-1", Status.PASS)
+                        .toBuilder()
+                        .reference("agent-1")
+                        .build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-agent-not-evaluable", "target-agent-2", Status.NOT_EVALUABLE)
+                        .toBuilder()
+                        .reference("agent-1")
+                        .build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-agent-old", "target-agent-1", Status.BREACH)
+                        .toBuilder()
+                        .reference("agent-1")
+                        .latest(false)
+                        .build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-other-env", "target-other-env", Status.BREACH)
+                        .toBuilder()
+                        .reference("agent-2")
+                        .environmentId("other-environment")
+                        .build()
+                )
+            );
+            var request = new LatestPerformanceTargetEvaluationsRequest().references(
+                new LinkedHashSet<>(List.of(A2A_API, "agent-1", "agent-2", "unknown"))
+            );
+
+            var response = target.path("evaluations/_latest").request().post(json(request));
+
+            assertThat(response).hasStatus(HttpStatusCode.OK_200);
+            var data = new ObjectMapper().readTree(response.readEntity(String.class)).get("data");
+            assertThat(data.fieldNames()).toIterable().containsExactly(A2A_API, "agent-1", "agent-2", "unknown");
+            assertThat(data.get(A2A_API).get("id").asText()).isEqualTo("eval-api");
+            assertThat(data.get("agent-1").get("id").asText()).isEqualTo("eval-agent-not-evaluable");
+            assertThat(data.get("agent-2").isNull()).isTrue();
+            assertThat(data.get("unknown").isNull()).isTrue();
+        }
+
+        @Test
+        void should_reject_an_empty_reference_list() {
+            var response = target.path("evaluations/_latest").request().post(json(new LatestPerformanceTargetEvaluationsRequest()));
+
+            assertThat(response).hasStatus(HttpStatusCode.BAD_REQUEST_400);
+        }
+
+        @Test
+        void should_return_403_without_read_permission() {
+            var request = new LatestPerformanceTargetEvaluationsRequest().references(Set.of(A2A_API));
+
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.READ, () ->
+                target.path("evaluations/_latest").request().post(json(request))
+            );
+        }
+    }
+
+    @Nested
+    class Summary {
+
+        @Test
+        void should_count_the_latest_evaluations_of_the_environment_by_status() {
+            performanceTargetEvaluationCrudService.initWith(
+                List.of(
+                    PerformanceTargetFixtures.anEvaluation("eval-1", "target-1", Status.PASS),
+                    PerformanceTargetFixtures.anEvaluation("eval-2", "target-2", Status.PASS),
+                    PerformanceTargetFixtures.anEvaluation("eval-3", "target-3", Status.BREACH),
+                    PerformanceTargetFixtures.anEvaluation("eval-4", "target-4", Status.NOT_EVALUABLE),
+                    PerformanceTargetFixtures.anEvaluation("eval-3-old", "target-3", Status.BREACH).toBuilder().latest(false).build(),
+                    PerformanceTargetFixtures.anEvaluation("eval-other-env", "target-5", Status.BREACH)
+                        .toBuilder()
+                        .environmentId("other-environment")
+                        .build()
+                )
+            );
+
+            var response = target.path("_summary").request().get();
+
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(PerformanceTargetsSummary.class)
+                .isEqualTo(new PerformanceTargetsSummary().pass(2L).breach(1L).notEvaluable(1L));
+        }
+
+        @Test
+        void should_return_403_without_read_permission() {
+            shouldReturn403(RolePermission.ENVIRONMENT_API, ENVIRONMENT, RolePermissionAction.READ, () ->
+                target.path("_summary").request().get()
+            );
+        }
+    }
+
+    private static PerformanceTargetRule aLatencyRule() {
+        return new PerformanceTargetRule()
+            .metric("HTTP_GATEWAY_RESPONSE_TIME")
+            .measure("P95")
+            .operator(PerformanceTargetOperator.LTE)
+            .threshold(2000.0);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -171,6 +171,7 @@ import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudSer
 import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificationDomainService;
 import io.gravitee.apim.core.open_api.OpenApiValidator;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
+import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
@@ -1590,6 +1591,14 @@ public class ResourceContextConfiguration {
     @Bean
     public AnalyticsDefinitionQueryService analyticsDefinitionQueryService() {
         return new AnalyticsDefinitionYAMLQueryService();
+    }
+
+    @Bean
+    public ValidatePerformanceTargetDomainService validatePerformanceTargetDomainService(
+        ApiCrudServiceInMemory apiCrudServiceInMemory,
+        AnalyticsDefinitionQueryService analyticsDefinitionQueryService
+    ) {
+        return new ValidatePerformanceTargetDomainService(apiCrudServiceInMemory, analyticsDefinitionQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetCrudService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.performance_target.crud_service;
 
+import io.gravitee.apim.core.performance_target.exception.PerformanceTargetNotFoundException;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +24,15 @@ public interface PerformanceTargetCrudService {
     PerformanceTarget create(PerformanceTarget target);
 
     Optional<PerformanceTarget> findById(String id);
+
+    /**
+     * @throws PerformanceTargetNotFoundException when the target does not exist or belongs to another environment
+     */
+    default PerformanceTarget get(String environmentId, String id) {
+        return findById(id)
+            .filter(target -> target.environmentId().equals(environmentId))
+            .orElseThrow(() -> new PerformanceTargetNotFoundException(id));
+    }
 
     PerformanceTarget update(PerformanceTarget target);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainService.java
@@ -75,8 +75,12 @@ public class ValidatePerformanceTargetDomainService {
         }
 
         var subjectApiTypes = subjectApiTypes(target);
-        for (var rule : target.rules()) {
-            validateRule(rule, subjectApiTypes);
+        for (int ruleIndex = 0; ruleIndex < target.rules().size(); ruleIndex++) {
+            try {
+                validateRule(target.rules().get(ruleIndex), subjectApiTypes);
+            } catch (InvalidPerformanceTargetException e) {
+                throw new InvalidPerformanceTargetException(e.getMessage(), ruleIndex);
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetEvaluatedTooRecentlyException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetEvaluatedTooRecentlyException.java
@@ -15,21 +15,15 @@
  */
 package io.gravitee.apim.core.performance_target.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
-import java.util.Map;
+import io.gravitee.apim.core.exception.TooManyRequestsDomainException;
+import java.time.Duration;
 
-public class InvalidPerformanceTargetException extends ValidationDomainException {
+public class PerformanceTargetEvaluatedTooRecentlyException extends TooManyRequestsDomainException {
 
-    public static final String RULE_INDEX_PARAMETER = "ruleIndex";
-
-    public InvalidPerformanceTargetException(String message) {
-        super(message);
-    }
-
-    /**
-     * @param ruleIndex the position, in the target's rules, of the rule the message is about
-     */
-    public InvalidPerformanceTargetException(String message, int ruleIndex) {
-        super(message, Map.of(RULE_INDEX_PARAMETER, String.valueOf(ruleIndex)));
+    public PerformanceTargetEvaluatedTooRecentlyException(String targetId, Duration retryAfter) {
+        super(
+            "Performance target %s was evaluated too recently, retry in %d seconds".formatted(targetId, retryAfter.toSeconds()),
+            retryAfter
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetNotEvaluatedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetNotEvaluatedException.java
@@ -15,21 +15,11 @@
  */
 package io.gravitee.apim.core.performance_target.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
-import java.util.Map;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
 
-public class InvalidPerformanceTargetException extends ValidationDomainException {
+public class PerformanceTargetNotEvaluatedException extends NotFoundDomainException {
 
-    public static final String RULE_INDEX_PARAMETER = "ruleIndex";
-
-    public InvalidPerformanceTargetException(String message) {
-        super(message);
-    }
-
-    /**
-     * @param ruleIndex the position, in the target's rules, of the rule the message is about
-     */
-    public InvalidPerformanceTargetException(String message, int ruleIndex) {
-        super(message, Map.of(RULE_INDEX_PARAMETER, String.valueOf(ruleIndex)));
+    public PerformanceTargetNotEvaluatedException(String targetId) {
+        super("Performance target %s has not been evaluated yet".formatted(targetId), targetId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/exception/PerformanceTargetNotFoundException.java
@@ -15,21 +15,11 @@
  */
 package io.gravitee.apim.core.performance_target.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
-import java.util.Map;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
 
-public class InvalidPerformanceTargetException extends ValidationDomainException {
+public class PerformanceTargetNotFoundException extends NotFoundDomainException {
 
-    public static final String RULE_INDEX_PARAMETER = "ruleIndex";
-
-    public InvalidPerformanceTargetException(String message) {
-        super(message);
-    }
-
-    /**
-     * @param ruleIndex the position, in the target's rules, of the rule the message is about
-     */
-    public InvalidPerformanceTargetException(String message, int ruleIndex) {
-        super(message, Map.of(RULE_INDEX_PARAMETER, String.valueOf(ruleIndex)));
+    public PerformanceTargetNotFoundException(String id) {
+        super("Performance target with id %s not found".formatted(id), id);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/query_service/PerformanceTargetEvaluationQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/query_service/PerformanceTargetEvaluationQueryService.java
@@ -35,5 +35,10 @@ public interface PerformanceTargetEvaluationQueryService {
      */
     Page<PerformanceTargetEvaluation> findEnvironmentLatest(String environmentId, Pageable pageable);
 
+    /**
+     * @return the stored evaluations of the target, most recently evaluated first
+     */
+    Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable);
+
     PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/service_provider/PerformanceTargetEvaluator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/service_provider/PerformanceTargetEvaluator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.service_provider;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import java.time.Instant;
+
+/**
+ * Evaluates a target against gateway telemetry. Shared by the scheduler and by evaluate-on-demand so that both produce
+ * the same numbers as the analytics dashboards.
+ */
+public interface PerformanceTargetEvaluator {
+    /**
+     * Evaluates the target over its window ending at {@code now}. The result is not stored and carries no id: the
+     * caller decides whether it becomes the target's latest evaluation.
+     */
+    PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/CreatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/CreatePerformanceTargetUseCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class CreatePerformanceTargetUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final ValidatePerformanceTargetDomainService validatePerformanceTargetDomainService;
+
+    public Output execute(Input input) {
+        var now = TimeProvider.now();
+        var target = input
+            .target()
+            .toBuilder()
+            .id(UuidString.generateRandom())
+            .environmentId(input.auditInfo().environmentId())
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+        validatePerformanceTargetDomainService.validate(target);
+        return new Output(performanceTargetCrudService.create(target));
+    }
+
+    /**
+     * @param target the target to create; its id, environment and timestamps are set by the use case
+     */
+    public record Input(PerformanceTarget target, AuditInfo auditInfo) {}
+
+    public record Output(PerformanceTarget target) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/DeletePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/DeletePerformanceTargetUseCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class DeletePerformanceTargetUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
+
+    public void execute(Input input) {
+        var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
+
+        performanceTargetEvaluationCrudService.deleteByTargetId(target.id());
+        performanceTargetCrudService.delete(target.id());
+    }
+
+    public record Input(String environmentId, String targetId) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Evaluates a target on demand and stores the result as its latest evaluation, through the same evaluator as the
+ * scheduler. A target is evaluated at most once per {@link #MIN_DELAY_BETWEEN_EVALUATIONS}, whoever triggered the
+ * previous run, so a UI refresh cannot turn into a query storm.
+ */
+@RequiredArgsConstructor
+@UseCase
+public class EvaluatePerformanceTargetUseCase {
+
+    public static final Duration MIN_DELAY_BETWEEN_EVALUATIONS = Duration.ofSeconds(30);
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+    private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
+    // Optional until the evaluation engine lands: the REST contract ships first, the engine follows.
+    private final Optional<PerformanceTargetEvaluator> performanceTargetEvaluator;
+
+    public Output execute(Input input) {
+        var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
+
+        var now = TimeProvider.instantNow();
+        performanceTargetEvaluationQueryService
+            .findByTargetId(target.id(), new PageableImpl(1, 1))
+            .getContent()
+            .stream()
+            .findFirst()
+            .map(latest -> Duration.between(now, latest.evaluatedAt().plus(MIN_DELAY_BETWEEN_EVALUATIONS)))
+            .filter(Duration::isPositive)
+            .ifPresent(retryAfter -> {
+                throw new PerformanceTargetEvaluatedTooRecentlyException(target.id(), retryAfter);
+            });
+
+        var evaluator = performanceTargetEvaluator.orElseThrow(() ->
+            new TechnicalDomainException("Performance target evaluation is not available")
+        );
+        var evaluation = evaluator.evaluate(target, now).toBuilder().id(UuidString.generateRandom()).latest(true).build();
+        return new Output(performanceTargetEvaluationCrudService.create(evaluation));
+    }
+
+    public record Input(String environmentId, String targetId) {}
+
+    public record Output(PerformanceTargetEvaluation evaluation) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetLatestPerformanceTargetEvaluationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetLatestPerformanceTargetEvaluationUseCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.exception.PerformanceTargetNotEvaluatedException;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetLatestPerformanceTargetEvaluationUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+
+    public Output execute(Input input) {
+        var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
+
+        var latest = performanceTargetEvaluationQueryService
+            .findByTargetId(target.id(), new PageableImpl(1, 1))
+            .getContent()
+            .stream()
+            .findFirst()
+            .orElseThrow(() -> new PerformanceTargetNotEvaluatedException(target.id()));
+        return new Output(latest);
+    }
+
+    public record Input(String environmentId, String targetId) {}
+
+    public record Output(PerformanceTargetEvaluation evaluation) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetLatestPerformanceTargetEvaluationsByReferencesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetLatestPerformanceTargetEvaluationsByReferencesUseCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import static java.util.stream.Collectors.groupingBy;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The status to show next to each reference of a list: its worst latest evaluation, so that a reference with a
+ * target that cannot be evaluated never reads as a pass.
+ */
+@RequiredArgsConstructor
+@UseCase
+public class GetLatestPerformanceTargetEvaluationsByReferencesUseCase {
+
+    private static final Comparator<PerformanceTargetEvaluation> WORST_LAST = Comparator.comparing(
+        (PerformanceTargetEvaluation evaluation) -> severity(evaluation.status())
+    ).thenComparing(PerformanceTargetEvaluation::evaluatedAt);
+
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+
+    public Output execute(Input input) {
+        var latestByReference = performanceTargetEvaluationQueryService
+            .findLatestByReferences(input.environmentId(), input.references())
+            .stream()
+            .collect(groupingBy(PerformanceTargetEvaluation::reference));
+
+        var result = new LinkedHashMap<String, PerformanceTargetEvaluation>();
+        for (var reference : input.references()) {
+            result.put(reference, latestByReference.getOrDefault(reference, List.of()).stream().max(WORST_LAST).orElse(null));
+        }
+        return new Output(result);
+    }
+
+    private static int severity(PerformanceTargetEvaluation.Status status) {
+        return switch (status) {
+            case BREACH -> 2;
+            case NOT_EVALUABLE -> 1;
+            case PASS -> 0;
+        };
+    }
+
+    public record Input(String environmentId, Collection<String> references) {}
+
+    /**
+     * @param latestByReference one entry per requested reference, in request order; {@code null} when the reference has
+     *                          no evaluation
+     */
+    public record Output(Map<String, PerformanceTargetEvaluation> latestByReference) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetEvaluationHistoryUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetEvaluationHistoryUseCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetPerformanceTargetEvaluationHistoryUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+
+    public Output execute(Input input) {
+        var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
+
+        return new Output(performanceTargetEvaluationQueryService.findByTargetId(target.id(), input.pageable()));
+    }
+
+    public record Input(String environmentId, String targetId, Pageable pageable) {}
+
+    /**
+     * @param evaluations most recently evaluated first
+     */
+    public record Output(Page<PerformanceTargetEvaluation> evaluations) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetUseCase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetPerformanceTargetUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+
+    public Output execute(Input input) {
+        return new Output(performanceTargetCrudService.get(input.environmentId(), input.targetId()));
+    }
+
+    public record Input(String environmentId, String targetId) {}
+
+    public record Output(PerformanceTarget target) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetsByReferenceUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetsByReferenceUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetPerformanceTargetsByReferenceUseCase {
+
+    private final PerformanceTargetQueryService performanceTargetQueryService;
+
+    public Output execute(Input input) {
+        return new Output(performanceTargetQueryService.findByReference(input.environmentId(), input.reference()));
+    }
+
+    public record Input(String environmentId, String reference) {}
+
+    public record Output(List<PerformanceTarget> targets) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetsSummaryUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/GetPerformanceTargetsSummaryUseCase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEnvironmentSummary;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetPerformanceTargetsSummaryUseCase {
+
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+
+    public Output execute(Input input) {
+        return new Output(performanceTargetEvaluationQueryService.getEnvironmentSummary(input.environmentId()));
+    }
+
+    public record Input(String environmentId) {}
+
+    public record Output(PerformanceTargetEnvironmentSummary summary) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.common.utils.TimeProvider;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class UpdatePerformanceTargetUseCase {
+
+    private final PerformanceTargetCrudService performanceTargetCrudService;
+    private final ValidatePerformanceTargetDomainService validatePerformanceTargetDomainService;
+
+    public Output execute(Input input) {
+        var updated = performanceTargetCrudService
+            .get(input.environmentId(), input.targetId())
+            .toBuilder()
+            .subject(input.target().subject())
+            .window(input.target().window())
+            .interval(input.target().interval())
+            .minSampleSize(input.target().minSampleSize())
+            .rules(input.target().rules())
+            .updatedAt(TimeProvider.now())
+            .build();
+        validatePerformanceTargetDomainService.validate(updated);
+        return new Output(performanceTargetCrudService.update(updated));
+    }
+
+    /**
+     * @param target the new subject, schedule and rules; id, environment and creation date are kept from the stored target
+     */
+    public record Input(String environmentId, String targetId, PerformanceTarget target) {}
+
+    public record Output(PerformanceTarget target) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetEvaluationQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetEvaluationQueryServiceImpl.java
@@ -88,6 +88,20 @@ public class PerformanceTargetEvaluationQueryServiceImpl extends AbstractService
     }
 
     @Override
+    public Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable) {
+        try {
+            return evaluationRepository
+                .findByTargetId(targetId, convert(pageable))
+                .map(PerformanceTargetEvaluationAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(
+                "An error occurred while finding Performance Target Evaluations of target " + targetId,
+                e
+            );
+        }
+    }
+
+    @Override
     public PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId) {
         try {
             return PerformanceTargetEvaluationAdapter.INSTANCE.toEntity(evaluationRepository.getEnvironmentSummary(environmentId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PerformanceTargetFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PerformanceTargetFixtures.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class PerformanceTargetFixtures {
+
+    private PerformanceTargetFixtures() {}
+
+    public static final String ENVIRONMENT_ID = "environment-id";
+    public static final String A2A_API_ID = "a2a-api";
+
+    public static final Supplier<PerformanceTarget.PerformanceTargetBuilder> BASE = () ->
+        PerformanceTarget.builder()
+            .id("target-id")
+            .environmentId(ENVIRONMENT_ID)
+            .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID), A2A_API_ID))
+            .window(Duration.ofMinutes(15))
+            .interval(Duration.ofMinutes(5))
+            .minSampleSize(20)
+            .rules(List.of(aLatencyRule()))
+            .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()));
+
+    public static PerformanceTarget aTarget() {
+        return BASE.get().build();
+    }
+
+    public static PerformanceTarget aTarget(String id) {
+        return BASE.get().id(id).build();
+    }
+
+    public static PerformanceTarget.Rule aLatencyRule() {
+        return PerformanceTarget.Rule.builder()
+            .metric(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME)
+            .measure(MetricSpec.Measure.P95)
+            .operator(PerformanceTarget.Operator.LTE)
+            .threshold(2000)
+            .build();
+    }
+
+    public static PerformanceTargetEvaluation anEvaluation(String id, String targetId, PerformanceTargetEvaluation.Status status) {
+        return anEvaluation(id, targetId, status, Instant.parse("2020-02-03T20:37:02.00Z"));
+    }
+
+    public static PerformanceTargetEvaluation anEvaluation(
+        String id,
+        String targetId,
+        PerformanceTargetEvaluation.Status status,
+        Instant evaluatedAt
+    ) {
+        var breached = status == PerformanceTargetEvaluation.Status.BREACH;
+        return PerformanceTargetEvaluation.builder()
+            .id(id)
+            .targetId(targetId)
+            .environmentId(ENVIRONMENT_ID)
+            .reference(A2A_API_ID)
+            .status(status)
+            .rules(
+                List.of(
+                    new PerformanceTargetEvaluation.RuleResult(
+                        MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+                        MetricSpec.Measure.P95,
+                        PerformanceTarget.Operator.LTE,
+                        2000,
+                        status == PerformanceTargetEvaluation.Status.NOT_EVALUABLE ? null : breached ? 4810.0 : 1500.0,
+                        status == PerformanceTargetEvaluation.Status.NOT_EVALUABLE
+                            ? null
+                            : new PerformanceTargetEvaluation.Deviation(breached ? 2810 : -500, breached ? 1.405 : -0.25),
+                        status == PerformanceTargetEvaluation.Status.NOT_EVALUABLE ? 0 : 63,
+                        status
+                    )
+                )
+            )
+            .windowFrom(evaluatedAt.minus(Duration.ofMinutes(15)))
+            .windowTo(evaluatedAt)
+            .coveredApiIds(List.of(A2A_API_ID))
+            .evaluatedAt(evaluatedAt)
+            .latest(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetCrudServiceInMemory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class PerformanceTargetCrudServiceInMemory implements PerformanceTargetCrudService, InMemoryAlternative<PerformanceTarget> {
+
+    final ArrayList<PerformanceTarget> storage = new ArrayList<>();
+
+    @Override
+    public PerformanceTarget create(PerformanceTarget target) {
+        storage.add(target);
+        return target;
+    }
+
+    @Override
+    public Optional<PerformanceTarget> findById(String id) {
+        return storage
+            .stream()
+            .filter(target -> target.id().equals(id))
+            .findFirst();
+    }
+
+    @Override
+    public PerformanceTarget update(PerformanceTarget target) {
+        var index = findIndex(storage, stored -> stored.id().equals(target.id()));
+        if (index.isEmpty()) {
+            throw new IllegalStateException("Performance target not found");
+        }
+        storage.set(index.getAsInt(), target);
+        return target;
+    }
+
+    @Override
+    public void delete(String id) {
+        storage.removeIf(target -> target.id().equals(id));
+    }
+
+    @Override
+    public List<String> deleteByReference(String environmentId, String reference) {
+        var deleted = storage
+            .stream()
+            .filter(target -> target.environmentId().equals(environmentId) && target.subject().reference().equals(reference))
+            .map(PerformanceTarget::id)
+            .toList();
+        storage.removeIf(target -> deleted.contains(target.id()));
+        return deleted;
+    }
+
+    @Override
+    public List<String> removeApiId(String apiId) {
+        var affected = new ArrayList<String>();
+        for (int i = 0; i < storage.size(); i++) {
+            var target = storage.get(i);
+            if (target.subject().apiIds().contains(apiId)) {
+                affected.add(target.id());
+                var remaining = target
+                    .subject()
+                    .apiIds()
+                    .stream()
+                    .filter(id -> !id.equals(apiId))
+                    .toList();
+                storage.set(i, target.toBuilder().subject(new PerformanceTarget.Subject(remaining, target.subject().reference())).build());
+            }
+        }
+        return affected;
+    }
+
+    @Override
+    public void initWith(List<PerformanceTarget> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PerformanceTarget> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PerformanceTargetEvaluationCrudServiceInMemory
+    implements PerformanceTargetEvaluationCrudService, InMemoryAlternative<PerformanceTargetEvaluation> {
+
+    final ArrayList<PerformanceTargetEvaluation> storage = new ArrayList<>();
+
+    @Override
+    public PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation) {
+        if (evaluation.latest()) {
+            storage.replaceAll(stored ->
+                stored.targetId().equals(evaluation.targetId()) && stored.latest() ? stored.toBuilder().latest(false).build() : stored
+            );
+        }
+        storage.add(evaluation);
+        return evaluation;
+    }
+
+    @Override
+    public List<String> deleteByReference(String environmentId, String reference) {
+        var deleted = storage
+            .stream()
+            .filter(evaluation -> evaluation.environmentId().equals(environmentId) && evaluation.reference().equals(reference))
+            .map(PerformanceTargetEvaluation::id)
+            .toList();
+        storage.removeIf(evaluation -> deleted.contains(evaluation.id()));
+        return deleted;
+    }
+
+    @Override
+    public void deleteByTargetId(String targetId) {
+        storage.removeIf(evaluation -> evaluation.targetId().equals(targetId));
+    }
+
+    @Override
+    public void initWith(List<PerformanceTargetEvaluation> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationQueryServiceInMemory.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEnvironmentSummary;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class PerformanceTargetEvaluationQueryServiceInMemory
+    implements PerformanceTargetEvaluationQueryService, InMemoryAlternative<PerformanceTargetEvaluation> {
+
+    private final List<PerformanceTargetEvaluation> storage;
+
+    public PerformanceTargetEvaluationQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    public PerformanceTargetEvaluationQueryServiceInMemory(PerformanceTargetEvaluationCrudServiceInMemory crudService) {
+        storage = crudService.storage;
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> findLatestByReference(String environmentId, String reference) {
+        return latestOf(environmentId)
+            .filter(evaluation -> evaluation.reference().equals(reference))
+            .toList();
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> findLatestByReferences(String environmentId, Collection<String> references) {
+        return latestOf(environmentId)
+            .filter(evaluation -> references.contains(evaluation.reference()))
+            .toList();
+    }
+
+    @Override
+    public Page<PerformanceTargetEvaluation> findEnvironmentLatest(String environmentId, Pageable pageable) {
+        return page(
+            latestOf(environmentId).sorted(Comparator.comparing(PerformanceTargetEvaluation::evaluatedAt).reversed()).toList(),
+            pageable
+        );
+    }
+
+    @Override
+    public Page<PerformanceTargetEvaluation> findByTargetId(String targetId, Pageable pageable) {
+        return page(
+            storage
+                .stream()
+                .filter(evaluation -> evaluation.targetId().equals(targetId))
+                .sorted(Comparator.comparing(PerformanceTargetEvaluation::evaluatedAt).reversed())
+                .toList(),
+            pageable
+        );
+    }
+
+    @Override
+    public PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId) {
+        var latest = latestOf(environmentId).toList();
+        return new PerformanceTargetEnvironmentSummary(
+            environmentId,
+            latest
+                .stream()
+                .filter(e -> e.status() == PerformanceTargetEvaluation.Status.PASS)
+                .count(),
+            latest
+                .stream()
+                .filter(e -> e.status() == PerformanceTargetEvaluation.Status.BREACH)
+                .count(),
+            latest
+                .stream()
+                .filter(e -> e.status() == PerformanceTargetEvaluation.Status.NOT_EVALUABLE)
+                .count()
+        );
+    }
+
+    private java.util.stream.Stream<PerformanceTargetEvaluation> latestOf(String environmentId) {
+        return storage.stream().filter(evaluation -> evaluation.environmentId().equals(environmentId) && evaluation.latest());
+    }
+
+    private static Page<PerformanceTargetEvaluation> page(List<PerformanceTargetEvaluation> matches, Pageable pageable) {
+        var pageNumber = pageable.getPageNumber();
+        var pageSize = pageable.getPageSize();
+        var from = Math.min((pageNumber - 1) * pageSize, matches.size());
+        var to = Math.min(pageNumber * pageSize, matches.size());
+        return new Page<>(matches.subList(from, to), pageNumber, pageSize, matches.size());
+    }
+
+    @Override
+    public void initWith(List<PerformanceTargetEvaluation> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluatorInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluatorInMemory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
+import java.time.Instant;
+
+/**
+ * Passes every rule with an observed value at half the threshold, so tests can focus on what happens around the
+ * evaluation rather than on the numbers.
+ */
+public class PerformanceTargetEvaluatorInMemory implements PerformanceTargetEvaluator {
+
+    @Override
+    public PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now) {
+        return PerformanceTargetEvaluation.builder()
+            .targetId(target.id())
+            .environmentId(target.environmentId())
+            .reference(target.subject().reference())
+            .status(PerformanceTargetEvaluation.Status.PASS)
+            .rules(
+                target
+                    .rules()
+                    .stream()
+                    .map(rule ->
+                        new PerformanceTargetEvaluation.RuleResult(
+                            rule.metric(),
+                            rule.measure(),
+                            rule.operator(),
+                            rule.threshold(),
+                            rule.threshold() / 2,
+                            new PerformanceTargetEvaluation.Deviation(-rule.threshold() / 2, -0.5),
+                            42,
+                            PerformanceTargetEvaluation.Status.PASS
+                        )
+                    )
+                    .toList()
+            )
+            .windowFrom(now.minus(target.window()))
+            .windowTo(now)
+            .coveredApiIds(target.subject().apiIds())
+            .evaluatedAt(now)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetQueryServiceInMemory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetQueryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PerformanceTargetQueryServiceInMemory implements PerformanceTargetQueryService, InMemoryAlternative<PerformanceTarget> {
+
+    private final List<PerformanceTarget> storage;
+
+    public PerformanceTargetQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    public PerformanceTargetQueryServiceInMemory(PerformanceTargetCrudServiceInMemory crudService) {
+        storage = crudService.storage;
+    }
+
+    @Override
+    public List<PerformanceTarget> findByReference(String environmentId, String reference) {
+        return storage
+            .stream()
+            .filter(target -> target.environmentId().equals(environmentId) && target.subject().reference().equals(reference))
+            .toList();
+    }
+
+    @Override
+    public void initWith(List<PerformanceTarget> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PerformanceTarget> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -640,4 +640,31 @@ public class InMemoryConfiguration {
     ) {
         return new PortalCategoryDomainService(portalCategoryCrudServiceInMemory, portalCategoryQueryServiceInMemory);
     }
+
+    @Bean
+    public PerformanceTargetCrudServiceInMemory performanceTargetCrudService() {
+        return new PerformanceTargetCrudServiceInMemory();
+    }
+
+    @Bean
+    public PerformanceTargetQueryServiceInMemory performanceTargetQueryService(PerformanceTargetCrudServiceInMemory crudService) {
+        return new PerformanceTargetQueryServiceInMemory(crudService);
+    }
+
+    @Bean
+    public PerformanceTargetEvaluationCrudServiceInMemory performanceTargetEvaluationCrudService() {
+        return new PerformanceTargetEvaluationCrudServiceInMemory();
+    }
+
+    @Bean
+    public PerformanceTargetEvaluationQueryServiceInMemory performanceTargetEvaluationQueryService(
+        PerformanceTargetEvaluationCrudServiceInMemory crudService
+    ) {
+        return new PerformanceTargetEvaluationQueryServiceInMemory(crudService);
+    }
+
+    @Bean
+    public PerformanceTargetEvaluatorInMemory performanceTargetEvaluator() {
+        return new PerformanceTargetEvaluatorInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.PerformanceTargetCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationQueryServiceInMemory;
+import inmemory.PerformanceTargetEvaluatorInMemory;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
+import io.gravitee.apim.core.performance_target.exception.PerformanceTargetNotFoundException;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EvaluatePerformanceTargetUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = PerformanceTargetFixtures.ENVIRONMENT_ID;
+    private static final String TARGET_ID = "target-id";
+    private static final Instant NOW = Instant.parse("2021-06-01T10:00:00Z");
+
+    PerformanceTargetCrudServiceInMemory targetCrudService = new PerformanceTargetCrudServiceInMemory();
+    PerformanceTargetEvaluationCrudServiceInMemory evaluationCrudService = new PerformanceTargetEvaluationCrudServiceInMemory();
+    PerformanceTargetEvaluationQueryServiceInMemory evaluationQueryService = new PerformanceTargetEvaluationQueryServiceInMemory(
+        evaluationCrudService
+    );
+
+    EvaluatePerformanceTargetUseCase useCase = new EvaluatePerformanceTargetUseCase(
+        targetCrudService,
+        evaluationQueryService,
+        evaluationCrudService,
+        Optional.of(new PerformanceTargetEvaluatorInMemory())
+    );
+
+    @BeforeEach
+    void setUp() {
+        TimeProvider.overrideClock(Clock.fixed(NOW, ZoneId.systemDefault()));
+        UuidString.overrideGenerator(() -> "evaluation-id");
+        targetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TimeProvider.reset();
+        UuidString.reset();
+        Stream.of(targetCrudService, evaluationCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_store_the_evaluation_as_the_latest_of_the_target() {
+        var output = useCase.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID));
+
+        assertThat(output.evaluation().id()).isEqualTo("evaluation-id");
+        assertThat(output.evaluation().latest()).isTrue();
+        assertThat(output.evaluation().evaluatedAt()).isEqualTo(NOW);
+        assertThat(evaluationCrudService.storage()).containsExactly(output.evaluation());
+    }
+
+    @Test
+    void should_refuse_when_the_target_was_evaluated_less_than_30_seconds_ago() {
+        givenLatestEvaluationAt(NOW.minusSeconds(12));
+
+        assertThatThrownBy(() ->
+            useCase.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID))
+        ).isInstanceOfSatisfying(PerformanceTargetEvaluatedTooRecentlyException.class, e ->
+            assertThat(e.getRetryAfter()).isEqualTo(Duration.ofSeconds(18))
+        );
+        assertThat(evaluationCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_evaluate_when_exactly_30_seconds_have_passed() {
+        givenLatestEvaluationAt(NOW.minusSeconds(30));
+
+        useCase.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID));
+
+        assertThat(evaluationCrudService.storage())
+            .filteredOn(PerformanceTargetEvaluation::latest)
+            .extracting(e -> e.id())
+            .containsExactly("evaluation-id");
+    }
+
+    @Test
+    void should_fail_when_no_evaluator_is_available() {
+        var withoutEvaluator = new EvaluatePerformanceTargetUseCase(
+            targetCrudService,
+            evaluationQueryService,
+            evaluationCrudService,
+            Optional.empty()
+        );
+
+        assertThatThrownBy(() ->
+            withoutEvaluator.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID))
+        ).isInstanceOf(TechnicalDomainException.class);
+        assertThat(evaluationCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_not_evaluate_a_target_of_another_environment() {
+        assertThatThrownBy(() -> useCase.execute(new EvaluatePerformanceTargetUseCase.Input("other-environment", TARGET_ID))).isInstanceOf(
+            PerformanceTargetNotFoundException.class
+        );
+    }
+
+    private void givenLatestEvaluationAt(Instant evaluatedAt) {
+        evaluationCrudService.initWith(
+            List.of(PerformanceTargetFixtures.anEvaluation("previous", TARGET_ID, PerformanceTargetEvaluation.Status.PASS, evaluatedAt))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetEvaluationQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetEvaluationQueryServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEnvironmentSummary;
@@ -35,6 +36,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class PerformanceTargetEvaluationQueryServiceImplTest {
 
@@ -75,6 +77,23 @@ class PerformanceTargetEvaluationQueryServiceImplTest {
 
         assertThat(page.getTotalElements()).isEqualTo(7);
         assertThat(page.getContent()).extracting(PerformanceTargetEvaluation::id).containsExactly("eval-1", "eval-2");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_page_evaluations_of_a_target_with_zero_based_repository_page() {
+        when(repository.findByTargetId(eq("target-id"), any())).thenReturn(
+            new Page<>(List.of(aRepositoryEvaluation("eval-3"), aRepositoryEvaluation("eval-2")), 1, 2, 5)
+        );
+
+        var page = service.findByTargetId("target-id", new PageableImpl(2, 2));
+
+        var pageable = ArgumentCaptor.forClass(io.gravitee.repository.management.api.search.Pageable.class);
+        verify(repository).findByTargetId(eq("target-id"), pageable.capture());
+        assertThat(pageable.getValue().pageNumber()).isEqualTo(1);
+        assertThat(pageable.getValue().pageSize()).isEqualTo(2);
+        assertThat(page.getTotalElements()).isEqualTo(5);
+        assertThat(page.getContent()).extracting(PerformanceTargetEvaluation::id).containsExactly("eval-3", "eval-2");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-509

## Description

Management API v2 surface for performance targets (epic AIAM-436), OpenAPI first, on top of the AIAM-508 model already on `amp_demo`.

Endpoints under `/environments/{envId}/performance-targets`:

- `POST` create, `GET ?reference=` list the targets of a reference, `GET/PUT/DELETE /{targetId}`
- `GET /_summary` counts of the latest evaluations by status
- `POST /evaluations/_latest` batch: one entry per requested reference, keyed by reference, `null` when it has no evaluation, worst status wins when several targets share a reference (for list badges)
- `GET /{targetId}/evaluations` paged history (most recent first) and `GET /{targetId}/evaluations/latest`
- `POST /{targetId}/_evaluate` evaluate now through the same evaluator as the scheduler; refused with `429` and a `Retry-After` header inside the 30 s window

Design points:

- Validation errors surface as `400` with the failing rule index in `parameters.ruleIndex` (mapper vocabulary errors and domain validation alike).
- `metric`, `measure` and filter names travel as strings validated against the analytics definition, since the environments and analytics specs generate into different packages.
- The evaluator is a core port (`PerformanceTargetEvaluator`) injected as `Optional` so the product boots before AIAM-510 provides the engine; evaluate-now answers `500` until then.
- New repository query `findByTargetId` (Mongo + JDBC) backs the history and the "latest for a target" lookups.
- New generic `TooManyRequestsDomainException` in gravitee-apim-common with its JAX-RS mapper.

Permissions: `ENVIRONMENT_API` READ for reads, CREATE/UPDATE/DELETE for writes, UPDATE for evaluate-now. The ticket left per-API permissions "to confirm"; not added because agent references have no API to check against.

Automation API: assessed, no mirror needed (new surface, not an API definition or CRD field).

## Additional context

Security-sensitive surfaces touched: new public REST endpoints and generated models, permission checks, new repository interface method, new domain exception type.

Verification (local, on this `amp_demo` base): the two new `EnvironmentPerformanceTarget*ResourceTest` classes (34 tests), the performance-target service-module tests (51 tests), and the shared `PerformanceTargetEvaluationRepositoryTest` on Mongo and JDBC (16 tests each). The full Management API v2 REST module suite was green on the same change set before the rebase onto `amp_demo` (1890 tests).

Follow-ups: AIAM-510 (evaluation engine, implements the port), AIAM-511 (scheduler).
