### PR TITLE
fix(observability): make the filter catalog the single source for names and values

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -62,6 +62,8 @@ public interface AnalyticsDefinitionMapper {
     @ValueMapping(source = "TRANSACTION_ID", target = MappingConstants.THROW_EXCEPTION)
     // LOGS-only, like the four above: no analytics dimension, so it must never appear on a metric filter list.
     @ValueMapping(source = "NATIVE_CLIENT_SOFTWARE_VERSION", target = MappingConstants.THROW_EXCEPTION)
+    // LOGS-only too: uri is the only path a log document carries, and HTTP_PATH is its analytics counterpart.
+    @ValueMapping(source = "URI", target = MappingConstants.THROW_EXCEPTION)
     FilterName mapAnalyticsFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
 
     List<MetricSpec> mapMetricSpecs(List<io.gravitee.apim.core.analytics_engine.model.MetricSpec> metricSpecs);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -74,10 +74,12 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
             .satisfies(filters -> {
                 // The bare count keeps every catalog addition a deliberate decision. On its own it
                 // says nothing about what broke, so the names of the last additions come with it.
-                assertThat(filters).hasSize(60);
+                assertThat(filters).hasSize(62);
                 assertThat(filters)
                     .extracting(filter -> filter.getName().getValue())
                     .contains(
+                        "URI",
+                        "ENTRYPOINT",
                         "NATIVE_FAILURE_SIDE",
                         "NATIVE_CLIENT_ID",
                         "NATIVE_CLIENT_SOFTWARE_NAME",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -212,7 +212,9 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                     "HTTP_METHOD",
                     "HTTP_STATUS",
                     "HTTP_STATUS_CODE_GROUP",
-                    "HTTP_PATH",
+                    // URI, not HTTP_PATH: a log document carries uri and no path-info, so the path
+                    // filter is split by signal — HTTP_PATH is the ANALYTICS counterpart.
+                    "URI",
                     "HTTP_GATEWAY_RESPONSE_TIME",
                     "MCP_PROXY_METHOD",
                     "API_TYPE",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -153,8 +153,9 @@ public class AnalyticsQueryValidator {
      * from a list kept in step with it by hand.
      *
      * <p>A name the catalog does not describe at all is accepted, as it was before the axis existed: the
-     * catalog omits several names the engines still know ({@code URI}, {@code ENTRYPOINT}, the edge ones), and
-     * rejecting those here would be a behaviour change rather than a refactor.
+     * catalog omits a few names the engines still know ({@code MESSAGE_CONNECTOR_ID} and the edge dimensions, pinned by
+     * AnalyticsDefinitionYAMLQueryServiceTest for their owners to decide), and rejecting those here would be a
+     * behaviour change rather than a refactor.
      */
     private boolean supportsAnalytics(FilterSpec.Name name) {
         return definition

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1874,6 +1874,14 @@ spec:
               - EQ
               - IN
 
+        - name: URI
+          label: Request URI
+          type: STRING
+
+        - name: ENTRYPOINT
+          label: Entrypoint
+          type: KEYWORD
+
         - name: HOST
           label: Host
           type: KEYWORD

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1856,12 +1856,16 @@ spec:
               - LTE
               - GTE
 
-        # EQ only: the logs engine matches a single exact path, and IN over full paths has no
-        # known consumer. Gamma's reconciled vocabulary made the same call (URI is EQ-only).
+        # ANALYTICS only, and URI is the LOGS counterpart: the two are different fields, not two
+        # spellings. HTTP_PATH reads path-info, the templated path a metrics document stores; a log
+        # document has no path-info at all, only uri. Advertising HTTP_PATH on both signals made one
+        # name mean the templated path on a dashboard and the concrete request in the logs, so the
+        # same `=` matched different things depending on the screen.
+        #
+        # EQ only: a full path is matched exactly, and IN over full paths has no known consumer.
         - name: HTTP_PATH
           label: HTTP Path
           signals:
-              - LOGS
               - ANALYTICS
           type: STRING
           operators:
@@ -1874,10 +1878,15 @@ spec:
               - EQ
               - IN
 
-        # EQ only, for the reason HTTP_PATH gives above: a full path is matched exactly, and IN over
-        # full paths has no known consumer.
+        # LOGS only, the counterpart of HTTP_PATH above: uri is the concrete request, query string
+        # included, and it is the only path a log document carries. It is a poor analytics dimension
+        # anyway — unbounded cardinality gives one bucket per request.
+        #
+        # EQ only, for the reason HTTP_PATH gives: a full path is matched exactly.
         - name: URI
           label: Request URI
+          signals:
+              - LOGS
           type: STRING
           operators:
               - EQ

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1874,13 +1874,21 @@ spec:
               - EQ
               - IN
 
+        # EQ only, for the reason HTTP_PATH gives above: a full path is matched exactly, and IN over
+        # full paths has no known consumer.
         - name: URI
           label: Request URI
           type: STRING
+          operators:
+              - EQ
 
+        # IN as well as EQ: `ENTRYPOINT IN [...]` is the default scoping Gamma injects on every query.
         - name: ENTRYPOINT
           label: Entrypoint
           type: KEYWORD
+          operators:
+              - EQ
+              - IN
 
         - name: HOST
           label: Host

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
@@ -219,10 +219,10 @@ class AnalyticsQueryValidatorTest {
 
         @Test
         void should_keep_accepting_names_the_catalog_does_not_describe() {
-            // URI, ENTRYPOINT and the edge filters are known to the engines but absent from the catalog.
-            // Deriving from the catalog must not start rejecting them.
-            assertThat(accepts(FilterSpec.Name.URI)).isTrue();
-            assertThat(accepts(FilterSpec.Name.ENTRYPOINT)).isTrue();
+            // MESSAGE_CONNECTOR_ID and the edge dimensions are known to the engines but absent from the catalog
+            // (pinned by AnalyticsDefinitionYAMLQueryServiceTest). Deriving from the catalog must not start
+            // rejecting them.
+            assertThat(accepts(FilterSpec.Name.MESSAGE_CONNECTOR_ID)).isTrue();
             assertThat(accepts(FilterSpec.Name.EDGE_VERSION)).isTrue();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
@@ -213,7 +213,10 @@ class AnalyticsQueryValidatorTest {
                 FilterSpec.Name.TRANSACTION_ID,
                 // A version detached from its library is not a readable grouping — several clients share
                 // version numbers — so it narrows a library on the logs screen and has no analytics dimension.
-                FilterSpec.Name.NATIVE_CLIENT_SOFTWARE_VERSION
+                FilterSpec.Name.NATIVE_CLIENT_SOFTWARE_VERSION,
+                // The path filter is split by signal: URI reads uri, the only path a log document carries,
+                // and HTTP_PATH reads the templated path-info an analytics query groups by.
+                FilterSpec.Name.URI
             );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryServiceTest.java
@@ -164,6 +164,28 @@ class AnalyticsDefinitionYAMLQueryServiceTest {
             ).containsExactlyInAnyOrderElementsOf(KNOWN_UNCATALOGUED_FILTERS);
         }
 
+        /**
+         * The same loss one level up: a name the engines evaluate but the catalog does not describe is advertised
+         * to no signal and cannot list values, which is how the observability Entrypoint picker broke while the
+         * engine was filtering on it all along. What is left undescribed is exactly the pinned dimensions above,
+         * so this set shrinks with them and never grows.
+         */
+        @Test
+        void should_describe_every_engine_name_outside_the_pinned_dimension_gaps() {
+            var service = new AnalyticsDefinitionYAMLQueryService();
+            var pinnedNames = KNOWN_UNCATALOGUED_FILTERS.stream()
+                .map(entry -> entry.substring(entry.indexOf("-> ") + 3))
+                .distinct()
+                .toList();
+
+            var undescribed = Arrays.stream(FilterSpec.Name.values())
+                .filter(name -> service.findFilter(name).isEmpty())
+                .map(FilterSpec.Name::name)
+                .toList();
+
+            assertThat(undescribed).containsExactlyInAnyOrderElementsOf(pinnedNames);
+        }
+
         private static <T> List<String> droppedDimensions(
             Function<MetricSpec, List<T>> declared,
             BiFunction<AnalyticsDefinitionYAMLQueryService, MetricSpec.Name, List<T>> surfaced

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryServiceTest.java
@@ -87,6 +87,26 @@ class AnalyticsDefinitionYAMLQueryServiceTest {
     }
 
     @Nested
+    class Operators {
+
+        // A filter with no operator is unusable: the filter bar renders it with nothing to pick, and the
+        // catalog is the only place that says what an engine accepts — nothing downstream validates it.
+        @Test
+        void should_advertise_at_least_one_operator_for_every_filter() {
+            var service = new AnalyticsDefinitionYAMLQueryService();
+
+            var withoutOperator = service
+                .getAllFilters()
+                .stream()
+                .filter(spec -> spec.operators() == null || spec.operators().isEmpty())
+                .map(FilterSpec::name)
+                .toList();
+
+            assertThat(withoutOperator).isEmpty();
+        }
+    }
+
+    @Nested
     class Apis {
 
         // getApis() is what GET /analytics/definition/apis returns, and a metric declaring an api kind

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/FilterCatalogDriftException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/FilterCatalogDriftException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.exception;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+
+/**
+ * The observability catalog advertises a filter the platform analytics catalog cannot serve: the
+ * two declarations drifted apart. A build-time parity test keeps this unreachable; when it fires
+ * anyway the cause is a catalog bug, not a caller mistake, so it maps to HTTP 500 rather than 400.
+ *
+ * @author GraviteeSource Team
+ */
+public class FilterCatalogDriftException extends TechnicalDomainException {
+
+    public FilterCatalogDriftException(String filterName, Throwable cause) {
+        super(
+            "Filter '" + filterName + "' is advertised by the observability catalog but the platform analytics catalog cannot serve it",
+            cause
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
@@ -69,6 +69,13 @@ public class UnsupportedObservabilityFilterException extends ValidationDomainExc
         );
     }
 
+    public static UnsupportedObservabilityFilterException valuesPageOutOfRange(int page, int max) {
+        return new UnsupportedObservabilityFilterException(
+            "page must be between 1 and " + max + ", got " + page,
+            "observability.filter.values_page_out_of_range"
+        );
+    }
+
     public static UnsupportedObservabilityFilterException searchTranslationNotSupported(String filterName) {
         return new UnsupportedObservabilityFilterException(
             "Filter '" + filterName + "' is not yet supported for log search",

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -120,7 +120,8 @@ public enum StaticFilters {
     CONSUMER_IP("Consumer IP", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.HTTP_LLM_MCP_A2A),
     HTTP_USER_AGENT_OS_NAME("User Agent OS", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.HTTP_LLM_MCP_A2A),
     HTTP_USER_AGENT_DEVICE("User Agent Device", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.HTTP_LLM_MCP_A2A),
-    ERROR_KEY("Error Key", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Defs.HTTP_CONNECTION_KINDS_NATIVE),
+    // The analytics engine has no error-key dimension; the platform catalog serves it for logs only.
+    ERROR_KEY("Error Key", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS, Defs.HTTP_CONNECTION_KINDS_NATIVE),
     REQUEST_ID("Request ID", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS, Defs.REQUEST_BEARING_KINDS),
     TRANSACTION_ID("Transaction ID", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS, Defs.HTTP_CONNECTION_KINDS_NATIVE),
     // MESSAGE is deliberately absent: the connection-level body a payload search reads is never
@@ -248,7 +249,8 @@ public enum StaticFilters {
      * is unbounded, and the set of Kafka protocol operations grows with the protocol. Neither is
      * resolvable from the management database, so the filter bar offers no value suggestions for
      * them until a value lookup over the event-metrics index is wired in; faceting (Top topics, Top
-     * operations) works regardless.
+     * operations) works regardless. The values endpoint answers 400 for both; see
+     * {@link #withoutValueListing()}.
      */
     NATIVE_TOPIC("Kafka Topic", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Set.of(ApiType.NATIVE)),
     NATIVE_OPERATION("Kafka Operation", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Set.of(ApiType.NATIVE)),
@@ -292,6 +294,13 @@ public enum StaticFilters {
 
     public FilterSpec toSpec() {
         return new FilterSpec(name(), label, type, operators, enumValues, range, signals, apiTypes);
+    }
+
+    /** KEYWORD filters whose store holds no value pool to list: the values endpoint refuses them with a 400. */
+    private static final Set<String> WITHOUT_VALUE_LISTING = Set.of(NATIVE_TOPIC.name(), NATIVE_OPERATION.name());
+
+    public static Set<String> withoutValueListing() {
+        return WITHOUT_VALUE_LISTING;
     }
 
     /**

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -33,10 +33,15 @@ import java.util.Set;
  * two discovery axes ({@link Signal} × {@link ApiType}) shared by the logs and analytics surfaces.
  *
  * <p>Names are reconciled across the legacy logs and analytics engines (see GMA-422): e.g. the
- * gateway response time is {@code HTTP_GATEWAY_RESPONSE_TIME} (not the logs-side {@code RESPONSE_TIME}),
- * the MCP method is {@code MCP_PROXY_METHOD} (not {@code MCP_METHOD}), and request-path filtering is
- * {@code URI} (the v4-populated field) — the analytics {@code HTTP_PATH} is dropped (empty on v4) and
- * {@code HTTP_PATH_MAPPING} is an analytics facet, not a filter, so neither appears here.
+ * gateway response time is {@code HTTP_GATEWAY_RESPONSE_TIME} (not the logs-side {@code RESPONSE_TIME})
+ * and the MCP method is {@code MCP_PROXY_METHOD} (not {@code MCP_METHOD}). {@code HTTP_PATH_MAPPING}
+ * is an analytics facet, not a filter, so it does not appear here.
+ *
+ * <p>Request-path filtering is <b>two filters, one per signal</b>, because they read two different
+ * fields: {@link #HTTP_PATH} is ANALYTICS and reads {@code path-info}, the templated path a metrics
+ * document stores; {@link #URI} is LOGS and reads {@code uri}, the concrete request, which is the only
+ * path a log document carries. A concrete URI is a poor analytics dimension anyway — unbounded
+ * cardinality gives one bucket per request.
  *
  * <p>Operators advertised here are restricted to what the v4 analytics/logs engines actually
  * translate today: {@code EQ, IN} for KEYWORD/ENUM and for the identifier-shaped STRING filters
@@ -90,7 +95,11 @@ public enum StaticFilters {
         Defs.LOGS_ANALYTICS,
         Defs.HTTP_CONNECTION_KINDS
     ),
-    URI("HTTP Path", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.LOGS_ANALYTICS, Defs.HTTP_CONNECTION_KINDS),
+    // Two fields, two names, one signal each — see the class javadoc. Advertising one of them on
+    // both signals would make the same `=` match the templated path on a dashboard and the concrete
+    // request in the logs.
+    HTTP_PATH("HTTP Path", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.ANALYTICS, Defs.HTTP_CONNECTION_KINDS),
+    URI("Request URI", FilterType.STRING, Defs.EQ_ONLY, null, null, Defs.LOGS, Defs.HTTP_CONNECTION_KINDS),
     HOST("Host", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.HTTP_CONNECTION_KINDS),
     HTTP_GATEWAY_RESPONSE_TIME(
         "Gateway Response Time",

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
+import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
 import java.util.List;
@@ -39,15 +40,16 @@ import lombok.AllArgsConstructor;
  *   <li><b>{@code KEYWORD}</b> — distinct values from the data store via
  *       {@link ObservabilityFilterDataPort} (id-based listing for
  *       {@code API}/{@code APPLICATION}/{@code PLAN}/{@code API_PRODUCT}, direct values otherwise).
- *       The port surfaces {@link UnsupportedObservabilityFilterException#valueListingNotSupported}
- *       for filters the backing store cannot list yet.</li>
+ *       Filters the catalog marks as having no value pool ({@link StaticFilters#withoutValueListing()})
+ *       answer {@link UnsupportedObservabilityFilterException#valueListingNotSupported} before the port
+ *       is called.</li>
  *   <li><b>{@code NUMBER} / {@code STRING} / {@code BOOLEAN}</b> — no enumerable value pool, so
  *       value listing is unsupported (HTTP 400).</li>
  * </ul>
  *
  * <p>An unknown {@code filterName} yields {@link ObservabilityFilterNotFoundException} → HTTP 404
  * (the filter is addressed via the URL path). Pagination is <b>1-based</b>; {@code perPage} is
- * clamped to {@value #MAX_PER_PAGE}.
+ * clamped to {@value #MAX_PER_PAGE} and a {@code page} above {@value #MAX_PAGE} is refused (HTTP 400).
  *
  * @author GraviteeSource Team
  */
@@ -59,6 +61,9 @@ public class GetObservabilityFilterValuesUseCase {
 
     /** Hard cap matching apim's values endpoint — keeps the slice (and future ES round-trips) bounded. */
     private static final int MAX_PER_PAGE = 100;
+
+    /** Same ceiling as the platform values use case, checked here so the port never sees it. */
+    private static final int MAX_PAGE = 10_000;
 
     private final FilterRegistry filterRegistry;
     private final ObservabilityFilterDataPort filterDataPort;
@@ -78,7 +83,7 @@ public class GetObservabilityFilterValuesUseCase {
         int perPage = resolvePerPage(input);
         FilterValuesPage values = switch (spec.type()) {
             case ENUM -> handleEnum(spec, input, apiTypes, page, perPage);
-            case KEYWORD -> filterDataPort.listKeywordValues(spec.name(), input.query(), input.from(), input.to(), page, perPage, apiTypes);
+            case KEYWORD -> listKeywordValues(spec, input, apiTypes, page, perPage);
             case NUMBER, STRING, BOOLEAN -> throw UnsupportedObservabilityFilterException.valueListingNotSupported(
                 spec.name(),
                 spec.type().name()
@@ -88,11 +93,21 @@ public class GetObservabilityFilterValuesUseCase {
     }
 
     private static int resolvePage(Input input) {
+        if (input.page() != null && input.page() > MAX_PAGE) {
+            throw UnsupportedObservabilityFilterException.valuesPageOutOfRange(input.page(), MAX_PAGE);
+        }
         return (input.page() != null && input.page() > 0) ? input.page() : 1;
     }
 
     private static int resolvePerPage(Input input) {
         return (input.perPage() != null && input.perPage() > 0) ? Math.min(input.perPage(), MAX_PER_PAGE) : DEFAULT_PER_PAGE;
+    }
+
+    private FilterValuesPage listKeywordValues(FilterSpec spec, Input input, Set<ApiType> apiTypes, int page, int perPage) {
+        if (StaticFilters.withoutValueListing().contains(spec.name())) {
+            throw UnsupportedObservabilityFilterException.valueListingNotSupported(spec.name(), spec.type().name());
+        }
+        return filterDataPort.listKeywordValues(spec.name(), input.query(), input.from(), input.to(), page, perPage, apiTypes);
     }
 
     private FilterSpec lookupFilter(String filterName, Set<ApiType> apiTypes) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCase.java
@@ -48,8 +48,10 @@ import lombok.AllArgsConstructor;
  * </ul>
  *
  * <p>An unknown {@code filterName} yields {@link ObservabilityFilterNotFoundException} → HTTP 404
- * (the filter is addressed via the URL path). Pagination is <b>1-based</b>; {@code perPage} is
- * clamped to {@value #MAX_PER_PAGE} and a {@code page} above {@value #MAX_PAGE} is refused (HTTP 400).
+ * (the filter is addressed via the URL path). Pagination is <b>1-based</b>: {@code perPage} is clamped
+ * to {@value #MAX_PER_PAGE}, while a {@code page} outside 1..{@value #MAX_PAGE} is refused (HTTP 400)
+ * rather than clamped — serving a different page than the caller asked for would hide their bug. An
+ * absent {@code page} is the documented default of 1, not an out-of-range value.
  *
  * @author GraviteeSource Team
  */
@@ -93,10 +95,13 @@ public class GetObservabilityFilterValuesUseCase {
     }
 
     private static int resolvePage(Input input) {
-        if (input.page() != null && input.page() > MAX_PAGE) {
+        if (input.page() == null) {
+            return 1;
+        }
+        if (input.page() < 1 || input.page() > MAX_PAGE) {
             throw UnsupportedObservabilityFilterException.valuesPageOutOfRange(input.page(), MAX_PAGE);
         }
-        return (input.page() != null && input.page() > 0) ? input.page() : 1;
+        return input.page();
     }
 
     private static int resolvePerPage(Input input) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapter.java
@@ -20,7 +20,7 @@ import io.gravitee.apim.core.analytics_engine.use_case.ResolveFilterLabelsUseCas
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.exception.FilterCatalogDriftException;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
@@ -106,10 +106,10 @@ public class ObservabilityFilterDataPortAdapter implements ObservabilityFilterDa
                 ? valuesPage.totalFilteredCount()
                 : (long) (page - 1) * perPage + data.size();
             return new FilterValuesPage(data, total);
-        } catch (ValidationDomainException e) {
-            // The platform analytics catalog doesn't list values for this filter yet (unknown name or
-            // unsupported type on its side) — surface a coherent "not supported" 400 for the caller.
-            throw UnsupportedObservabilityFilterException.valueListingNotSupported(filterName, "KEYWORD");
+        } catch (ValidationDomainException | UnsupportedOperationException e) {
+            // Page bounds and unlistable filters are refused by the use case before this call, so what the
+            // platform rejects here is a filter its catalog or its store does not know: drift, not caller input.
+            throw new FilterCatalogDriftException(filterName, e);
         }
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -185,8 +185,10 @@ paths:
             description: |
                 Paginated selectable values for one filter. ENUM filters return their static labelled
                 values (optionally filtered by a case-insensitive substring `query`). KEYWORD filters
-                return distinct values from the data store. NUMBER and STRING filters have no
-                enumerable values and return 400.
+                return distinct values from the data store, except `NATIVE_TOPIC` and `NATIVE_OPERATION`,
+                whose values live in a stream the store does not aggregate over and which return 400.
+                NUMBER and STRING filters have no enumerable values and return 400. `page` is capped at
+                10000; a larger page returns 400.
             operationId: getObservabilityFilterValues
             parameters:
                 - name: filterName

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/CommonFiltersTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/CommonFiltersTest.java
@@ -42,8 +42,10 @@ class CommonFiltersTest {
 
     @Test
     void should_not_expose_dropped_or_renamed_legacy_filter_names() {
-        // URI replaces HTTP_PATH (empty on v4); HTTP_PATH_MAPPING is an analytics facet, not a filter;
-        // the unified vocabulary uses the reconciled names (HTTP_GATEWAY_RESPONSE_TIME / MCP_PROXY_METHOD).
-        assertThat(CommonFilters.names()).doesNotContain("HTTP_PATH", "HTTP_PATH_MAPPING", "RESPONSE_TIME", "MCP_METHOD");
+        // HTTP_PATH_MAPPING is an analytics facet, not a filter; the unified vocabulary uses the
+        // reconciled names (HTTP_GATEWAY_RESPONSE_TIME / MCP_PROXY_METHOD). HTTP_PATH is not in this
+        // list: it is a filter in its own right, reading path-info on the analytics signal, where URI
+        // reads uri on the logs one.
+        assertThat(CommonFilters.names()).doesNotContain("HTTP_PATH_MAPPING", "RESPONSE_TIME", "MCP_METHOD");
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/FilterCatalogParityTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/FilterCatalogParityTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Holds the observability catalog to the platform analytics catalog it delegates to. A filter Gamma
+ * advertises for the analytics signal is served by the platform engine, so the platform must
+ * declare it and declare it for analytics; otherwise value listing and queries fail at runtime with
+ * an error the caller cannot act on. Gamma-only names are legitimate only on the logs side, where
+ * Gamma owns the translation.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FilterCatalogParityTest {
+
+    private static final String RECORD_TYPE = "RECORD_TYPE";
+
+    private final FilterRegistry gamma = new SpiFilterRegistry();
+    private final AnalyticsDefinitionYAMLQueryService platform = new AnalyticsDefinitionYAMLQueryService();
+
+    @Test
+    void every_gamma_analytics_filter_should_be_a_platform_filter_that_applies_to_analytics() {
+        List<String> offenders = gamma
+            .getFilters(Set.of(Signal.ANALYTICS), null)
+            .stream()
+            .map(spec -> spec.name())
+            .filter(name -> !RECORD_TYPE.equals(name))
+            .filter(name ->
+                platformFilter(name)
+                    .map(spec -> !appliesToAnalytics(spec))
+                    .orElse(true)
+            )
+            .toList();
+
+        assertThat(offenders).as("Gamma analytics filters the platform catalog does not declare for analytics").isEmpty();
+    }
+
+    @Test
+    void gamma_only_filter_names_should_never_apply_to_analytics() {
+        List<String> gammaOnlyAnalytics = gamma
+            .getFilters(null, null)
+            .stream()
+            .filter(spec -> !RECORD_TYPE.equals(spec.name()))
+            .filter(spec -> platformFilter(spec.name()).isEmpty())
+            .filter(spec -> spec.signals().contains(Signal.ANALYTICS))
+            .map(spec -> spec.name())
+            .toList();
+
+        assertThat(gammaOnlyAnalytics).as("filters the platform catalog does not know yet advertised by Gamma for analytics").isEmpty();
+    }
+
+    /** Two catalogs, two {@code Signal} enums: the platform one is spelled out here, once. */
+    private static boolean appliesToAnalytics(FilterSpec platformSpec) {
+        return platformSpec.appliesTo(io.gravitee.apim.core.observability.model.Signal.ANALYTICS);
+    }
+
+    private Optional<FilterSpec> platformFilter(String gammaName) {
+        try {
+            return platform.findFilter(FilterSpec.Name.valueOf(gammaName));
+        } catch (IllegalArgumentException unknownToThePlatform) {
+            return Optional.empty();
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
@@ -50,8 +50,8 @@ class SpiFilterRegistryTest {
         assertThat(result).hasSize(StaticFilters.values().length + ExtensibleFilters.values().length);
         assertThat(result)
             .extracting(FilterSpec::name)
-            .contains("API", "HTTP_STATUS", "API_TYPE", "HTTP_GATEWAY_RESPONSE_TIME", "MCP_PROXY_METHOD", "URI")
-            .doesNotContain("HTTP_PATH", "HTTP_PATH_MAPPING");
+            .contains("API", "HTTP_STATUS", "API_TYPE", "HTTP_GATEWAY_RESPONSE_TIME", "MCP_PROXY_METHOD", "URI", "HTTP_PATH")
+            .doesNotContain("HTTP_PATH_MAPPING");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/inmemory/InMemoryObservabilityFilterDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/inmemory/InMemoryObservabilityFilterDataPort.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.inmemory;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * In-memory {@link ObservabilityFilterDataPort}: the distinct values a KEYWORD filter holds in the
+ * store, seeded per filter name, served with the same query narrowing and 1-based pagination the
+ * real store applies. Records the last listing call so a test can assert what the use case asked for.
+ */
+public class InMemoryObservabilityFilterDataPort implements ObservabilityFilterDataPort {
+
+    private final Map<String, List<FilterValue>> valuesByFilter = new HashMap<>();
+    private final Map<String, Map<String, String>> labelsByFilter = new HashMap<>();
+    private Call lastCall;
+
+    /** One {@link #listKeywordValues} invocation, as received. */
+    public record Call(String filterName, String query, Long from, Long to, int page, int perPage, Set<ApiType> apiTypes) {}
+
+    public InMemoryObservabilityFilterDataPort givenKeywordValues(String filterName, List<FilterValue> values) {
+        valuesByFilter.put(filterName, List.copyOf(values));
+        return this;
+    }
+
+    public InMemoryObservabilityFilterDataPort givenLabels(String filterName, Map<String, String> labels) {
+        labelsByFilter.put(filterName, Map.copyOf(labels));
+        return this;
+    }
+
+    public Optional<Call> lastCall() {
+        return Optional.ofNullable(lastCall);
+    }
+
+    public void reset() {
+        valuesByFilter.clear();
+        labelsByFilter.clear();
+        lastCall = null;
+    }
+
+    @Override
+    public FilterValuesPage listKeywordValues(
+        String filterName,
+        String query,
+        Long from,
+        Long to,
+        int page,
+        int perPage,
+        Set<ApiType> apiTypes
+    ) {
+        lastCall = new Call(filterName, query, from, to, page, perPage, apiTypes);
+        String needle = query == null || query.isBlank() ? null : query.toLowerCase();
+        List<FilterValue> matching = valuesByFilter
+            .getOrDefault(filterName, List.of())
+            .stream()
+            .filter(value -> needle == null || matches(value, needle))
+            .toList();
+        int fromIndex = (int) Math.min((long) (page - 1) * perPage, matching.size());
+        int toIndex = Math.min(fromIndex + perPage, matching.size());
+        return new FilterValuesPage(matching.subList(fromIndex, toIndex), matching.size());
+    }
+
+    @Override
+    public List<ResolvedLabels> resolveLabels(List<ResolveRequest> requests) {
+        return requests
+            .stream()
+            .map(request -> {
+                Map<String, String> known = labelsByFilter.getOrDefault(request.filterName(), Map.of());
+                Map<String, String> resolved = new LinkedHashMap<>();
+                request
+                    .ids()
+                    .stream()
+                    .filter(known::containsKey)
+                    .forEach(id -> resolved.put(id, known.get(id)));
+                return new ResolvedLabels(request.filterName(), resolved);
+            })
+            .toList();
+    }
+
+    private static boolean matches(FilterValue value, String needle) {
+        return (value.value().toLowerCase().contains(needle) || (value.label() != null && value.label().toLowerCase().contains(needle)));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/inmemory/InMemoryObservabilityFilterDataPortTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/inmemory/InMemoryObservabilityFilterDataPortTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.inmemory;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
+import io.gravitee.gamma.rest.core.observability.filter.port.ObservabilityFilterDataPortContractTest;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
+import java.util.List;
+import java.util.Map;
+
+class InMemoryObservabilityFilterDataPortTest extends ObservabilityFilterDataPortContractTest {
+
+    private final InMemoryObservabilityFilterDataPort port = new InMemoryObservabilityFilterDataPort();
+
+    @Override
+    protected ObservabilityFilterDataPort port() {
+        return port;
+    }
+
+    @Override
+    protected void givenKeywordValues(String filterName, List<FilterValue> values) {
+        port.givenKeywordValues(filterName, values);
+    }
+
+    @Override
+    protected void givenLabels(String filterName, Map<String, String> labels) {
+        port.givenLabels(filterName, labels);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/port/ObservabilityFilterDataPortContractTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/port/ObservabilityFilterDataPortContractTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.port;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort.ResolveRequest;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort.ResolvedLabels;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The behaviour every {@link ObservabilityFilterDataPort} implementation must honour, whatever the
+ * store behind it. The in-memory variant runs it on every build; a real-backend variant runs it on
+ * the assembled store.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class ObservabilityFilterDataPortContractTest {
+
+    protected abstract ObservabilityFilterDataPort port();
+
+    /** Makes the store hold these distinct values for a KEYWORD filter. */
+    protected abstract void givenKeywordValues(String filterName, List<FilterValue> values);
+
+    /** Makes the store know these display names for the ids of an id-based filter. */
+    protected abstract void givenLabels(String filterName, Map<String, String> labels);
+
+    @Test
+    void should_list_the_distinct_values_of_a_keyword_filter() {
+        givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null), new FilterValue("mcp-studio", null)));
+
+        var page = port().listKeywordValues("ENTRYPOINT", null, null, null, 1, 10, Set.of());
+
+        assertThat(page.data()).extracting(FilterValue::value).containsExactly("http-proxy", "mcp-studio");
+        assertThat(page.totalElements()).isEqualTo(2L);
+    }
+
+    @Test
+    void should_narrow_values_by_a_case_insensitive_substring_of_value_or_label() {
+        givenKeywordValues(
+            "API",
+            List.of(new FilterValue("api-1", "Petstore"), new FilterValue("api-2", "Weather"), new FilterValue("pet-3", "Other"))
+        );
+
+        var page = port().listKeywordValues("API", "PET", null, null, 1, 10, Set.of());
+
+        assertThat(page.data()).extracting(FilterValue::value).containsExactly("api-1", "pet-3");
+        assertThat(page.totalElements()).isEqualTo(2L);
+    }
+
+    @Test
+    void should_paginate_values_one_based_and_report_the_total() {
+        givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("a", null), new FilterValue("b", null), new FilterValue("c", null)));
+
+        var secondPage = port().listKeywordValues("ENTRYPOINT", null, null, null, 2, 2, Set.of());
+
+        assertThat(secondPage.data()).extracting(FilterValue::value).containsExactly("c");
+        assertThat(secondPage.totalElements()).isEqualTo(3L);
+    }
+
+    @Test
+    void should_return_an_empty_page_for_a_filter_without_values() {
+        var page = port().listKeywordValues("ENTRYPOINT", null, null, null, 1, 10, Set.of());
+
+        assertThat(page.data()).isEmpty();
+        assertThat(page.totalElements()).isZero();
+    }
+
+    @Test
+    void should_resolve_labels_per_filter_for_the_requested_ids_only() {
+        givenLabels("API", Map.of("api-1", "Petstore", "api-2", "Weather"));
+        givenLabels("APPLICATION", Map.of("app-1", "Mobile"));
+
+        List<ResolvedLabels> resolved = port().resolveLabels(
+            List.of(new ResolveRequest("API", List.of("api-1", "unknown")), new ResolveRequest("APPLICATION", List.of("app-1")))
+        );
+
+        assertThat(resolved)
+            .extracting(ResolvedLabels::filterName, ResolvedLabels::labels)
+            .containsExactly(tuple("API", Map.of("api-1", "Petstore")), tuple("APPLICATION", Map.of("app-1", "Mobile")));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterDefinitionsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterDefinitionsUseCaseTest.java
@@ -42,8 +42,8 @@ class GetObservabilityFilterDefinitionsUseCaseTest {
         assertThat(output.filters()).hasSize(StaticFilters.values().length + ExtensibleFilters.values().length);
         assertThat(output.filters())
             .extracting(FilterSpec::name)
-            .contains("API", "API_TYPE", "HTTP_GATEWAY_RESPONSE_TIME", "MCP_PROXY_METHOD", "URI")
-            .doesNotContain("HTTP_PATH", "HTTP_PATH_MAPPING");
+            .contains("API", "API_TYPE", "HTTP_GATEWAY_RESPONSE_TIME", "MCP_PROXY_METHOD", "URI", "HTTP_PATH")
+            .doesNotContain("HTTP_PATH_MAPPING");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
@@ -20,13 +20,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.gamma.rest.core.observability.filter.exception.ObservabilityFilterNotFoundException;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.inmemory.InMemoryObservabilityFilterDataPort;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
-import io.gravitee.gamma.rest.core.observability.filter.model.FilterValuesPage;
-import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.ObservabilityFilterDataPort;
 import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -35,7 +33,7 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GetObservabilityFilterValuesUseCaseTest {
 
-    private final RecordingDataPort dataPort = new RecordingDataPort();
+    private final InMemoryObservabilityFilterDataPort dataPort = new InMemoryObservabilityFilterDataPort();
     private final GetObservabilityFilterValuesUseCase useCase = new GetObservabilityFilterValuesUseCase(new SpiFilterRegistry(), dataPort);
 
     @Test
@@ -80,19 +78,31 @@ class GetObservabilityFilterValuesUseCaseTest {
 
     @Test
     void should_delegate_keyword_filter_to_the_data_port_with_resolved_pagination() {
-        dataPort.nextPage = new FilterValuesPage(List.of(new FilterValue("api-1", "Petstore")), 1L);
+        dataPort.givenKeywordValues("API", List.of(new FilterValue("api-1", "Petstore"), new FilterValue("api-2", "Weather")));
 
         var output = useCase.execute(new GetObservabilityFilterValuesUseCase.Input("API", "pet", null, null, null, null));
 
-        assertThat(output.values()).isSameAs(dataPort.nextPage);
-        assertThat(dataPort.lastFilterName).isEqualTo("API");
-        assertThat(dataPort.lastQuery).isEqualTo("pet");
-        // null page/perPage are resolved to the defaults (1 / 10) before reaching the port.
-        assertThat(dataPort.lastPage).isEqualTo(1);
-        assertThat(dataPort.lastPerPage).isEqualTo(10);
+        assertThat(output.values().data()).containsExactly(new FilterValue("api-1", "Petstore"));
+        assertThat(dataPort.lastCall()).hasValueSatisfying(call -> {
+            assertThat(call.filterName()).isEqualTo("API");
+            assertThat(call.query()).isEqualTo("pet");
+            // null page/perPage are resolved to the defaults (1 / 10) before reaching the port.
+            assertThat(call.page()).isEqualTo(1);
+            assertThat(call.perPage()).isEqualTo(10);
+        });
         // The resolved pagination is surfaced on the output so the REST layer builds a consistent envelope.
         assertThat(output.page()).isEqualTo(1);
         assertThat(output.perPage()).isEqualTo(10);
+    }
+
+    @Test
+    void should_list_entrypoint_values_from_the_data_port() {
+        dataPort.givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null), new FilterValue("mcp-studio", null)));
+
+        var output = useCase.execute(new GetObservabilityFilterValuesUseCase.Input("ENTRYPOINT", null, null, null, null, null));
+
+        assertThat(output.values().data()).extracting(FilterValue::value).containsExactly("http-proxy", "mcp-studio");
+        assertThat(output.values().totalElements()).isEqualTo(2L);
     }
 
     @Test
@@ -105,11 +115,24 @@ class GetObservabilityFilterValuesUseCaseTest {
     }
 
     @Test
+    void should_reject_a_page_beyond_the_maximum_before_reaching_the_data_port() {
+        dataPort.givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null)));
+
+        assertThatThrownBy(() ->
+            useCase.execute(new GetObservabilityFilterValuesUseCase.Input("ENTRYPOINT", null, null, null, 10_001, null))
+        )
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .extracting("technicalCode")
+            .isEqualTo("observability.filter.values_page_out_of_range");
+        assertThat(dataPort.lastCall()).isEmpty();
+    }
+
+    @Test
     void should_not_touch_the_data_port_for_number_filter() {
         assertThatThrownBy(() ->
             useCase.execute(new GetObservabilityFilterValuesUseCase.Input("HTTP_STATUS", null, null, null, null, null))
         ).isInstanceOf(UnsupportedObservabilityFilterException.class);
-        assertThat(dataPort.lastFilterName).isNull();
+        assertThat(dataPort.lastCall()).isEmpty();
     }
 
     @Test
@@ -117,7 +140,20 @@ class GetObservabilityFilterValuesUseCaseTest {
         assertThatThrownBy(() ->
             useCase.execute(new GetObservabilityFilterValuesUseCase.Input("URI", null, null, null, null, null))
         ).isInstanceOf(UnsupportedObservabilityFilterException.class);
-        assertThat(dataPort.lastFilterName).isNull();
+        assertThat(dataPort.lastCall()).isEmpty();
+    }
+
+    @Test
+    void should_answer_400_for_a_keyword_filter_whose_values_the_store_cannot_list() {
+        // NATIVE_TOPIC is a KEYWORD filter whose values live in the event-metrics stream the store does
+        // not aggregate over: the catalog offers the filter, not its values, and says so before the port.
+        assertThatThrownBy(() ->
+            useCase.execute(new GetObservabilityFilterValuesUseCase.Input("NATIVE_TOPIC", null, null, null, null, null))
+        )
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .extracting("technicalCode")
+            .isEqualTo("observability.filter.value_listing_not_supported");
+        assertThat(dataPort.lastCall()).isEmpty();
     }
 
     @Test
@@ -132,50 +168,10 @@ class GetObservabilityFilterValuesUseCaseTest {
 
     @Test
     void should_propagate_apiTypes_to_the_data_port_for_keyword_filters() {
-        dataPort.nextPage = new FilterValuesPage(List.of(new FilterValue("api-1", "Petstore")), 1L);
+        dataPort.givenKeywordValues("API", List.of(new FilterValue("api-1", "Petstore")));
 
         useCase.execute(new GetObservabilityFilterValuesUseCase.Input("API", null, null, null, null, null, Set.of(ApiType.HTTP_PROXY)));
 
-        assertThat(dataPort.lastApiTypes).containsExactly(ApiType.HTTP_PROXY);
-    }
-
-    private static final class RecordingDataPort implements ObservabilityFilterDataPort {
-
-        private FilterValuesPage nextPage = new FilterValuesPage(List.of(), 0L);
-        private String lastFilterName;
-        private String lastQuery;
-        private Long lastFrom;
-        private Long lastTo;
-        private Integer lastPage;
-        private Integer lastPerPage;
-        private Set<ApiType> lastApiTypes;
-
-        @Override
-        public FilterValuesPage listKeywordValues(
-            String filterName,
-            String query,
-            Long from,
-            Long to,
-            int page,
-            int perPage,
-            Set<ApiType> apiTypes
-        ) {
-            this.lastFilterName = filterName;
-            this.lastQuery = query;
-            this.lastFrom = from;
-            this.lastTo = to;
-            this.lastPage = page;
-            this.lastPerPage = perPage;
-            this.lastApiTypes = apiTypes;
-            return nextPage;
-        }
-
-        @Override
-        public List<ResolvedLabels> resolveLabels(List<ResolveRequest> requests) {
-            return requests
-                .stream()
-                .map(r -> new ResolvedLabels(r.filterName(), Map.of()))
-                .toList();
-        }
+        assertThat(dataPort.lastCall()).hasValueSatisfying(call -> assertThat(call.apiTypes()).containsExactly(ApiType.HTTP_PROXY));
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/use_case/GetObservabilityFilterValuesUseCaseTest.java
@@ -128,6 +128,29 @@ class GetObservabilityFilterValuesUseCaseTest {
     }
 
     @Test
+    void should_reject_a_page_below_the_first_one_before_reaching_the_data_port() {
+        // The OpenAPI parameter declares `minimum: 1`, and the platform use case refuses both bounds.
+        // Normalising a non-positive page to 1 would serve a different page than the caller asked for.
+        dataPort.givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null)));
+
+        assertThatThrownBy(() -> useCase.execute(new GetObservabilityFilterValuesUseCase.Input("ENTRYPOINT", null, null, null, 0, null)))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .extracting("technicalCode")
+            .isEqualTo("observability.filter.values_page_out_of_range");
+        assertThat(dataPort.lastCall()).isEmpty();
+    }
+
+    @Test
+    void should_default_an_absent_page_to_the_first_one() {
+        // `page` is optional and defaults to 1 in the spec: absent is not the same as out of range.
+        dataPort.givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null)));
+
+        var output = useCase.execute(new GetObservabilityFilterValuesUseCase.Input("ENTRYPOINT", null, null, null, null, null));
+
+        assertThat(output.page()).isEqualTo(1);
+    }
+
+    @Test
     void should_not_touch_the_data_port_for_number_filter() {
         assertThatThrownBy(() ->
             useCase.execute(new GetObservabilityFilterValuesUseCase.Input("HTTP_STATUS", null, null, null, null, null))

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityFilterDataPortAdapterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import io.gravitee.apim.core.analytics_engine.use_case.GetFilterValuesUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ResolveFilterLabelsUseCase;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.filter.exception.FilterCatalogDriftException;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ObservabilityFilterDataPortAdapterTest {
+
+    private final GetFilterValuesUseCase getFilterValuesUseCase = mock(GetFilterValuesUseCase.class);
+    private final ResolveFilterLabelsUseCase resolveFilterLabelsUseCase = mock(ResolveFilterLabelsUseCase.class);
+    private final ObservabilityFilterDataPortAdapter adapter = new ObservabilityFilterDataPortAdapter(
+        getFilterValuesUseCase,
+        resolveFilterLabelsUseCase
+    );
+
+    /** Two {@code FilterValue} records, one per catalog: the platform one is spelled out here, once. */
+    private static io.gravitee.apim.core.analytics_engine.model.FilterValue platformValue(String value, String label) {
+        return new io.gravitee.apim.core.analytics_engine.model.FilterValue(value, label);
+    }
+
+    @Test
+    void should_map_platform_values_to_core_values_and_keep_the_reported_total() {
+        when(getFilterValuesUseCase.execute(any())).thenReturn(
+            new GetFilterValuesUseCase.Output(
+                new FilterValuesPage(List.of(platformValue("mcp-studio", null), platformValue("Petstore", "api-1")), Map.of(), 7L)
+            )
+        );
+
+        var page = adapter.listKeywordValues("ENTRYPOINT", null, null, null, 1, 10, Set.of());
+
+        assertThat(page.data()).containsExactly(new FilterValue("mcp-studio", null), new FilterValue("api-1", "Petstore"));
+        assertThat(page.totalElements()).isEqualTo(7L);
+    }
+
+    @Test
+    void should_surface_a_platform_catalog_miss_as_a_drift_error_not_a_400() {
+        // "Filter not found" from the platform means the observability catalog advertises a filter the
+        // platform catalog does not declare: a catalog bug, never something the caller can fix.
+        when(getFilterValuesUseCase.execute(any())).thenThrow(
+            new ValidationDomainException("Filter not found", Map.of("filterName", "ENTRYPOINT"))
+        );
+
+        assertThatThrownBy(() -> adapter.listKeywordValues("ENTRYPOINT", null, null, null, 1, 10, Set.of()))
+            .isInstanceOf(FilterCatalogDriftException.class)
+            .hasMessageContaining("ENTRYPOINT");
+    }
+
+    @Test
+    void should_surface_a_missing_store_mapping_as_a_drift_error() {
+        // The platform knows the filter but has no field to aggregate on: the same drift, seen one layer lower.
+        when(getFilterValuesUseCase.execute(any())).thenThrow(
+            new UnsupportedOperationException("No ES field mapping for filter: NATIVE_TOPIC")
+        );
+
+        assertThatThrownBy(() -> adapter.listKeywordValues("NATIVE_TOPIC", null, null, null, 1, 10, Set.of()))
+            .isInstanceOf(FilterCatalogDriftException.class)
+            .hasMessageContaining("NATIVE_TOPIC");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/filters/ObservabilityFilterValuesResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/filters/ObservabilityFilterValuesResourceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resource.observability.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gamma.rest.core.observability.filter.inmemory.InMemoryObservabilityFilterDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterValue;
+import io.gravitee.gamma.rest.core.observability.filter.use_case.GetObservabilityFilterDefinitionsUseCase;
+import io.gravitee.gamma.rest.core.observability.filter.use_case.GetObservabilityFilterValuesUseCase;
+import io.gravitee.gamma.rest.core.observability.filter.use_case.ResolveObservabilityFilterLabelsUseCase;
+import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
+import io.gravitee.gamma.rest.resource.AbstractResourceTest;
+import io.gravitee.gamma.rest.resource.observability.filters.ObservabilityFilterValuesResourceTest.ValuesTestConfiguration;
+import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Drives real filter-value requests through the resource, the real use case and the real catalog,
+ * with only the data store replaced: what a caller gets for a filter the catalog offers, and for one
+ * whose values the store cannot list.
+ */
+@ContextConfiguration(classes = { ResourceContextConfiguration.class, ValuesTestConfiguration.class })
+class ObservabilityFilterValuesResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "fake-env";
+
+    @Inject
+    private InMemoryObservabilityFilterDataPort dataPort;
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/observability/filters";
+    }
+
+    @BeforeEach
+    void prepareEnvironment() {
+        EnvironmentEntity env = new EnvironmentEntity();
+        env.setId(ENVIRONMENT);
+        env.setOrganizationId(ORGANIZATION);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(env);
+    }
+
+    @AfterEach
+    void resetStore() {
+        dataPort.reset();
+    }
+
+    @Test
+    void should_list_entrypoint_values_from_the_data_store() {
+        dataPort.givenKeywordValues("ENTRYPOINT", List.of(new FilterValue("http-proxy", null), new FilterValue("mcp-studio", null)));
+
+        Response response = rootTarget("ENTRYPOINT/values").queryParam("apiType", "MCP").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertThat(body.get("data"))
+            .extracting(node -> node.get("value").asText())
+            .containsExactly("http-proxy", "mcp-studio");
+        assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(2L);
+        assertThat(dataPort.lastCall()).hasValueSatisfying(call -> assertThat(call.filterName()).isEqualTo("ENTRYPOINT"));
+    }
+
+    @Test
+    void should_answer_400_for_a_keyword_filter_whose_values_the_store_cannot_list() {
+        // A Kafka topic name is unbounded and lives in the event-metrics stream the store does not
+        // aggregate over: the catalog offers the filter, not its values, and says so instead of failing.
+        Response response = rootTarget("NATIVE_TOPIC/values").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertThat(body.get("message").asText()).contains("NATIVE_TOPIC");
+        assertThat(dataPort.lastCall()).isEmpty();
+    }
+
+    @Test
+    void should_answer_400_for_a_page_beyond_the_maximum() {
+        Response response = rootTarget("ENTRYPOINT/values").queryParam("page", 10_001).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(dataPort.lastCall()).isEmpty();
+    }
+
+    @Configuration
+    static class ValuesTestConfiguration {
+
+        @Bean
+        GetObservabilityFilterDefinitionsUseCase getObservabilityFilterDefinitionsUseCase() {
+            return mock(GetObservabilityFilterDefinitionsUseCase.class);
+        }
+
+        @Bean
+        ResolveObservabilityFilterLabelsUseCase resolveObservabilityFilterLabelsUseCase() {
+            return mock(ResolveObservabilityFilterLabelsUseCase.class);
+        }
+
+        @Bean
+        InMemoryObservabilityFilterDataPort observabilityFilterDataPort() {
+            return new InMemoryObservabilityFilterDataPort();
+        }
+
+        @Bean
+        GetObservabilityFilterValuesUseCase getObservabilityFilterValuesUseCase(InMemoryObservabilityFilterDataPort dataPort) {
+            return new GetObservabilityFilterValuesUseCase(new SpiFilterRegistry(), dataPort);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The observability filter bar offers an **Entrypoint** filter, but its values endpoint answered
`400 Filter 'ENTRYPOINT' of type KEYWORD does not support value listing` — so the GMA-982 demo had to
be driven from a hand-built URL.

The filter type was never the problem. `ENTRYPOINT` and `URI` were simply **missing from the platform
catalog** (`analytics-definition.yaml`), and the Gamma adapter relabelled the platform's "filter not
found" as a type limitation. This PR makes the catalog the single source for names and values on the
Gamma side, and makes any future drift fail loudly instead of silently.

Three adjacent defects surfaced while fixing it and are fixed here too, each in its own commit — see
*Commits* below.

## What it brings

| Surface | Before | After |
| --- | --- | --- |
| `GET …/observability/filters/ENTRYPOINT/values` | `400` — "type KEYWORD does not support value listing" | `200` with the entrypoints present in the window |
| Gamma logs view — Entrypoint picker | empty, unusable | populated; an MCP Studio API can be isolated from the UI alone |
| `NATIVE_TOPIC` / `NATIVE_OPERATION` values | `500` from the platform field resolver | documented `400`, declared in the catalog |
| `ERROR_KEY` on the analytics signal | advertised, then refused by the engine | no longer advertised — LOGS only |
| A platform rejection of a catalogued filter | `400` "not supported" — blames the caller | `500 FilterCatalogDriftException` — names the real cause |
| `page` out of range | above the ceiling reached the port and failed there; `0` or negative was silently served as page 1 | `400` at both ends, before the port is called |
| `ENTRYPOINT` / `URI` operators | none advertised — filter bar had nothing to pick | `EQ, IN` and `EQ` |
| **HTTP path filtering** | one name, two fields: `path-info` on a dashboard, `uri` in the logs | `HTTP_PATH` (ANALYTICS, `path-info`) and `URI` (LOGS, `uri`) — one name, one field |

## Commits

**1. `make the filter catalog the single source for names and values`** — the reported bug.

- Declare `ENTRYPOINT` (KEYWORD) and `URI` (STRING) in `analytics-definition.yaml`.
- Pin the engine names still outside the catalog to exactly `MESSAGE_CONNECTOR_ID` and the edge
  dimensions, so that set can only shrink.
- Gamma: `ERROR_KEY` becomes LOGS-only; `NATIVE_TOPIC` / `NATIVE_OPERATION` are declared as having no
  value pool (`StaticFilters.withoutValueListing()`), so the decision lives in the catalog instead of
  being inferred from a caught exception; `page > 10000` is refused before the port;
  `ObservabilityFilterDataPortAdapter` stops relabelling a platform rejection as a caller error and
  raises `FilterCatalogDriftException` instead.
- `FilterCatalogParityTest` makes that exception unreachable: every Gamma analytics filter must exist
  in the platform catalog and apply to analytics.
- `AnalyticsQueryValidator` behaviour is unchanged — only its javadoc examples were wrong.

**2. `declare operators for the ENTRYPOINT and URI filters`** — the two new entries carried no
`operators` block, and `FilterSpec`'s compact constructor normalises only `signals`, so they shipped
as `null`. The filter bar would have rendered two filters with nothing to pick. `URI` is `EQ`,
`ENTRYPOINT` is `EQ, IN` (`ENTRYPOINT IN [...]` is the default scoping Gamma injects). Guarded by an
invariant rather than by the two names: a catalog filter with no operator now fails the build.

**3. `split the HTTP path filter by signal`** — off-theme but adjacent, and folded in to spare a
second CI run. `HTTP_PATH` carried both signals and resolved to a **different field on each**:
`path-info.keyword` for analytics, `uri` for logs, because a log document has no `path-info` at all.
A value that appeared in a dashboard bucket could therefore fail to match a log search. Each field
now has its own name on the signal where it exists. Gamma had followed the same confusion in the
other direction — advertising `URI` on both signals and dropping `HTTP_PATH` as "empty on v4", which
is wrong: the v4 reporter never writes `path`, but it does write `path-info`.

**4. `refuse a filter values page below the first one`** — reported by Aikido. The page bound added
in commit 1 only rejected the upper end, so `page=0` was normalised to 1 and served, while the error
message it raised claimed the page had to be between 1 and the maximum. The OpenAPI parameter
declares `minimum: 1` and the platform use case this mirrors refuses both ends. Both ends are now
refused here too; an absent `page` still defaults to 1, since absent is the documented default rather
than an out-of-range value.

## Test plan

- [ ] Full suites green: `gravitee-apim-rest-api-service` (9718), `…-management-v2-rest` (1860),
      `gravitee-gamma-rest-api` (428, via `verify` for the archrules gate).
- [ ] On a running stack, `GET …/observability/filters/ENTRYPOINT/values?apiType=MCP` returns the
      entrypoints present in the window (e.g. `mcp-studio`) with a `200`.
- [ ] The AIM logs view Entrypoint picker is populated, and an MCP Studio API can be isolated from
      the UI alone.
- [ ] `GET …/observability/filters/NATIVE_TOPIC/values` answers `400` naming the filter;
      `…/ENTRYPOINT/values?page=10001` and `…?page=0` both answer `400`; `…` with no `page` serves page 1.
- [ ] `GET …/observability/filters/definition` lists `ENTRYPOINT` and `URI`, each with its operators.
- [ ] `GET …/observability/filters/definition?signal=LOGS` lists `URI` and **not** `HTTP_PATH`;
      `?signal=ANALYTICS` lists `HTTP_PATH` and **not** `URI`.
- [ ] Filtering an analytics screen by `HTTP_PATH` matches the templated path; filtering a logs
      search by `URI` matches the concrete request.
- [ ] A logs link saved before this change, carrying `HTTP_PATH`, still resolves (`LogsEngineMapper`
      keeps its alias arm).
- [ ] Console v4 analytics screens unchanged:
      `GET …/analytics/definition/metrics/{metric}/filters` returns the same lists as before.

## Reviewer notes

**Compatibility-sensitive** — `analytics-definition.yaml` is a served catalog, and commit 3 changes
which filters each signal advertises. The Console logs filter bar shows "Request URI" where it showed
"HTTP Path"; the analytics filter bar keeps "HTTP Path" and loses "Request URI". Saved logs links
carrying `HTTP_PATH` keep working. No validator behaviour changes, and no metric filter list changes.

**Only `HTTP_PATH` was moved, not the other two legacy spellings** — `RESPONSE_TIME` and `MCP_METHOD`
really are one dimension under two names, unlike `HTTP_PATH`/`URI`. They are wire values carried by
saved links, so retiring them needs a deprecation and is deliberately left out.

**`ENTRYPOINT` values are raw store ids** — no registry narrowing, no labels. An explicit `ENTRYPOINT`
condition is honoured as an exact `terms` by the engine, so every offered value matches. Registry
narrowing and the synthetic `(none)` value follow with OBS-90, where the default scope becomes
fail-open.

**Four names stay outside the catalog on purpose** — `MESSAGE_CONNECTOR_ID`, `EDGE_VERSION`,
`EDGE_MODEL`, `EDGE_TOOL`. `AnalyticsDefinitionYAMLQueryServiceTest.MetricDimensionParity` pins them
as gaps for the Message and Edge owners to decide; the platform values resolver has no field mapping
for them, so cataloguing them here would surface Console pickers that answer `500`.

**Not security-sensitive** — no authentication, authorization or parsing path is touched.

Closes [OBS-67](https://gravitee.atlassian.net/browse/OBS-67).


[OBS-67]: https://gravitee.atlassian.net/browse/OBS-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ