### PR TITLE
feat(gateway): report the entrypoint a refused request was addressed to

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/pom.xml
@@ -628,6 +628,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.graviteesource.entrypoint</groupId>
+            <artifactId>gravitee-entrypoint-mcp-tool-server</artifactId>
+            <version>${gravitee-entrypoint-mcp-tool-server.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.graviteesource.connector</groupId>
             <artifactId>gravitee-entrypoint-native-kafka</artifactId>
             <version>${gravitee-reactor-native-kafka.version}</version>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/EntrypointAttributionIntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/EntrypointAttributionIntegrationTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.reporting;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.mcp.MCPEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.websocket.WebSocketEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.subjects.ReplaySubject;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A request the gateway refuses before selecting an entrypoint connector (plan 401, CORS preflight) is reported
+ * with the {@code entrypoint-id} of the entrypoint it was addressed to, resolved with the same matching rules as
+ * accepted traffic, on APIs exposing several entrypoints. Status codes are asserted alongside to show the request
+ * chain itself is unchanged: security still runs before entrypoint selection.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EntrypointAttributionIntegrationTest {
+
+    private static final String API_KEY_HEADER = "X-Gravitee-Api-Key";
+    private static final String MCP_ACCEPT = "application/json, text/event-stream";
+    private static final String MCP_INITIALIZE =
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"attribution-test\",\"version\":\"1.0\"}}}";
+
+    abstract static class AttributionTest extends AbstractGatewayTest {
+
+        ReplaySubject<Metrics> reported;
+
+        @BeforeEach
+        void captureReportedMetrics() {
+            reported = ReplaySubject.create();
+            getBean(FakeReporter.class).setReportableHandler(reportable -> {
+                if (reportable instanceof Metrics metrics) {
+                    reported.onNext(metrics.toBuilder().build());
+                }
+            });
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                Api definition = (Api) api.getDefinition();
+                configurePlans(definition, Set.of("api-key"));
+                Analytics analytics = new Analytics();
+                analytics.setEnabled(true);
+                definition.setAnalytics(analytics);
+            }
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "api-key",
+                PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+            );
+        }
+
+        /** The v4 metrics document reported for the request, identified by its URI and status. */
+        Metrics reportedFor(String uri, int status) {
+            return reported
+                .filter(metrics -> uri.equals(metrics.getUri()) && metrics.getStatus() == status)
+                .firstOrError()
+                .timeout(10, SECONDS)
+                .blockingGet();
+        }
+
+        ApiKey givenAValidApiKey(String apiId) {
+            ApiKey apiKey = new ApiKey();
+            apiKey.setApi(apiId);
+            apiKey.setApplication("application-id");
+            apiKey.setSubscription("subscription-id");
+            apiKey.setPlan(PLAN_APIKEY_ID);
+            apiKey.setKey("attribution-api-key");
+            when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+            when(
+                getBean(SubscriptionService.class).getByApiAndSecurityToken(
+                    eq(apiId),
+                    argThat(token -> token.getTokenType().equals(API_KEY.name()) && token.getTokenValue().equals(apiKey.getKey())),
+                    eq(PLAN_APIKEY_ID)
+                )
+            ).thenReturn(Optional.of(createSubscription(apiId, PLAN_APIKEY_ID, false)));
+            return apiKey;
+        }
+
+        static int send(HttpClient client, HttpMethod method, String path, Map<String, String> headers, String body) {
+            HttpClientResponse response = client
+                .rxRequest(method, path)
+                .flatMap(request -> {
+                    headers.forEach(request::putHeader);
+                    return body == null ? request.rxSend() : request.rxSend(body);
+                })
+                .timeout(10, SECONDS)
+                .blockingGet();
+            response.rxBody().timeout(10, SECONDS).blockingGet();
+            return response.statusCode();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/entrypoint-attribution/proxy-with-mcp.json")
+    class ProxyApiExposingHttpProxyAndMcp extends AttributionTest {
+
+        private static final String API_ID = "entrypoint-attribution-proxy";
+        private static final String MCP_URI = "/entrypoint-attribution/mcp";
+        private static final String PROXY_URI = "/entrypoint-attribution/resource";
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+            entrypoints.putIfAbsent("mcp", EntrypointBuilder.build("mcp", MCPEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Test
+        void should_attribute_a_refused_mcp_call_to_the_mcp_entrypoint(HttpClient client) {
+            int status = send(client, HttpMethod.POST, MCP_URI, Map.of("Accept", MCP_ACCEPT), MCP_INITIALIZE);
+
+            assertThat(status).isEqualTo(401);
+            assertThat(reportedFor(MCP_URI, 401).getEntrypointId()).isEqualTo("mcp");
+        }
+
+        @Test
+        void should_attribute_a_refused_proxy_call_to_the_http_proxy_entrypoint(HttpClient client) {
+            int status = send(client, HttpMethod.GET, PROXY_URI, Map.of(), null);
+
+            assertThat(status).isEqualTo(401);
+            assertThat(reportedFor(PROXY_URI, 401).getEntrypointId()).isEqualTo("http-proxy");
+        }
+
+        @Test
+        void should_attribute_a_cors_preflight_to_the_entrypoint_that_would_serve_the_request(HttpClient client) {
+            int status = send(
+                client,
+                HttpMethod.OPTIONS,
+                PROXY_URI,
+                Map.of("Origin", "https://mydomain.com", "Access-Control-Request-Method", "GET"),
+                null
+            );
+
+            assertThat(status).isEqualTo(200);
+            assertThat(reportedFor(PROXY_URI, 200).getEntrypointId()).isEqualTo("http-proxy");
+        }
+
+        @Test
+        void should_keep_attributing_an_accepted_proxy_call_to_the_connector_that_handled_it(HttpClient client) {
+            wiremock.stubFor(get("/endpoint/resource").willReturn(ok("endpoint response")));
+            ApiKey apiKey = givenAValidApiKey(API_ID);
+
+            int status = send(client, HttpMethod.GET, PROXY_URI, Map.of(API_KEY_HEADER, apiKey.getKey()), null);
+
+            assertThat(status).isEqualTo(200);
+            assertThat(reportedFor(PROXY_URI, 200).getEntrypointId()).isEqualTo("http-proxy");
+        }
+
+        @Test
+        void should_keep_attributing_an_accepted_mcp_call_to_the_mcp_entrypoint(HttpClient client) {
+            ApiKey apiKey = givenAValidApiKey(API_ID);
+
+            int status = send(
+                client,
+                HttpMethod.POST,
+                MCP_URI,
+                Map.of("Accept", MCP_ACCEPT, API_KEY_HEADER, apiKey.getKey()),
+                MCP_INITIALIZE
+            );
+
+            assertThat(status).isNotIn(401, 404);
+            assertThat(reportedFor(MCP_URI, status).getEntrypointId()).isEqualTo("mcp");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/entrypoint-attribution/message-with-several-entrypoints.json")
+    class MessageApiExposingSeveralEntrypoints extends AttributionTest {
+
+        private static final String URI = "/entrypoint-attribution-message";
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+            entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+            entrypoints.putIfAbsent("sse", EntrypointBuilder.build("sse", SseEntrypointConnectorFactory.class));
+            entrypoints.putIfAbsent("websocket", EntrypointBuilder.build("websocket", WebSocketEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+        }
+
+        @Test
+        void should_attribute_a_refused_event_stream_subscription_to_the_sse_entrypoint(HttpClient client) {
+            int status = send(client, HttpMethod.GET, URI, Map.of("Accept", "text/event-stream"), null);
+
+            assertThat(status).isEqualTo(401);
+            assertThat(reportedFor(URI, 401).getEntrypointId()).isEqualTo("sse");
+        }
+
+        @Test
+        void should_attribute_a_refused_publication_to_the_http_post_entrypoint(HttpClient client) {
+            int status = send(client, HttpMethod.POST, URI, Map.of(), "{\"message\":\"hello\"}");
+
+            assertThat(status).isEqualTo(401);
+            assertThat(reportedFor(URI, 401).getEntrypointId()).isEqualTo("http-post");
+        }
+
+        @Test
+        void should_attribute_a_refused_poll_to_the_http_get_entrypoint(HttpClient client) {
+            int status = send(client, HttpMethod.GET, URI, Map.of(), null);
+
+            assertThat(status).isEqualTo(401);
+            assertThat(reportedFor(URI, 401).getEntrypointId()).isEqualTo("http-get");
+        }
+    }
+}

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/http/entrypoint-attribution/proxy-with-mcp.json
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/http/entrypoint-attribution/proxy-with-mcp.json
@@ -1,0 +1,56 @@
+{
+    "id": "entrypoint-attribution-proxy",
+    "name": "entrypoint-attribution-proxy",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "cors": {
+                "enabled": true,
+                "allowCredentials": true,
+                "allowHeaders": ["x-gravitee-test"],
+                "allowMethods": ["GET", "POST"],
+                "allowOrigin": ["https://mydomain.com"],
+                "runPolicies": false
+            },
+            "paths": [
+                {
+                    "path": "/entrypoint-attribution"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                },
+                {
+                    "type": "mcp",
+                    "configuration": {
+                        "mcpPath": "/mcp"
+                    }
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [],
+    "analytics": {
+        "enabled": true
+    }
+}

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/messages/entrypoint-attribution/message-with-several-entrypoints.json
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/resources/apis/v4/messages/entrypoint-attribution/message-with-several-entrypoints.json
@@ -1,0 +1,64 @@
+{
+    "id": "entrypoint-attribution-message",
+    "name": "entrypoint-attribution-message",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "message",
+    "description": "Message API exposing several entrypoints, to check which one a refused request is attributed to",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/entrypoint-attribution-message"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-get",
+                    "configuration": {
+                        "messagesLimitCount": 12,
+                        "messagesLimitDurationMs": 500,
+                        "headersInPayload": true,
+                        "metadataInPayload": true
+                    }
+                },
+                {
+                    "type": "http-post",
+                    "configuration": {
+                        "requestHeadersToMessage": true
+                    }
+                },
+                {
+                    "type": "sse"
+                },
+                {
+                    "type": "websocket"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "mock",
+            "endpoints": [
+                {
+                    "name": "default-endpoint",
+                    "type": "mock",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "messageInterval": 1,
+                        "messageContent": "Mock data",
+                        "messageCount": 15
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [],
+    "analytics": {
+        "enabled": true
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/entrypoint/DefaultEntrypointConnectorResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/entrypoint/DefaultEntrypointConnectorResolver.java
@@ -44,6 +44,14 @@ import lombok.Getter;
 @SuppressWarnings("unchecked")
 public class DefaultEntrypointConnectorResolver extends AbstractService<DefaultEntrypointConnectorResolver> {
 
+    /**
+     * Internal attribute under which the API reactor publishes this resolver before the request chain runs, so
+     * that a request refused before an entrypoint connector was selected (plan 401/403, CORS preflight, request
+     * validation, timeout or client abort during the security chain) can still be attributed at report time to
+     * the entrypoint it was addressed to, with the same matching rules as accepted traffic.
+     */
+    public static final String ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER = "entrypointConnector.resolver";
+
     @Getter
     private final List<BaseEntrypointConnector> entrypointConnectors;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -23,6 +23,7 @@ import static io.gravitee.gateway.reactive.api.context.ContextAttributes.*;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER_SKIP;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SERVER_ID;
+import static io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER;
 import static java.lang.Boolean.TRUE;
 
 import io.gravitee.common.component.Lifecycle;
@@ -322,6 +323,9 @@ public class DefaultApiReactor extends AbstractApiReactor {
 
         // Prepare attributes and metrics before handling the request.
         prepareExecutionContext(ctx);
+        // Published here rather than in prepareExecutionContext so the resolver is only reachable once every attribute
+        // its connectors match on (the context path) is in place; the reporter uses it to attribute refused requests.
+        ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, entrypointConnectorResolver);
         prepareMetrics(ctx);
 
         return handleRequest(ctx);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.gateway.reactive.api.ExecutionPhase.RESPONSE;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER_SKIP;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_VALIDATE_SUBSCRIPTION;
+import static io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER;
 import static io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactor.PENDING_REQUESTS_TIMEOUT_PROPERTY;
 import static io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactor.REQUEST_TIMEOUT_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -459,6 +460,27 @@ class DefaultApiReactorTest {
         verify(ctx).setAttribute(ContextAttributes.ATTR_API, API_ID);
         verify(ctx).setAttribute(ContextAttributes.ATTR_ORGANIZATION, ORGANIZATION_ID);
         verify(ctx).setAttribute(ContextAttributes.ATTR_ENVIRONMENT, ENVIRONMENT_ID);
+    }
+
+    @Test
+    void shouldPublishEntrypointResolverWithContextAttributes() {
+        cut.handle(ctx).test().assertComplete();
+
+        InOrder inOrder = inOrder(ctx);
+        inOrder.verify(ctx).setAttribute(ContextAttributes.ATTR_CONTEXT_PATH, CONTEXT_PATH);
+        inOrder.verify(ctx).setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, entrypointConnectorResolver);
+    }
+
+    @Test
+    void shouldPublishEntrypointResolverWithoutResolvingWhenSecurityChainRefusesTheRequest() {
+        // The reporter attributes the refused request through the published resolver; the reactor itself still
+        // resolves the entrypoint only after the security chain, so 401 keeps precedence over 404.
+        when(securityChain.execute(ctx)).thenReturn(spyInterruptionFailureException);
+
+        cut.handle(ctx).test().assertComplete();
+
+        verify(ctx).setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, entrypointConnectorResolver);
+        verify(entrypointConnectorResolver, never()).resolve(any());
     }
 
     private static LogEntry<?> requestMethodLogEntry;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -15,13 +15,17 @@
  */
 package io.gravitee.gateway.reactive.reactor.processor.reporter;
 
+import static io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER;
+
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.gateway.reactive.api.ComponentType;
 import io.gravitee.gateway.reactive.api.connector.Connector;
+import io.gravitee.gateway.reactive.api.connector.entrypoint.BaseEntrypointConnector;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.reporter.api.common.Request;
@@ -117,10 +121,33 @@ public class ReporterProcessor implements Processor {
             .onErrorComplete();
     }
 
+    /**
+     * The connector that handled the request wins. A request refused before one was selected (plan 401/403, CORS
+     * preflight, request validation, timeout or client abort during the security chain) is attributed to the
+     * entrypoint it was addressed to, resolved now with the rules accepted traffic goes through. The connector
+     * attribute itself stays untouched: setting it means "this connector handled the request", and readers act on
+     * that (endpoint resolution, the connector's own response handling).
+     */
     private static void setEntrypointId(HttpExecutionContextInternal ctx, Metrics metrics) {
         final Connector connector = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR);
         if (connector != null) {
             metrics.setEntrypointId(connector.id());
+            return;
+        }
+        final DefaultEntrypointConnectorResolver resolver = ctx.getInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER);
+        if (resolver == null) {
+            return;
+        }
+        try {
+            final BaseEntrypointConnector<HttpExecutionContextInternal> addressed = resolver.resolve(ctx);
+            if (addressed != null) {
+                metrics.setEntrypointId(addressed.id());
+            }
+        } catch (Exception e) {
+            // Connector matching is plugin code; a failure here must not cost the whole report.
+            ctx
+                .withLogger(log)
+                .warn("Unable to attribute request [{}] of api [{}] to an entrypoint", metrics.getRequestId(), metrics.getApiId(), e);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.gateway.reactive.reactor.processor.reporter;
 
+import static io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,8 +33,11 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ComponentType;
 import io.gravitee.gateway.reactive.api.connector.Connector;
+import io.gravitee.gateway.reactive.api.connector.entrypoint.BaseEntrypointConnector;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
 import io.gravitee.gateway.reactive.reactor.processor.AbstractProcessorTest;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.report.ReporterService;
@@ -366,6 +371,95 @@ class ReporterProcessorTest extends AbstractProcessorTest {
             // Then
             assertNull(ctx.metrics().getLog());
             verifyNoInteractions(reporterService);
+        }
+    }
+
+    /**
+     * Requests refused before an entrypoint connector was selected are attributed to the entrypoint they were
+     * addressed to, through the resolver the API reactor publishes; the connector attribute itself is never set
+     * here, since it means "this connector handled the request".
+     */
+    @Nested
+    class EntrypointAttribution {
+
+        @Mock
+        private DefaultEntrypointConnectorResolver resolver;
+
+        @Mock
+        private BaseEntrypointConnector<HttpExecutionContextInternal> addressedConnector;
+
+        @BeforeEach
+        void givenAV4Api() {
+            lenient().when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, reactableApi);
+        }
+
+        @Test
+        void should_keep_the_connector_that_handled_the_request_without_resolving_again() {
+            final Connector handlingConnector = mock(Connector.class);
+            when(handlingConnector.id()).thenReturn("http-proxy");
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR, handlingConnector);
+            ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, resolver);
+
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            assertThat(ctx.metrics().getEntrypointId()).isEqualTo("http-proxy");
+            verifyNoInteractions(resolver);
+            verify(reporterService).report(ctx.metrics());
+        }
+
+        @Test
+        void should_attribute_a_request_refused_before_entrypoint_selection_to_the_entrypoint_it_was_addressed_to() {
+            when(addressedConnector.id()).thenReturn("mcp");
+            when(resolver.resolve(ctx)).thenReturn(addressedConnector);
+            ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, resolver);
+
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            assertThat(ctx.metrics().getEntrypointId()).isEqualTo("mcp");
+            assertThat((Object) ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR)).isNull();
+            verify(reporterService).report(ctx.metrics());
+        }
+
+        @Test
+        void should_leave_the_entrypoint_unset_when_no_entrypoint_matches_the_request() {
+            when(resolver.resolve(ctx)).thenReturn(null);
+            ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, resolver);
+
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            assertThat(ctx.metrics().getEntrypointId()).isNull();
+            verify(reporterService).report(ctx.metrics());
+        }
+
+        @Test
+        void should_still_report_when_resolving_the_entrypoint_fails() {
+            when(resolver.resolve(ctx)).thenThrow(new IllegalStateException("connector matching failed"));
+            ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, resolver);
+
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            assertThat(ctx.metrics().getEntrypointId()).isNull();
+            verify(reporterService).report(ctx.metrics());
+        }
+
+        @Test
+        void should_leave_the_entrypoint_unset_when_no_reactor_published_a_resolver() {
+            // Not-found and rejected-path chains never reach an API reactor: nothing to attribute to.
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            assertThat(ctx.metrics().getEntrypointId()).isNull();
+            verify(reporterService).report(ctx.metrics());
+        }
+
+        @Test
+        void should_not_resolve_anything_when_metrics_are_disabled() {
+            ctx.metrics(new NoopMetrics());
+            ctx.setInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR_RESOLVER, resolver);
+
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            verifyNoInteractions(resolver, reporterService);
         }
     }
 }


### PR DESCRIPTION
## Summary
A v4 metrics document carries an `entrypoint-id` only when an entrypoint connector handled the request, and `DefaultApiReactor` selects that connector **after** the security chain. Every request refused before that point (plan 401/403, CORS preflight, request-validation rejection, timeout or client abort during the security chain) was reported without an entrypoint: per-entrypoint analytics never added up to the total, and an exact `ENTRYPOINT` filter hid an API's refused calls (the GMA-982 confusion, where observability compensates with a field-missing fallback). This PR attributes those requests at report time, with the same matching rules as accepted traffic, without touching the request chain.

## Changes
- `DefaultEntrypointConnectorResolver` declares the internal attribute key `entrypointConnector.resolver` (gateway-core; `InternalContextAttributes` lives in the external gateway-api SPI and is not touched).
- `DefaultApiReactor.handle()` publishes its resolver under that key right after `prepareExecutionContext(ctx)`, so the context-path attribute the MCP connector matches on is in place. Every reactor built on `DefaultApiReactor` (MCP proxy, Message, LLM, A2A) inherits it without a plugin release.
- `ReporterProcessor.setEntrypointId`: the connector that handled the request still wins; otherwise, when metrics are enabled and a resolver was published, the reporter calls `resolve(ctx)` inside a try/catch and writes `Metrics.entrypointId` only. `ATTR_INTERNAL_ENTRYPOINT_CONNECTOR` is never set late: its readers (endpoint resolution, the connector's own response handling, the Message reactor) take it as "this connector handled the request". No match (for example `POST` on an sse-only API) or a throwing connector leaves the field absent and never blocks the report (one WARN with the request and API ids).
- Tests: `ReporterProcessorTest.EntrypointAttribution` (handling connector wins without resolving; lazy attribution leaves the connector attribute null; no match; throwing resolver still reports; no resolver published; metrics disabled), `DefaultApiReactorTest` (resolver published with the context attributes; published but never resolved by the reactor when the security chain refuses the request), and `EntrypointAttributionIntegrationTest` in the distribution integration tests: a PROXY API exposing `http-proxy` + `mcp` (real `gravitee-entrypoint-mcp-tool-server` plugin, API-key plan, CORS with `runPolicies=false`) and a Message API exposing `http-get` + `http-post` + `sse` + `websocket` with an API-key plan, asserting the reported `entrypoint-id` and the unchanged status codes (401 before 404, preflight 200, accepted calls unchanged).
- `gravitee-apim-distribution-integration-tests/pom.xml`: `gravitee-entrypoint-mcp-tool-server` added as a test dependency (version already managed by the distribution pom).

## Test plan
- [ ] Full suites of `gravitee-apim-gateway-core`, `gravitee-apim-gateway-reactor`, `gravitee-apim-gateway-handlers-api` green.
- [ ] `EntrypointAttributionIntegrationTest` green in the distribution integration tests (`-Pengine-snapshot,integration-tests-modules`).
- [ ] On a running stack: an unauthenticated `POST /mcp` on an MCP API and an unauthenticated `GET` (Accept `text/event-stream`) on an sse Message API, then `terms api-id → terms entrypoint-id (missing: "__none__")` on `gravitee-v4-metrics-*`: the 401s sit under `mcp` and `sse`; the `__none__` bucket only holds documents older than the upgrade or requests no entrypoint matches.
- [ ] Regression: 401 still answered before 404 on an API whose entrypoint would not match; CORS preflight still served before the security chain; sse / websocket responses unchanged (the connector attribute is never set late).

## Release note
Requests refused before an entrypoint connector was selected (plan 401/403, CORS preflight, request validation, timeouts or client aborts during the security chain) are now reported with the `entrypoint-id` of the entrypoint they were addressed to, using the same matching rules as accepted traffic. Per-entrypoint analytics include them from this version, so the Console's per-entrypoint breakdowns (requests count, status ranges, average connection duration on the Message analytics tab) gain the 401/403/preflights under their entrypoint, and the average connection duration of an sse / websocket entrypoint can drop (short 401s against long-lived connections). Early-refused traffic on sse, websocket, webhook, TCP and authz APIs is no longer counted in the HTTP request scope of observability. Documents written by earlier gateway versions are not updated.

## Reviewer notes
- Data-plane change on the reporting path only: one attribute put per request on the happy path, one extra connector-matching pass only for requests that never resolved. Connector matching is plugin code, hence the try/catch.
- Rejected alternatives, with the evidence: resolving before the security chain (moves the connector's `handleRequest` before authentication, answers 404 before 401, and is not inherited by the MCP proxy and Message reactors, which own their chains); a "single-entrypoint" rule in the reporter (misses exactly `http-proxy` + `mcp` and `http-get` + `http-post` + `sse` APIs); late resolution inside `handleEntrypointResponse` (misses client aborts during the security chain).
- Security-sensitive per the repository policy: touches the reporting/metrics path (audit and analytics data), not authentication or authorization; the security chain and its ordering are unchanged and asserted by the integration tests.
- Console Classic code is not modified; its owners are informed through OBS-69. Same release as the observability fail-open scope (OBS-90) or earlier.

Closes [OBS-91](https://gravitee.atlassian.net/browse/OBS-91).


[OBS-91]: https://gravitee.atlassian.net/browse/OBS-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ