### PR TITLE
feat(console): subscription-form catalog screen with master-detail layout

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture.ts
@@ -28,6 +28,7 @@ import {
   NewLinkPortalNavigationItem,
   NewApiPortalNavigationItem,
   NewApiProductPortalNavigationItem,
+  NewSubscriptionFormPortalNavigationItem,
   UpdatePagePortalNavigationItem,
   UpdateLinkPortalNavigationItem,
   UpdateFolderPortalNavigationItem,
@@ -302,6 +303,27 @@ export function fakeNewApiProductPortalNavigationItem(
     area: 'TOP_NAVBAR',
     apiProductId: 'api-product-1',
     visibility: 'PUBLIC',
+  };
+
+  if (isFunction(overrides)) {
+    return overrides(base);
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+export function fakeNewSubscriptionFormPortalNavigationItem(
+  overrides?: Partial<NewSubscriptionFormPortalNavigationItem>,
+): NewSubscriptionFormPortalNavigationItem {
+  const base: NewSubscriptionFormPortalNavigationItem = {
+    title: 'New Subscription Form',
+    type: 'SUBSCRIPTION_FORM',
+    area: 'SUBSCRIPTION_FORM',
+    visibility: 'PUBLIC',
+    portalPageContentId: 'subscription-form-content-1',
   };
 
   if (isFunction(overrides)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalNavigationItem/portalNavigationItem.ts
@@ -200,12 +200,18 @@ export interface NewApiProductPortalNavigationItem extends BaseNewPortalNavigati
   categoryIds?: string[];
 }
 
+export interface NewSubscriptionFormPortalNavigationItem extends BaseNewPortalNavigationItem<'SUBSCRIPTION_FORM'> {
+  /** If omitted, default GRAVITEE_MARKDOWN content is created automatically — edit it afterwards via portal-page-contents. */
+  portalPageContentId?: string;
+}
+
 export type NewPortalNavigationItem =
   | NewPagePortalNavigationItem
   | NewFolderPortalNavigationItem
   | NewLinkPortalNavigationItem
   | NewApiPortalNavigationItem
-  | NewApiProductPortalNavigationItem;
+  | NewApiProductPortalNavigationItem
+  | NewSubscriptionFormPortalNavigationItem;
 
 interface BaseUpdatePortalNavigationItem<T extends PortalNavigationItemType> {
   title: string;

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.html
@@ -15,34 +15,127 @@
     limitations under the License.
 
 -->
-<portal-header
-  subtitle="Define the subscription form that will be displayed to users when subscribing to APIs"
-  [title]="'Subscription Form'"
-  [showActions]="true"
->
-  <div additionalActions class="actions">
-    <mat-slide-toggle
-      aria-label="Visible to API consumers"
-      labelPosition="before"
-      [formControl]="enabledControl"
-      [matTooltip]="enabledControlTooltip()"
-      [matTooltipDisabled]="!enabledControlTooltip()"
-      data-testid="enable-toggle"
-    >
-      Visible to API consumers
-    </mat-slide-toggle>
-    <button
-      *gioPermission="{ anyOf: ['environment-metadata-u'] }"
-      mat-flat-button
-      color="primary"
-      aria-label="Update subscription form"
-      (click)="updateSubscriptionForm()"
-      [disabled]="isSaveDisabled()"
-      [matTooltip]="saveButtonTooltip()"
-      [matTooltipDisabled]="!saveButtonTooltip()"
-    >
-      Save
-    </button>
+<main class="page-layout">
+  <section class="panel sections-panel" [style.width.px]="panelWidth()">
+    <header class="panel-header sections-panel__header">
+      <h3>Subscription Forms</h3>
+      <div class="panel-header__actions">
+        <button
+          *gioPermission="{ anyOf: ['environment-metadata-u'] }"
+          mat-stroked-button
+          type="button"
+          aria-label="Add subscription form"
+          data-testid="create-subscription-form-button"
+          (click)="startCreate()"
+        >
+          <mat-icon>add</mat-icon>
+          Add
+        </button>
+      </div>
+    </header>
+
+    <div class="sections-panel__tree__container">
+      <gio-table-wrapper
+        [searchLabel]="'Search'"
+        [length]="total()"
+        [filters]="filters()"
+        [disablePaginator]="true"
+        (filtersChange)="onFiltersChanged($event)"
+      >
+        <table mat-table [dataSource]="pagedRows()" aria-label="Subscription forms table">
+          <ng-container matColumnDef="title">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let row">
+              {{ row.item.title }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="published">
+            <th mat-header-cell *matHeaderCellDef>Published</th>
+            <td mat-cell *matCellDef="let row">
+              <mat-slide-toggle
+                [checked]="row.item.published"
+                [disabled]="!canUpdate()"
+                [attr.aria-label]="'Published — ' + row.item.title"
+                [attr.data-testid]="'publish-toggle-' + row.item.id"
+                (click)="$event.stopPropagation()"
+                (change)="onPublishToggle(row)"
+              ></mat-slide-toggle>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: displayedColumns"
+            role="button"
+            tabindex="0"
+            [class.selected]="row.item.id === selectedItem()?.id"
+            [attr.data-testid]="'subscription-form-row-' + row.item.id"
+            (click)="selectItem(row)"
+            (keydown.enter)="selectItem(row)"
+          ></tr>
+
+          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+              <span data-testid="subscription-form-empty">No subscription forms yet.</span>
+            </td>
+          </tr>
+        </table>
+      </gio-table-wrapper>
+    </div>
+  </section>
+
+  <div class="resize-handle-container" (mousedown)="onResizeStart($event)">
+    <hr class="resize-handle" aria-label="Resize subscription forms panel" aria-orientation="vertical" />
+    <mat-icon svgIcon="gio:drag-indicator"></mat-icon>
   </div>
-</portal-header>
-<gmd-form-editor [formControl]="contentControl" />
+
+  <section class="panel editor-panel">
+    <header class="panel-header editor-panel__header">
+      @if (hasSelection()) {
+        <div class="panel-header__title">
+          <mat-form-field appearance="outline" subscriptSizing="dynamic" class="panel-header__title__field">
+            <input matInput [formControl]="titleControl" required placeholder="Title" data-testid="subscription-form-title-input" />
+          </mat-form-field>
+
+          @if (!isCreating()) {
+            <div class="panel-header__title__badges">
+              <span [class]="selectedItemIsPublished() ? 'gio-badge-success' : 'gio-badge-warning'">
+                {{ selectedItemIsPublished() ? 'Published' : 'Unpublished' }}
+              </span>
+            </div>
+          }
+        </div>
+      }
+      <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-metadata-u'] }">
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          [disabled]="isSaveDisabled()"
+          data-testid="subscription-form-save-button"
+          (click)="save()"
+        >
+          {{ saveButtonLabel() }}
+        </button>
+      </div>
+    </header>
+
+    @if (hasSelection()) {
+      <gmd-form-editor [formControl]="contentControl" />
+    } @else {
+      <div class="empty-editor">
+        <mat-card appearance="outlined" class="empty-state">
+          <mat-card-content>
+            <empty-state
+              iconName="gio:code"
+              title="Subscription form"
+              message="Select a form from the list to edit it, or create a new one."
+            />
+          </mat-card-content>
+        </mat-card>
+      </div>
+    }
+  </section>
+</main>

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.scss
@@ -1,30 +1,179 @@
-@use '../../scss/gio-layout' as gio-layout;
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 @use '@gravitee/gravitee-markdown' as gmd;
 
+@use '../../scss/gio-layout' as gio-layout;
+
+$outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80);
+
 :host {
   @include gio-layout.gio-responsive-content-container;
 
-  & {
+  @include gmd.editor-overrides(
+    (
+      container-outline-color: $outline-color,
+    )
+  );
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.page-layout {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 0;
+  flex-grow: 1;
+  min-height: 0;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  background-color: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
+  min-height: 0;
+  min-width: 0;
+}
+
+.panel-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+
+  &__title {
     display: flex;
-    flex-direction: column;
-    height: 100%;
+    flex-direction: row;
+    gap: 12px;
+    align-items: center;
+
+    &__field {
+      width: 280px;
+    }
+
+    &__badges {
+      display: flex;
+      gap: 4px;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 }
 
-.actions {
-  display: flex;
-  gap: 16px;
-  align-items: center;
+.sections-panel {
+  padding: 16px;
+  width: 500px;
+  min-width: 280px;
+  max-width: 600px;
+  resize: none;
+  overflow: hidden;
+
+  &__header {
+    padding-bottom: 16px;
+
+    h3 {
+      margin: 0;
+    }
+  }
+
+  &__tree__container {
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width: 100%;
+
+    table {
+      width: 100%;
+    }
+
+    tr[mat-row] {
+      cursor: pointer;
+
+      &:hover {
+        background-color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, lighter60);
+      }
+
+      &.selected {
+        background-color: mat.m2-get-color-from-palette(gio.$mat-accent-palette, lighter20);
+      }
+    }
+  }
 }
 
-gmd-form-editor {
-  @include gmd.editor-overrides(
+.editor-panel {
+  @include mat.card-overrides(
     (
-      container-outline-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20'),
+      outlined-outline-color: $outline-color,
     )
   );
+
+  gmd-form-editor {
+    flex-grow: 1;
+    min-height: 0;
+  }
+
+  &__header {
+    padding: 16px 16px 0 16px;
+  }
+}
+
+.empty-state {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.empty-editor {
+  display: flex;
+  padding: 16px;
+  height: 100%;
   flex-grow: 1;
-  min-height: 0;
+
+  mat-card {
+    flex: 1;
+  }
+}
+
+.resize-handle-container {
+  position: relative;
+  width: 2px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .resize-handle {
+    width: 2px;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80);
+    cursor: col-resize;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter70);
+    }
+  }
+
+  mat-icon {
+    position: absolute;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter60);
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    cursor: grab;
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
 }

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.spec.ts
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {
-  ConfigureTestingGraviteeMarkdownEditor,
-  GmdFormEditorHarness,
-  GMD_FORM_STATE_STORE,
-  provideGmdFormStore,
-} from '@gravitee/gravitee-markdown';
-
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
@@ -40,7 +33,7 @@ import {
   fakePortalNavigationItemsResponse,
 } from '../../entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture';
 import { fakePortalPageContent } from '../../entities/management-api-v2/portalPageContent/portalPageContent.fixture';
-import { PortalNavigationSubscriptionForm, PortalPageContent } from '../../entities/management-api-v2';
+import { PortalNavigationSubscriptionForm } from '../../entities/management-api-v2';
 
 describe('SubscriptionFormComponent', () => {
   let fixture: ComponentFixture<SubscriptionFormComponent>;
@@ -49,15 +42,10 @@ describe('SubscriptionFormComponent', () => {
   let rootLoader: HarnessLoader;
   let snackBarService: SnackBarService;
 
-  const init = async (
-    canUpdate: boolean,
-    navItem: PortalNavigationSubscriptionForm = fakePortalNavigationSubscriptionForm(),
-    content: PortalPageContent = fakePortalPageContent({ id: navItem.portalPageContentId }),
-  ) => {
+  const init = async (canUpdate: boolean) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, SubscriptionFormComponent],
       providers: [
-        provideGmdFormStore(),
         {
           provide: GioPermissionService,
           useValue: {
@@ -67,351 +55,400 @@ describe('SubscriptionFormComponent', () => {
       ],
     }).compileComponents();
 
-    ConfigureTestingGraviteeMarkdownEditor();
-
     fixture = TestBed.createComponent(SubscriptionFormComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
 
-    // Spy on snackbar
     snackBarService = TestBed.inject(SnackBarService);
     jest.spyOn(snackBarService, 'success');
     jest.spyOn(snackBarService, 'error');
 
     fixture.detectChanges();
-
-    // Expect GET request for the SUBSCRIPTION_FORM-area navigation item, then for its content
-    const navItemReq = httpTestingController.expectOne({
-      method: 'GET',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`,
-    });
-    navItemReq.flush(fakePortalNavigationItemsResponse({ items: [navItem] }));
-
-    const contentReq = httpTestingController.expectOne({
-      method: 'GET',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${navItem.portalPageContentId}`,
-    });
-    contentReq.flush(content);
   };
 
   afterEach(() => {
     httpTestingController.verify();
   });
 
+  function expectGetNavigationItems(items: PortalNavigationSubscriptionForm[]): void {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`,
+    });
+    req.flush(fakePortalNavigationItemsResponse({ items }));
+    fixture.detectChanges();
+  }
+
+  function expectGetContent(contentId: string, content = 'Original content'): void {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}`,
+    });
+    req.flush(fakePortalPageContent({ id: contentId, content }));
+    fixture.detectChanges();
+  }
+
   it('should create component', async () => {
     await init(true);
+    expectGetNavigationItems([]);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should load subscription form content from API', async () => {
-    const gmdContent = '# Test Form\n\n<gmd-input name="email" label="Email" fieldKey="email" required="true"></gmd-input>';
-    const navItem = fakePortalNavigationSubscriptionForm();
-    const content = fakePortalPageContent({ id: navItem.portalPageContentId, content: gmdContent });
-
-    await init(true, navItem, content);
-
-    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
-    // The mock editor might normalize newlines to spaces or remove them if it's an input
-    const receivedValue = await editorHarness.getEditorValue();
-    expect(receivedValue.replace(/\s/g, '')).toEqual(gmdContent.replace(/\s/g, ''));
-  });
-
-  it('should disable editor when user has no update permission', async () => {
-    await init(false);
-    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
-    expect(await editorHarness.isEditorReadOnly()).toBe(true);
-  });
-
-  it('should enable editor when user has update permission', async () => {
+  it('should render every subscription form item and auto-select the published one', async () => {
     await init(true);
-    const editorHarness = await harnessLoader.getHarness(GmdFormEditorHarness);
-    expect(await editorHarness.isEditorReadOnly()).toBe(false);
+    const formA = fakePortalNavigationSubscriptionForm({
+      id: 'form-a',
+      title: 'Form A',
+      published: false,
+      portalPageContentId: 'content-a',
+    });
+    const formB = fakePortalNavigationSubscriptionForm({
+      id: 'form-b',
+      title: 'Form B',
+      published: true,
+      portalPageContentId: 'content-b',
+    });
+    expectGetNavigationItems([formA, formB]);
+
+    const text = fixture.debugElement.nativeElement.textContent;
+    expect(text).toContain('Form A');
+    expect(text).toContain('Form B');
+
+    expectGetContent('content-b', 'Form B content');
+    expect(fixture.componentInstance.titleControl.value).toBe('Form B');
+    expect(fixture.componentInstance.contentControl.value).toBe('Form B content');
   });
 
-  it('should disable save button when content is empty or unchanged', async () => {
-    const navItem = fakePortalNavigationSubscriptionForm();
-    await init(true, navItem, fakePortalPageContent({ id: navItem.portalPageContentId, content: '# Hello world' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    fixture.componentInstance.contentControl.setValue('Updated form content');
-    fixture.detectChanges();
-
-    const saveButton = await getSaveButton();
-    expect(await saveButton.isDisabled()).toBeFalsy();
-
-    fixture.componentInstance.contentControl.setValue('# Hello world');
-    fixture.detectChanges();
-    expect(await saveButton.isDisabled()).toBeTruthy();
-
-    fixture.componentInstance.contentControl.setValue('');
-    fixture.detectChanges();
-    expect(await saveButton.isDisabled()).toBeTruthy();
-
-    fixture.componentInstance.contentControl.setValue('     ');
-    fixture.detectChanges();
-    expect(await saveButton.isDisabled()).toBeTruthy();
-  });
-
-  it('should update subscription form content', async () => {
-    const navItem = fakePortalNavigationSubscriptionForm();
-    const content = fakePortalPageContent({ id: navItem.portalPageContentId });
-    const updatedContent = '# Updated Form\n\n<gmd-input name="name" label="Name" fieldKey="name"></gmd-input>';
-    await init(true, navItem, content);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    fixture.componentInstance.contentControl.setValue(updatedContent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    const saveButton = await getSaveButton();
-    expect(await saveButton.isDisabled()).toBeFalsy();
-    await saveButton.click();
-
-    expectPageContentUpdate(navItem.portalPageContentId, updatedContent, { ...content, content: updatedContent });
-    expect(snackBarService.success).toHaveBeenCalledWith('The subscription form has been updated successfully');
-    expect(await saveButton.isDisabled()).toBeTruthy();
-  });
-
-  it('should disable save button when critical config errors exist', async () => {
+  it('should not render a paginator', async () => {
     await init(true);
-    await fixture.whenStable();
-    fixture.detectChanges();
-    const store = getGmdFormStore();
+    expectGetNavigationItems([fakePortalNavigationSubscriptionForm({ id: 'form-a' })]);
+    expectGetContent('subscription-form-content-1');
 
-    fixture.componentInstance.contentControl.setValue('Updated form content');
-    fixture.detectChanges();
-
-    const saveButton = await getSaveButton();
-    expect(await saveButton.isDisabled()).toBeFalsy();
-
-    store.updateField(fieldStateWithConfigError('error'));
-    fixture.detectChanges();
-
-    expect(await saveButton.isDisabled()).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('[data-testid=paginator-header]'))).toBeFalsy();
   });
 
-  it('should not disable save button when only config warnings exist', async () => {
+  it('should show an empty state and select nothing when there are no subscription forms', async () => {
     await init(true);
-    await fixture.whenStable();
-    fixture.detectChanges();
-    const store = getGmdFormStore();
+    expectGetNavigationItems([]);
 
-    fixture.componentInstance.contentControl.setValue('Updated form content');
-    fixture.detectChanges();
-
-    const saveButton = await getSaveButton();
-    store.updateField(fieldStateWithConfigError('warning'));
-    fixture.detectChanges();
-
-    expect(await saveButton.isDisabled()).toBeFalsy();
+    expect(fixture.debugElement.query(By.css('[data-testid=subscription-form-empty]'))).toBeTruthy();
+    expect(fixture.componentInstance.selectedItem()).toBeNull();
   });
 
-  describe('enable/disable toggle functionality', () => {
-    it('should enable a disabled form after confirmation', async () => {
-      const disabledNavItem = fakePortalNavigationSubscriptionForm({ published: false });
-      await init(true, disabledNavItem);
+  it('should show an error message when loading the list fails', async () => {
+    await init(true);
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items?area=SUBSCRIPTION_FORM`,
+    });
+    req.flush({ message: 'Load failed' }, { status: 500, statusText: 'Server Error' });
 
-      const toggle = await getEnableToggle();
-      expect(await toggle.isChecked()).toBe(false);
+    expect(snackBarService.error).toHaveBeenCalledWith('Load failed');
+  });
+
+  describe('permissions', () => {
+    it('should hide the create button, disable the publish toggle and disable editing when user lacks permission', async () => {
+      await init(false);
+      const form = fakePortalNavigationSubscriptionForm({ id: 'form-a', published: true });
+      expectGetNavigationItems([form]);
+      expectGetContent(form.portalPageContentId);
+
+      await expect(
+        harnessLoader.getHarness(MatButtonHarness.with({ selector: '[data-testid=create-subscription-form-button]' })),
+      ).rejects.toThrow();
+
+      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=publish-toggle-form-a]' }));
+      expect(await toggle.isDisabled()).toBe(true);
+
+      expect(fixture.componentInstance.titleControl.disabled).toBe(true);
+      expect(fixture.componentInstance.contentControl.disabled).toBe(true);
+    });
+  });
+
+  describe('create flow', () => {
+    it('should keep Save disabled until both title and content are provided', async () => {
+      await init(true);
+      expectGetNavigationItems([]);
+
+      const createButton = await harnessLoader.getHarness(
+        MatButtonHarness.with({ selector: '[data-testid=create-subscription-form-button]' }),
+      );
+      await createButton.click();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.isCreating()).toBe(true);
+
+      const saveButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[data-testid=subscription-form-save-button]' }));
+      expect(await saveButton.isDisabled()).toBe(true);
+
+      fixture.componentInstance.titleControl.setValue('New Form');
+      fixture.detectChanges();
+      expect(await saveButton.isDisabled()).toBe(true);
+
+      fixture.componentInstance.contentControl.setValue('New content');
+      fixture.detectChanges();
+      expect(await saveButton.isDisabled()).toBe(false);
+    });
+
+    it('should create a navigation item then overwrite its auto-created content, and refresh the list', async () => {
+      await init(true);
+      expectGetNavigationItems([]);
+
+      const createButton = await harnessLoader.getHarness(
+        MatButtonHarness.with({ selector: '[data-testid=create-subscription-form-button]' }),
+      );
+      await createButton.click();
+      fixture.detectChanges();
+
+      fixture.componentInstance.titleControl.setValue('New Form');
+      fixture.componentInstance.contentControl.setValue('New content');
+      fixture.detectChanges();
+
+      const saveButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[data-testid=subscription-form-save-button]' }));
+      await saveButton.click();
+
+      const createReq = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items`,
+      });
+      expect(createReq.request.body).toEqual({
+        type: 'SUBSCRIPTION_FORM',
+        area: 'SUBSCRIPTION_FORM',
+        title: 'New Form',
+        visibility: 'PUBLIC',
+      });
+      createReq.flush(fakePortalNavigationSubscriptionForm({ id: 'new-form', title: 'New Form', portalPageContentId: 'new-content-id' }));
+
+      const updateContentReq = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/new-content-id`,
+      });
+      expect(updateContentReq.request.body).toEqual({ content: 'New content' });
+      updateContentReq.flush(fakePortalPageContent({ id: 'new-content-id', content: 'New content' }));
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form created successfully.');
+      expectGetNavigationItems([
+        fakePortalNavigationSubscriptionForm({ id: 'new-form', title: 'New Form', portalPageContentId: 'new-content-id' }),
+      ]);
+      // The newly created item is now selected and present in the refreshed list, so its content is
+      // (redundantly but harmlessly) re-fetched.
+      expectGetContent('new-content-id', 'New content');
+    });
+  });
+
+  describe('edit flow', () => {
+    it('should load content on selection, then update content and title on save', async () => {
+      await init(true);
+      const form = fakePortalNavigationSubscriptionForm({
+        id: 'form-a',
+        title: 'Form A',
+        portalPageContentId: 'content-a',
+        published: true,
+      });
+      expectGetNavigationItems([form]);
+      expectGetContent('content-a', 'Original content');
+      expect(fixture.componentInstance.titleControl.value).toBe('Form A');
+
+      fixture.componentInstance.titleControl.setValue('Updated Form A');
+      fixture.componentInstance.contentControl.setValue('Updated content');
+      fixture.detectChanges();
+
+      const saveButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[data-testid=subscription-form-save-button]' }));
+      await saveButton.click();
+
+      const updateContentReq = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-a`,
+      });
+      expect(updateContentReq.request.body).toEqual({ content: 'Updated content' });
+      updateContentReq.flush(fakePortalPageContent({ id: 'content-a', content: 'Updated content' }));
+
+      const updateItemReq = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/form-a`,
+      });
+      expect(updateItemReq.request.body).toEqual({
+        type: 'SUBSCRIPTION_FORM',
+        title: 'Updated Form A',
+        order: form.order,
+        published: true,
+        visibility: 'PUBLIC',
+      });
+      updateItemReq.flush({ ...form, title: 'Updated Form A' });
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form updated successfully.');
+      expectGetNavigationItems([{ ...form, title: 'Updated Form A' }]);
+    });
+
+    it('should not update the navigation item when only the content changed', async () => {
+      await init(true);
+      const form = fakePortalNavigationSubscriptionForm({
+        id: 'form-a',
+        title: 'Form A',
+        portalPageContentId: 'content-a',
+        published: false,
+      });
+      expectGetNavigationItems([form]);
+      expectGetContent('content-a');
+
+      fixture.componentInstance.contentControl.setValue('Updated content');
+      fixture.detectChanges();
+
+      const saveButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[data-testid=subscription-form-save-button]' }));
+      await saveButton.click();
+
+      httpTestingController
+        .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/content-a` })
+        .flush(fakePortalPageContent({ id: 'content-a', content: 'Updated content' }));
+
+      expectGetNavigationItems([form]);
+    });
+  });
+
+  describe('selection', () => {
+    it('should load a different form when selecting a different row', async () => {
+      await init(true);
+      const formA = fakePortalNavigationSubscriptionForm({
+        id: 'form-a',
+        title: 'Form A',
+        portalPageContentId: 'content-a',
+        published: true,
+      });
+      const formB = fakePortalNavigationSubscriptionForm({
+        id: 'form-b',
+        title: 'Form B',
+        portalPageContentId: 'content-b',
+        published: false,
+      });
+      expectGetNavigationItems([formA, formB]);
+      expectGetContent('content-a', 'Content A');
+
+      fixture.debugElement.query(By.css('[data-testid=subscription-form-row-form-b]')).nativeElement.click();
+      fixture.detectChanges();
+
+      expectGetContent('content-b', 'Content B');
+      expect(fixture.componentInstance.titleControl.value).toBe('Form B');
+    });
+
+    it('should prompt to discard unsaved changes before switching selection', async () => {
+      await init(true);
+      const formA = fakePortalNavigationSubscriptionForm({
+        id: 'form-a',
+        title: 'Form A',
+        portalPageContentId: 'content-a',
+        published: true,
+      });
+      const formB = fakePortalNavigationSubscriptionForm({
+        id: 'form-b',
+        title: 'Form B',
+        portalPageContentId: 'content-b',
+        published: false,
+      });
+      expectGetNavigationItems([formA, formB]);
+      expectGetContent('content-a', 'Content A');
+
+      fixture.componentInstance.titleControl.setValue('Dirty title');
+      fixture.detectChanges();
+
+      fixture.debugElement.query(By.css('[data-testid=subscription-form-row-form-b]')).nativeElement.click();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      const discardButton = await dialog.getHarness(MatButtonHarness.with({ text: /Discard/ }));
+      await discardButton.click();
+
+      expectGetContent('content-b', 'Content B');
+      expect(fixture.componentInstance.titleControl.value).toBe('Form B');
+    });
+  });
+
+  describe('publish toggle', () => {
+    it('should publish the item after confirmation', async () => {
+      await init(true);
+      const form = fakePortalNavigationSubscriptionForm({ id: 'form-a', title: 'Form A', published: false });
+      expectGetNavigationItems([form]);
+      expectGetContent(form.portalPageContentId);
+
+      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=publish-toggle-form-a]' }));
       await toggle.toggle();
 
-      await confirmDialog('Enable');
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: /Publish/ }));
+      await confirmButton.click();
 
       const req = httpTestingController.expectOne({
         method: 'PUT',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${disabledNavItem.id}`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/form-a`,
       });
-      req.flush({ ...disabledNavItem, published: true });
-      fixture.detectChanges();
+      expect(req.request.body).toEqual({
+        type: 'SUBSCRIPTION_FORM',
+        title: 'Form A',
+        order: form.order,
+        published: true,
+        visibility: 'PUBLIC',
+      });
+      req.flush({ ...form, published: true });
 
-      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
-      expect(await toggle.isChecked()).toBe(true);
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form "Form A" has been published successfully.');
+      expectGetNavigationItems([{ ...form, published: true }]);
     });
 
-    it('should disable an enabled form after confirmation', async () => {
-      const enabledNavItem = fakePortalNavigationSubscriptionForm({ published: true });
-      await init(true, enabledNavItem);
+    it('should unpublish the item after confirmation', async () => {
+      await init(true);
+      const form = fakePortalNavigationSubscriptionForm({ id: 'form-a', title: 'Form A', published: true });
+      expectGetNavigationItems([form]);
+      expectGetContent(form.portalPageContentId);
 
-      const toggle = await getEnableToggle();
-      expect(await toggle.isChecked()).toBe(true);
+      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=publish-toggle-form-a]' }));
       await toggle.toggle();
 
-      await confirmDialog('Disable');
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: /Unpublish/ }));
+      await confirmButton.click();
 
       const req = httpTestingController.expectOne({
         method: 'PUT',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${enabledNavItem.id}`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/form-a`,
       });
-      req.flush({ ...enabledNavItem, published: false });
-      fixture.detectChanges();
+      req.flush({ ...form, published: false });
 
-      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been disabled successfully.');
-      expect(await toggle.isChecked()).toBe(false);
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form "Form A" has been unpublished successfully.');
+      expectGetNavigationItems([{ ...form, published: false }]);
     });
 
-    it('should not perform any action if the confirmation dialog is cancelled', async () => {
-      const disabledNavItem = fakePortalNavigationSubscriptionForm({ published: false });
-      await init(true, disabledNavItem);
+    it('should not update anything when the confirmation dialog is cancelled', async () => {
+      await init(true);
+      const form = fakePortalNavigationSubscriptionForm({ id: 'form-a', published: false });
+      expectGetNavigationItems([form]);
+      expectGetContent(form.portalPageContentId);
 
-      const toggle = await getEnableToggle();
+      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=publish-toggle-form-a]' }));
       await toggle.toggle();
 
       const dialog = await rootLoader.getHarness(MatDialogHarness);
       await dialog.close();
-
-      // Toggle should be reset to previous state
-      expect(await toggle.isChecked()).toBe(false);
-      httpTestingController.verify();
     });
 
-    it('should show an error message if enabling fails', async () => {
-      const disabledNavItem = fakePortalNavigationSubscriptionForm({ published: false });
-      await init(true, disabledNavItem);
-
-      const toggle = await getEnableToggle();
-      await toggle.toggle();
-      await confirmDialog('Enable');
-
-      const req = httpTestingController.expectOne({
-        method: 'PUT',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${disabledNavItem.id}`,
-      });
-      req.flush({ message: 'API error on enable' }, { status: 500, statusText: 'Server Error' });
-
-      expect(snackBarService.error).toHaveBeenCalledWith('API error on enable');
-      // Toggle should be reset to previous state
-      expect(await toggle.isChecked()).toBe(false);
-    });
-
-    it('should save changes before enabling when form has unsaved changes', async () => {
-      const disabledNavItem = fakePortalNavigationSubscriptionForm({ published: false });
-      const content = fakePortalPageContent({ id: disabledNavItem.portalPageContentId });
-      await init(true, disabledNavItem, content);
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      fixture.componentInstance.contentControl.setValue('Updated form content');
-      fixture.detectChanges();
-
-      const toggle = await getEnableToggle();
-      await toggle.toggle();
-
-      await confirmDialog('Save and enable');
-
-      expectPageContentUpdate(disabledNavItem.portalPageContentId, 'Updated form content', {
-        ...content,
-        content: 'Updated form content',
-      });
-
-      const req = httpTestingController.expectOne({
-        method: 'PUT',
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${disabledNavItem.id}`,
-      });
-      req.flush({ ...disabledNavItem, published: true });
-      fixture.detectChanges();
-
-      expect(snackBarService.success).toHaveBeenCalledWith('Subscription form has been enabled successfully.');
-      expect(await toggle.isChecked()).toBe(true);
-    });
-
-    it('should disable toggle when config errors exist', async () => {
+    it('should show an error message if publishing fails', async () => {
       await init(true);
-      await fixture.whenStable();
-      fixture.detectChanges();
-      const store = getGmdFormStore();
+      const form = fakePortalNavigationSubscriptionForm({ id: 'form-a', title: 'Form A', published: false });
+      expectGetNavigationItems([form]);
+      expectGetContent(form.portalPageContentId);
 
-      store.updateField(fieldStateWithConfigError('error'));
-      fixture.detectChanges();
-      await fixture.whenStable();
+      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=publish-toggle-form-a]' }));
+      await toggle.toggle();
 
-      const toggle = await getEnableToggle();
-      expect(await toggle.isDisabled()).toBe(true);
+      const dialog = await rootLoader.getHarness(MatDialogHarness);
+      const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: /Publish/ }));
+      await confirmButton.click();
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/form-a`,
+      });
+      req.flush({ message: 'A subscription form is already published for this environment' }, { status: 409, statusText: 'Conflict' });
+
+      expect(snackBarService.error).toHaveBeenCalledWith('A subscription form is already published for this environment');
     });
   });
-
-  it('should have unsaved changes when content is modified', async () => {
-    const navItem = fakePortalNavigationSubscriptionForm();
-    await init(true, navItem, fakePortalPageContent({ id: navItem.portalPageContentId, content: 'Initial content' }));
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
-
-    fixture.componentInstance.contentControl.setValue('Modified content');
-    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
-  });
-
-  it('should not have unsaved changes when content is modified and then reverted', async () => {
-    const navItem = fakePortalNavigationSubscriptionForm();
-    await init(true, navItem, fakePortalPageContent({ id: navItem.portalPageContentId, content: 'Initial content' }));
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
-
-    fixture.componentInstance.contentControl.setValue('Modified content');
-    expect(fixture.componentInstance.hasUnsavedChanges()).toBeTruthy();
-
-    fixture.componentInstance.contentControl.setValue('Initial content');
-    expect(fixture.componentInstance.hasUnsavedChanges()).toBeFalsy();
-  });
-
-  it('should show action bar, hide Save and disable toggle when user lacks permission', async () => {
-    await init(false);
-
-    const toggle = await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
-
-    await expect(
-      harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' })),
-    ).rejects.toThrow();
-    await expect(toggle.isDisabled()).resolves.toBe(true);
-  });
-
-  async function getEnableToggle() {
-    return await harnessLoader.getHarness(MatSlideToggleHarness.with({ selector: '[data-testid=enable-toggle]' }));
-  }
-
-  async function confirmDialog(action: string) {
-    const dialog = await rootLoader.getHarness(MatDialogHarness);
-    const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: new RegExp(action) }));
-    await confirmButton.click();
-  }
-
-  async function getSaveButton() {
-    return await harnessLoader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Update subscription form"]' }));
-  }
-
-  function getGmdFormStore() {
-    return fixture.debugElement.injector.get(GMD_FORM_STATE_STORE);
-  }
-
-  /** Returns a field state with one config error, for tests that need hasConfigErrors() to be true. */
-  function fieldStateWithConfigError(severity: 'error' | 'warning') {
-    return {
-      id: 'field-1',
-      fieldKey: 'key-1',
-      valid: true,
-      value: '',
-      required: false,
-      touched: false,
-      validationErrors: [],
-      configErrors: [
-        severity === 'error'
-          ? { code: 'emptyFieldKey' as const, message: 'Missing property', severity: 'error' as const }
-          : { code: 'normalizedValue' as const, message: 'Missing property', severity: 'warning' as const },
-      ],
-    };
-  }
-
-  function expectPageContentUpdate(contentId: string, expectedContent: string, response: PortalPageContent) {
-    const req = httpTestingController.expectOne({
-      method: 'PUT',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}`,
-    });
-    expect(req.request.body).toStrictEqual({ content: expectedContent });
-    req.flush(response);
-  }
 });

--- a/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
+++ b/gravitee-apim-console-webui/src/portal/subscription-form/subscription-form.component.ts
@@ -15,47 +15,52 @@
  */
 import { GMD_FORM_STATE_STORE, GmdFormEditorComponent, provideGmdFormStore } from '@gravitee/gravitee-markdown';
 
-import { Component, computed, DestroyRef, effect, HostListener, inject, signal, untracked, WritableSignal } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, effect, HostListener, inject, NgZone, signal, untracked } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { catchError, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
-import { EMPTY, Observable, of } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
-import {
-  GIO_DIALOG_WIDTH,
-  GioConfirmDialogComponent,
-  GioConfirmDialogData,
-  GioFormSlideToggleModule,
-} from '@gravitee/ui-particles-angular';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTableModule } from '@angular/material/table';
+import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 
-import { PortalHeaderComponent } from '../components/header/portal-header.component';
+import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
-import {
-  PortalNavigationSubscriptionForm,
-  PortalPageContent,
-  UpdateSubscriptionFormPortalNavigationItem,
-} from '../../entities/management-api-v2';
+import { PortalNavigationSubscriptionForm, UpdateSubscriptionFormPortalNavigationItem } from '../../entities/management-api-v2';
 import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
+import { GioTableWrapperFilters } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { HasUnsavedChanges } from '../../shared/guards/has-unsaved-changes.guard';
-import { normalizeContent } from '../../shared/utils/content.util';
-import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
+import { confirmDiscardChanges, normalizeContent } from '../../shared/utils/content.util';
+
+interface SubscriptionFormRow {
+  item: PortalNavigationSubscriptionForm;
+}
 
 @Component({
   selector: 'subscription-form',
   imports: [
-    PortalHeaderComponent,
+    EmptyStateComponent,
     ReactiveFormsModule,
-    GmdFormEditorComponent,
     MatButtonModule,
-    MatTooltipModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatTableModule,
     MatSlideToggleModule,
-    GioFormSlideToggleModule,
     GioPermissionModule,
+    GioTableWrapperModule,
+    GmdFormEditorComponent,
   ],
   templateUrl: './subscription-form.component.html',
   styleUrl: './subscription-form.component.scss',
@@ -68,82 +73,137 @@ export class SubscriptionFormComponent implements HasUnsavedChanges {
   private readonly gioPermissionService = inject(GioPermissionService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly matDialog = inject(MatDialog);
+  private readonly ngZone = inject(NgZone);
   private readonly store = inject(GMD_FORM_STATE_STORE);
 
-  private readonly navigationItem: WritableSignal<PortalNavigationSubscriptionForm | null> = signal(null);
-  private readonly pageContent: WritableSignal<PortalPageContent | null> = signal(null);
-  private readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-metadata-u']));
-  contentControl = new FormControl<string>('', { nonNullable: true });
-  enabledControl = new FormControl<boolean>(false, { nonNullable: true });
+  private readonly MIN_PANEL_WIDTH = 280;
+  private readonly MAX_PANEL_WIDTH = 600;
+  panelWidth = signal(500);
 
-  private readonly contentValue = toSignal(this.contentControl.valueChanges.pipe(startWith(this.contentControl.value)));
-  private readonly subscriptionFormResult = toSignal(
-    this.portalNavigationItemService.getNavigationItems('SUBSCRIPTION_FORM').pipe(
-      switchMap(response => {
-        const item = response.items[0] as PortalNavigationSubscriptionForm | undefined;
-        if (!item) {
-          return of(null);
-        }
-        return this.portalPageContentService.getPageContent(item.portalPageContentId).pipe(map(content => ({ item, content })));
-      }),
+  readonly canUpdate = signal(this.gioPermissionService.hasAnyMatching(['environment-metadata-u']));
+  readonly displayedColumns = ['title', 'published'];
+
+  readonly filters = signal<GioTableWrapperFilters>({ pagination: { index: 1, size: 10 }, searchTerm: '' });
+
+  private readonly refreshList = new BehaviorSubject<number>(1);
+  private readonly forms = toSignal(
+    this.refreshList.pipe(
+      switchMap(() => this.portalNavigationItemService.getNavigationItems('SUBSCRIPTION_FORM')),
+      map(response => response.items as PortalNavigationSubscriptionForm[]),
       catchError(({ error }) => {
-        this.snackbarService.error(error?.message ?? 'An error occurred while loading the subscription form');
-        return EMPTY;
+        this.snackbarService.error(error?.message ?? 'An error occurred while loading subscription forms.');
+        return of([] as PortalNavigationSubscriptionForm[]);
+      }),
+    ),
+    { initialValue: [] as PortalNavigationSubscriptionForm[] },
+  );
+
+  private readonly rows = computed<SubscriptionFormRow[]>(() => this.forms().map(item => ({ item })));
+
+  private readonly filteredRows = computed<SubscriptionFormRow[]>(() => {
+    const term = this.filters().searchTerm?.trim().toLowerCase() ?? '';
+    const rows = this.rows();
+    return term ? rows.filter(row => row.item.title.toLowerCase().includes(term)) : rows;
+  });
+
+  readonly total = computed(() => this.filteredRows().length);
+
+  readonly pagedRows = computed<SubscriptionFormRow[]>(() => {
+    const { index, size } = this.filters().pagination;
+    const start = (index - 1) * size;
+    return this.filteredRows().slice(start, start + size);
+  });
+
+  /** `'new'` while creating an unsaved form; an item id while viewing/editing one; `null` before anything is ever selected. */
+  private readonly selectedItemId = signal<string | 'new' | null>(null);
+  readonly isCreating = computed(() => this.selectedItemId() === 'new');
+  readonly hasSelection = computed(() => this.selectedItemId() !== null);
+  readonly selectedItem = computed<PortalNavigationSubscriptionForm | null>(() => {
+    const id = this.selectedItemId();
+    if (id === null || id === 'new') return null;
+    return this.forms().find(form => form.id === id) ?? null;
+  });
+
+  readonly titleControl = new FormControl<string>('', { nonNullable: true, validators: [Validators.required] });
+  readonly contentControl = new FormControl<string>('', { nonNullable: true });
+
+  private readonly initialTitle = signal('');
+  private readonly initialContent = signal('');
+
+  // Keyed purely on the selected id (not on the wider `forms` list) so an unrelated row's publish
+  // toggle refreshing the list never clobbers in-progress edits open in this panel.
+  private readonly selectedContentResult = toSignal(
+    toObservable(this.selectedItemId).pipe(
+      switchMap(id => {
+        if (id === null || id === 'new') return of(null);
+        const item = this.forms().find(form => form.id === id);
+        if (!item) return of(null);
+        return this.portalPageContentService.getPageContent(item.portalPageContentId).pipe(
+          map(content => ({ item, content })),
+          catchError(({ error }) => {
+            this.snackbarService.error(error?.message ?? 'An error occurred while loading the subscription form.');
+            return of(null);
+          }),
+        );
       }),
     ),
     { initialValue: null },
   );
-  private readonly enabledControlChanges = toSignal(this.enabledControl.valueChanges.pipe(filter(() => this.canUpdate())), {
-    initialValue: undefined,
-  });
 
-  /** Only severity `error` blocks save; `warning` (e.g. normalized lengths) does not. */
+  private readonly titleValue = toSignal(this.titleControl.valueChanges.pipe(startWith(this.titleControl.value)));
+  private readonly contentValue = toSignal(this.contentControl.valueChanges.pipe(startWith(this.contentControl.value)));
+
+  readonly selectedItemIsPublished = computed(() => this.selectedItem()?.published ?? false);
+
+  readonly saveButtonLabel = computed(() => (this.isCreating() ? 'Create' : 'Save'));
+
   protected readonly hasConfigErrors = computed(() => this.store.criticalConfigErrors().length > 0);
-  readonly configErrorsTooltip = 'Fix configuration errors before continuing.';
-  readonly subscriptionFormEnabled = computed(() => this.navigationItem()?.published ?? false);
 
-  readonly enabledControlTooltip = computed(() => {
-    if (!this.canUpdate()) return 'You do not have permission to change this.';
-    if (this.hasConfigErrors()) return this.configErrorsTooltip;
-    return '';
-  });
-
-  readonly saveButtonTooltip = computed(() => {
-    if (this.hasConfigErrors()) return this.configErrorsTooltip;
-    return '';
-  });
-
-  isSaveDisabled = computed(() => {
-    const currentContent = this.contentValue() ?? '';
-    const normalized = normalizeContent(currentContent);
-    const isEmpty = normalized.length === 0;
-    const hasConfigErrors = this.hasConfigErrors();
-    const isUnchanged = !this.hasUnsavedChanges();
-    return isEmpty || hasConfigErrors || isUnchanged;
+  readonly isSaveDisabled = computed(() => {
+    if (this.selectedItemId() === null) return true;
+    const title = (this.titleValue() ?? '').trim();
+    const content = normalizeContent(this.contentValue());
+    if (title.length === 0 || content.length === 0 || this.hasConfigErrors()) return true;
+    return !this.hasUnsavedChanges();
   });
 
   private readonly controlsDisabledStateEffect = effect(() => {
     const canUpdate = this.canUpdate();
-    const hasConfigErrors = this.hasConfigErrors();
+    const hasSelection = this.selectedItemId() !== null;
     const options = { emitEvent: false };
-    canUpdate ? this.contentControl.enable(options) : this.contentControl.disable(options);
-    const enableToggle = canUpdate && !hasConfigErrors;
-    enableToggle ? this.enabledControl.enable(options) : this.enabledControl.disable(options);
+    const shouldEnable = canUpdate && hasSelection;
+    shouldEnable ? this.titleControl.enable(options) : this.titleControl.disable(options);
+    shouldEnable ? this.contentControl.enable(options) : this.contentControl.disable(options);
   });
 
-  private readonly subscriptionFormLoadEffect = effect(() => {
-    const result = this.subscriptionFormResult();
+  private readonly formLoadEffect = effect(() => {
+    if (this.isCreating()) {
+      untracked(() => {
+        this.initialTitle.set('');
+        this.initialContent.set('');
+        this.titleControl.reset('', { emitEvent: true });
+        this.contentControl.reset('', { emitEvent: true });
+      });
+      return;
+    }
+    const result = this.selectedContentResult();
     if (!result) return;
-    this.navigationItem.set(result.item);
-    this.pageContent.set(result.content);
-    this.contentControl.reset(result.content.content || '', { emitEvent: true });
-    this.enabledControl.setValue(result.item.published, { emitEvent: false });
+    untracked(() => {
+      this.initialTitle.set(result.item.title);
+      this.initialContent.set(result.content.content || '');
+      this.titleControl.reset(result.item.title, { emitEvent: true });
+      this.contentControl.reset(result.content.content || '', { emitEvent: true });
+    });
   });
 
-  private readonly enabledControlEffect = effect(() => {
-    const enabled = this.enabledControlChanges();
-    if (enabled === undefined) return;
-    untracked(() => this.handleToggleChange(enabled));
+  /** Selects the environment default (or the first row) once, the first time the list loads. */
+  private readonly autoSelectEffect = effect(() => {
+    const forms = this.forms();
+    untracked(() => {
+      if (this.selectedItemId() !== null || forms.length === 0) return;
+      const defaultForm = forms.find(form => form.published) ?? forms[0];
+      this.selectedItemId.set(defaultForm.id);
+    });
   });
 
   @HostListener('window:beforeunload', ['$event'])
@@ -156,58 +216,41 @@ export class SubscriptionFormComponent implements HasUnsavedChanges {
   }
 
   hasUnsavedChanges(): boolean {
-    const current = normalizeContent(this.contentValue() ?? '');
-    const initial = normalizeContent(this.pageContent()?.content ?? '');
-    return current !== initial;
+    if (this.selectedItemId() === null) return false;
+    const currentTitle = (this.titleValue() ?? '').trim();
+    const currentContent = normalizeContent(this.contentValue());
+    return currentTitle !== this.initialTitle().trim() || currentContent !== normalizeContent(this.initialContent());
   }
 
-  updateSubscriptionForm(): void {
-    const item = this.navigationItem();
-    if (!item) return;
-
-    this.portalPageContentService
-      .updatePageContent(item.portalPageContentId, {
-        content: this.contentControl.value,
-      })
-      .pipe(
-        tap(updatedContent => {
-          this.pageContent.set(updatedContent);
-          this.snackbarService.success(`The subscription form has been updated successfully`);
-        }),
-        catchError(({ error }) => {
-          this.snackbarService.error(error?.message ?? 'An error occurred while updating the subscription form');
-          return EMPTY;
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+  onFiltersChanged(filters: GioTableWrapperFilters): void {
+    this.filters.set(filters);
   }
 
-  private resetEnabledToInitial(): void {
-    this.enabledControl.setValue(this.subscriptionFormEnabled(), { emitEvent: false });
+  selectItem(row: SubscriptionFormRow): void {
+    this.checkUnsavedChangesAndRun(() => this.selectedItemId.set(row.item.id));
   }
 
-  private handleToggleChange(enabled: boolean): void {
-    if (this.hasConfigErrors()) {
-      this.resetEnabledToInitial();
-      return;
-    }
-    const saveBeforeToggle = this.hasUnsavedChanges();
-    const action = enabled ? 'Enable' : 'Disable';
-    const data: GioConfirmDialogData = saveBeforeToggle
-      ? {
-          title: `${action} subscription form?`,
-          content: `You have unsaved changes. Save the form before changing visibility.`,
-          confirmButton: `Save and ${action.toLowerCase()}`,
-          cancelButton: 'Cancel',
-        }
-      : {
-          title: `${action} subscription form?`,
-          content: enabled
-            ? `This action will enable the subscription form. It will be visible to API consumers in the Developer Portal.`
-            : `This action will disable the subscription form. It will no longer be visible in the Developer Portal, but you can enable it again at any time.`,
-          confirmButton: action,
-        };
+  startCreate(): void {
+    this.checkUnsavedChangesAndRun(() => this.selectedItemId.set('new'));
+  }
+
+  save(): void {
+    if (this.isSaveDisabled()) return;
+    const save$ = this.isCreating() ? this.createForm() : this.updateForm(this.selectedItem()!);
+    save$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+  }
+
+  onPublishToggle(row: SubscriptionFormRow): void {
+    const item = row.item;
+    const publishing = !item.published;
+    const action = publishing ? 'Publish' : 'Unpublish';
+    const data: GioConfirmDialogData = {
+      title: `${action} subscription form?`,
+      content: publishing
+        ? `This action will publish "${item.title}". It will become the environment's default subscription form shown to API consumers in the Developer Portal. Any currently published form must be unpublished first.`
+        : `This action will unpublish "${item.title}". It will no longer be shown to API consumers in the Developer Portal.`,
+      confirmButton: action,
+    };
 
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
@@ -218,61 +261,136 @@ export class SubscriptionFormComponent implements HasUnsavedChanges {
       })
       .afterClosed()
       .pipe(
-        filter(confirmed => {
-          if (!confirmed) this.resetEnabledToInitial();
-          return confirmed;
-        }),
-        switchMap(() => this.toggleEnabled(enabled, saveBeforeToggle)),
+        filter(confirmed => !!confirmed),
+        switchMap(() => this.togglePublished(item, publishing)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
 
-  private buildUpdatePayload(item: PortalNavigationSubscriptionForm, published: boolean): UpdateSubscriptionFormPortalNavigationItem {
+  onResizeStart(event: MouseEvent): void {
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startWidth = this.panelWidth();
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    this.ngZone.runOutsideAngular(() => {
+      const onMove = (e: MouseEvent) => {
+        const deltaX = e.clientX - startX;
+        const newWidth = Math.max(this.MIN_PANEL_WIDTH, Math.min(this.MAX_PANEL_WIDTH, startWidth + deltaX));
+
+        this.ngZone.run(() => this.panelWidth.set(newWidth));
+      };
+
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
+  private checkUnsavedChangesAndRun(action: () => void): void {
+    if (!this.hasUnsavedChanges()) {
+      action();
+      return;
+    }
+
+    confirmDiscardChanges(this.matDialog)
+      .pipe(
+        filter(confirmed => !!confirmed),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => action());
+  }
+
+  private createForm(): Observable<unknown> {
+    const title = this.titleControl.value.trim();
+    const content = this.contentControl.value;
+    // No portalPageContentId is sent: the backend auto-creates default GRAVITEE_MARKDOWN content
+    // (mirroring how PAGE items are created), which is then immediately overwritten below with the
+    // form's actually-authored content via the already-existing content-update endpoint.
+    return this.portalNavigationItemService
+      .createNavigationItem({
+        type: 'SUBSCRIPTION_FORM',
+        area: 'SUBSCRIPTION_FORM',
+        title,
+        visibility: 'PUBLIC',
+      })
+      .pipe(
+        switchMap(created =>
+          this.portalPageContentService
+            .updatePageContent((created as PortalNavigationSubscriptionForm).portalPageContentId, { content })
+            .pipe(map(() => created)),
+        ),
+        tap(created => {
+          this.snackbarService.success('Subscription form created successfully.');
+          this.initialTitle.set(title);
+          this.initialContent.set(content);
+          this.selectedItemId.set(created.id);
+          this.refreshList.next(1);
+        }),
+        catchError(({ error }) => {
+          this.snackbarService.error(error?.message ?? 'An error occurred while creating the subscription form.');
+          return EMPTY;
+        }),
+      );
+  }
+
+  private updateForm(item: PortalNavigationSubscriptionForm): Observable<unknown> {
+    const newTitle = this.titleControl.value.trim();
+    const newContent = this.contentControl.value;
+    const titleChanged = newTitle !== item.title;
+    const title$ = titleChanged
+      ? this.portalNavigationItemService.updateNavigationItem(item.id, this.buildUpdatePayload(item, item.published, newTitle))
+      : of(item);
+
+    return this.portalPageContentService.updatePageContent(item.portalPageContentId, { content: newContent }).pipe(
+      switchMap(() => title$),
+      tap(() => {
+        this.snackbarService.success('Subscription form updated successfully.');
+        this.initialTitle.set(newTitle);
+        this.initialContent.set(newContent);
+        this.refreshList.next(1);
+      }),
+      catchError(({ error }) => {
+        this.snackbarService.error(error?.message ?? 'An error occurred while updating the subscription form.');
+        return EMPTY;
+      }),
+    );
+  }
+
+  private togglePublished(item: PortalNavigationSubscriptionForm, published: boolean): Observable<unknown> {
+    return this.portalNavigationItemService.updateNavigationItem(item.id, this.buildUpdatePayload(item, published, item.title)).pipe(
+      tap(() => {
+        this.snackbarService.success(`Subscription form "${item.title}" has been ${published ? 'published' : 'unpublished'} successfully.`);
+        this.refreshList.next(1);
+      }),
+      catchError(({ error }) => {
+        this.snackbarService.error(error?.message ?? `Failed to ${published ? 'publish' : 'unpublish'} subscription form.`);
+        return EMPTY;
+      }),
+    );
+  }
+
+  private buildUpdatePayload(
+    item: PortalNavigationSubscriptionForm,
+    published: boolean,
+    title: string,
+  ): UpdateSubscriptionFormPortalNavigationItem {
     return {
       type: 'SUBSCRIPTION_FORM',
-      title: item.title,
+      title,
       order: item.order,
       published,
       visibility: item.visibility,
     };
-  }
-
-  private toggleEnabled(enabled: boolean, saveBeforeToggle: boolean): Observable<PortalNavigationSubscriptionForm> {
-    const item = this.navigationItem();
-    if (!item) {
-      this.resetEnabledToInitial();
-      return EMPTY;
-    }
-
-    const action = enabled ? 'enable' : 'disable';
-    const toggle$ = this.portalNavigationItemService.updateNavigationItem(
-      item.id,
-      this.buildUpdatePayload(item, enabled),
-    ) as Observable<PortalNavigationSubscriptionForm>;
-
-    const request$ = saveBeforeToggle
-      ? this.portalPageContentService
-          .updatePageContent(item.portalPageContentId, {
-            content: this.contentControl.value,
-          })
-          .pipe(
-            tap(updatedContent => this.pageContent.set(updatedContent)),
-            switchMap(() => toggle$),
-          )
-      : toggle$;
-
-    return request$.pipe(
-      tap(updatedItem => {
-        this.navigationItem.set(updatedItem);
-        this.enabledControl.setValue(updatedItem.published, { emitEvent: false });
-        this.snackbarService.success(`Subscription form has been ${updatedItem.published ? 'enabled' : 'disabled'} successfully.`);
-      }),
-      catchError(({ error }) => {
-        this.resetEnabledToInitial();
-        this.snackbarService.error(error?.message ?? `Failed to ${action} subscription form.`);
-        return EMPTY;
-      }),
-    );
   }
 }


### PR DESCRIPTION
PORTAL-166 §6: rework the Console's subscription-form screen from a single-item editor into a catalog, per the Figma design (Forms section, node 43650:15580).

**Stack**: 4th (last) of 4 PRs, based on #19641 (§5).

## Changes

- List panel (search, Name + Published columns, no pagination) next to a resizable divider and an inline editor panel, mirroring `portal-navigation-items.component.ts`'s own layout exactly (same CSS grid, drag-handle logic, panel-width bounds).
- Selecting a row loads its content into the editor panel; "Add" starts a new, unpublished form. Publishing a row via its toggle is the only way to make a form "the default" — the same publish/unpublish action generalized to per-row, reusing the existing confirm dialog. Publishing a second form while one is already published surfaces §1's 409 as a snack-bar error.
- Row selection and "Add" are guarded by a discard-changes confirmation when the panel has unsaved edits, matching `portal-navigation-items`' `checkUnsavedChangesAndRun` pattern. Content for the selected item is fetched keyed only on its id (not on the wider list), so an unrelated row's publish toggle can never clobber in-progress edits open in the panel.
- `NewSubscriptionFormPortalNavigationItem` added to the create-item union, with an optional `portalPageContentId` (see §5: when omitted, the backend auto-creates default content).
- `canDeactivate: [HasUnsavedChangesGuard]` on the `subscription-form` route, since the page holds real in-page editable state again.

## Compatibility

Console-only change; no public API surface. Design-system components only (Particles/Material), no new patterns.