### PR TITLE
feat(portal): allow creating a subscription form via the generic REST create endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -2587,6 +2587,7 @@ components:
           LINK: "#/components/schemas/CreatePortalNavigationLink"
           API:  "#/components/schemas/CreatePortalNavigationApi"
           API_PRODUCT: "#/components/schemas/CreatePortalNavigationApiProduct"
+          SUBSCRIPTION_FORM: "#/components/schemas/CreatePortalNavigationSubscriptionForm"
       required: [ title, type, area, visibility ]
     CreatePortalNavigationFolder:
       type: object
@@ -2665,6 +2666,18 @@ components:
                 format: uuid
               example: [ "00f8c9e7-78fc-4907-b8c9-e778fc790750" ]
           required: [ apiProductId ]
+    CreatePortalNavigationSubscriptionForm:
+      type: object
+      title: "CreatePortalNavigationSubscriptionForm"
+      description: Portal navigation subscription form to create. If portalPageContentId is not provided, default GRAVITEE_MARKDOWN content is created automatically (as for CreatePortalNavigationPage) — edit it afterwards through the portal-page-contents endpoints. Newly created forms are unpublished by default.
+      allOf:
+        - $ref: "#/components/schemas/BaseCreatePortalNavigationItem"
+        - properties:
+            portalPageContentId:
+              type: string
+              format: uuid
+              description: The UUID of an existing portal page content backing this subscription form. Must be of type GRAVITEE_MARKDOWN. If omitted, default content is created automatically.
+              example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
     CreatePortalNavigationItem:
       oneOf:
         - $ref: "#/components/schemas/CreatePortalNavigationPage"
@@ -2672,6 +2685,7 @@ components:
         - $ref: "#/components/schemas/CreatePortalNavigationLink"
         - $ref: "#/components/schemas/CreatePortalNavigationApi"
         - $ref: "#/components/schemas/CreatePortalNavigationApiProduct"
+        - $ref: "#/components/schemas/CreatePortalNavigationSubscriptionForm"
 
       discriminator:
         propertyName: type
@@ -2681,6 +2695,7 @@ components:
           LINK: "#/components/schemas/CreatePortalNavigationLink"
           API: "#/components/schemas/CreatePortalNavigationApi"
           API_PRODUCT: "#/components/schemas/CreatePortalNavigationApiProduct"
+          SUBSCRIPTION_FORM: "#/components/schemas/CreatePortalNavigationSubscriptionForm"
 
     CreatePortalNavigationItems:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiPr
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.model.FetchPortalNavigationItemResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationRequest;
 import io.gravitee.rest.api.management.v2.rest.model.ImportPortalNavigationResponse;
@@ -149,6 +150,13 @@ public interface PortalNavigationItemsMapper {
     @Mapping(target = "apiProductId", source = "apiProductId")
     io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(CreatePortalNavigationApiProduct apiProduct);
 
+    @Mapping(target = "contentType", constant = "GRAVITEE_MARKDOWN")
+    @Mapping(
+        target = "portalPageContentId",
+        expression = "java(subscriptionForm.getPortalPageContentId() == null ? null : io.gravitee.apim.core.portal_page.model.PortalPageContentId.of(subscriptionForm.getPortalPageContentId().toString()))"
+    )
+    io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(CreatePortalNavigationSubscriptionForm subscriptionForm);
+
     default io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem map(
         BaseCreatePortalNavigationItem createPortalNavigationItem
     ) {
@@ -158,6 +166,7 @@ public interface PortalNavigationItemsMapper {
             case CreatePortalNavigationLink link -> map(link);
             case CreatePortalNavigationApi api -> map(api);
             case CreatePortalNavigationApiProduct apiProduct -> map(apiProduct);
+            case CreatePortalNavigationSubscriptionForm subscriptionForm -> map(subscriptionForm);
             default -> throw new TechnicalDomainException(
                 String.format("Unknown PortalNavigationItem class %s", createPortalNavigationItem.getClass().getSimpleName())
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -44,6 +44,7 @@ import java.util.UUID;
 public class PortalNavigationItemsFixtures {
 
     static final String MY_FOLDER = "My Folder";
+    static final String SUBSCRIPTION_FORM_TITLE = "Subscription Form";
 
     private PortalNavigationItemsFixtures() {}
 
@@ -153,7 +154,7 @@ public class PortalNavigationItemsFixtures {
     }
 
     public static BaseCreatePortalNavigationItem aCreatePortalNavigationSubscriptionForm() {
-        var title = "Subscription Form";
+        var title = SUBSCRIPTION_FORM_TITLE;
         var id = UUID.fromString("00000000-0000-0000-0000-000000000021");
         var contentId = UUID.fromString("00000000-0000-0000-0000-000000000020");
         return new CreatePortalNavigationSubscriptionForm()
@@ -171,8 +172,8 @@ public class PortalNavigationItemsFixtures {
             .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000021"))
             .organizationId(organizationId)
             .environmentId(environmentId)
-            .title("Subscription Form")
-            .segment(PortalNavigationItem.slugify("Subscription Form").value())
+            .title(SUBSCRIPTION_FORM_TITLE)
+            .segment(PortalNavigationItem.slugify(SUBSCRIPTION_FORM_TITLE).value())
             .area(PortalArea.SUBSCRIPTION_FORM)
             .order(0)
             .portalPageContentId(PortalPageContentId.of("00000000-0000-0000-0000-000000000020"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PortalNavigationItemsFixtures.java
@@ -23,7 +23,9 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
@@ -31,6 +33,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiPr
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
@@ -147,6 +150,36 @@ public class PortalNavigationItemsFixtures {
         var apiProduct = anUpdatePortalNavigationApiProduct();
         apiProduct.setCategoryIds(categoryIds);
         return apiProduct;
+    }
+
+    public static BaseCreatePortalNavigationItem aCreatePortalNavigationSubscriptionForm() {
+        var title = "Subscription Form";
+        var id = UUID.fromString("00000000-0000-0000-0000-000000000021");
+        var contentId = UUID.fromString("00000000-0000-0000-0000-000000000020");
+        return new CreatePortalNavigationSubscriptionForm()
+            .portalPageContentId(contentId)
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .id(id)
+            .title(title)
+            .area(io.gravitee.rest.api.management.v2.rest.model.PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .visibility(PortalVisibility.PUBLIC);
+    }
+
+    public static PortalNavigationItem aPortalNavigationSubscriptionForm(String organizationId, String environmentId) {
+        return PortalNavigationSubscriptionForm.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000021"))
+            .organizationId(organizationId)
+            .environmentId(environmentId)
+            .title("Subscription Form")
+            .segment(PortalNavigationItem.slugify("Subscription Form").value())
+            .area(PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.of("00000000-0000-0000-0000-000000000020"))
+            .validationConstraints(SubscriptionFormFieldConstraints.empty())
+            .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .published(false)
+            .build();
     }
 
     public static BaseCreatePortalNavigationItem aPrivateCreatePortalNavigationPage() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.management.v2.rest.model.BasePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
@@ -312,6 +313,24 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(3);
             assertThat(result.getParentId().id()).isEqualTo(link.getParentId());
             assertThat(result.getUrl()).isEqualTo(((CreatePortalNavigationLink) link).getUrl());
+        }
+
+        @Test
+        void should_map_create_portal_navigation_subscription_form() {
+            final var subscriptionForm = PortalNavigationItemsFixtures.aCreatePortalNavigationSubscriptionForm();
+
+            var result = mapper.map(subscriptionForm);
+
+            assertThat(result).isInstanceOf(CreatePortalNavigationItem.class);
+            assertThat(result.getType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalNavigationItemType.SUBSCRIPTION_FORM);
+            assertThat(result.getContentType()).isEqualTo(io.gravitee.apim.core.portal_page.model.PortalPageContentType.GRAVITEE_MARKDOWN);
+            assertThat(result.getId()).isNotNull();
+            assertThat(result.getTitle()).isEqualTo(subscriptionForm.getTitle());
+            assertThat(result.getArea()).isEqualTo(PortalArea.SUBSCRIPTION_FORM);
+            assertThat(result.getOrder()).isEqualTo(0);
+            assertThat(result.getPortalPageContentId().id()).isEqualTo(
+                ((CreatePortalNavigationSubscriptionForm) subscriptionForm).getPortalPageContentId()
+            );
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_CreateTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
+import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationSubscriptionForm;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemType;
 import io.gravitee.rest.api.management.v2.rest.model.PortalVisibility;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
@@ -314,6 +315,36 @@ class PortalNavigationItemsResource_CreateTest extends AbstractResourceTest {
             .hasFieldOrPropertyWithValue("apiProductId", ((CreatePortalNavigationApiProduct) apiProduct).getApiProductId())
             .hasFieldOrPropertyWithValue("parentId", apiProduct.getParentId())
             .hasFieldOrPropertyWithValue("published", false);
+    }
+
+    @Test
+    void should_create_portal_navigation_subscription_form() {
+        // Given
+        final var subscriptionForm = PortalNavigationItemsFixtures.aCreatePortalNavigationSubscriptionForm();
+
+        final var output = PortalNavigationItemsFixtures.aPortalNavigationSubscriptionForm(ORGANIZATION, ENVIRONMENT);
+        when(createPortalNavigationItemUseCase.execute(any())).thenReturn(new CreatePortalNavigationItemUseCase.Output(output));
+
+        // When
+        Response response = target.request().post(json(subscriptionForm));
+
+        // Then
+        assertThat(response).hasStatus(CREATED_201);
+
+        final var item = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.PortalNavigationSubscriptionForm.class);
+        assertThat(item)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("id", subscriptionForm.getId())
+            .hasFieldOrPropertyWithValue("title", subscriptionForm.getTitle())
+            .hasFieldOrPropertyWithValue("type", PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .hasFieldOrPropertyWithValue(
+                "portalPageContentId",
+                ((CreatePortalNavigationSubscriptionForm) subscriptionForm).getPortalPageContentId()
+            )
+            .hasFieldOrPropertyWithValue("order", subscriptionForm.getOrder())
+            .hasFieldOrPropertyWithValue("area", io.gravitee.rest.api.management.v2.rest.model.PortalArea.SUBSCRIPTION_FORM)
+            .hasFieldOrPropertyWithValue("published", false)
+            .hasFieldOrPropertyWithValue("visibility", io.gravitee.rest.api.management.v2.rest.model.PortalVisibility.PUBLIC);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -73,7 +73,8 @@ public class PortalNavigationItemDomainService {
         createPortalNavigationItem.setOrder(sanitizedOrder);
 
         if (
-            createPortalNavigationItem.getType() == PortalNavigationItemType.PAGE &&
+            (createPortalNavigationItem.getType() == PortalNavigationItemType.PAGE ||
+                createPortalNavigationItem.getType() == PortalNavigationItemType.SUBSCRIPTION_FORM) &&
             createPortalNavigationItem.getPortalPageContentId() == null
         ) {
             final var defaultPageContent = pageContentCrudService.createDefault(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreatePortalNavigationItemUseCaseTest.java
@@ -49,6 +49,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSubscriptionForm;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
@@ -345,6 +346,36 @@ class CreatePortalNavigationItemUseCaseTest {
 
         // Then
         final var contentId = ((PortalNavigationPage) output.item()).getPortalPageContentId();
+        final var contents = pageContentCrudService.storage();
+        assertThat(contents)
+            .hasSize(numberOfContents + 1)
+            .anySatisfy(content -> {
+                assertThat(content.getId()).isEqualTo(contentId);
+                assertThat(content.getOrganizationId()).isEqualTo(ORG_ID);
+                assertThat(content.getEnvironmentId()).isEqualTo(ENV_ID);
+                assertThat(content).isInstanceOf(GraviteeMarkdownPageContent.class);
+                assertThat(((GraviteeMarkdownPageContent) content).getContent().value()).isEqualTo("default page content");
+            });
+    }
+
+    @Test
+    void should_create_default_subscription_form_content_when_content_id_is_null() {
+        // Given
+        final var createPortalNavigationItem = CreatePortalNavigationItem.builder()
+            .id(PortalNavigationItemId.random())
+            .type(PortalNavigationItemType.SUBSCRIPTION_FORM)
+            .title("Alternate Subscription Form")
+            .area(PortalArea.SUBSCRIPTION_FORM)
+            .order(0)
+            .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+            .build();
+        final var numberOfContents = pageContentCrudService.storage().size();
+
+        // When
+        final var output = useCase.execute(new CreatePortalNavigationItemUseCase.Input(ORG_ID, ENV_ID, createPortalNavigationItem));
+
+        // Then
+        final var contentId = ((PortalNavigationSubscriptionForm) output.item()).getPortalPageContentId();
         final var contents = pageContentCrudService.storage();
         assertThat(contents)
             .hasSize(numberOfContents + 1)


### PR DESCRIPTION
PORTAL-166 §5: expose a `SUBSCRIPTION_FORM` create variant on the generic `POST /portal-navigation-items` endpoint, plus a backend fix found during manual verification of the Console change stacked on top (#19642): there was no `POST /portal-page-contents` endpoint to create standalone content, so the Console needed the backend to auto-create default content the same way `PAGE` items already do.

**Stack**: 3rd of 4 PRs, based on #19640 (§2+§3).

## Changes

- New `CreatePortalNavigationSubscriptionForm` OpenAPI schema (`openapi-environments.yaml`), registered in both the `BaseCreatePortalNavigationItem` and `CreatePortalNavigationItem` discriminators, mirroring how `UpdatePortalNavigationSubscriptionForm` is already registered on the update side. `portalPageContentId` is optional.
- `PortalNavigationItemsMapper` (management-v2-rest): maps the new variant, `contentType=GRAVITEE_MARKDOWN`.
- `PortalNavigationItemDomainService.create()`: widened the existing PAGE-only auto-default-content condition to also cover `SUBSCRIPTION_FORM` when `portalPageContentId` is null — creates a default `GraviteeMarkdownPageContent`, exactly as it already does for `PAGE`.

## Compatibility

Public REST API: new `CreatePortalNavigationSubscriptionForm` OpenAPI schema/discriminator entry on the existing generic create endpoint. No schema change, no auth/security-relevant change.