### PR TITLE
feat(portal): tighten subscription-form uniqueness to publish-time, enforced on update too

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemValidatorService.java
@@ -91,11 +91,12 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
         var sourcedItemReadOnlyRule = new SourcedItemReadOnlyRule(new SourcedAncestorFinder(navigationItemsQueryService));
         var fileListingSourceOnFolderRule = new FileListingSourceOnFolderRule(portalNavigationItemSourceDomainService::supportsFileListing);
         var subscriptionFormNoParentRule = new SubscriptionFormNoParentRule();
+        var subscriptionFormUniquenessRule = new SubscriptionFormUniquenessRule(navigationItemsQueryService);
 
         this.createRules = List.of(
             new UniqueItemIdRule(navigationItemsQueryService),
             new HomepageUniquenessRule(navigationItemsQueryService),
-            new SubscriptionFormUniquenessRule(navigationItemsQueryService),
+            subscriptionFormUniquenessRule,
             new PageContentExistsRule(pageContentQueryService),
             new SubscriptionFormContentTypeRule(pageContentQueryService),
             titleRequiredRule,
@@ -118,6 +119,7 @@ public class PortalNavigationItemValidatorService implements PortalNavigationVal
             new ApiProductItemUpdateRule(),
             parentRule,
             subscriptionFormNoParentRule,
+            subscriptionFormUniquenessRule,
             segmentConflictRule,
             linkUrlRule,
             externalSourceItemTypeRule,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRule.java
@@ -16,34 +16,57 @@
 package io.gravitee.apim.core.portal_page.domain_service.validation;
 
 import io.gravitee.apim.core.portal.model.PortalArea;
-import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyPublishedException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import lombok.RequiredArgsConstructor;
 
 /**
- * For SUBSCRIPTION_FORM area, ensures no item already exists in that area — there is exactly one
- * subscription form per environment.
+ * For SUBSCRIPTION_FORM area, ensures at most one item is published per environment. There is no
+ * stored "default" flag: the environment's default subscription form is derived as "the one
+ * published item" (see {@link PortalNavigationItemsQueryService#findPublishedSubscriptionForm}), so
+ * this rule is what keeps that derivation unambiguous.
  */
 @RequiredArgsConstructor
-public class SubscriptionFormUniquenessRule implements CreatePortalNavigationItemValidationRule {
+public class SubscriptionFormUniquenessRule implements CreatePortalNavigationItemValidationRule, UpdatePortalNavigationItemValidationRule {
 
     private final PortalNavigationItemsQueryService navigationItemsQueryService;
 
     @Override
     public boolean appliesTo(CreatePortalNavigationItem item) {
-        return item.getArea() == PortalArea.SUBSCRIPTION_FORM;
+        return item.getArea() == PortalArea.SUBSCRIPTION_FORM && Boolean.TRUE.equals(item.getPublished());
     }
 
     @Override
     public void validate(CreatePortalNavigationItem item, String environmentId, CreateValidationContext ctx) {
-        var existing = navigationItemsQueryService.findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(
-            environmentId,
-            PortalArea.SUBSCRIPTION_FORM,
-            item.getReference()
-        );
-        if (!existing.isEmpty()) {
-            throw new SubscriptionFormAlreadyExistsException();
+        var alreadyPublished = navigationItemsQueryService
+            .findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(environmentId, PortalArea.SUBSCRIPTION_FORM, item.getReference())
+            .stream()
+            .anyMatch(existing -> Boolean.TRUE.equals(existing.getPublished()));
+        if (alreadyPublished) {
+            throw new SubscriptionFormAlreadyPublishedException();
+        }
+    }
+
+    @Override
+    public boolean appliesTo(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem) {
+        return existingItem.getArea() == PortalArea.SUBSCRIPTION_FORM && Boolean.TRUE.equals(toUpdate.getPublished());
+    }
+
+    @Override
+    public void validate(UpdatePortalNavigationItem toUpdate, PortalNavigationItem existingItem, UpdateValidationContext ctx) {
+        var anotherAlreadyPublished = navigationItemsQueryService
+            .findTopLevelItemsByEnvironmentIdAndPortalAreaAndReference(
+                existingItem.getEnvironmentId(),
+                PortalArea.SUBSCRIPTION_FORM,
+                existingItem.getReference()
+            )
+            .stream()
+            .anyMatch(existing -> !existing.getId().equals(existingItem.getId()) && Boolean.TRUE.equals(existing.getPublished()));
+        if (anotherAlreadyPublished) {
+            throw new SubscriptionFormAlreadyPublishedException();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/SubscriptionFormAlreadyPublishedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/SubscriptionFormAlreadyPublishedException.java
@@ -17,9 +17,9 @@ package io.gravitee.apim.core.portal_page.exception;
 
 import io.gravitee.apim.core.exception.ConflictDomainException;
 
-public class SubscriptionFormAlreadyExistsException extends ConflictDomainException {
+public class SubscriptionFormAlreadyPublishedException extends ConflictDomainException {
 
-    public SubscriptionFormAlreadyExistsException() {
-        super("Subscription form already exists for this environment");
+    public SubscriptionFormAlreadyPublishedException() {
+        super("A subscription form is already published for this environment");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -96,4 +96,20 @@ public interface PortalNavigationItemsQueryService {
             .filter(subscriptionForm -> subscriptionForm.getPortalPageContentId().equals(contentId))
             .findFirst();
     }
+
+    /**
+     * The environment's effective default subscription form: there is no stored "default" flag — a
+     * SUBSCRIPTION_FORM item is the default exactly when it is the only one currently published. Zero or more
+     * than one published item both resolve to empty, matching "behave as if there is no subscription form" for
+     * an ambiguous state.
+     */
+    default Optional<PortalNavigationSubscriptionForm> findPublishedSubscriptionForm(String environmentId) {
+        var published = findTopLevelItemsByEnvironmentIdAndPortalArea(environmentId, PortalArea.SUBSCRIPTION_FORM)
+            .stream()
+            .filter(PortalNavigationSubscriptionForm.class::isInstance)
+            .map(PortalNavigationSubscriptionForm.class::cast)
+            .filter(item -> Boolean.TRUE.equals(item.getPublished()))
+            .toList();
+        return published.size() == 1 ? Optional.of(published.get(0)) : Optional.empty();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -110,6 +110,9 @@ public interface PortalNavigationItemsQueryService {
             .map(PortalNavigationSubscriptionForm.class::cast)
             .filter(item -> Boolean.TRUE.equals(item.getPublished()))
             .toList();
-        return published.size() == 1 ? Optional.of(published.get(0)) : Optional.empty();
+        if (published.size() != 1) {
+            return Optional.empty();
+        }
+        return Optional.of(published.get(0));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRuleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/validation/SubscriptionFormUniquenessRuleTest.java
@@ -19,18 +19,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import fixtures.core.model.PortalNavigationItemFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.portal.model.PortalArea;
-import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyExistsException;
+import io.gravitee.apim.core.portal_page.exception.SubscriptionFormAlreadyPublishedException;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,45 +50,106 @@ class SubscriptionFormUniquenessRuleTest {
         rule = new SubscriptionFormUniquenessRule(navigationItemsQueryService);
     }
 
-    @Test
-    void applies_only_to_subscription_form_area() {
-        assertThat(rule.appliesTo(subscriptionFormCreateItem())).isTrue();
-        assertThat(
-            rule.appliesTo(
-                CreatePortalNavigationItem.builder()
-                    .type(PortalNavigationItemType.FOLDER)
-                    .title("Navbar")
-                    .segment("navbar")
-                    .area(PortalArea.TOP_NAVBAR)
-                    .order(0)
-                    .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
-                    .build()
-            )
-        ).isFalse();
+    @Nested
+    class Create {
+
+        @Test
+        void applies_only_to_published_subscription_form_items() {
+            assertThat(rule.appliesTo(subscriptionFormCreateItem(true))).isTrue();
+            assertThat(rule.appliesTo(subscriptionFormCreateItem(false))).isFalse();
+            assertThat(
+                rule.appliesTo(
+                    CreatePortalNavigationItem.builder()
+                        .type(PortalNavigationItemType.FOLDER)
+                        .title("Navbar")
+                        .segment("navbar")
+                        .area(PortalArea.TOP_NAVBAR)
+                        .order(0)
+                        .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                        .published(true)
+                        .build()
+                )
+            ).isFalse();
+        }
+
+        @Test
+        void rejects_creating_a_second_published_subscription_form_for_the_same_environment() {
+            navigationItemsQueryService.storage().add(PortalNavigationItem.from(subscriptionFormCreateItem(true), ORG_ID, ENV_ID, null));
+
+            assertThatThrownBy(() -> rule.validate(subscriptionFormCreateItem(true), ENV_ID, null)).isInstanceOf(
+                SubscriptionFormAlreadyPublishedException.class
+            );
+        }
+
+        @Test
+        void allows_the_first_published_subscription_form_for_an_environment() {
+            assertThatCode(() -> rule.validate(subscriptionFormCreateItem(true), ENV_ID, null)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void existing_published_subscription_form_in_a_different_environment_does_not_conflict() {
+            navigationItemsQueryService
+                .storage()
+                .add(PortalNavigationItem.from(subscriptionFormCreateItem(true), ORG_ID, "env-other", null));
+
+            assertThatCode(() -> rule.validate(subscriptionFormCreateItem(true), ENV_ID, null)).doesNotThrowAnyException();
+        }
     }
 
-    @Test
-    void rejects_a_second_subscription_form_for_the_same_environment() {
-        navigationItemsQueryService.storage().add(PortalNavigationItem.from(subscriptionFormCreateItem(), ORG_ID, ENV_ID, null));
+    @Nested
+    class Update {
 
-        assertThatThrownBy(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).isInstanceOf(
-            SubscriptionFormAlreadyExistsException.class
-        );
+        @Test
+        void applies_only_to_subscription_form_items_being_published() {
+            var existing = subscriptionForm(false);
+
+            assertThat(rule.appliesTo(updatePublished(true), existing)).isTrue();
+            assertThat(rule.appliesTo(updatePublished(false), existing)).isFalse();
+        }
+
+        @Test
+        void rejects_publishing_a_second_form_while_another_is_already_published() {
+            var alreadyPublished = subscriptionForm(true);
+            var toBePublished = subscriptionForm(false);
+            navigationItemsQueryService.storage().add(alreadyPublished);
+            navigationItemsQueryService.storage().add(toBePublished);
+
+            assertThatThrownBy(() -> rule.validate(updatePublished(true), toBePublished, null)).isInstanceOf(
+                SubscriptionFormAlreadyPublishedException.class
+            );
+        }
+
+        @Test
+        void allows_republishing_the_same_form_that_is_already_the_only_published_one() {
+            var alreadyPublished = subscriptionForm(true);
+            navigationItemsQueryService.storage().add(alreadyPublished);
+
+            assertThatCode(() -> rule.validate(updatePublished(true), alreadyPublished, null)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void allows_publishing_when_no_other_form_is_currently_published() {
+            var toBePublished = subscriptionForm(false);
+            navigationItemsQueryService.storage().add(toBePublished);
+
+            assertThatCode(() -> rule.validate(updatePublished(true), toBePublished, null)).doesNotThrowAnyException();
+        }
+
+        private PortalNavigationSubscriptionForm subscriptionForm(boolean published) {
+            return (PortalNavigationSubscriptionForm) PortalNavigationItem.from(
+                subscriptionFormCreateItem(published),
+                ORG_ID,
+                ENV_ID,
+                null
+            );
+        }
+
+        private UpdatePortalNavigationItem updatePublished(boolean published) {
+            return UpdatePortalNavigationItem.builder().title("Subscription Form").published(published).build();
+        }
     }
 
-    @Test
-    void allows_the_first_subscription_form_for_an_environment() {
-        assertThatCode(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void existing_subscription_form_in_a_different_environment_does_not_conflict() {
-        navigationItemsQueryService.storage().add(PortalNavigationItem.from(subscriptionFormCreateItem(), ORG_ID, "env-other", null));
-
-        assertThatCode(() -> rule.validate(subscriptionFormCreateItem(), ENV_ID, null)).doesNotThrowAnyException();
-    }
-
-    private static CreatePortalNavigationItem subscriptionFormCreateItem() {
+    private static CreatePortalNavigationItem subscriptionFormCreateItem(boolean published) {
         return CreatePortalNavigationItem.builder()
             .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
             .title("Subscription Form")
@@ -95,6 +158,7 @@ class SubscriptionFormUniquenessRuleTest {
             .order(0)
             .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
             .portalPageContentId(PortalPageContentId.random())
+            .published(published)
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryServiceDefaultMethodsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryServiceDefaultMethodsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.query_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemsQueryServiceDefaultMethodsTest {
+
+    private static final String ENV_ID = PortalNavigationItemFixtures.ENV_ID;
+
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+
+    @BeforeEach
+    void setUp() {
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+    }
+
+    @Test
+    void returns_empty_when_no_subscription_form_is_published() {
+        var form = PortalNavigationItemFixtures.aSubscriptionForm(PortalNavigationItemId.random().json(), PortalPageContentId.random())
+            .toBuilder()
+            .published(false)
+            .build();
+        navigationItemsQueryService.storage().add(form);
+
+        assertThat(navigationItemsQueryService.findPublishedSubscriptionForm(ENV_ID)).isEmpty();
+    }
+
+    @Test
+    void returns_the_item_when_exactly_one_subscription_form_is_published() {
+        var published = PortalNavigationItemFixtures.aSubscriptionForm(
+            PortalNavigationItemId.random().json(),
+            PortalPageContentId.random()
+        );
+        var unpublished = PortalNavigationItemFixtures.aSubscriptionForm(
+            PortalNavigationItemId.random().json(),
+            PortalPageContentId.random()
+        )
+            .toBuilder()
+            .published(false)
+            .build();
+        navigationItemsQueryService.storage().add(published);
+        navigationItemsQueryService.storage().add(unpublished);
+
+        assertThat(navigationItemsQueryService.findPublishedSubscriptionForm(ENV_ID)).contains(published);
+    }
+
+    @Test
+    void returns_empty_when_more_than_one_subscription_form_is_published() {
+        var first = PortalNavigationItemFixtures.aSubscriptionForm(PortalNavigationItemId.random().json(), PortalPageContentId.random());
+        var second = PortalNavigationItemFixtures.aSubscriptionForm(PortalNavigationItemId.random().json(), PortalPageContentId.random());
+        navigationItemsQueryService.storage().add(first);
+        navigationItemsQueryService.storage().add(second);
+
+        assertThat(navigationItemsQueryService.findPublishedSubscriptionForm(ENV_ID)).isEmpty();
+    }
+}


### PR DESCRIPTION
PORTAL-166 §1+§4: foundation for a catalog of subscription forms. Replaces "at most one SUBSCRIPTION_FORM item may exist" (create-only) with "at most one may be published=true" (enforced on create *and* update), so "the default" can later be derived as the single currently-published item instead of the environment's one-and-only item.

**Stack**: 1st of 4 PRs, based on the US_1/PORTAL-164 stack tip (#19577).

## Changes

- `PortalNavigationItemsQueryService.findPublishedSubscriptionForm(String environmentId)` — new default method, the single source of truth for "what is the environment's default subscription form right now." Returns empty when zero or more than one item is published (graceful degradation).
- `SubscriptionFormUniquenessRule` rewritten to implement both `CreatePortalNavigationItemValidationRule` and `UpdatePortalNavigationItemValidationRule` (mirroring `SubscriptionFormNoParentRule`'s existing dual-interface pattern), wired into both `createRules` and `updateRules` in `PortalNavigationItemValidatorService`.
- `SubscriptionFormAlreadyExistsException` renamed to `SubscriptionFormAlreadyPublishedException` — the old name/message would be misleading once multiple items are allowed to exist and only publishing a second one is rejected.

## Compatibility

New 409 failure mode on the update endpoint specifically for `SUBSCRIPTION_FORM` items (publishing a second one while another is already published). No schema change.