### PR TITLE
fix(rest-api): let domain exceptions propagate on the API CRD update path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
@@ -188,6 +188,27 @@ class ApisResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_return_400_and_no_fqcn_when_use_case_throws_validation_domain_exception() {
+            when(importApiCRDUseCase.execute(any(ImportApiCRDUseCase.Input.class))).thenThrow(
+                new io.gravitee.apim.core.exception.ValidationDomainException("bad payload")
+            );
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", false)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-with-hrid.json")))
+            ) {
+                var body = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Error.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(response.getStatus()).isEqualTo(400);
+                    soft.assertThat(body.getMessage()).doesNotContain("io.gravitee.apim.core");
+                    soft.assertThat(body.getMessage()).contains("bad payload");
+                });
+            }
+        }
+
+        @Test
         void should_return_state_from_hrid_and_have_spg_hrid_replaced() {
             var state = expectEntity("api-with-hrid-spg-hrid.json");
             SoftAssertions.assertSoftly(soft -> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -336,6 +336,8 @@ public class ImportApiCRDUseCase {
                 .state(api.getLifecycleState().name())
                 .plans(planKeyIdMapping)
                 .build();
+        } catch (AbstractDomainException e) {
+            throw e;
         } catch (Exception e) {
             throw new TechnicalManagementException(e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -1244,6 +1244,18 @@ class ImportApiCRDUseCaseTest {
         }
 
         @Test
+        void should_let_domain_exceptions_propagate_without_wrapping_in_technical_management_exception() {
+            givenExistingApi();
+            givenExistingPlans(List.of(KEYLESS));
+            var domain = new ValidationDomainException("boom");
+            when(updateApiDomainService.update(any(), any(), any())).thenThrow(domain);
+
+            var throwable = catchThrowable(() -> useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().build())));
+
+            assertThat(throwable).isSameAs(domain);
+        }
+
+        @Test
         void should_return_native_CRD_status() {
             givenExistingNativeApi();
             givenExistingPlans(List.of(NATIVE_KEYLESS));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-179

## Description

ImportApiCRDUseCase.update(...) was missing the AbstractDomainException passthrough that create(...) already has, so every domain exception on the API update path was wrapped in TechnicalManagementException and mapped to 500 / technicalCode: "unexpected".
