### PR TITLE
feat: evaluate performance targets over the analytics engine

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
@@ -50,6 +50,13 @@ public interface PerformanceTargetEvaluationRepository {
     PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId) throws TechnicalException;
 
     /**
+     * Deletes every evaluation of the target but its {@code retention} most recent ones.
+     *
+     * @return the ids of the deleted evaluations
+     */
+    List<String> pruneHistory(String targetId, int retention) throws TechnicalException;
+
+    /**
      * @return the ids of the deleted evaluations
      */
     List<String> deleteByReference(String environmentId, String reference) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
@@ -207,6 +207,28 @@ public class JdbcPerformanceTargetEvaluationRepository
     }
 
     @Override
+    public List<String> pruneHistory(String targetId, int retention) throws TechnicalException {
+        log.debug("JdbcPerformanceTargetEvaluationRepository.pruneHistory({}, {})", targetId, retention);
+        try {
+            var ids = jdbcTemplate.queryForList(
+                "select id from " + this.tableName + " where target_id = ? order by evaluated_at desc, id",
+                String.class,
+                targetId
+            );
+            if (ids.size() <= retention) {
+                return List.of();
+            }
+            var pruned = List.copyOf(ids.subList(retention, ids.size()));
+            jdbcTemplate.update("delete from " + this.tableName + " where id in (" + getOrm().buildInClause(pruned) + ")", ps ->
+                getOrm().setArguments(ps, pruned, 1)
+            );
+            return pruned;
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to prune performance target evaluations of target " + targetId, ex);
+        }
+    }
+
+    @Override
     public List<String> deleteByReference(String environmentId, String reference) throws TechnicalException {
         log.debug("JdbcPerformanceTargetEvaluationRepository.deleteByReference({}, {})", environmentId, reference);
         try {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
@@ -97,6 +97,16 @@ class MongoPerformanceTargetEvaluationRepository implements PerformanceTargetEva
     }
 
     @Override
+    public List<String> pruneHistory(String targetId, int retention) throws TechnicalException {
+        log.debug("Prune performance target evaluations of target [{}] beyond the {} most recent", targetId, retention);
+        try {
+            return internalRepository.pruneHistory(targetId, retention);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to prune performance target evaluations of target " + targetId, ex);
+        }
+    }
+
+    @Override
     public List<String> deleteByReference(String environmentId, String reference) throws TechnicalException {
         log.debug("Delete performance target evaluations by reference [{}/{}]", environmentId, reference);
         try {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.PerformanceTargetEnvironmentSummary;
 import io.gravitee.repository.mongodb.management.internal.model.PerformanceTargetEvaluationMongo;
+import java.util.List;
 
 public interface PerformanceTargetEvaluationMongoRepositoryCustom {
     void unsetLatest(String targetId);
@@ -28,4 +29,6 @@ public interface PerformanceTargetEvaluationMongoRepositoryCustom {
     Page<PerformanceTargetEvaluationMongo> findByTargetId(String targetId, Pageable pageable);
 
     PerformanceTargetEnvironmentSummary getEnvironmentSummary(String environmentId);
+
+    List<String> pruneHistory(String targetId, int retention);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
@@ -41,6 +41,8 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class PerformanceTargetEvaluationMongoRepositoryImpl implements PerformanceTargetEvaluationMongoRepositoryCustom {
 
+    private static final Sort MOST_RECENT_FIRST = Sort.by(Sort.Order.desc("evaluatedAt"), Sort.Order.asc("_id"));
+
     private final MongoTemplate mongoTemplate;
 
     @Override
@@ -65,13 +67,25 @@ public class PerformanceTargetEvaluationMongoRepositoryImpl implements Performan
     private Page<PerformanceTargetEvaluationMongo> pageMostRecentFirst(Query query, Pageable pageable) {
         long total = mongoTemplate.count(query, PerformanceTargetEvaluationMongo.class);
         var content = mongoTemplate.find(
-            query
-                .with(Sort.by(Sort.Order.desc("evaluatedAt"), Sort.Order.asc("_id")))
-                .skip((long) pageable.pageNumber() * pageable.pageSize())
-                .limit(pageable.pageSize()),
+            query.with(MOST_RECENT_FIRST).skip((long) pageable.pageNumber() * pageable.pageSize()).limit(pageable.pageSize()),
             PerformanceTargetEvaluationMongo.class
         );
         return new Page<>(content, pageable.pageNumber(), content.size(), total);
+    }
+
+    @Override
+    public List<String> pruneHistory(String targetId, int retention) {
+        var beyondRetention = query(where("targetId").is(targetId)).with(MOST_RECENT_FIRST).skip(retention);
+        beyondRetention.fields().include("_id");
+        var pruned = mongoTemplate
+            .find(beyondRetention, PerformanceTargetEvaluationMongo.class)
+            .stream()
+            .map(PerformanceTargetEvaluationMongo::getId)
+            .toList();
+        if (!pruned.isEmpty()) {
+            mongoTemplate.remove(query(where("_id").in(pruned)), PerformanceTargetEvaluationMongo.class);
+        }
+        return pruned;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
@@ -230,6 +230,37 @@ public class PerformanceTargetEvaluationRepositoryTest extends AbstractManagemen
             .containsExactly("eval-other-env");
     }
 
+    // pruneHistory
+    @Test
+    public void pruneHistory_should_keep_only_the_most_recent_evaluations_of_the_target() throws TechnicalException {
+        var pruned = performanceTargetEvaluationRepository.pruneHistory("target1", 1);
+
+        assertThat(pruned).containsExactly("eval-1a");
+        var history = performanceTargetEvaluationRepository.findByTargetId(
+            "target1",
+            new PageableBuilder().pageNumber(0).pageSize(10).build()
+        );
+        assertThat(history.getTotalElements()).isEqualTo(1);
+        assertThat(history.getContent()).extracting(PerformanceTargetEvaluation::getId).containsExactly("eval-1b");
+        assertThat(
+            performanceTargetEvaluationRepository.findByTargetId("target3", new PageableBuilder().pageNumber(0).pageSize(10).build())
+        )
+            .extracting(page -> page.getTotalElements())
+            .isEqualTo(2L);
+    }
+
+    @Test
+    public void pruneHistory_should_delete_nothing_when_the_history_fits_the_retention() throws TechnicalException {
+        var pruned = performanceTargetEvaluationRepository.pruneHistory("target1", 2);
+
+        assertThat(pruned).isEmpty();
+        assertThat(
+            performanceTargetEvaluationRepository.findByTargetId("target1", new PageableBuilder().pageNumber(0).pageSize(10).build())
+        )
+            .extracting(page -> page.getTotalElements())
+            .isEqualTo(2L);
+    }
+
     // deleteByTargetId
     @Test
     public void deleteByTargetId_should_delete_history_of_target() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetEvaluationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetEvaluationCrudService.java
@@ -25,6 +25,13 @@ public interface PerformanceTargetEvaluationCrudService {
     PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation);
 
     /**
+     * Deletes every evaluation of the target but its {@code retention} most recent ones.
+     *
+     * @return the ids of the deleted evaluations
+     */
+    List<String> pruneHistory(String targetId, int retention);
+
+    /**
      * @return the ids of the deleted evaluations
      */
     List<String> deleteByReference(String environmentId, String reference);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTarget.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTarget.java
@@ -84,12 +84,53 @@ public record PerformanceTarget(
             apiTypes = apiTypes == null ? Set.of() : Set.copyOf(apiTypes);
             filters = filters == null ? List.of() : List.copyOf(filters);
         }
+
+        /**
+         * Judges {@code observed} against the threshold. Without a value, or with fewer samples than the target's
+         * minimum, the rule is NOT_EVALUABLE and reports no observed value, never a PASS.
+         */
+        public PerformanceTargetEvaluation.RuleResult evaluate(Double observed, long sampleCount, int minSampleSize) {
+            if (observed == null || sampleCount < minSampleSize) {
+                return new PerformanceTargetEvaluation.RuleResult(
+                    metric,
+                    measure,
+                    operator,
+                    threshold,
+                    null,
+                    null,
+                    sampleCount,
+                    PerformanceTargetEvaluation.Status.NOT_EVALUABLE
+                );
+            }
+            var status = operator.holds(observed, threshold)
+                ? PerformanceTargetEvaluation.Status.PASS
+                : PerformanceTargetEvaluation.Status.BREACH;
+            return new PerformanceTargetEvaluation.RuleResult(
+                metric,
+                measure,
+                operator,
+                threshold,
+                observed,
+                PerformanceTargetEvaluation.Deviation.of(observed, threshold),
+                sampleCount,
+                status
+            );
+        }
     }
 
     public enum Operator {
         LT,
         LTE,
         GT,
-        GTE,
+        GTE;
+
+        public boolean holds(double observed, double threshold) {
+            return switch (this) {
+                case LT -> observed < threshold;
+                case LTE -> observed <= threshold;
+                case GT -> observed > threshold;
+                case GTE -> observed >= threshold;
+            };
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetEvaluation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetEvaluation.java
@@ -38,6 +38,9 @@ public record PerformanceTargetEvaluation(
     Instant evaluatedAt,
     boolean latest
 ) {
+    /** Evaluations kept per target: 24 h of history at the default 5 min interval. */
+    public static final int HISTORY_RETENTION = 288;
+
     public PerformanceTargetEvaluation {
         rules = rules == null ? List.of() : List.copyOf(rules);
         coveredApiIds = coveredApiIds == null ? List.of() : List.copyOf(coveredApiIds);
@@ -46,7 +49,15 @@ public record PerformanceTargetEvaluation(
     public enum Status {
         PASS,
         BREACH,
-        NOT_EVALUABLE,
+        NOT_EVALUABLE;
+
+        /** The target status: any missed rule is a BREACH, PASS needs every rule to pass, anything else is NOT_EVALUABLE. */
+        public static Status of(List<RuleResult> rules) {
+            if (rules.stream().anyMatch(rule -> rule.status() == BREACH)) {
+                return BREACH;
+            }
+            return !rules.isEmpty() && rules.stream().allMatch(rule -> rule.status() == PASS) ? PASS : NOT_EVALUABLE;
+        }
     }
 
     @Builder(toBuilder = true)
@@ -63,7 +74,12 @@ public record PerformanceTargetEvaluation(
 
     /**
      * How far {@code observed} is from the threshold: {@code absolute} in the metric's unit, {@code ratio} relative to
-     * the threshold.
+     * the threshold. A zero threshold cannot be exceeded by a ratio, so any excess counts as a full ratio of 1.
      */
-    public record Deviation(double absolute, double ratio) {}
+    public record Deviation(double absolute, double ratio) {
+        public static Deviation of(double observed, double threshold) {
+            var absolute = observed - threshold;
+            return new Deviation(absolute, threshold == 0 ? Math.signum(absolute) : absolute / threshold);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.core.performance_target.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
@@ -27,13 +26,13 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Duration;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /**
  * Evaluates a target on demand and stores the result as its latest evaluation, through the same evaluator as the
- * scheduler. A target is evaluated at most once per {@link #MIN_DELAY_BETWEEN_EVALUATIONS}, whoever triggered the
- * previous run, so a UI refresh cannot turn into a query storm.
+ * scheduler, then prunes the history beyond {@link PerformanceTargetEvaluation#HISTORY_RETENTION}. A target is
+ * evaluated at most once per {@link #MIN_DELAY_BETWEEN_EVALUATIONS}, whoever triggered the previous run, so a UI
+ * refresh cannot turn into a query storm.
  */
 @RequiredArgsConstructor
 @UseCase
@@ -44,8 +43,7 @@ public class EvaluatePerformanceTargetUseCase {
     private final PerformanceTargetCrudService performanceTargetCrudService;
     private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
     private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
-    // Optional until the evaluation engine lands: the REST contract ships first, the engine follows.
-    private final Optional<PerformanceTargetEvaluator> performanceTargetEvaluator;
+    private final PerformanceTargetEvaluator performanceTargetEvaluator;
 
     public Output execute(Input input) {
         var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
@@ -62,11 +60,10 @@ public class EvaluatePerformanceTargetUseCase {
                 throw new PerformanceTargetEvaluatedTooRecentlyException(target.id(), retryAfter);
             });
 
-        var evaluator = performanceTargetEvaluator.orElseThrow(() ->
-            new TechnicalDomainException("Performance target evaluation is not available")
-        );
-        var evaluation = evaluator.evaluate(target, now).toBuilder().id(UuidString.generateRandom()).latest(true).build();
-        return new Output(performanceTargetEvaluationCrudService.create(evaluation));
+        var evaluation = performanceTargetEvaluator.evaluate(target, now).toBuilder().id(UuidString.generateRandom()).latest(true).build();
+        var stored = performanceTargetEvaluationCrudService.create(evaluation);
+        performanceTargetEvaluationCrudService.pruneHistory(target.id(), PerformanceTargetEvaluation.HISTORY_RETENTION);
+        return new Output(stored);
     }
 
     public record Input(String environmentId, String targetId) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/performance_target/PerformanceTargetEvaluationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/performance_target/PerformanceTargetEvaluationCrudServiceImpl.java
@@ -48,6 +48,15 @@ public class PerformanceTargetEvaluationCrudServiceImpl extends AbstractService 
     }
 
     @Override
+    public List<String> pruneHistory(String targetId, int retention) {
+        try {
+            return evaluationRepository.pruneHistory(targetId, retention);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when pruning Performance Target Evaluations of target: " + targetId, e);
+        }
+    }
+
+    @Override
     public List<String> deleteByReference(String environmentId, String reference) {
         try {
             return evaluationRepository.deleteByReference(environmentId, reference);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.performance_target;
+
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeRange;
+import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Evaluates a target through the analytics engine query services the dashboards use, with the same
+ * {@code API IN [...]} filter a single-API dashboard applies, so a breach shows the number the chart shows. Rules
+ * sharing a filter set (resolved API ids plus rule filters) are answered by one measures request that also carries
+ * the request-count metric of the subject's API family; that count is the sample size every rule of the set is
+ * judged on.
+ *
+ * <p>The engine is called without a caller context on purpose: a target is validated against its environment when
+ * it is written, and the scheduler evaluates it with no user at hand.
+ *
+ * <p>Known limit: MCP and A2A APIs expose HTTP-level metrics only. A JSON-RPC error carried by an HTTP 200, or an
+ * A2A task that failed, is invisible to a target until protocol-level analytics exist.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluator {
+
+    private static final MetricMeasuresRequest HTTP_REQUEST_COUNT = new MetricMeasuresRequest(
+        MetricSpec.Name.HTTP_REQUESTS,
+        List.of(MetricSpec.Measure.COUNT)
+    );
+
+    /** The metric counting the samples a rule is judged on, per API type of the subject. */
+    private static final Map<ApiType, MetricMeasuresRequest> SAMPLE_COUNT_METRICS = Map.of(
+        ApiType.PROXY,
+        HTTP_REQUEST_COUNT,
+        ApiType.LLM_PROXY,
+        HTTP_REQUEST_COUNT,
+        ApiType.MCP_PROXY,
+        HTTP_REQUEST_COUNT,
+        ApiType.A2A_PROXY,
+        HTTP_REQUEST_COUNT,
+        ApiType.MESSAGE,
+        HTTP_REQUEST_COUNT,
+        ApiType.NATIVE,
+        new MetricMeasuresRequest(MetricSpec.Name.NATIVE_OPERATIONS_RECEIVED, List.of(MetricSpec.Measure.SUM)),
+        ApiType.EDGE,
+        new MetricMeasuresRequest(MetricSpec.Name.EDGE_DETECTION_COUNT, List.of(MetricSpec.Measure.COUNT)),
+        ApiType.AUTHZ,
+        new MetricMeasuresRequest(MetricSpec.Name.AUTHZ_OPERATIONS, List.of(MetricSpec.Measure.COUNT))
+    );
+
+    private final ApiCrudService apiCrudService;
+    private final EnvironmentCrudService environmentCrudService;
+    private final AnalyticsQueryContextProvider queryContextProvider;
+
+    @Override
+    public PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now) {
+        var window = new TimeRange(now.minus(target.window()), now);
+        var organizationId = environmentCrudService.get(target.environmentId()).getOrganizationId();
+        var executionContext = new ExecutionContext(organizationId, target.environmentId());
+        var apiTypesById = apiTypesById(target);
+
+        var rules = target.rules();
+        var results = new PerformanceTargetEvaluation.RuleResult[rules.size()];
+        var ruleIndexesByScope = new LinkedHashMap<Scope, List<Integer>>();
+        for (int i = 0; i < rules.size(); i++) {
+            var rule = rules.get(i);
+            var apiIds = target.apiIdsFor(rule, apiTypesById).stream().filter(apiTypesById::containsKey).toList();
+            if (apiIds.isEmpty()) {
+                results[i] = rule.evaluate(null, 0, target.minSampleSize());
+            } else {
+                ruleIndexesByScope.computeIfAbsent(new Scope(apiIds, rule.filters()), scope -> new ArrayList<>()).add(i);
+            }
+        }
+
+        ruleIndexesByScope.forEach((scope, ruleIndexes) -> {
+            var sampleCountMetric = sampleCountMetric(scope, apiTypesById);
+            var measures = search(executionContext, window, scope, sampleCountMetric, ruleIndexes.stream().map(rules::get).toList());
+            var sampleCount = value(measures, sampleCountMetric.name(), sampleCountMetric.measures().getFirst())
+                .map(Math::round)
+                .orElse(0L);
+            for (var i : ruleIndexes) {
+                var rule = rules.get(i);
+                results[i] = rule.evaluate(
+                    value(measures, rule.metric(), rule.measure()).orElse(null),
+                    sampleCount,
+                    target.minSampleSize()
+                );
+            }
+        });
+
+        var ruleResults = Arrays.asList(results);
+        return PerformanceTargetEvaluation.builder()
+            .targetId(target.id())
+            .environmentId(target.environmentId())
+            .reference(target.subject().reference())
+            .status(PerformanceTargetEvaluation.Status.of(ruleResults))
+            .rules(ruleResults)
+            .windowFrom(window.from())
+            .windowTo(window.to())
+            .coveredApiIds(List.copyOf(apiTypesById.keySet()))
+            .evaluatedAt(now)
+            .build();
+    }
+
+    /** The typed subject APIs that still exist, in subject order; a deleted or untyped API is not covered. */
+    private Map<String, ApiType> apiTypesById(PerformanceTarget target) {
+        var apis = apiCrudService
+            .findByIds(target.subject().apiIds())
+            .stream()
+            .filter(api -> api.getType() != null)
+            .collect(Collectors.toMap(Api::getId, Api::getType));
+        var apiTypesById = new LinkedHashMap<String, ApiType>();
+        for (var apiId : target.subject().apiIds()) {
+            if (apis.containsKey(apiId)) {
+                apiTypesById.put(apiId, apis.get(apiId));
+            }
+        }
+        return apiTypesById;
+    }
+
+    private static MetricMeasuresRequest sampleCountMetric(Scope scope, Map<String, ApiType> apiTypesById) {
+        var metrics = scope
+            .apiIds()
+            .stream()
+            .map(apiTypesById::get)
+            .map(apiType ->
+                Objects.requireNonNull(SAMPLE_COUNT_METRICS.get(apiType), () -> "No request-count metric for API type " + apiType)
+            )
+            .distinct()
+            .toList();
+        if (metrics.size() != 1) {
+            throw new IllegalStateException("A rule cannot span API types counted by different metrics: " + scope.apiIds());
+        }
+        return metrics.getFirst();
+    }
+
+    private MeasuresResponse search(
+        ExecutionContext executionContext,
+        TimeRange window,
+        Scope scope,
+        MetricMeasuresRequest sampleCountMetric,
+        List<PerformanceTarget.Rule> rules
+    ) {
+        var measuresByMetric = new LinkedHashMap<MetricSpec.Name, LinkedHashSet<MetricSpec.Measure>>();
+        measuresByMetric.put(sampleCountMetric.name(), new LinkedHashSet<>(sampleCountMetric.measures()));
+        for (var rule : rules) {
+            measuresByMetric.computeIfAbsent(rule.metric(), metric -> new LinkedHashSet<>()).add(rule.measure());
+        }
+        var metrics = measuresByMetric
+            .entrySet()
+            .stream()
+            .map(entry -> new MetricMeasuresRequest(entry.getKey(), List.copyOf(entry.getValue())))
+            .toList();
+
+        var filters = new ArrayList<Filter>();
+        filters.add(new Filter(FilterSpec.Name.API, FilterOperator.IN, scope.apiIds()));
+        filters.addAll(scope.filters());
+
+        var request = new MeasuresRequest(window, filters, metrics);
+        return MeasuresResponse.merge(
+            queryContextProvider
+                .resolve(request)
+                .entrySet()
+                .stream()
+                .map(entry -> entry.getKey().searchMeasures(executionContext, entry.getValue()))
+                .toList()
+        );
+    }
+
+    private static Optional<Double> value(MeasuresResponse response, MetricSpec.Name metric, MetricSpec.Measure measure) {
+        return response
+            .metrics()
+            .stream()
+            .filter(metricResponse -> metricResponse.name() == metric)
+            .flatMap(metricResponse -> metricResponse.measures().stream())
+            .filter(measureResponse -> measureResponse.name() == measure)
+            .map(Measure::value)
+            .filter(Objects::nonNull)
+            .map(Number::doubleValue)
+            .findFirst();
+    }
+
+    /** The documents a set of rules is measured on: the API ids they resolve to, narrowed by their own filters. */
+    private record Scope(List<String> apiIds, List<Filter> filters) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEv
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class PerformanceTargetEvaluationCrudServiceInMemory
@@ -35,6 +36,19 @@ public class PerformanceTargetEvaluationCrudServiceInMemory
         }
         storage.add(evaluation);
         return evaluation;
+    }
+
+    @Override
+    public List<String> pruneHistory(String targetId, int retention) {
+        var pruned = storage
+            .stream()
+            .filter(evaluation -> evaluation.targetId().equals(targetId))
+            .sorted(Comparator.comparing(PerformanceTargetEvaluation::evaluatedAt).reversed())
+            .skip(retention)
+            .map(PerformanceTargetEvaluation::id)
+            .toList();
+        storage.removeIf(evaluation -> pruned.contains(evaluation.id()));
+        return pruned;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetEvaluationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetEvaluationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.model;
+
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.BREACH;
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.PASS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PerformanceTargetEvaluationTest {
+
+    @Nested
+    class StatusOf {
+
+        @Test
+        void should_pass_when_every_rule_passes() {
+            assertThat(PerformanceTargetEvaluation.Status.of(List.of(aRuleResult(PASS), aRuleResult(PASS)))).isEqualTo(PASS);
+        }
+
+        @Test
+        void should_breach_when_any_rule_breaches_even_if_another_is_not_evaluable() {
+            assertThat(
+                PerformanceTargetEvaluation.Status.of(List.of(aRuleResult(PASS), aRuleResult(NOT_EVALUABLE), aRuleResult(BREACH)))
+            ).isEqualTo(BREACH);
+        }
+
+        @Test
+        void should_not_be_evaluable_when_no_rule_breaches_and_one_is_not_evaluable() {
+            assertThat(PerformanceTargetEvaluation.Status.of(List.of(aRuleResult(PASS), aRuleResult(NOT_EVALUABLE)))).isEqualTo(
+                NOT_EVALUABLE
+            );
+        }
+
+        @Test
+        void should_not_be_evaluable_without_any_rule() {
+            assertThat(PerformanceTargetEvaluation.Status.of(List.of())).isEqualTo(NOT_EVALUABLE);
+        }
+    }
+
+    @Nested
+    class DeviationOf {
+
+        @Test
+        void should_measure_the_distance_to_the_threshold_in_the_metric_unit_and_relative_to_it() {
+            assertThat(PerformanceTargetEvaluation.Deviation.of(4810, 2000)).isEqualTo(
+                new PerformanceTargetEvaluation.Deviation(2810, 1.405)
+            );
+            assertThat(PerformanceTargetEvaluation.Deviation.of(1.5, 6)).isEqualTo(new PerformanceTargetEvaluation.Deviation(-4.5, -0.75));
+        }
+
+        @Test
+        void should_report_a_full_ratio_when_a_zero_threshold_is_exceeded() {
+            assertThat(PerformanceTargetEvaluation.Deviation.of(3, 0)).isEqualTo(new PerformanceTargetEvaluation.Deviation(3, 1));
+            assertThat(PerformanceTargetEvaluation.Deviation.of(0, 0)).isEqualTo(new PerformanceTargetEvaluation.Deviation(0, 0));
+        }
+    }
+
+    private static PerformanceTargetEvaluation.RuleResult aRuleResult(PerformanceTargetEvaluation.Status status) {
+        return new PerformanceTargetEvaluation.RuleResult(
+            MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+            MetricSpec.Measure.P95,
+            PerformanceTarget.Operator.LTE,
+            2000,
+            null,
+            null,
+            0,
+            status
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetTest.java
@@ -23,7 +23,10 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class PerformanceTargetTest {
 
@@ -64,6 +67,96 @@ class PerformanceTargetTest {
         var rule = aRule(Set.of(ApiType.A2A_PROXY));
 
         assertThat(target.apiIdsFor(rule, Map.of("llm-api", ApiType.LLM_PROXY))).isEmpty();
+    }
+
+    @Nested
+    class Evaluate {
+
+        private final PerformanceTarget.Rule rule = aRule(Set.of());
+
+        @Test
+        void should_pass_when_the_observed_value_meets_the_threshold() {
+            var result = rule.evaluate(1500.0, 63, 20);
+
+            assertThat(result).isEqualTo(
+                new PerformanceTargetEvaluation.RuleResult(
+                    MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+                    MetricSpec.Measure.P95,
+                    PerformanceTarget.Operator.LTE,
+                    2000,
+                    1500.0,
+                    new PerformanceTargetEvaluation.Deviation(-500, -0.25),
+                    63,
+                    PerformanceTargetEvaluation.Status.PASS
+                )
+            );
+        }
+
+        @Test
+        void should_breach_when_the_observed_value_misses_the_threshold() {
+            var result = rule.evaluate(4810.0, 63, 20);
+
+            assertThat(result.status()).isEqualTo(PerformanceTargetEvaluation.Status.BREACH);
+            assertThat(result.observed()).isEqualTo(4810.0);
+            assertThat(result.deviation()).isEqualTo(new PerformanceTargetEvaluation.Deviation(2810, 1.405));
+            assertThat(result.sampleCount()).isEqualTo(63);
+        }
+
+        @Test
+        void should_pass_when_the_observed_value_equals_an_inclusive_threshold() {
+            assertThat(rule.evaluate(2000.0, 63, 20).status()).isEqualTo(PerformanceTargetEvaluation.Status.PASS);
+        }
+
+        @Test
+        void should_not_be_evaluable_below_the_minimum_sample_size_even_with_an_observed_value() {
+            var result = rule.evaluate(4810.0, 19, 20);
+
+            assertThat(result.status()).isEqualTo(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+            assertThat(result.observed()).isNull();
+            assertThat(result.deviation()).isNull();
+            assertThat(result.sampleCount()).isEqualTo(19);
+        }
+
+        @Test
+        void should_not_be_evaluable_without_an_observed_value() {
+            var result = rule.evaluate(null, 63, 20);
+
+            assertThat(result.status()).isEqualTo(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+            assertThat(result.observed()).isNull();
+            assertThat(result.deviation()).isNull();
+            assertThat(result.sampleCount()).isEqualTo(63);
+        }
+
+        @Test
+        void should_evaluate_exactly_the_minimum_sample_size() {
+            assertThat(rule.evaluate(1500.0, 20, 20).status()).isEqualTo(PerformanceTargetEvaluation.Status.PASS);
+        }
+    }
+
+    @Nested
+    class OperatorHolds {
+
+        @ParameterizedTest
+        @CsvSource(
+            {
+                "LT, 1, 2, true",
+                "LT, 2, 2, false",
+                "LTE, 2, 2, true",
+                "LTE, 3, 2, false",
+                "GT, 3, 2, true",
+                "GT, 2, 2, false",
+                "GTE, 2, 2, true",
+                "GTE, 1, 2, false",
+            }
+        )
+        void should_compare_the_observed_value_to_the_threshold(
+            PerformanceTarget.Operator operator,
+            double observed,
+            double threshold,
+            boolean expected
+        ) {
+            assertThat(operator.holds(observed, threshold)).isEqualTo(expected);
+        }
     }
 
     private static PerformanceTarget.Rule aRule(Set<ApiType> apiTypes) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
@@ -24,7 +24,6 @@ import inmemory.PerformanceTargetCrudServiceInMemory;
 import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
 import inmemory.PerformanceTargetEvaluationQueryServiceInMemory;
 import inmemory.PerformanceTargetEvaluatorInMemory;
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetNotFoundException;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
@@ -35,7 +34,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +56,7 @@ class EvaluatePerformanceTargetUseCaseTest {
         targetCrudService,
         evaluationQueryService,
         evaluationCrudService,
-        Optional.of(new PerformanceTargetEvaluatorInMemory())
+        new PerformanceTargetEvaluatorInMemory()
     );
 
     @BeforeEach
@@ -109,18 +108,26 @@ class EvaluatePerformanceTargetUseCaseTest {
     }
 
     @Test
-    void should_fail_when_no_evaluator_is_available() {
-        var withoutEvaluator = new EvaluatePerformanceTargetUseCase(
-            targetCrudService,
-            evaluationQueryService,
-            evaluationCrudService,
-            Optional.empty()
-        );
+    void should_prune_the_history_of_the_target_beyond_the_retention() {
+        var history = IntStream.range(0, PerformanceTargetEvaluation.HISTORY_RETENTION)
+            .mapToObj(i ->
+                PerformanceTargetFixtures.anEvaluation(
+                    "old-" + i,
+                    TARGET_ID,
+                    PerformanceTargetEvaluation.Status.PASS,
+                    NOW.minus(Duration.ofHours(1)).minus(Duration.ofMinutes(5L * i))
+                )
+            )
+            .toList();
+        evaluationCrudService.initWith(history);
 
-        assertThatThrownBy(() ->
-            withoutEvaluator.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID))
-        ).isInstanceOf(TechnicalDomainException.class);
-        assertThat(evaluationCrudService.storage()).isEmpty();
+        useCase.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID));
+
+        assertThat(evaluationCrudService.storage())
+            .hasSize(PerformanceTargetEvaluation.HISTORY_RETENTION)
+            .extracting(PerformanceTargetEvaluation::id)
+            .contains("evaluation-id", "old-0")
+            .doesNotContain("old-" + (PerformanceTargetEvaluation.HISTORY_RETENTION - 1));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.performance_target;
+
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.BREACH;
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
+import static io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation.Status.PASS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.EnvironmentCrudServiceInMemory;
+import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeRange;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
+import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
+import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
+import io.gravitee.apim.core.environment.model.Environment;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PerformanceTargetEvaluatorImplTest {
+
+    private static final String ENVIRONMENT_ID = PerformanceTargetFixtures.ENVIRONMENT_ID;
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String A2A_API_ID = "a2a-api";
+    private static final String LLM_API_ID = "llm-api";
+    private static final Instant NOW = Instant.parse("2021-06-01T10:00:00Z");
+    private static final Duration WINDOW = Duration.ofMinutes(15);
+
+    private static final PerformanceTarget.Rule A2A_LATENCY = PerformanceTargetFixtures.aLatencyRule()
+        .toBuilder()
+        .apiTypes(Set.of(ApiType.A2A_PROXY))
+        .build();
+    private static final PerformanceTarget.Rule ERROR_RATE = PerformanceTarget.Rule.builder()
+        .metric(MetricSpec.Name.HTTP_ERROR_RATE)
+        .measure(MetricSpec.Measure.PERCENTAGE)
+        .operator(PerformanceTarget.Operator.LTE)
+        .threshold(5)
+        .build();
+    private static final PerformanceTarget.Rule LLM_COST = PerformanceTarget.Rule.builder()
+        .metric(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST)
+        .measure(MetricSpec.Measure.AVG)
+        .operator(PerformanceTarget.Operator.LTE)
+        .threshold(0.01)
+        .apiTypes(Set.of(ApiType.LLM_PROXY))
+        .build();
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    RecordingAnalyticsEngineQueryService analytics = new RecordingAnalyticsEngineQueryService();
+
+    PerformanceTargetEvaluatorImpl evaluator = new PerformanceTargetEvaluatorImpl(
+        apiCrudService,
+        environmentCrudService,
+        new AnalyticsQueryContextProvider(List.of(analytics))
+    );
+
+    @BeforeEach
+    void setUp() {
+        environmentCrudService.initWith(List.of(Environment.builder().id(ENVIRONMENT_ID).organizationId(ORGANIZATION_ID).build()));
+        apiCrudService.initWith(
+            List.of(
+                ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API_ID).build(),
+                ApiFixtures.aLLMProxyApiV4().toBuilder().id(LLM_API_ID).build()
+            )
+        );
+    }
+
+    @Test
+    void should_query_each_filter_set_once_with_the_request_count_and_the_rules_metrics() {
+        evaluator.evaluate(anAgentTarget(A2A_LATENCY, ERROR_RATE, LLM_COST), NOW);
+
+        assertThat(analytics.contexts).containsOnly(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID));
+        assertThat(analytics.requests)
+            .hasSize(3)
+            .allSatisfy(request -> assertThat(request.timeRange()).isEqualTo(new TimeRange(NOW.minus(WINDOW), NOW)))
+            .satisfiesExactlyInAnyOrder(
+                request -> {
+                    assertThat(request.filters()).containsExactly(apiIn(A2A_API_ID));
+                    assertThat(request.metrics()).containsExactlyInAnyOrder(
+                        new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)),
+                        new MetricMeasuresRequest(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, List.of(MetricSpec.Measure.P95))
+                    );
+                },
+                request -> {
+                    assertThat(request.filters()).containsExactly(apiIn(A2A_API_ID, LLM_API_ID));
+                    assertThat(request.metrics()).containsExactlyInAnyOrder(
+                        new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)),
+                        new MetricMeasuresRequest(MetricSpec.Name.HTTP_ERROR_RATE, List.of(MetricSpec.Measure.PERCENTAGE))
+                    );
+                },
+                request -> {
+                    assertThat(request.filters()).containsExactly(apiIn(LLM_API_ID));
+                    assertThat(request.metrics()).containsExactlyInAnyOrder(
+                        new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)),
+                        new MetricMeasuresRequest(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, List.of(MetricSpec.Measure.AVG))
+                    );
+                }
+            );
+    }
+
+    @Test
+    void should_evaluate_each_rule_against_the_documents_of_its_own_scope() {
+        analytics.given(
+            Set.of(A2A_API_ID),
+            requests(63),
+            measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 4810)
+        );
+        analytics.given(
+            Set.of(A2A_API_ID, LLM_API_ID),
+            requests(91),
+            measure(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 1.5)
+        );
+        analytics.given(Set.of(LLM_API_ID), requests(0), measure(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, MetricSpec.Measure.AVG, 0));
+
+        var evaluation = evaluator.evaluate(anAgentTarget(A2A_LATENCY, ERROR_RATE, LLM_COST), NOW);
+
+        assertThat(evaluation).isEqualTo(
+            PerformanceTargetEvaluation.builder()
+                .targetId("target-id")
+                .environmentId(ENVIRONMENT_ID)
+                .reference("agent-42")
+                .status(BREACH)
+                .rules(
+                    List.of(
+                        new PerformanceTargetEvaluation.RuleResult(
+                            MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+                            MetricSpec.Measure.P95,
+                            PerformanceTarget.Operator.LTE,
+                            2000,
+                            4810.0,
+                            new PerformanceTargetEvaluation.Deviation(2810, 1.405),
+                            63,
+                            BREACH
+                        ),
+                        new PerformanceTargetEvaluation.RuleResult(
+                            MetricSpec.Name.HTTP_ERROR_RATE,
+                            MetricSpec.Measure.PERCENTAGE,
+                            PerformanceTarget.Operator.LTE,
+                            5,
+                            1.5,
+                            new PerformanceTargetEvaluation.Deviation(-3.5, -0.7),
+                            91,
+                            PASS
+                        ),
+                        new PerformanceTargetEvaluation.RuleResult(
+                            MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST,
+                            MetricSpec.Measure.AVG,
+                            PerformanceTarget.Operator.LTE,
+                            0.01,
+                            null,
+                            null,
+                            0,
+                            NOT_EVALUABLE
+                        )
+                    )
+                )
+                .windowFrom(NOW.minus(WINDOW))
+                .windowTo(NOW)
+                .coveredApiIds(List.of(A2A_API_ID, LLM_API_ID))
+                .evaluatedAt(NOW)
+                .latest(false)
+                .build()
+        );
+    }
+
+    @Test
+    void should_not_be_evaluable_without_traffic() {
+        analytics.given(
+            Set.of(A2A_API_ID, LLM_API_ID),
+            requests(0),
+            measure(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 0)
+        );
+
+        var evaluation = evaluator.evaluate(anAgentTarget(ERROR_RATE), NOW);
+
+        assertThat(evaluation.status()).isEqualTo(NOT_EVALUABLE);
+        assertThat(evaluation.rules())
+            .singleElement()
+            .satisfies(rule -> {
+                assertThat(rule.status()).isEqualTo(NOT_EVALUABLE);
+                assertThat(rule.observed()).isNull();
+                assertThat(rule.deviation()).isNull();
+                assertThat(rule.sampleCount()).isZero();
+            });
+    }
+
+    @Test
+    void should_not_be_evaluable_below_the_minimum_sample_size() {
+        analytics.given(
+            Set.of(A2A_API_ID, LLM_API_ID),
+            requests(19),
+            measure(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 50)
+        );
+
+        var evaluation = evaluator.evaluate(anAgentTarget(ERROR_RATE), NOW);
+
+        assertThat(evaluation.status()).isEqualTo(NOT_EVALUABLE);
+        assertThat(evaluation.rules()).singleElement().extracting(PerformanceTargetEvaluation.RuleResult::sampleCount).isEqualTo(19L);
+    }
+
+    @Test
+    void should_keep_evaluating_the_other_rules_when_a_metric_is_missing_from_the_response() {
+        analytics.given(Set.of(A2A_API_ID), requests(63));
+        analytics.given(
+            Set.of(A2A_API_ID, LLM_API_ID),
+            requests(91),
+            measure(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 1.5)
+        );
+
+        var evaluation = evaluator.evaluate(anAgentTarget(A2A_LATENCY, ERROR_RATE), NOW);
+
+        assertThat(evaluation.status()).isEqualTo(NOT_EVALUABLE);
+        assertThat(evaluation.rules())
+            .extracting(PerformanceTargetEvaluation.RuleResult::status, PerformanceTargetEvaluation.RuleResult::sampleCount)
+            .containsExactly(tuple(NOT_EVALUABLE, 63L), tuple(PASS, 91L));
+    }
+
+    @Test
+    void should_not_query_for_a_rule_whose_api_types_are_absent_from_the_subject() {
+        analytics.given(
+            Set.of(A2A_API_ID),
+            requests(63),
+            measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1500)
+        );
+        var target = anAgentTarget(A2A_LATENCY, LLM_COST)
+            .toBuilder()
+            .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID), "agent-42"))
+            .build();
+
+        var evaluation = evaluator.evaluate(target, NOW);
+
+        assertThat(analytics.requests).singleElement().extracting(MeasuresRequest::filters).isEqualTo(List.of(apiIn(A2A_API_ID)));
+        assertThat(evaluation.status()).isEqualTo(NOT_EVALUABLE);
+        assertThat(evaluation.rules())
+            .extracting(PerformanceTargetEvaluation.RuleResult::status, PerformanceTargetEvaluation.RuleResult::sampleCount)
+            .containsExactly(tuple(PASS, 63L), tuple(NOT_EVALUABLE, 0L));
+    }
+
+    @Test
+    void should_cover_only_the_subject_apis_that_still_exist() {
+        var target = anAgentTarget(ERROR_RATE)
+            .toBuilder()
+            .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID, "deleted-api", LLM_API_ID), "agent-42"))
+            .build();
+
+        var evaluation = evaluator.evaluate(target, NOW);
+
+        assertThat(evaluation.coveredApiIds()).containsExactly(A2A_API_ID, LLM_API_ID);
+        assertThat(analytics.requests)
+            .singleElement()
+            .extracting(MeasuresRequest::filters)
+            .isEqualTo(List.of(apiIn(A2A_API_ID, LLM_API_ID)));
+    }
+
+    @Test
+    void should_forward_the_rule_filters_and_query_them_separately() {
+        var searchTool = new Filter(FilterSpec.Name.MCP_PROXY_TOOL, FilterOperator.EQ, "search");
+        var searchToolErrorRate = ERROR_RATE.toBuilder().filters(List.of(searchTool)).build();
+
+        evaluator.evaluate(anAgentTarget(ERROR_RATE, searchToolErrorRate), NOW);
+
+        assertThat(analytics.requests)
+            .extracting(MeasuresRequest::filters)
+            .containsExactlyInAnyOrder(List.of(apiIn(A2A_API_ID, LLM_API_ID)), List.of(apiIn(A2A_API_ID, LLM_API_ID), searchTool));
+    }
+
+    @Test
+    void should_request_every_measure_of_a_metric_shared_by_several_rules_at_once() {
+        var averageLatency = PerformanceTargetFixtures.aLatencyRule().toBuilder().measure(MetricSpec.Measure.AVG).threshold(800).build();
+        analytics.given(
+            Set.of(A2A_API_ID, LLM_API_ID),
+            requests(63),
+            measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1500),
+            measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.AVG, 900)
+        );
+
+        var evaluation = evaluator.evaluate(anAgentTarget(PerformanceTargetFixtures.aLatencyRule(), averageLatency), NOW);
+
+        assertThat(analytics.requests)
+            .singleElement()
+            .extracting(MeasuresRequest::metrics)
+            .asInstanceOf(list(MetricMeasuresRequest.class))
+            .containsExactlyInAnyOrder(
+                new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)),
+                new MetricMeasuresRequest(
+                    MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+                    List.of(MetricSpec.Measure.P95, MetricSpec.Measure.AVG)
+                )
+            );
+        assertThat(evaluation.rules())
+            .extracting(PerformanceTargetEvaluation.RuleResult::observed, PerformanceTargetEvaluation.RuleResult::status)
+            .containsExactly(tuple(1500.0, PASS), tuple(900.0, BREACH));
+    }
+
+    @Test
+    void should_count_samples_with_the_metric_of_the_subject_api_family() {
+        apiCrudService.initWith(List.of(ApiFixtures.aNativeApi().toBuilder().id("kafka-api").build()));
+        var throughput = PerformanceTarget.Rule.builder()
+            .metric(MetricSpec.Name.NATIVE_OPERATION_BROKER_DURATION)
+            .measure(MetricSpec.Measure.AVG)
+            .operator(PerformanceTarget.Operator.LTE)
+            .threshold(50)
+            .build();
+        var target = anAgentTarget(throughput)
+            .toBuilder()
+            .subject(new PerformanceTarget.Subject(List.of("kafka-api"), "kafka-api"))
+            .build();
+
+        evaluator.evaluate(target, NOW);
+
+        assertThat(analytics.requests)
+            .singleElement()
+            .extracting(MeasuresRequest::metrics)
+            .asInstanceOf(list(MetricMeasuresRequest.class))
+            .containsExactlyInAnyOrder(
+                new MetricMeasuresRequest(MetricSpec.Name.NATIVE_OPERATIONS_RECEIVED, List.of(MetricSpec.Measure.SUM)),
+                new MetricMeasuresRequest(MetricSpec.Name.NATIVE_OPERATION_BROKER_DURATION, List.of(MetricSpec.Measure.AVG))
+            );
+    }
+
+    private static PerformanceTarget anAgentTarget(PerformanceTarget.Rule... rules) {
+        return PerformanceTargetFixtures.aTarget()
+            .toBuilder()
+            .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID, LLM_API_ID), "agent-42"))
+            .window(WINDOW)
+            .rules(List.of(rules))
+            .build();
+    }
+
+    private static Filter apiIn(String... apiIds) {
+        return new Filter(FilterSpec.Name.API, FilterOperator.IN, List.of(apiIds));
+    }
+
+    private static MetricMeasuresResponse requests(long count) {
+        return measure(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Measure.COUNT, count);
+    }
+
+    private static MetricMeasuresResponse measure(MetricSpec.Name metric, MetricSpec.Measure measure, Number value) {
+        return new MetricMeasuresResponse(metric, null, List.of(new Measure(measure, value)));
+    }
+
+    /**
+     * Answers a measures request with the metrics configured for the API ids it filters on, merging several
+     * configured responses for the same metric, and records what it was asked so tests can assert the query shape.
+     */
+    static class RecordingAnalyticsEngineQueryService implements AnalyticsEngineQueryService {
+
+        final List<ExecutionContext> contexts = new ArrayList<>();
+        final List<MeasuresRequest> requests = new ArrayList<>();
+        private final Map<Set<String>, List<MetricMeasuresResponse>> responsesByApiIds = new HashMap<>();
+
+        void given(Set<String> apiIds, MetricMeasuresResponse... metrics) {
+            for (var metric : metrics) {
+                responsesByApiIds.computeIfAbsent(apiIds, ids -> new ArrayList<>()).add(metric);
+            }
+        }
+
+        @Override
+        public Set<MetricSpec.Name> metrics() {
+            return Set.of(MetricSpec.Name.values());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public MeasuresResponse searchMeasures(ExecutionContext context, MeasuresRequest request) {
+            contexts.add(context);
+            requests.add(request);
+            var apiIds = request
+                .filters()
+                .stream()
+                .filter(filter -> filter.name() == FilterSpec.Name.API)
+                .findFirst()
+                .map(filter -> Set.copyOf((Collection<String>) filter.value()))
+                .orElse(Set.of());
+            var byMetric = new HashMap<MetricSpec.Name, List<Measure>>();
+            for (var response : responsesByApiIds.getOrDefault(apiIds, List.of())) {
+                byMetric.computeIfAbsent(response.name(), name -> new ArrayList<>()).addAll(response.measures());
+            }
+            return new MeasuresResponse(
+                new TreeSet<>(byMetric.keySet())
+                    .stream()
+                    .map(name -> new MetricMeasuresResponse(name, null, byMetric.get(name)))
+                    .toList()
+            );
+        }
+
+        @Override
+        public FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TimeSeriesResponse searchTimeSeries(ExecutionContext context, TimeSeriesRequest request) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

[AIAM-510](https://gravitee.atlassian.net/browse/AIAM-510) — part of epic [AIAM-436](https://gravitee.atlassian.net/browse/AIAM-436). Builds on AIAM-508 (model, repositories) and AIAM-509 (REST), already on `amp_demo`.

## Description

Target evaluation engine over the analytics measures engine.

**Pure logic on the core model**
- `Operator.holds`, `Rule.evaluate(observed, sampleCount, minSampleSize)`, `Deviation.of`, `Status.of` rollup.
- A rule with no value, or fewer samples than the target's minimum, is `NOT_EVALUABLE` and reports no observed value — never `PASS`.
- Target status: any `BREACH` → `BREACH`; `PASS` only when every rule passes; otherwise `NOT_EVALUABLE`.

**Evaluator** (`PerformanceTargetEvaluatorImpl`, infra)
- Resolves the subject's API types, groups rules by filter set (resolved API ids + rule `filters`), and issues one measures request per set carrying the request-count metric plus the rules' metrics/measures. Time range is `now − window .. now`.
- A latency rule scoped to `A2A_PROXY` queries only the A2A ids, a cost rule scoped to `LLM_PROXY` only the LLM ids, an unscoped error-rate rule both.
- Sample count is read from the request-count metric of the same filter set (`HTTP_REQUESTS` for the HTTP family; native / edge / authz have their own operation-count metric). The Elasticsearch adapter returns `0` for every measure when there are no documents, so this count is the only reliable "no data" signal.
- `coveredApiIds` are the subject APIs that still exist; a rule whose API types are absent from the subject is `NOT_EVALUABLE` without any query.
- Calls the analytics engine query services directly, not `ComputeMeasuresUseCase`: that use case loads a permission context from the security context holder, which the scheduler (AIAM-511) cannot provide. The `API IN [...]` filter is set explicitly, so numbers equal a single-API dashboard.

**Retention**
- New `pruneHistory(targetId, retention)` on the evaluation repository (API, Mongo, JDBC, shared test), crud service and in-memory fake.
- `EvaluatePerformanceTargetUseCase` records the result as latest, then prunes to `PerformanceTargetEvaluation.HISTORY_RETENTION` (288 = 24 h at 5 min).
- The evaluator port is no longer `Optional` in the use case; the temporary "not available" path is removed.

**Known limit (documented in the evaluator javadoc):** MCP and A2A expose HTTP-level metrics only; JSON-RPC errors on HTTP 200 and A2A task states are invisible to a target until protocol-level analytics exist.

## Verification

| Suite | Result |
| --- | --- |
| Service unit tests (model, use case, evaluator, validation) | 59 pass |
| `PerformanceTargetEvaluationRepositoryTest` on JDBC and on MongoDB | 18 pass each |
| Management v2 REST performance target resources | 34 pass |

Not done: no Elasticsearch container test from `gravitee-apim-rest-api-service` (the module has no ES test dependency). The query shape is asserted against a recording `AnalyticsEngineQueryService`; the numbers rely on the shared ES repository tests.

## Compatibility-sensitive

- `PerformanceTargetEvaluationRepository` (repository API) gains `pruneHistory`; any external implementation must add it.

## Security-sensitive

- The evaluator queries analytics **without a caller permission context** by design (the scheduler has no user). Scope is bounded server-side: a target's subject APIs are validated against the target's environment at write time, and the evaluator filters on exactly those ids.

## Additional context

- Formatted with `mvn prettier:write` on every changed module.
- Automation API sync: no mirror needed (no OpenAPI or CRD change).


[AIAM-510]: https://gravitee.atlassian.net/browse/AIAM-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIAM-436]: https://gravitee.atlassian.net/browse/AIAM-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ