### PR TITLE
feat(rest-api): schedule the evaluation of performance targets

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/pom.xml
@@ -226,6 +226,20 @@
 
         <dependency>
             <groupId>io.gravitee.apim.rest.api.services</groupId>
+            <artifactId>gravitee-apim-rest-api-services-performance-targets</artifactId>
+            <version>${apim.server.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api.services</groupId>
             <artifactId>gravitee-apim-rest-api-services-audit</artifactId>
             <version>${apim.server.version}</version>
             <scope>runtime</scope>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -448,6 +448,25 @@ services:
     enabled: true
     cron: "0 */5 * * * *"
 
+  # Performance targets evaluation service.
+  # Evaluates the performance targets against gateway telemetry, on the primary node of a cluster only.
+  # Each tick evaluates the targets whose interval has elapsed, spread over the ticks by a stable per-target
+  # offset; targets sharing an environment and a window are evaluated with one analytics request.
+  # Disabling the service leaves the evaluate-on-demand endpoint working.
+  performance-targets:
+    enabled: true
+    cron: "0 * * * * *"
+    # Analytics queries in flight per node for target evaluation, scheduled and on demand alike.
+    concurrency: 2
+    backoff:
+      # Consecutive windows without enough traffic before an idle target's interval starts doubling.
+      after: 3
+      # Longest interval, in minutes, an idle target backs off to. The declared interval applies again as soon as
+      # a window can be evaluated.
+      cap: 60
+    # Evaluations kept per target, 288 being 24 hours of history at the default 5 minute interval.
+    retention: 288
+
   # Subscription service
   subscription:
     enabled: true

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -453,6 +453,9 @@ services:
   # Each tick evaluates the targets whose interval has elapsed, spread over the ticks by a stable per-target
   # offset; targets sharing an environment and a window are evaluated with one analytics request.
   # Disabling the service leaves the evaluate-on-demand endpoint working.
+  # Without a cluster manager (cluster.type: hazelcast) every node believes it is the primary and evaluates every
+  # target on the same tick; the store keeps a single evaluation per target and slot, but the analytics queries are
+  # multiplied by the number of nodes. Configure the cluster manager, or enable the service on one node only.
   performance-targets:
     enabled: true
     cron: "0 * * * * *"

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetEvaluationRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.PerformanceTargetEnvironmentSummary;
@@ -27,6 +28,8 @@ public interface PerformanceTargetEvaluationRepository {
     /**
      * Stores an evaluation. When it is flagged latest, the previous latest evaluation of the same target loses the flag,
      * so a target has at most one latest evaluation.
+     *
+     * @throws DuplicateKeyException when an evaluation with the same id exists; the stored one and its flag are untouched
      */
     PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PerformanceTargetRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.PerformanceTarget;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PerformanceTargetRepository {
     PerformanceTarget create(PerformanceTarget target) throws TechnicalException;
@@ -28,6 +29,11 @@ public interface PerformanceTargetRepository {
     PerformanceTarget update(PerformanceTarget target) throws TechnicalException;
 
     void delete(String id) throws TechnicalException;
+
+    /**
+     * @return every target of every environment, the scheduler's view of what is to be evaluated
+     */
+    Set<PerformanceTarget> findAll() throws TechnicalException;
 
     List<PerformanceTarget> findByReference(String environmentId, String reference) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetEvaluationRepository.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfigura
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.PerformanceTargetEvaluationRepository;
@@ -87,16 +88,20 @@ public class JdbcPerformanceTargetEvaluationRepository
     public PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation) throws TechnicalException {
         log.debug("JdbcPerformanceTargetEvaluationRepository.create({})", evaluation.getId());
         try {
+            // insert first: a rejected duplicate must leave the stored evaluation and its latest flag untouched
+            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(evaluation));
             if (evaluation.isLatest()) {
                 jdbcTemplate.update(
-                    "update " + this.tableName + " set latest = ? where target_id = ? and latest = ?",
+                    "update " + this.tableName + " set latest = ? where target_id = ? and latest = ? and id <> ?",
                     false,
                     evaluation.getTargetId(),
-                    true
+                    true,
+                    evaluation.getId()
                 );
             }
-            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(evaluation));
             return jdbcTemplate.query(getOrm().getSelectByIdSql(), getRowMapper(), evaluation.getId()).stream().findFirst().orElse(null);
+        } catch (org.springframework.dao.DuplicateKeyException ex) {
+            throw new DuplicateKeyException("Performance target evaluation " + evaluation.getId() + " already exists", ex);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to create performance target evaluation " + evaluation.getId(), ex);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPerformanceTargetRepository.java
@@ -22,11 +22,16 @@ import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.PerformanceTargetRepository;
 import io.gravitee.repository.management.model.PerformanceTarget;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.stereotype.Repository;
 
 @CustomLog
@@ -122,6 +127,24 @@ public class JdbcPerformanceTargetRepository
             jdbcTemplate.update(getOrm().getDeleteSql(), id);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to delete performance target " + id, ex);
+        }
+    }
+
+    @Override
+    public Set<PerformanceTarget> findAll() throws TechnicalException {
+        log.debug("JdbcPerformanceTargetRepository.findAll()");
+        try {
+            var targets = jdbcTemplate.query(getOrm().getSelectAllSql() + " order by id", getRowMapper());
+            var apiIdsByTarget = new HashMap<String, List<String>>();
+            jdbcTemplate.query(
+                "select target_id, api_id from " + PERFORMANCE_TARGET_APIS,
+                (RowCallbackHandler) rs ->
+                    apiIdsByTarget.computeIfAbsent(rs.getString("target_id"), id -> new ArrayList<>()).add(rs.getString("api_id"))
+            );
+            targets.forEach(target -> target.setApiIds(apiIdsByTarget.getOrDefault(target.getId(), List.of())));
+            return new LinkedHashSet<>(targets);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find all performance targets", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetEvaluationRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PerformanceTargetEvaluationRepository;
 import io.gravitee.repository.management.api.search.Pageable;
@@ -42,12 +43,15 @@ class MongoPerformanceTargetEvaluationRepository implements PerformanceTargetEva
     public PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation) throws TechnicalException {
         log.debug("Create performance target evaluation [{}]", evaluation.getId());
         try {
-            if (evaluation.isLatest()) {
-                internalRepository.unsetLatest(evaluation.getTargetId());
-            }
+            // insert first: a rejected duplicate must leave the stored evaluation and its latest flag untouched
             var created = mapper.map(internalRepository.insert(mapper.map(evaluation)));
+            if (evaluation.isLatest()) {
+                internalRepository.unsetLatestExcept(evaluation.getTargetId(), evaluation.getId());
+            }
             log.debug("Create performance target evaluation [{}] - Done", created.getId());
             return created;
+        } catch (org.springframework.dao.DuplicateKeyException ex) {
+            throw new DuplicateKeyException("Performance target evaluation " + evaluation.getId() + " already exists", ex);
         } catch (Exception ex) {
             throw new TechnicalException("Failed to create performance target evaluation", ex);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPerformanceTargetRepository.java
@@ -23,6 +23,8 @@ import io.gravitee.repository.mongodb.management.internal.performancetarget.Perf
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -72,6 +74,14 @@ class MongoPerformanceTargetRepository implements PerformanceTargetRepository {
         log.debug("Delete performance target [{}]", id);
         internalRepository.deleteById(id);
         log.debug("Delete performance target [{}] - Done", id);
+    }
+
+    @Override
+    public Set<PerformanceTarget> findAll() throws TechnicalException {
+        log.debug("Find all performance targets");
+        var result = internalRepository.findAll().stream().map(mapper::map).collect(Collectors.toSet());
+        log.debug("Find all performance targets - Done");
+        return result;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryCustom.java
@@ -22,7 +22,7 @@ import io.gravitee.repository.mongodb.management.internal.model.PerformanceTarge
 import java.util.List;
 
 public interface PerformanceTargetEvaluationMongoRepositoryCustom {
-    void unsetLatest(String targetId);
+    void unsetLatestExcept(String targetId, String evaluationId);
 
     Page<PerformanceTargetEvaluationMongo> findEnvironmentLatest(String environmentId, Pageable pageable);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/performancetarget/PerformanceTargetEvaluationMongoRepositoryImpl.java
@@ -46,9 +46,9 @@ public class PerformanceTargetEvaluationMongoRepositoryImpl implements Performan
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public void unsetLatest(String targetId) {
+    public void unsetLatestExcept(String targetId, String evaluationId) {
         mongoTemplate.updateMulti(
-            query(where("targetId").is(targetId).and("latest").is(true)),
+            query(where("targetId").is(targetId).and("latest").is(true).and("_id").ne(evaluationId)),
             new Update().set("latest", false),
             PerformanceTargetEvaluationMongo.class
         );

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetEvaluationRepositoryTest.java
@@ -16,8 +16,11 @@
 package io.gravitee.repository.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.gravitee.common.utils.UUID;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.PerformanceTargetEnvironmentSummary;
@@ -56,6 +59,17 @@ public class PerformanceTargetEvaluationRepositoryTest extends AbstractManagemen
         assertThat(performanceTargetEvaluationRepository.findLatestByReference("my-env", "agent-1"))
             .extracting(PerformanceTargetEvaluation::getId)
             .containsExactlyInAnyOrder("eval-2", "eval-3");
+    }
+
+    @Test
+    public void create_should_reject_a_duplicate_id_and_keep_the_stored_latest() throws TechnicalException {
+        var duplicate = anEvaluation("eval-1b", "target1", "api-1", Status.PASS, true);
+
+        assertThatThrownBy(() -> performanceTargetEvaluationRepository.create(duplicate)).isInstanceOf(DuplicateKeyException.class);
+
+        assertThat(performanceTargetEvaluationRepository.findLatestByReference("my-env", "api-1"))
+            .extracting(PerformanceTargetEvaluation::getId, PerformanceTargetEvaluation::getStatus)
+            .containsExactly(tuple("eval-1b", Status.BREACH));
     }
 
     // findLatestByReference

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PerformanceTargetRepositoryTest.java
@@ -132,6 +132,32 @@ public class PerformanceTargetRepositoryTest extends AbstractManagementRepositor
         assertThat(performanceTargetRepository.removeApiId("api-to-delete")).isEmpty();
     }
 
+    // findAll
+    @Test
+    public void findAll_should_return_every_target_of_every_environment_with_its_api_ids() throws TechnicalException {
+        var found = performanceTargetRepository.findAll();
+
+        assertThat(found)
+            .extracting(PerformanceTarget::getId)
+            .containsExactlyInAnyOrder(
+                "target1",
+                "target2",
+                "target3",
+                "other-env-target",
+                "to-delete",
+                "86adbd41-8a3f-45f3-b1ca-f980042db19d",
+                "b8c2ef52-ebb5-4d0f-be1e-a41cc5579fc8"
+            );
+        assertThat(found)
+            .filteredOn(target -> target.getId().equals("target2"))
+            .singleElement()
+            .satisfies(target -> {
+                assertThat(target.getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+                assertThat(target.getRules()).hasSize(1);
+                assertThat(target.getIntervalSeconds()).isEqualTo(300);
+            });
+    }
+
     // findByReference
     @Test
     public void findByReference_should_return_targets_of_reference_in_environment_only() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetEvaluationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/crud_service/PerformanceTargetEvaluationCrudService.java
@@ -17,12 +17,21 @@ package io.gravitee.apim.core.performance_target.crud_service;
 
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceTargetEvaluationCrudService {
     /**
      * Stores an evaluation; when it is flagged latest it replaces the target's previous latest evaluation.
      */
     PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation);
+
+    /**
+     * Stores an evaluation unless one with the same id already exists, so that several nodes evaluating the same
+     * target for the same slot keep a single record.
+     *
+     * @return the stored evaluation, or empty when the id was already taken
+     */
+    Optional<PerformanceTargetEvaluation> createIfAbsent(PerformanceTargetEvaluation evaluation);
 
     /**
      * Deletes every evaluation of the target but its {@code retention} most recent ones.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.model;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * When a target is due. Each target owns the slots {@code k * interval + jitter} of the epoch, where the jitter is a
+ * stable hash of its id spread across its declared interval: a target is due once a slot has started since its last
+ * evaluation. Targets are so evaluated exactly once per interval, at phases spread over the ticks, and a restart or a
+ * bulk import does not make them all due at once for long.
+ *
+ * <p>An idle target backs off: from {@code backoffAfter} consecutive NOT_EVALUABLE evaluations on, every further
+ * miss doubles the interval it is judged on, up to {@code backoffCap}; the first evaluable window brings it back to
+ * the declared interval.
+ *
+ * @param retention evaluations kept per target after each evaluation
+ */
+public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, int retention) {
+    public PerformanceTargetSchedule {
+        if (backoffAfter < 1) {
+            throw new IllegalArgumentException("The backoff threshold must be at least 1 evaluation");
+        }
+        if (backoffCap == null || !backoffCap.isPositive()) {
+            throw new IllegalArgumentException("The backoff cap must be a positive duration");
+        }
+        if (retention < 1) {
+            throw new IllegalArgumentException("The retention must keep at least 1 evaluation");
+        }
+    }
+
+    public Duration effectiveInterval(PerformanceTarget target, int consecutiveNotEvaluable) {
+        var interval = target.interval();
+        var cap = backoffCap.compareTo(interval) > 0 ? backoffCap : interval;
+        for (var misses = consecutiveNotEvaluable; misses >= backoffAfter && interval.compareTo(cap) < 0; misses--) {
+            interval = interval.multipliedBy(2);
+        }
+        return interval.compareTo(cap) > 0 ? cap : interval;
+    }
+
+    public Duration jitter(PerformanceTarget target) {
+        return Duration.ofSeconds(Math.floorMod(target.id().hashCode(), Math.max(1, target.interval().toSeconds())));
+    }
+
+    /**
+     * @param lastEvaluatedAt {@code null} when the target was never evaluated, which makes it due at once
+     */
+    public boolean isDue(PerformanceTarget target, Instant lastEvaluatedAt, int consecutiveNotEvaluable, Instant now) {
+        if (lastEvaluatedAt == null) {
+            return true;
+        }
+        var interval = Math.max(1, effectiveInterval(target, consecutiveNotEvaluable).toSeconds());
+        var jitter = jitter(target).toSeconds();
+        var slotStart = Math.floorDiv(now.getEpochSecond() - jitter, interval) * interval + jitter;
+        return lastEvaluatedAt.getEpochSecond() < slotStart;
+    }
+
+    /**
+     * How many of the latest evaluations tell the effective interval of a target: past this many consecutive misses
+     * the interval is capped, so older history changes nothing.
+     */
+    public int historyDepth(PerformanceTarget target) {
+        var depth = backoffAfter;
+        while (effectiveInterval(target, depth).compareTo(effectiveInterval(target, depth + 1)) < 0) {
+            depth++;
+        }
+        return depth;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
@@ -60,13 +60,14 @@ public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, i
      * @param lastEvaluatedAt {@code null} when the target was never evaluated, which makes it due at once
      */
     public boolean isDue(PerformanceTarget target, Instant lastEvaluatedAt, int consecutiveNotEvaluable, Instant now) {
-        if (lastEvaluatedAt == null) {
-            return true;
-        }
+        return lastEvaluatedAt == null || lastEvaluatedAt.isBefore(slotStart(target, consecutiveNotEvaluable, now));
+    }
+
+    /** The start of the target's slot {@code now} falls in; every node computes the same one for the same tick. */
+    public Instant slotStart(PerformanceTarget target, int consecutiveNotEvaluable, Instant now) {
         var interval = Math.max(1, effectiveInterval(target, consecutiveNotEvaluable).toSeconds());
         var jitter = jitter(target).toSeconds();
-        var slotStart = Math.floorDiv(now.getEpochSecond() - jitter, interval) * interval + jitter;
-        return lastEvaluatedAt.getEpochSecond() < slotStart;
+        return Instant.ofEpochSecond(Math.floorDiv(now.getEpochSecond() - jitter, interval) * interval + jitter);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/query_service/PerformanceTargetQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/query_service/PerformanceTargetQueryService.java
@@ -19,5 +19,10 @@ import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import java.util.List;
 
 public interface PerformanceTargetQueryService {
+    /**
+     * @return every target of every environment
+     */
+    List<PerformanceTarget> findAll();
+
     List<PerformanceTarget> findByReference(String environmentId, String reference);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/service_provider/PerformanceTargetEvaluator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/service_provider/PerformanceTargetEvaluator.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.performance_target.service_provider;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import java.time.Instant;
+import java.util.List;
 
 /**
  * Evaluates a target against gateway telemetry. Shared by the scheduler and by evaluate-on-demand so that both produce
@@ -29,4 +30,12 @@ public interface PerformanceTargetEvaluator {
      * caller decides whether it becomes the target's latest evaluation.
      */
     PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now);
+
+    /**
+     * Evaluates many targets over their windows ending at {@code now}, with as few analytics requests as their
+     * shapes allow: the number of requests is bounded by the number of distinct environments and windows, not by
+     * the number of targets. Results come in the order of the targets; a target that could not be evaluated on its
+     * own is left out, so the list may be shorter than the input.
+     */
+    List<PerformanceTargetEvaluation> evaluateAll(List<PerformanceTarget> targets, Instant now);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
@@ -86,14 +86,25 @@ public class EvaluateDuePerformanceTargetsUseCase {
                 states.put(target.id(), new State(now, previous.consecutiveNotEvaluable()));
                 continue;
             }
-            var latest = performanceTargetEvaluationCrudService.create(
-                evaluation.toBuilder().id(UuidString.generateRandom()).latest(true).build()
-            );
-            performanceTargetEvaluationCrudService.pruneHistory(target.id(), schedule.retention());
+            var slotStart = schedule.slotStart(target, previous.consecutiveNotEvaluable(), now);
+            var latest = evaluation.toBuilder().id(evaluationId(target, slotStart)).latest(true).build();
+            performanceTargetEvaluationCrudService
+                .createIfAbsent(latest)
+                .ifPresent(created -> {
+                    performanceTargetEvaluationCrudService.pruneHistory(target.id(), schedule.retention());
+                    stored.add(created);
+                });
             states.put(target.id(), previous.after(latest));
-            stored.add(latest);
         }
         return new Output(targets.size(), stored);
+    }
+
+    /**
+     * One id per target and slot, the same on every node: without a cluster manager every node believes it is the
+     * primary and evaluates the same slot, and the store keeps only the first record.
+     */
+    private static String evaluationId(PerformanceTarget target, Instant slotStart) {
+        return UuidString.generateForEnvironment(target.environmentId(), target.id(), String.valueOf(slotStart.getEpochSecond()));
     }
 
     private State seed(PerformanceTarget target, PerformanceTargetSchedule schedule) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
+import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetQueryService;
+import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * One tick of the scheduler: evaluates every target whose slot has started since its last evaluation (see
+ * {@link PerformanceTargetSchedule}), stores each result as the target's latest evaluation and prunes its history.
+ *
+ * <p>The schedule state of a target, when it was last evaluated and how many times in a row it was not evaluable,
+ * is kept in memory and seeded from its stored evaluations the first time the target is seen, so a restart resumes
+ * where the previous node left off instead of evaluating everything at once. A target the evaluator leaves out is
+ * still counted as attempted: it is retried at its next slot, not at every tick.
+ */
+@RequiredArgsConstructor
+@UseCase
+public class EvaluateDuePerformanceTargetsUseCase {
+
+    private final PerformanceTargetQueryService performanceTargetQueryService;
+    private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
+    private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
+    private final PerformanceTargetEvaluator performanceTargetEvaluator;
+
+    private final Map<String, State> states = new ConcurrentHashMap<>();
+
+    public Output execute(Input input) {
+        var schedule = input.schedule();
+        var now = TimeProvider.instantNow();
+        var targets = performanceTargetQueryService.findAll();
+        states.keySet().retainAll(targets.stream().map(PerformanceTarget::id).collect(toSet()));
+
+        var due = targets
+            .stream()
+            .filter(target -> {
+                var state = states.computeIfAbsent(target.id(), id -> seed(target, schedule));
+                return schedule.isDue(target, state.lastEvaluatedAt(), state.consecutiveNotEvaluable(), now);
+            })
+            .toList();
+        if (due.isEmpty()) {
+            return new Output(targets.size(), List.of());
+        }
+
+        var evaluationsByTarget = performanceTargetEvaluator
+            .evaluateAll(due, now)
+            .stream()
+            .collect(toMap(PerformanceTargetEvaluation::targetId, identity()));
+        var stored = new ArrayList<PerformanceTargetEvaluation>();
+        for (var target : due) {
+            var previous = states.get(target.id());
+            var evaluation = evaluationsByTarget.get(target.id());
+            if (evaluation == null) {
+                states.put(target.id(), new State(now, previous.consecutiveNotEvaluable()));
+                continue;
+            }
+            var latest = performanceTargetEvaluationCrudService.create(
+                evaluation.toBuilder().id(UuidString.generateRandom()).latest(true).build()
+            );
+            performanceTargetEvaluationCrudService.pruneHistory(target.id(), schedule.retention());
+            states.put(target.id(), previous.after(latest));
+            stored.add(latest);
+        }
+        return new Output(targets.size(), stored);
+    }
+
+    private State seed(PerformanceTarget target, PerformanceTargetSchedule schedule) {
+        var history = performanceTargetEvaluationQueryService
+            .findByTargetId(target.id(), new PageableImpl(1, schedule.historyDepth(target)))
+            .getContent();
+        var state = new State(null, 0);
+        for (var evaluation : history.reversed()) {
+            state = state.after(evaluation);
+        }
+        return state;
+    }
+
+    /**
+     * @param lastEvaluatedAt {@code null} when the target was never evaluated
+     */
+    private record State(Instant lastEvaluatedAt, int consecutiveNotEvaluable) {
+        State after(PerformanceTargetEvaluation evaluation) {
+            var notEvaluable = evaluation.status() == PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
+            return new State(evaluation.evaluatedAt(), notEvaluable ? consecutiveNotEvaluable + 1 : 0);
+        }
+    }
+
+    public record Input(PerformanceTargetSchedule schedule) {}
+
+    /**
+     * @param targets     how many targets exist, due or not
+     * @param evaluations the evaluations stored by this tick
+     */
+    public record Output(int targets, List<PerformanceTargetEvaluation> evaluations) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/performance_target/PerformanceTargetEvaluationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/performance_target/PerformanceTargetEvaluationCrudServiceImpl.java
@@ -18,11 +18,13 @@ package io.gravitee.apim.infra.crud_service.performance_target;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.infra.adapter.PerformanceTargetEvaluationAdapter;
+import io.gravitee.repository.exceptions.DuplicateKeyException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PerformanceTargetEvaluationRepository;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.List;
+import java.util.Optional;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -42,6 +44,18 @@ public class PerformanceTargetEvaluationCrudServiceImpl extends AbstractService 
         try {
             var created = evaluationRepository.create(PerformanceTargetEvaluationAdapter.INSTANCE.toRepository(evaluation));
             return PerformanceTargetEvaluationAdapter.INSTANCE.toEntity(created);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when creating Performance Target Evaluation: " + evaluation.id(), e);
+        }
+    }
+
+    @Override
+    public Optional<PerformanceTargetEvaluation> createIfAbsent(PerformanceTargetEvaluation evaluation) {
+        try {
+            var created = evaluationRepository.create(PerformanceTargetEvaluationAdapter.INSTANCE.toRepository(evaluation));
+            return Optional.of(PerformanceTargetEvaluationAdapter.INSTANCE.toEntity(created));
+        } catch (DuplicateKeyException e) {
+            return Optional.empty();
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("Error when creating Performance Target Evaluation: " + evaluation.id(), e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
@@ -15,12 +15,17 @@
  */
 package io.gravitee.apim.infra.performance_target;
 
+import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
+import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.Measure;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
@@ -33,25 +38,38 @@ import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluatio
 import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * Evaluates a target through the analytics engine query services the dashboards use, with the same
- * {@code API IN [...]} filter a single-API dashboard applies, so a breach shows the number the chart shows. Rules
- * sharing a filter set (resolved API ids plus rule filters) are answered by one measures request that also carries
- * the request-count metric of the subject's API family; that count is the sample size every rule of the set is
- * judged on.
+ * Evaluates targets through the analytics engine query services the dashboards use, with the same
+ * {@code API IN [...]} filter a single-API dashboard applies, so a breach shows the number the chart shows.
+ *
+ * <p>One target: rules sharing a filter set (resolved API ids plus rule filters) are answered by one measures request
+ * that also carries the request-count metric of the subject's API family; that count is the sample size every rule
+ * of the set is judged on.
+ *
+ * <p>Many targets: those whose every rule resolves to a single API and carries no filter are answered per
+ * environment and window by facets requests grouped by API, one bucket per API, so a thousand targets cost a
+ * handful of requests. A cheap request-count query comes first and the aggregation only covers the APIs with enough
+ * samples. Any other target is evaluated on its own. Analytics calls from the scheduler and from evaluate-on-demand
+ * share a cap on the queries in flight.
  *
  * <p>The engine is called without a caller context on purpose: a target is validated against its environment when
  * it is written, and the scheduler evaluates it with no user at hand.
@@ -60,8 +78,13 @@ import org.springframework.stereotype.Service;
  * A2A task that failed, is invisible to a target until protocol-level analytics exist.
  */
 @Service
-@RequiredArgsConstructor
+@CustomLog
 public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluator {
+
+    /** Targets per facets request, which bounds the number of buckets a single response carries. */
+    static final int MAX_TARGETS_PER_REQUEST = 500;
+
+    private static final int DEFAULT_CONCURRENCY = 2;
 
     private static final MetricMeasuresRequest HTTP_REQUEST_COUNT = new MetricMeasuresRequest(
         MetricSpec.Name.HTTP_REQUESTS,
@@ -91,20 +114,93 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
     private final ApiCrudService apiCrudService;
     private final EnvironmentCrudService environmentCrudService;
     private final AnalyticsQueryContextProvider queryContextProvider;
+    private final Semaphore queriesInFlight;
+
+    public PerformanceTargetEvaluatorImpl(
+        ApiCrudService apiCrudService,
+        EnvironmentCrudService environmentCrudService,
+        AnalyticsQueryContextProvider queryContextProvider
+    ) {
+        this(apiCrudService, environmentCrudService, queryContextProvider, DEFAULT_CONCURRENCY);
+    }
+
+    @Autowired
+    public PerformanceTargetEvaluatorImpl(
+        ApiCrudService apiCrudService,
+        EnvironmentCrudService environmentCrudService,
+        AnalyticsQueryContextProvider queryContextProvider,
+        @Value("${services.performance-targets.concurrency:2}") int concurrency
+    ) {
+        if (concurrency < 1) {
+            throw new IllegalArgumentException("services.performance-targets.concurrency must allow at least 1 query in flight");
+        }
+        this.apiCrudService = apiCrudService;
+        this.environmentCrudService = environmentCrudService;
+        this.queryContextProvider = queryContextProvider;
+        this.queriesInFlight = new Semaphore(concurrency);
+    }
 
     @Override
     public PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now) {
+        return evaluate(target, now, apiTypesById(target.subject().apiIds()));
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> evaluateAll(List<PerformanceTarget> targets, Instant now) {
+        var apiTypesById = apiTypesById(
+            targets
+                .stream()
+                .flatMap(target -> target.subject().apiIds().stream())
+                .distinct()
+                .toList()
+        );
+        var results = new PerformanceTargetEvaluation[targets.size()];
+        var batches = new LinkedHashMap<Batch, List<Integer>>();
+        for (int i = 0; i < targets.size(); i++) {
+            var target = targets.get(i);
+            if (isBatchable(target, apiTypesById)) {
+                batches.computeIfAbsent(new Batch(target.environmentId(), target.window()), batch -> new ArrayList<>()).add(i);
+            } else {
+                results[i] = evaluateAlone(target, now, apiTypesById);
+            }
+        }
+        batches.forEach((batch, indexes) -> {
+            for (int from = 0; from < indexes.size(); from += MAX_TARGETS_PER_REQUEST) {
+                var chunk = indexes.subList(from, Math.min(from + MAX_TARGETS_PER_REQUEST, indexes.size()));
+                var evaluations = evaluateBatch(batch, chunk.stream().map(targets::get).toList(), now, apiTypesById);
+                for (int k = 0; k < chunk.size(); k++) {
+                    results[chunk.get(k)] = evaluations.get(k);
+                }
+            }
+        });
+        return Arrays.stream(results).filter(Objects::nonNull).toList();
+    }
+
+    private PerformanceTargetEvaluation evaluateAlone(PerformanceTarget target, Instant now, Map<String, ApiType> apiTypesById) {
+        try {
+            return evaluate(target, now, apiTypesById);
+        } catch (RuntimeException e) {
+            log.warn(
+                "Performance target [{}] of environment [{}] could not be evaluated, it is retried at its next slot",
+                target.id(),
+                target.environmentId(),
+                e
+            );
+            return null;
+        }
+    }
+
+    private PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now, Map<String, ApiType> knownApiTypes) {
         var window = new TimeRange(now.minus(target.window()), now);
-        var organizationId = environmentCrudService.get(target.environmentId()).getOrganizationId();
-        var executionContext = new ExecutionContext(organizationId, target.environmentId());
-        var apiTypesById = apiTypesById(target);
+        var executionContext = executionContext(target.environmentId());
+        var apiTypesById = subjectApiTypes(target, knownApiTypes);
 
         var rules = target.rules();
         var results = new PerformanceTargetEvaluation.RuleResult[rules.size()];
         var ruleIndexesByScope = new LinkedHashMap<Scope, List<Integer>>();
         for (int i = 0; i < rules.size(); i++) {
             var rule = rules.get(i);
-            var apiIds = target.apiIdsFor(rule, apiTypesById).stream().filter(apiTypesById::containsKey).toList();
+            var apiIds = scopeApiIds(target, rule, apiTypesById);
             if (apiIds.isEmpty()) {
                 results[i] = rule.evaluate(null, 0, target.minSampleSize());
             } else {
@@ -113,11 +209,15 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         }
 
         ruleIndexesByScope.forEach((scope, ruleIndexes) -> {
-            var sampleCountMetric = sampleCountMetric(scope, apiTypesById);
-            var measures = search(executionContext, window, scope, sampleCountMetric, ruleIndexes.stream().map(rules::get).toList());
-            var sampleCount = value(measures, sampleCountMetric.name(), sampleCountMetric.measures().getFirst())
-                .map(Math::round)
-                .orElse(0L);
+            var sampleCountMetric = sampleCountMetric(scope.apiIds(), apiTypesById);
+            var measures = searchMeasures(
+                executionContext,
+                window,
+                scope,
+                sampleCountMetric,
+                ruleIndexes.stream().map(rules::get).toList()
+            );
+            var sampleCount = sampleCount(measures, sampleCountMetric);
             for (var i : ruleIndexes) {
                 var rule = rules.get(i);
                 results[i] = rule.evaluate(
@@ -128,13 +228,114 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
             }
         });
 
-        var ruleResults = Arrays.asList(results);
+        return evaluation(target, window, Arrays.asList(results), apiTypesById, now);
+    }
+
+    /**
+     * A target is batchable when every rule can be read from an API bucket: one API, no rule filter, and an API
+     * family whose analytics can be grouped by API, which excludes Edge.
+     */
+    private static boolean isBatchable(PerformanceTarget target, Map<String, ApiType> knownApiTypes) {
+        var apiTypesById = subjectApiTypes(target, knownApiTypes);
+        for (var rule : target.rules()) {
+            if (!rule.filters().isEmpty()) {
+                return false;
+            }
+            var apiIds = scopeApiIds(target, rule, apiTypesById);
+            if (apiIds.size() > 1 || (apiIds.size() == 1 && apiTypesById.get(apiIds.getFirst()) == ApiType.EDGE)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<PerformanceTargetEvaluation> evaluateBatch(
+        Batch batch,
+        List<PerformanceTarget> targets,
+        Instant now,
+        Map<String, ApiType> knownApiTypes
+    ) {
+        var window = new TimeRange(now.minus(batch.window()), now);
+        var executionContext = executionContext(batch.environmentId());
+
+        var subjects = targets.stream().collect(Collectors.toMap(PerformanceTarget::id, target -> subjectApiTypes(target, knownApiTypes)));
+        // the API each rule reads its bucket from, by target then rule position; null when the rule has no API
+        var ruleApiIds = new HashMap<String, List<String>>();
+        var apiIds = new LinkedHashSet<String>();
+        for (var target : targets) {
+            var perRule = new ArrayList<String>();
+            for (var rule : target.rules()) {
+                var scope = scopeApiIds(target, rule, subjects.get(target.id()));
+                perRule.add(scope.isEmpty() ? null : scope.getFirst());
+                apiIds.addAll(scope);
+            }
+            ruleApiIds.put(target.id(), perRule);
+        }
+
+        var countMetrics = apiIds
+            .stream()
+            .map(apiId -> SAMPLE_COUNT_METRICS.get(knownApiTypes.get(apiId)))
+            .distinct()
+            .toList();
+        var counts = apiIds.isEmpty()
+            ? Map.<String, MeasuresResponse>of()
+            : searchFacetsByApi(executionContext, window, List.copyOf(apiIds), countMetrics);
+        var sampleCounts = new HashMap<String, Long>();
+        for (var apiId : apiIds) {
+            var countMetric = SAMPLE_COUNT_METRICS.get(knownApiTypes.get(apiId));
+            sampleCounts.put(apiId, counts.containsKey(apiId) ? sampleCount(counts.get(apiId), countMetric) : 0L);
+        }
+
+        var measuredApiIds = new LinkedHashSet<String>();
+        var measuresByMetric = new LinkedHashMap<MetricSpec.Name, LinkedHashSet<MetricSpec.Measure>>();
+        for (var target : targets) {
+            var rules = target.rules();
+            for (int i = 0; i < rules.size(); i++) {
+                var apiId = ruleApiIds.get(target.id()).get(i);
+                if (apiId != null && sampleCounts.get(apiId) >= target.minSampleSize()) {
+                    measuredApiIds.add(apiId);
+                    measuresByMetric.computeIfAbsent(rules.get(i).metric(), metric -> new LinkedHashSet<>()).add(rules.get(i).measure());
+                }
+            }
+        }
+        var measures = measuredApiIds.isEmpty()
+            ? Map.<String, MeasuresResponse>of()
+            : searchFacetsByApi(executionContext, window, List.copyOf(measuredApiIds), metrics(measuresByMetric));
+
+        var evaluations = new ArrayList<PerformanceTargetEvaluation>();
+        for (var target : targets) {
+            var rules = target.rules();
+            var results = new ArrayList<PerformanceTargetEvaluation.RuleResult>();
+            for (int i = 0; i < rules.size(); i++) {
+                var rule = rules.get(i);
+                var apiId = ruleApiIds.get(target.id()).get(i);
+                if (apiId == null) {
+                    results.add(rule.evaluate(null, 0, target.minSampleSize()));
+                } else {
+                    var observed = Optional.ofNullable(measures.get(apiId))
+                        .flatMap(m -> value(m, rule.metric(), rule.measure()))
+                        .orElse(null);
+                    results.add(rule.evaluate(observed, sampleCounts.get(apiId), target.minSampleSize()));
+                }
+            }
+            evaluations.add(evaluation(target, window, results, subjects.get(target.id()), now));
+        }
+        return evaluations;
+    }
+
+    private static PerformanceTargetEvaluation evaluation(
+        PerformanceTarget target,
+        TimeRange window,
+        List<PerformanceTargetEvaluation.RuleResult> results,
+        Map<String, ApiType> apiTypesById,
+        Instant now
+    ) {
         return PerformanceTargetEvaluation.builder()
             .targetId(target.id())
             .environmentId(target.environmentId())
             .reference(target.subject().reference())
-            .status(PerformanceTargetEvaluation.Status.of(ruleResults))
-            .rules(ruleResults)
+            .status(PerformanceTargetEvaluation.Status.of(results))
+            .rules(results)
             .windowFrom(window.from())
             .windowTo(window.to())
             .coveredApiIds(List.copyOf(apiTypesById.keySet()))
@@ -142,25 +343,39 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
             .build();
     }
 
-    /** The typed subject APIs that still exist, in subject order; a deleted or untyped API is not covered. */
-    private Map<String, ApiType> apiTypesById(PerformanceTarget target) {
-        var apis = apiCrudService
-            .findByIds(target.subject().apiIds())
+    private ExecutionContext executionContext(String environmentId) {
+        return new ExecutionContext(environmentCrudService.get(environmentId).getOrganizationId(), environmentId);
+    }
+
+    /** The typed APIs that still exist among {@code apiIds}; a deleted or untyped API is not covered. */
+    private Map<String, ApiType> apiTypesById(List<String> apiIds) {
+        if (apiIds.isEmpty()) {
+            return Map.of();
+        }
+        return apiCrudService
+            .findByIds(apiIds)
             .stream()
             .filter(api -> api.getType() != null)
-            .collect(Collectors.toMap(Api::getId, Api::getType));
+            .collect(Collectors.toMap(Api::getId, Api::getType, (first, second) -> first, LinkedHashMap::new));
+    }
+
+    /** The subject APIs that are known, in subject order. */
+    private static Map<String, ApiType> subjectApiTypes(PerformanceTarget target, Map<String, ApiType> knownApiTypes) {
         var apiTypesById = new LinkedHashMap<String, ApiType>();
         for (var apiId : target.subject().apiIds()) {
-            if (apis.containsKey(apiId)) {
-                apiTypesById.put(apiId, apis.get(apiId));
+            if (knownApiTypes.containsKey(apiId)) {
+                apiTypesById.put(apiId, knownApiTypes.get(apiId));
             }
         }
         return apiTypesById;
     }
 
-    private static MetricMeasuresRequest sampleCountMetric(Scope scope, Map<String, ApiType> apiTypesById) {
-        var metrics = scope
-            .apiIds()
+    private static List<String> scopeApiIds(PerformanceTarget target, PerformanceTarget.Rule rule, Map<String, ApiType> apiTypesById) {
+        return target.apiIdsFor(rule, apiTypesById).stream().filter(apiTypesById::containsKey).toList();
+    }
+
+    private static MetricMeasuresRequest sampleCountMetric(List<String> apiIds, Map<String, ApiType> apiTypesById) {
+        var metrics = apiIds
             .stream()
             .map(apiTypesById::get)
             .map(apiType ->
@@ -169,12 +384,24 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
             .distinct()
             .toList();
         if (metrics.size() != 1) {
-            throw new IllegalStateException("A rule cannot span API types counted by different metrics: " + scope.apiIds());
+            throw new IllegalStateException("A rule cannot span API types counted by different metrics: " + apiIds);
         }
         return metrics.getFirst();
     }
 
-    private MeasuresResponse search(
+    private static long sampleCount(MeasuresResponse measures, MetricMeasuresRequest sampleCountMetric) {
+        return value(measures, sampleCountMetric.name(), sampleCountMetric.measures().getFirst()).map(Math::round).orElse(0L);
+    }
+
+    private static List<MetricMeasuresRequest> metrics(Map<MetricSpec.Name, LinkedHashSet<MetricSpec.Measure>> measuresByMetric) {
+        return measuresByMetric
+            .entrySet()
+            .stream()
+            .map(entry -> new MetricMeasuresRequest(entry.getKey(), List.copyOf(entry.getValue())))
+            .toList();
+    }
+
+    private MeasuresResponse searchMeasures(
         ExecutionContext executionContext,
         TimeRange window,
         Scope scope,
@@ -186,25 +413,78 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         for (var rule : rules) {
             measuresByMetric.computeIfAbsent(rule.metric(), metric -> new LinkedHashSet<>()).add(rule.measure());
         }
-        var metrics = measuresByMetric
-            .entrySet()
-            .stream()
-            .map(entry -> new MetricMeasuresRequest(entry.getKey(), List.copyOf(entry.getValue())))
-            .toList();
 
         var filters = new ArrayList<Filter>();
-        filters.add(new Filter(FilterSpec.Name.API, FilterOperator.IN, scope.apiIds()));
+        filters.add(apiIn(scope.apiIds()));
         filters.addAll(scope.filters());
 
-        var request = new MeasuresRequest(window, filters, metrics);
+        var request = new MeasuresRequest(window, filters, metrics(measuresByMetric));
         return MeasuresResponse.merge(
             queryContextProvider
                 .resolve(request)
                 .entrySet()
                 .stream()
-                .map(entry -> entry.getKey().searchMeasures(executionContext, entry.getValue()))
+                .map(entry -> withPermit(() -> entry.getKey().searchMeasures(executionContext, entry.getValue())))
                 .toList()
         );
+    }
+
+    /** One facets request grouped by API; the answer is read back as one measures response per API id. */
+    private Map<String, MeasuresResponse> searchFacetsByApi(
+        ExecutionContext executionContext,
+        TimeRange window,
+        List<String> apiIds,
+        List<MetricMeasuresRequest> metrics
+    ) {
+        var request = new FacetsRequest(
+            window,
+            List.of(apiIn(apiIds)),
+            metrics
+                .stream()
+                .map(metric -> new FacetMetricMeasuresRequest(metric.name(), metric.measures(), List.of()))
+                .toList(),
+            List.of(FacetSpec.Name.API),
+            apiIds.size(),
+            List.of()
+        );
+        var response = FacetsResponse.merge(
+            queryContextProvider
+                .resolve(request)
+                .entrySet()
+                .stream()
+                .map(entry -> withPermit(() -> entry.getKey().searchFacets(executionContext, entry.getValue())))
+                .toList()
+        );
+
+        var metricsByApi = new HashMap<String, List<MetricMeasuresResponse>>();
+        for (var metric : response.metrics()) {
+            for (var bucket : metric.buckets()) {
+                metricsByApi
+                    .computeIfAbsent(bucket.key(), apiId -> new ArrayList<>())
+                    .add(new MetricMeasuresResponse(metric.metric(), metric.unit(), bucket.measures()));
+            }
+        }
+        var byApi = new HashMap<String, MeasuresResponse>();
+        metricsByApi.forEach((apiId, apiMetrics) -> byApi.put(apiId, new MeasuresResponse(apiMetrics)));
+        return byApi;
+    }
+
+    private <T> T withPermit(Supplier<T> query) {
+        try {
+            queriesInFlight.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for an analytics query slot", e);
+        }
+        try {
+            return query.get();
+        } finally {
+            queriesInFlight.release();
+        }
+    }
+
+    private static Filter apiIn(List<String> apiIds) {
+        return new Filter(FilterSpec.Name.API, FilterOperator.IN, apiIds);
     }
 
     private static Optional<Double> value(MeasuresResponse response, MetricSpec.Name metric, MetricSpec.Measure measure) {
@@ -222,4 +502,7 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
 
     /** The documents a set of rules is measured on: the API ids they resolve to, narrowed by their own filters. */
     private record Scope(List<String> apiIds, List<Filter> filters) {}
+
+    /** Targets answered by one facets request: same environment, hence same indices, and same window. */
+    private record Batch(String environmentId, Duration window) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/performance_target/PerformanceTargetQueryServiceImpl.java
@@ -37,6 +37,15 @@ public class PerformanceTargetQueryServiceImpl implements PerformanceTargetQuery
     }
 
     @Override
+    public List<PerformanceTarget> findAll() {
+        try {
+            return performanceTargetRepository.findAll().stream().map(PerformanceTargetAdapter.INSTANCE::toEntity).toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurred while finding all Performance Targets", e);
+        }
+    }
+
+    @Override
     public List<PerformanceTarget> findByReference(String environmentId, String reference) {
         try {
             return performanceTargetRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluationCrudServiceInMemory.java
@@ -21,11 +21,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 public class PerformanceTargetEvaluationCrudServiceInMemory
     implements PerformanceTargetEvaluationCrudService, InMemoryAlternative<PerformanceTargetEvaluation> {
 
     final ArrayList<PerformanceTargetEvaluation> storage = new ArrayList<>();
+
+    @Override
+    public Optional<PerformanceTargetEvaluation> createIfAbsent(PerformanceTargetEvaluation evaluation) {
+        if (storage.stream().anyMatch(stored -> stored.id().equals(evaluation.id()))) {
+            return Optional.empty();
+        }
+        return Optional.of(create(evaluation));
+    }
 
     @Override
     public PerformanceTargetEvaluation create(PerformanceTargetEvaluation evaluation) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluatorInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetEvaluatorInMemory.java
@@ -19,20 +19,28 @@ import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.core.performance_target.service_provider.PerformanceTargetEvaluator;
 import java.time.Instant;
+import java.util.List;
 
 /**
- * Passes every rule with an observed value at half the threshold, so tests can focus on what happens around the
- * evaluation rather than on the numbers.
+ * Gives every rule the configured status, PASS by default with an observed value at half the threshold, so tests can
+ * focus on what happens around the evaluation rather than on the numbers.
  */
 public class PerformanceTargetEvaluatorInMemory implements PerformanceTargetEvaluator {
 
+    private PerformanceTargetEvaluation.Status status = PerformanceTargetEvaluation.Status.PASS;
+
+    public void status(PerformanceTargetEvaluation.Status status) {
+        this.status = status;
+    }
+
     @Override
     public PerformanceTargetEvaluation evaluate(PerformanceTarget target, Instant now) {
+        var evaluable = status != PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
         return PerformanceTargetEvaluation.builder()
             .targetId(target.id())
             .environmentId(target.environmentId())
             .reference(target.subject().reference())
-            .status(PerformanceTargetEvaluation.Status.PASS)
+            .status(status)
             .rules(
                 target
                     .rules()
@@ -43,10 +51,10 @@ public class PerformanceTargetEvaluatorInMemory implements PerformanceTargetEval
                             rule.measure(),
                             rule.operator(),
                             rule.threshold(),
-                            rule.threshold() / 2,
-                            new PerformanceTargetEvaluation.Deviation(-rule.threshold() / 2, -0.5),
-                            42,
-                            PerformanceTargetEvaluation.Status.PASS
+                            evaluable ? rule.threshold() / 2 : null,
+                            evaluable ? new PerformanceTargetEvaluation.Deviation(-rule.threshold() / 2, -0.5) : null,
+                            evaluable ? 42 : 0,
+                            status
                         )
                     )
                     .toList()
@@ -56,5 +64,13 @@ public class PerformanceTargetEvaluatorInMemory implements PerformanceTargetEval
             .coveredApiIds(target.subject().apiIds())
             .evaluatedAt(now)
             .build();
+    }
+
+    @Override
+    public List<PerformanceTargetEvaluation> evaluateAll(List<PerformanceTarget> targets, Instant now) {
+        return targets
+            .stream()
+            .map(target -> evaluate(target, now))
+            .toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PerformanceTargetQueryServiceInMemory.java
@@ -34,6 +34,11 @@ public class PerformanceTargetQueryServiceInMemory implements PerformanceTargetQ
     }
 
     @Override
+    public List<PerformanceTarget> findAll() {
+        return List.copyOf(storage);
+    }
+
+    @Override
     public List<PerformanceTarget> findByReference(String environmentId, String reference) {
         return storage
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
@@ -105,6 +105,14 @@ class PerformanceTargetScheduleTest {
         }
 
         @Test
+        void should_name_the_slot_an_instant_belongs_to_by_its_start() {
+            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary)).isEqualTo(boundary);
+            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary.plus(INTERVAL).minusSeconds(1))).isEqualTo(boundary);
+            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary.plus(INTERVAL))).isEqualTo(boundary.plus(INTERVAL));
+            assertThat(SCHEDULE.slotStart(TARGET, 3, boundary.plus(INTERVAL))).isEqualTo(boundary);
+        }
+
+        @Test
         void should_wait_for_the_effective_interval_of_an_idle_target() {
             var backedOffBoundary = Instant.parse("2021-06-01T10:00:00Z").plus(SCHEDULE.jitter(TARGET));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PerformanceTargetFixtures;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PerformanceTargetScheduleTest {
+
+    private static final Duration INTERVAL = Duration.ofMinutes(5);
+    private static final PerformanceTargetSchedule SCHEDULE = new PerformanceTargetSchedule(3, Duration.ofHours(1), 288);
+    private static final PerformanceTarget TARGET = PerformanceTargetFixtures.aTarget().toBuilder().interval(INTERVAL).build();
+
+    @Nested
+    class EffectiveInterval {
+
+        @ParameterizedTest(name = "{0} consecutive not evaluable evaluations -> {1} minutes")
+        @CsvSource({ "0, 5", "1, 5", "2, 5", "3, 10", "4, 20", "5, 40", "6, 60", "7, 60", "50, 60" })
+        void should_double_the_interval_per_miss_past_the_backoff_threshold_up_to_the_cap(int consecutiveNotEvaluable, long minutes) {
+            assertThat(SCHEDULE.effectiveInterval(TARGET, consecutiveNotEvaluable)).isEqualTo(Duration.ofMinutes(minutes));
+        }
+
+        @Test
+        void should_keep_a_declared_interval_longer_than_the_cap() {
+            var daily = TARGET.toBuilder().interval(Duration.ofDays(1)).build();
+
+            assertThat(SCHEDULE.effectiveInterval(daily, 10)).isEqualTo(Duration.ofDays(1));
+        }
+
+        @Test
+        void should_know_how_many_evaluations_back_the_cap_is_reached() {
+            assertThat(SCHEDULE.historyDepth(TARGET)).isEqualTo(6);
+            assertThat(SCHEDULE.historyDepth(TARGET.toBuilder().interval(Duration.ofDays(1)).build())).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    class Jitter {
+
+        @Test
+        void should_be_stable_and_spread_across_the_declared_interval() {
+            var jitters = IntStream.range(0, 200)
+                .mapToObj(i -> SCHEDULE.jitter(TARGET.toBuilder().id("target-" + i).build()))
+                .toList();
+
+            assertThat(jitters).allSatisfy(jitter -> assertThat(jitter).isBetween(Duration.ZERO, INTERVAL.minusSeconds(1)));
+            assertThat(jitters.stream().distinct().count()).isGreaterThan(100);
+            assertThat(SCHEDULE.jitter(TARGET)).isEqualTo(SCHEDULE.jitter(PerformanceTargetFixtures.aTarget()));
+        }
+
+        @Test
+        void should_not_depend_on_the_backoff() {
+            assertThat(SCHEDULE.jitter(TARGET)).isEqualTo(new PerformanceTargetSchedule(1, Duration.ofDays(1), 10).jitter(TARGET));
+        }
+    }
+
+    @Nested
+    class IsDue {
+
+        private final Instant boundary = Instant.parse("2021-06-01T10:00:00Z").plus(SCHEDULE.jitter(TARGET));
+
+        @Test
+        void should_be_due_when_never_evaluated() {
+            assertThat(SCHEDULE.isDue(TARGET, null, 0, boundary.minusSeconds(1))).isTrue();
+        }
+
+        @Test
+        void should_be_due_once_a_slot_boundary_has_passed_since_the_last_evaluation() {
+            assertThat(SCHEDULE.isDue(TARGET, boundary.minusSeconds(1), 0, boundary)).isTrue();
+            assertThat(SCHEDULE.isDue(TARGET, boundary.minusSeconds(1), 0, boundary.plusSeconds(59))).isTrue();
+        }
+
+        @Test
+        void should_not_be_due_inside_the_slot_of_the_last_evaluation() {
+            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary)).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary.plus(INTERVAL).minusSeconds(1))).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, boundary.plusSeconds(30), 0, boundary.plus(INTERVAL).minusSeconds(1))).isFalse();
+        }
+
+        @Test
+        void should_be_due_exactly_one_interval_after_the_slot_of_the_last_evaluation() {
+            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary.plus(INTERVAL))).isTrue();
+        }
+
+        @Test
+        void should_wait_for_the_effective_interval_of_an_idle_target() {
+            var backedOffBoundary = Instant.parse("2021-06-01T10:00:00Z").plus(SCHEDULE.jitter(TARGET));
+
+            assertThat(SCHEDULE.isDue(TARGET, backedOffBoundary, 3, backedOffBoundary.plus(INTERVAL))).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, backedOffBoundary, 3, backedOffBoundary.plus(INTERVAL.multipliedBy(2)))).isTrue();
+        }
+    }
+
+    @Test
+    void should_reject_a_meaningless_configuration() {
+        assertThatThrownBy(() -> new PerformanceTargetSchedule(0, Duration.ofHours(1), 288)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PerformanceTargetSchedule(3, Duration.ZERO, 288)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PerformanceTargetSchedule(3, Duration.ofHours(1), 0)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.PerformanceTargetCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
+import inmemory.PerformanceTargetEvaluationQueryServiceInMemory;
+import inmemory.PerformanceTargetEvaluatorInMemory;
+import inmemory.PerformanceTargetQueryServiceInMemory;
+import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EvaluateDuePerformanceTargetsUseCaseTest {
+
+    private static final Instant T0 = Instant.parse("2021-06-01T10:00:00Z");
+    private static final Duration INTERVAL = Duration.ofMinutes(5);
+    private static final Duration TICK = Duration.ofMinutes(1);
+    private static final PerformanceTargetSchedule SCHEDULE = new PerformanceTargetSchedule(3, Duration.ofHours(1), 288);
+
+    PerformanceTargetCrudServiceInMemory targetCrudService = new PerformanceTargetCrudServiceInMemory();
+    PerformanceTargetQueryServiceInMemory targetQueryService = new PerformanceTargetQueryServiceInMemory(targetCrudService);
+    PerformanceTargetEvaluationCrudServiceInMemory evaluationCrudService = new PerformanceTargetEvaluationCrudServiceInMemory();
+    PerformanceTargetEvaluationQueryServiceInMemory evaluationQueryService = new PerformanceTargetEvaluationQueryServiceInMemory(
+        evaluationCrudService
+    );
+    PerformanceTargetEvaluatorInMemory evaluator = new PerformanceTargetEvaluatorInMemory();
+    AtomicInteger ids = new AtomicInteger();
+
+    EvaluateDuePerformanceTargetsUseCase useCase = newUseCase(evaluator);
+
+    @BeforeEach
+    void setUp() {
+        UuidString.overrideGenerator(() -> "evaluation-" + ids.incrementAndGet());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TimeProvider.reset();
+        UuidString.reset();
+        Stream.of(targetCrudService, evaluationCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_evaluate_every_target_never_evaluated_and_store_the_results_as_latest() {
+        targetCrudService.initWith(List.of(aTarget("a"), aTarget("b")));
+
+        var output = tick(T0);
+
+        assertThat(output.targets()).isEqualTo(2);
+        assertThat(output.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("a", "b");
+        assertThat(evaluationCrudService.storage())
+            .hasSize(2)
+            .allSatisfy(evaluation -> {
+                assertThat(evaluation.id()).startsWith("evaluation-");
+                assertThat(evaluation.latest()).isTrue();
+                assertThat(evaluation.evaluatedAt()).isEqualTo(T0);
+            });
+    }
+
+    @Test
+    void should_not_evaluate_a_target_again_inside_the_slot_of_its_last_evaluation() {
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
+        var boundary = slotBoundaryAfter(target, T0);
+
+        tick(boundary);
+        var inside = IntStream.range(1, 5)
+            .mapToObj(i -> tick(boundary.plus(TICK.multipliedBy(i))))
+            .toList();
+        var next = tick(boundary.plus(INTERVAL));
+
+        assertThat(inside).allSatisfy(output -> assertThat(output.evaluations()).isEmpty());
+        assertThat(next.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("a");
+        assertThat(evaluationCrudService.storage()).hasSize(2);
+    }
+
+    @Test
+    void should_seed_the_schedule_from_the_stored_evaluations_so_that_a_restart_evaluates_only_what_is_due() {
+        var inSlot = aTarget("in-slot");
+        var pastSlot = aTarget("past-slot");
+        targetCrudService.initWith(List.of(inSlot, pastSlot));
+        var now = slotBoundaryAfter(inSlot, T0).plusSeconds(30);
+        evaluationCrudService.initWith(
+            List.of(
+                PerformanceTargetFixtures.anEvaluation("old-1", "in-slot", PerformanceTargetEvaluation.Status.PASS, now.minusSeconds(20)),
+                PerformanceTargetFixtures.anEvaluation("old-2", "past-slot", PerformanceTargetEvaluation.Status.PASS, now.minus(INTERVAL))
+            )
+        );
+
+        var output = newUseCase(evaluator).execute(input(now));
+
+        assertThat(output.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("past-slot");
+    }
+
+    @Test
+    void should_spread_targets_last_evaluated_at_the_same_instant_over_the_following_ticks() {
+        // ids whose hashes fall on different minutes of the interval, unlike a numbered series whose hashes are consecutive
+        var targets = Stream.of("checkout", "payments", "inventory", "billing", "shipping")
+            .map(id -> aTarget(id))
+            .toList();
+        targetCrudService.initWith(targets);
+        evaluationCrudService.initWith(
+            targets
+                .stream()
+                .map(target ->
+                    PerformanceTargetFixtures.anEvaluation("old-" + target.id(), target.id(), PerformanceTargetEvaluation.Status.PASS, T0)
+                )
+                .toList()
+        );
+
+        var evaluatedPerTick = IntStream.rangeClosed(1, 5)
+            .mapToObj(i -> tick(T0.plus(TICK.multipliedBy(i))).evaluations().stream().map(PerformanceTargetEvaluation::targetId).toList())
+            .toList();
+
+        assertThat(evaluatedPerTick.stream().flatMap(List::stream)).containsExactlyInAnyOrderElementsOf(
+            targets.stream().map(PerformanceTarget::id).toList()
+        );
+        assertThat(
+            evaluatedPerTick
+                .stream()
+                .filter(tick -> !tick.isEmpty())
+                .count()
+        ).isGreaterThan(1);
+    }
+
+    @Test
+    void should_back_off_an_idle_target_and_return_to_its_interval_when_traffic_reappears() {
+        targetCrudService.initWith(List.of(aTarget("idle")));
+        evaluator.status(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+
+        var idleEvaluations = new ArrayList<Instant>();
+        var now = T0;
+        while (now.isBefore(T0.plus(Duration.ofHours(5)))) {
+            tick(now)
+                .evaluations()
+                .forEach(evaluation -> idleEvaluations.add(evaluation.evaluatedAt()));
+            now = now.plus(TICK);
+        }
+        var gaps = gaps(idleEvaluations);
+
+        // the first gap only reaches the target's slot; from then on it is evaluated every interval until the backoff bites
+        assertThat(gaps.getFirst()).isLessThanOrEqualTo(INTERVAL);
+        assertThat(gaps.get(1)).isEqualTo(INTERVAL);
+        assertThat(gaps).allSatisfy(gap -> assertThat(gap).isLessThanOrEqualTo(Duration.ofHours(1)));
+        assertThat(gaps.subList(gaps.size() - 2, gaps.size())).allSatisfy(gap -> assertThat(gap).isEqualTo(Duration.ofHours(1)));
+
+        evaluator.status(PerformanceTargetEvaluation.Status.PASS);
+        var recovered = new ArrayList<Instant>();
+        var end = now.plus(Duration.ofHours(2));
+        while (now.isBefore(end)) {
+            tick(now)
+                .evaluations()
+                .forEach(evaluation -> recovered.add(evaluation.evaluatedAt()));
+            now = now.plus(TICK);
+        }
+
+        assertThat(recovered).hasSizeGreaterThan(3);
+        assertThat(recovered.getFirst()).isBeforeOrEqualTo(T0.plus(Duration.ofHours(6)));
+        assertThat(gaps(recovered)).allSatisfy(gap -> assertThat(gap).isEqualTo(INTERVAL));
+    }
+
+    @Test
+    void should_resume_the_backoff_of_an_idle_target_after_a_restart() {
+        var target = aTarget("idle");
+        targetCrudService.initWith(List.of(target));
+        var lastBoundary = slotBoundaryAfter(target, T0);
+        evaluationCrudService.initWith(
+            IntStream.range(0, 4)
+                .mapToObj(i ->
+                    PerformanceTargetFixtures.anEvaluation(
+                        "old-" + i,
+                        "idle",
+                        PerformanceTargetEvaluation.Status.NOT_EVALUABLE,
+                        lastBoundary.minus(INTERVAL.multipliedBy(i))
+                    )
+                )
+                .toList()
+        );
+
+        var afterOneInterval = newUseCase(evaluator).execute(input(lastBoundary.plus(INTERVAL)));
+
+        assertThat(afterOneInterval.evaluations()).isEmpty();
+    }
+
+    @Test
+    void should_prune_the_history_of_an_evaluated_target_beyond_the_retention() {
+        var schedule = new PerformanceTargetSchedule(3, Duration.ofHours(1), 3);
+        targetCrudService.initWith(List.of(aTarget("a")));
+        evaluationCrudService.initWith(
+            IntStream.range(0, 3)
+                .mapToObj(i ->
+                    PerformanceTargetFixtures.anEvaluation(
+                        "old-" + i,
+                        "a",
+                        PerformanceTargetEvaluation.Status.PASS,
+                        T0.minus(Duration.ofHours(1)).minus(INTERVAL.multipliedBy(i))
+                    )
+                )
+                .toList()
+        );
+
+        TimeProvider.overrideClock(Clock.fixed(T0, ZoneId.systemDefault()));
+        useCase.execute(new EvaluateDuePerformanceTargetsUseCase.Input(schedule));
+
+        assertThat(evaluationCrudService.storage())
+            .extracting(PerformanceTargetEvaluation::id)
+            .containsExactlyInAnyOrder("evaluation-1", "old-0", "old-1");
+    }
+
+    @Test
+    void should_treat_a_recreated_target_as_new() {
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
+        tick(T0);
+        var justBeforeNextSlot = slotBoundaryAfter(target, T0.plusSeconds(1)).minusSeconds(1);
+
+        targetCrudService.delete("a");
+        evaluationCrudService.deleteByTargetId("a");
+        tick(T0.plusSeconds(1));
+        targetCrudService.create(target);
+
+        assertThat(tick(justBeforeNextSlot).evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("a");
+    }
+
+    @Test
+    void should_not_retry_a_target_the_evaluator_left_out_before_its_next_slot() {
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
+        var boundary = slotBoundaryAfter(target, T0);
+        var calls = new AtomicInteger();
+        var leavingOut = new PerformanceTargetEvaluatorInMemory() {
+            @Override
+            public List<PerformanceTargetEvaluation> evaluateAll(List<PerformanceTarget> targets, Instant now) {
+                calls.incrementAndGet();
+                return List.of();
+            }
+        };
+        var useCase = newUseCase(leavingOut);
+
+        var first = useCase.execute(input(boundary));
+        var retry = useCase.execute(input(boundary.plus(TICK)));
+
+        assertThat(first.targets()).isEqualTo(1);
+        assertThat(first.evaluations()).isEmpty();
+        assertThat(retry.evaluations()).isEmpty();
+        assertThat(calls).hasValue(1);
+        assertThat(evaluationCrudService.storage()).isEmpty();
+    }
+
+    private EvaluateDuePerformanceTargetsUseCase newUseCase(PerformanceTargetEvaluatorInMemory evaluator) {
+        return new EvaluateDuePerformanceTargetsUseCase(targetQueryService, evaluationQueryService, evaluationCrudService, evaluator);
+    }
+
+    private EvaluateDuePerformanceTargetsUseCase.Output tick(Instant now) {
+        return useCase.execute(input(now));
+    }
+
+    private static EvaluateDuePerformanceTargetsUseCase.Input input(Instant now) {
+        TimeProvider.overrideClock(Clock.fixed(now, ZoneId.systemDefault()));
+        return new EvaluateDuePerformanceTargetsUseCase.Input(SCHEDULE);
+    }
+
+    private static PerformanceTarget aTarget(String id) {
+        return PerformanceTargetFixtures.aTarget(id).toBuilder().interval(INTERVAL).build();
+    }
+
+    /** The first instant at or after {@code from} at which the target's slot starts. */
+    private static Instant slotBoundaryAfter(PerformanceTarget target, Instant from) {
+        var boundary = from;
+        while (!SCHEDULE.isDue(target, boundary.minusSeconds(1), 0, boundary)) {
+            boundary = boundary.plusSeconds(1);
+        }
+        return boundary;
+    }
+
+    private static List<Duration> gaps(List<Instant> instants) {
+        return IntStream.range(1, instants.size())
+            .mapToObj(i -> Duration.between(instants.get(i - 1), instants.get(i)))
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
@@ -28,7 +28,6 @@ import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -39,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class EvaluateDuePerformanceTargetsUseCaseTest {
@@ -56,19 +54,12 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         evaluationCrudService
     );
     PerformanceTargetEvaluatorInMemory evaluator = new PerformanceTargetEvaluatorInMemory();
-    AtomicInteger ids = new AtomicInteger();
 
     EvaluateDuePerformanceTargetsUseCase useCase = newUseCase(evaluator);
-
-    @BeforeEach
-    void setUp() {
-        UuidString.overrideGenerator(() -> "evaluation-" + ids.incrementAndGet());
-    }
 
     @AfterEach
     void tearDown() {
         TimeProvider.reset();
-        UuidString.reset();
         Stream.of(targetCrudService, evaluationCrudService).forEach(InMemoryAlternative::reset);
     }
 
@@ -83,10 +74,43 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         assertThat(evaluationCrudService.storage())
             .hasSize(2)
             .allSatisfy(evaluation -> {
-                assertThat(evaluation.id()).startsWith("evaluation-");
+                assertThat(evaluation.id()).isNotBlank();
                 assertThat(evaluation.latest()).isTrue();
                 assertThat(evaluation.evaluatedAt()).isEqualTo(T0);
             });
+    }
+
+    @Test
+    void should_store_one_evaluation_per_slot_when_several_nodes_tick_at_once() {
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
+        var boundary = slotBoundaryAfter(target, T0);
+        var otherNode = newUseCase(evaluator);
+
+        var first = useCase.execute(input(boundary));
+        var second = otherNode.execute(input(boundary.plusSeconds(1)));
+        var secondNextTick = otherNode.execute(input(boundary.plus(TICK)));
+
+        assertThat(first.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("a");
+        assertThat(second.evaluations()).isEmpty();
+        assertThat(secondNextTick.evaluations()).isEmpty();
+        assertThat(evaluationCrudService.storage()).singleElement().extracting(PerformanceTargetEvaluation::latest).isEqualTo(true);
+    }
+
+    @Test
+    void should_give_the_same_evaluation_the_same_id_on_every_node() {
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
+        var boundary = slotBoundaryAfter(target, T0);
+
+        var stored = useCase.execute(input(boundary)).evaluations().getFirst();
+        evaluationCrudService.reset();
+        var storedAgain = newUseCase(evaluator).execute(input(boundary.plusSeconds(30))).evaluations().getFirst();
+        evaluationCrudService.reset();
+        var nextSlot = newUseCase(evaluator).execute(input(boundary.plus(INTERVAL))).evaluations().getFirst();
+
+        assertThat(storedAgain.id()).isEqualTo(stored.id());
+        assertThat(nextSlot.id()).isNotEqualTo(stored.id());
     }
 
     @Test
@@ -236,7 +260,9 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
 
         assertThat(evaluationCrudService.storage())
             .extracting(PerformanceTargetEvaluation::id)
-            .containsExactlyInAnyOrder("evaluation-1", "old-0", "old-1");
+            .hasSize(3)
+            .contains("old-0", "old-1")
+            .doesNotContain("old-2");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
@@ -26,6 +26,9 @@ import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.PerformanceTargetFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
+import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
@@ -33,6 +36,7 @@ import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.Measure;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
@@ -41,6 +45,7 @@ import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsEngineQueryService;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.environment.model.Environment;
 import io.gravitee.apim.core.observability.model.FilterOperator;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
@@ -56,7 +61,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class PerformanceTargetEvaluatorImplTest {
@@ -381,19 +391,306 @@ class PerformanceTargetEvaluatorImplTest {
         return new MetricMeasuresResponse(metric, null, List.of(new Measure(measure, value)));
     }
 
+    @Nested
+    class EvaluateAll {
+
+        private static final PerformanceTarget.Rule LATENCY = PerformanceTargetFixtures.aLatencyRule();
+
+        @Test
+        void should_evaluate_a_thousand_single_api_targets_of_one_window_with_a_bounded_number_of_requests() {
+            var apiIds = IntStream.range(0, 1000)
+                .mapToObj(i -> "api-" + i)
+                .toList();
+            apiCrudService.initWith(
+                apiIds
+                    .stream()
+                    .<Api>map(id -> ApiFixtures.aProxyApiV4().toBuilder().id(id).build())
+                    .toList()
+            );
+            apiIds.forEach(apiId ->
+                analytics.givenApi(apiId, requests(50), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1000))
+            );
+            var targets = apiIds
+                .stream()
+                .map(apiId -> aSingleApiTarget(apiId, WINDOW, LATENCY))
+                .toList();
+
+            var evaluations = evaluator.evaluateAll(targets, NOW);
+
+            assertThat(analytics.requests).isEmpty();
+            assertThat(analytics.facetsRequests).hasSizeLessThanOrEqualTo(4);
+            assertThat(evaluations)
+                .hasSize(1000)
+                .allSatisfy(evaluation -> {
+                    assertThat(evaluation.status()).isEqualTo(PASS);
+                    assertThat(evaluation.coveredApiIds()).containsExactly(evaluation.targetId());
+                    assertThat(evaluation.rules())
+                        .singleElement()
+                        .extracting(PerformanceTargetEvaluation.RuleResult::sampleCount)
+                        .isEqualTo(50L);
+                });
+            assertThat(evaluations).extracting(PerformanceTargetEvaluation::targetId).containsExactlyElementsOf(apiIds);
+        }
+
+        @Test
+        void should_count_first_and_aggregate_only_the_targets_with_enough_samples() {
+            analytics.givenApi(A2A_API_ID, requests(63), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 4810));
+            analytics.givenApi(LLM_API_ID, requests(5), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 100));
+
+            var evaluations = evaluator.evaluateAll(
+                List.of(aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY), aSingleApiTarget(LLM_API_ID, WINDOW, LATENCY)),
+                NOW
+            );
+
+            assertThat(analytics.contexts).containsOnly(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID));
+            assertThat(analytics.facetsRequests)
+                .allSatisfy(request -> {
+                    assertThat(request.timeRange()).isEqualTo(new TimeRange(NOW.minus(WINDOW), NOW));
+                    assertThat(request.facets()).containsExactly(FacetSpec.Name.API);
+                })
+                .satisfiesExactly(
+                    count -> {
+                        assertThat(count.filters()).containsExactly(apiIn(A2A_API_ID, LLM_API_ID));
+                        assertThat(count.limit()).isEqualTo(2);
+                        assertThat(count.metrics()).containsExactly(
+                            new FacetMetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT), List.of())
+                        );
+                    },
+                    aggregation -> {
+                        assertThat(aggregation.filters()).containsExactly(apiIn(A2A_API_ID));
+                        assertThat(aggregation.limit()).isEqualTo(1);
+                        assertThat(aggregation.metrics()).containsExactly(
+                            new FacetMetricMeasuresRequest(
+                                MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+                                List.of(MetricSpec.Measure.P95),
+                                List.of()
+                            )
+                        );
+                    }
+                );
+            assertThat(evaluations)
+                .extracting(PerformanceTargetEvaluation::targetId, PerformanceTargetEvaluation::status)
+                .containsExactly(tuple(A2A_API_ID, BREACH), tuple(LLM_API_ID, NOT_EVALUABLE));
+            assertThat(evaluations)
+                .flatExtracting(PerformanceTargetEvaluation::rules)
+                .extracting(
+                    PerformanceTargetEvaluation.RuleResult::observed,
+                    PerformanceTargetEvaluation.RuleResult::sampleCount,
+                    PerformanceTargetEvaluation.RuleResult::status
+                )
+                .containsExactly(tuple(4810.0, 63L, BREACH), tuple(null, 5L, NOT_EVALUABLE));
+        }
+
+        @Test
+        void should_skip_the_aggregation_when_no_target_has_enough_samples() {
+            analytics.givenApi(A2A_API_ID, requests(3));
+
+            var evaluations = evaluator.evaluateAll(
+                List.of(aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY), aSingleApiTarget(LLM_API_ID, WINDOW, LATENCY)),
+                NOW
+            );
+
+            assertThat(analytics.facetsRequests).hasSize(1);
+            assertThat(evaluations)
+                .flatExtracting(PerformanceTargetEvaluation::rules)
+                .extracting(PerformanceTargetEvaluation.RuleResult::sampleCount, PerformanceTargetEvaluation.RuleResult::status)
+                .containsExactly(tuple(3L, NOT_EVALUABLE), tuple(0L, NOT_EVALUABLE));
+        }
+
+        @Test
+        void should_batch_per_environment_and_window() {
+            environmentCrudService.initWith(
+                List.of(
+                    Environment.builder().id(ENVIRONMENT_ID).organizationId(ORGANIZATION_ID).build(),
+                    Environment.builder().id("other-env").organizationId("other-org").build()
+                )
+            );
+            apiCrudService.initWith(
+                List.of(
+                    ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API_ID).build(),
+                    ApiFixtures.aLLMProxyApiV4().toBuilder().id(LLM_API_ID).build(),
+                    ApiFixtures.aProxyApiV4().toBuilder().id("hourly-api").build(),
+                    ApiFixtures.aProxyApiV4().toBuilder().id("other-env-api").environmentId("other-env").build()
+                )
+            );
+            var hour = Duration.ofHours(1);
+
+            evaluator.evaluateAll(
+                List.of(
+                    aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY),
+                    aSingleApiTarget("hourly-api", hour, LATENCY),
+                    aSingleApiTarget(LLM_API_ID, WINDOW, LATENCY),
+                    aSingleApiTarget("other-env-api", WINDOW, LATENCY).toBuilder().environmentId("other-env").build()
+                ),
+                NOW
+            );
+
+            assertThat(analytics.facetsRequests)
+                .extracting(FacetsRequest::timeRange, FacetsRequest::filters)
+                .containsExactlyInAnyOrder(
+                    tuple(new TimeRange(NOW.minus(WINDOW), NOW), List.of(apiIn(A2A_API_ID, LLM_API_ID))),
+                    tuple(new TimeRange(NOW.minus(hour), NOW), List.of(apiIn("hourly-api"))),
+                    tuple(new TimeRange(NOW.minus(WINDOW), NOW), List.of(apiIn("other-env-api")))
+                );
+            assertThat(analytics.contexts).containsExactlyInAnyOrder(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                new ExecutionContext("other-org", "other-env")
+            );
+        }
+
+        @Test
+        void should_fall_back_to_a_per_target_evaluation_when_a_rule_spans_several_apis_or_carries_filters() {
+            var searchTool = new Filter(FilterSpec.Name.MCP_PROXY_TOOL, FilterOperator.EQ, "search");
+            var filtered = aSingleApiTarget(A2A_API_ID, WINDOW, ERROR_RATE.toBuilder().filters(List.of(searchTool)).build());
+
+            var evaluations = evaluator.evaluateAll(
+                List.of(anAgentTarget(ERROR_RATE), filtered, aSingleApiTarget(LLM_API_ID, WINDOW, LATENCY)),
+                NOW
+            );
+
+            assertThat(analytics.requests)
+                .extracting(MeasuresRequest::filters)
+                .containsExactly(List.of(apiIn(A2A_API_ID, LLM_API_ID)), List.of(apiIn(A2A_API_ID), searchTool));
+            assertThat(analytics.facetsRequests).singleElement().extracting(FacetsRequest::filters).isEqualTo(List.of(apiIn(LLM_API_ID)));
+            assertThat(evaluations)
+                .extracting(PerformanceTargetEvaluation::targetId)
+                .containsExactly("target-id", filtered.id(), LLM_API_ID);
+        }
+
+        @Test
+        void should_batch_an_agent_target_whose_rules_each_resolve_to_one_api() {
+            analytics.givenApi(A2A_API_ID, requests(63), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1500));
+            analytics.givenApi(
+                LLM_API_ID,
+                requests(40),
+                measure(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, MetricSpec.Measure.AVG, 0.02)
+            );
+
+            var evaluations = evaluator.evaluateAll(List.of(anAgentTarget(A2A_LATENCY, LLM_COST)), NOW);
+
+            assertThat(analytics.requests).isEmpty();
+            assertThat(analytics.facetsRequests).hasSize(2);
+            assertThat(evaluations)
+                .singleElement()
+                .satisfies(evaluation -> {
+                    assertThat(evaluation.status()).isEqualTo(BREACH);
+                    assertThat(evaluation.coveredApiIds()).containsExactly(A2A_API_ID, LLM_API_ID);
+                    assertThat(evaluation.rules())
+                        .extracting(
+                            PerformanceTargetEvaluation.RuleResult::observed,
+                            PerformanceTargetEvaluation.RuleResult::sampleCount,
+                            PerformanceTargetEvaluation.RuleResult::status
+                        )
+                        .containsExactly(tuple(1500.0, 63L, PASS), tuple(0.02, 40L, BREACH));
+                });
+        }
+
+        @Test
+        void should_keep_the_input_order_and_leave_out_a_target_that_cannot_be_evaluated() {
+            apiCrudService.initWith(
+                List.of(
+                    ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API_ID).build(),
+                    ApiFixtures.aNativeApi().toBuilder().id("kafka-api").build()
+                )
+            );
+            var mixedFamilies = PerformanceTargetFixtures.aTarget("mixed")
+                .toBuilder()
+                .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID, "kafka-api"), "mixed"))
+                .rules(List.of(ERROR_RATE))
+                .build();
+
+            var evaluations = evaluator.evaluateAll(
+                List.of(aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY), mixedFamilies, anAgentTarget(ERROR_RATE)),
+                NOW
+            );
+
+            assertThat(evaluations).extracting(PerformanceTargetEvaluation::targetId).containsExactly(A2A_API_ID, "target-id");
+        }
+
+        @Test
+        void should_return_nothing_for_no_target() {
+            assertThat(evaluator.evaluateAll(List.of(), NOW)).isEmpty();
+            assertThat(analytics.facetsRequests).isEmpty();
+            assertThat(analytics.requests).isEmpty();
+        }
+    }
+
+    @Nested
+    class Concurrency {
+
+        @Test
+        void should_cap_the_analytics_queries_in_flight() throws Exception {
+            var entered = new CountDownLatch(2);
+            var release = new CountDownLatch(1);
+            var blocking = new RecordingAnalyticsEngineQueryService() {
+                @Override
+                public MeasuresResponse searchMeasures(ExecutionContext context, MeasuresRequest request) {
+                    entered.countDown();
+                    try {
+                        release.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return super.searchMeasures(context, request);
+                }
+            };
+            var capped = new PerformanceTargetEvaluatorImpl(
+                apiCrudService,
+                environmentCrudService,
+                new AnalyticsQueryContextProvider(List.of(blocking)),
+                1
+            );
+            var executor = Executors.newFixedThreadPool(2);
+            try {
+                var first = executor.submit(() -> capped.evaluate(anAgentTarget(ERROR_RATE), NOW));
+                var second = executor.submit(() -> capped.evaluate(anAgentTarget(ERROR_RATE), NOW));
+
+                assertThat(entered.await(500, TimeUnit.MILLISECONDS)).as("the second query must wait for the first one").isFalse();
+                assertThat(entered.getCount()).isEqualTo(1);
+
+                release.countDown();
+                first.get(5, TimeUnit.SECONDS);
+                second.get(5, TimeUnit.SECONDS);
+                assertThat(blocking.requests).hasSize(2);
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    private static PerformanceTarget aSingleApiTarget(String apiId, Duration window, PerformanceTarget.Rule... rules) {
+        return PerformanceTargetFixtures.aTarget(apiId)
+            .toBuilder()
+            .subject(new PerformanceTarget.Subject(List.of(apiId), apiId))
+            .window(window)
+            .rules(List.of(rules))
+            .build();
+    }
+
     /**
      * Answers a measures request with the metrics configured for the API ids it filters on, merging several
-     * configured responses for the same metric, and records what it was asked so tests can assert the query shape.
+     * configured responses for the same metric, and a facets request with one API bucket per API id that has
+     * configured metrics, the way Elasticsearch returns no bucket for an API without documents. Records what it was
+     * asked so tests can assert the query shape.
      */
     static class RecordingAnalyticsEngineQueryService implements AnalyticsEngineQueryService {
 
         final List<ExecutionContext> contexts = new ArrayList<>();
         final List<MeasuresRequest> requests = new ArrayList<>();
+        final List<FacetsRequest> facetsRequests = new ArrayList<>();
         private final Map<Set<String>, List<MetricMeasuresResponse>> responsesByApiIds = new HashMap<>();
+        private final Map<String, List<MetricMeasuresResponse>> responsesByApi = new HashMap<>();
 
         void given(Set<String> apiIds, MetricMeasuresResponse... metrics) {
             for (var metric : metrics) {
                 responsesByApiIds.computeIfAbsent(apiIds, ids -> new ArrayList<>()).add(metric);
+            }
+        }
+
+        void givenApi(String apiId, MetricMeasuresResponse... metrics) {
+            for (var metric : metrics) {
+                responsesByApi.computeIfAbsent(apiId, id -> new ArrayList<>()).add(metric);
             }
         }
 
@@ -403,19 +700,11 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public MeasuresResponse searchMeasures(ExecutionContext context, MeasuresRequest request) {
             contexts.add(context);
             requests.add(request);
-            var apiIds = request
-                .filters()
-                .stream()
-                .filter(filter -> filter.name() == FilterSpec.Name.API)
-                .findFirst()
-                .map(filter -> Set.copyOf((Collection<String>) filter.value()))
-                .orElse(Set.of());
             var byMetric = new HashMap<MetricSpec.Name, List<Measure>>();
-            for (var response : responsesByApiIds.getOrDefault(apiIds, List.of())) {
+            for (var response : responsesByApiIds.getOrDefault(apiIdsOf(request.filters()), List.of())) {
                 byMetric.computeIfAbsent(response.name(), name -> new ArrayList<>()).addAll(response.measures());
             }
             return new MeasuresResponse(
@@ -428,7 +717,46 @@ class PerformanceTargetEvaluatorImplTest {
 
         @Override
         public FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request) {
-            throw new UnsupportedOperationException();
+            contexts.add(context);
+            facetsRequests.add(request);
+            var apiIds = new TreeSet<>(apiIdsOf(request.filters()));
+            return new FacetsResponse(
+                request
+                    .metrics()
+                    .stream()
+                    .map(metric ->
+                        new MetricFacetsResponse(
+                            metric.name(),
+                            null,
+                            apiIds
+                                .stream()
+                                .map(apiId -> new FacetBucketResponse(apiId, null, null, measuresOf(apiId, metric)))
+                                .filter(bucket -> !bucket.measures().isEmpty())
+                                .toList()
+                        )
+                    )
+                    .toList()
+            );
+        }
+
+        private List<Measure> measuresOf(String apiId, FacetMetricMeasuresRequest metric) {
+            return responsesByApi
+                .getOrDefault(apiId, List.of())
+                .stream()
+                .filter(response -> response.name() == metric.name())
+                .flatMap(response -> response.measures().stream())
+                .filter(measure -> metric.measures().contains(measure.name()))
+                .toList();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Set<String> apiIdsOf(List<Filter> filters) {
+            return filters
+                .stream()
+                .filter(filter -> filter.name() == FilterSpec.Name.API)
+                .findFirst()
+                .map(filter -> Set.copyOf((Collection<String>) filter.value()))
+                .orElse(Set.of());
         }
 
         @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.rest.api.services</groupId>
+        <artifactId>gravitee-apim-rest-api-services</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-rest-api-services-performance-targets</artifactId>
+    <name>Gravitee.io APIM - Management API - Services - Performance Targets</name>
+
+    <dependencies>
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.performancetargets;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
+import io.gravitee.apim.core.performance_target.use_case.EvaluateDuePerformanceTargetsUseCase;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.cluster.ClusterManager;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+/**
+ * Evaluates the performance targets that are due against gateway telemetry, once per tick, on the primary node
+ * only. Disabling it leaves evaluate-on-demand untouched: that path is a distinct use case behind the REST API.
+ */
+@CustomLog
+public class ScheduledPerformanceTargetEvaluationService extends AbstractService implements Runnable {
+
+    private final TaskScheduler scheduler;
+    private final String cronTrigger;
+    private final boolean enabled;
+    private final PerformanceTargetSchedule schedule;
+    private final EvaluateDuePerformanceTargetsUseCase evaluateDuePerformanceTargetsUseCase;
+    private final ClusterManager clusterManager;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    public ScheduledPerformanceTargetEvaluationService(
+        @Qualifier("performanceTargetsTaskScheduler") TaskScheduler scheduler,
+        @Value("${services.performance-targets.cron:0 * * * * *}") String cronTrigger,
+        @Value("${services.performance-targets.enabled:true}") boolean enabled,
+        @Value("${services.performance-targets.backoff.after:3}") int backoffAfter,
+        @Value("${services.performance-targets.backoff.cap:60}") long backoffCapMinutes,
+        @Value("${services.performance-targets.retention:288}") int retention,
+        EvaluateDuePerformanceTargetsUseCase evaluateDuePerformanceTargetsUseCase,
+        ClusterManager clusterManager
+    ) {
+        this.scheduler = scheduler;
+        this.cronTrigger = cronTrigger;
+        this.enabled = enabled;
+        this.schedule = new PerformanceTargetSchedule(backoffAfter, Duration.ofMinutes(backoffCapMinutes), retention);
+        this.evaluateDuePerformanceTargetsUseCase = evaluateDuePerformanceTargetsUseCase;
+        this.clusterManager = clusterManager;
+    }
+
+    @Override
+    protected String name() {
+        return "Performance Targets Evaluation Service";
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        if (!enabled) {
+            log.warn("Performance targets evaluation service has been disabled, targets are only evaluated on demand");
+            return;
+        }
+        super.doStart();
+        try {
+            scheduler.schedule(this, new CronTrigger(cronTrigger));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                "Invalid cron expression [%s] in property 'services.performance-targets.cron'".formatted(cronTrigger),
+                e
+            );
+        }
+        log.info(
+            "Performance targets evaluation service has been initialized with cron [{}], backing off after {} empty windows up to {}",
+            cronTrigger,
+            schedule.backoffAfter(),
+            schedule.backoffCap()
+        );
+    }
+
+    /**
+     * Only the primary node runs the job: every node holds its own schedule state, so several nodes would evaluate
+     * the same targets on the same tick and multiply the analytics queries.
+     */
+    @Override
+    public void run() {
+        if (!clusterManager.self().primary()) {
+            log.debug("Performance targets evaluation is not on the primary node, skipping execution");
+            return;
+        }
+        var run = counter.incrementAndGet();
+        try {
+            var output = evaluateDuePerformanceTargetsUseCase.execute(new EvaluateDuePerformanceTargetsUseCase.Input(schedule));
+            // Kept at debug when nothing was due: the job ticks every minute on every installation.
+            if (output.evaluations().isEmpty()) {
+                log.debug("Performance targets evaluation #{}: none of the {} target(s) was due", run, output.targets());
+            } else {
+                var missed = output
+                    .evaluations()
+                    .stream()
+                    .filter(evaluation -> evaluation.status() == PerformanceTargetEvaluation.Status.BREACH)
+                    .count();
+                log.info(
+                    "Performance targets evaluation #{}: {} of {} target(s) evaluated, {} missed",
+                    run,
+                    output.evaluations().size(),
+                    output.targets(),
+                    missed
+                );
+            }
+        } catch (Exception e) {
+            log.error("Performance targets evaluation #{} failed, the targets left unevaluated are retried at their next slot", run, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/spring/PerformanceTargetsConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/spring/PerformanceTargetsConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.performancetargets.spring;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Dedicated scheduler thread, so that a slow analytics backend never delays the other scheduled services, and a
+ * tick that overruns is not run twice in parallel.
+ */
+@Configuration
+public class PerformanceTargetsConfiguration {
+
+    @Bean
+    @Qualifier("performanceTargetsTaskScheduler")
+    public TaskScheduler performanceTargetsTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("performance-targets-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/resources/plugin.properties
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/resources/plugin.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+id=performance-targets
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.rest.api.services.performancetargets.ScheduledPerformanceTargetEvaluationService
+type=service

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/test/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/test/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationServiceTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.performancetargets;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
+import io.gravitee.apim.core.performance_target.use_case.EvaluateDuePerformanceTargetsUseCase;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ScheduledPerformanceTargetEvaluationServiceTest {
+
+    private static final String CRON = "0 * * * * *";
+
+    @Mock
+    private TaskScheduler scheduler;
+
+    @Mock
+    private EvaluateDuePerformanceTargetsUseCase useCase;
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    private ScheduledPerformanceTargetEvaluationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = newService(CRON, true);
+    }
+
+    private ScheduledPerformanceTargetEvaluationService newService(String cron, boolean enabled) {
+        return new ScheduledPerformanceTargetEvaluationService(scheduler, cron, enabled, 3, 60, 288, useCase, clusterManager);
+    }
+
+    private void givenPrimaryNode(boolean primary) {
+        Member member = mock(Member.class);
+        when(member.primary()).thenReturn(primary);
+        when(clusterManager.self()).thenReturn(member);
+    }
+
+    @Test
+    void should_schedule_the_evaluation_when_enabled() throws Exception {
+        service.doStart();
+
+        verify(scheduler).schedule(eq(service), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_not_schedule_anything_when_disabled() throws Exception {
+        service = newService(CRON, false);
+
+        service.doStart();
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+        verifyNoInteractions(useCase);
+    }
+
+    @Test
+    void should_fail_to_start_when_the_configured_cron_is_invalid() {
+        service = newService("not-a-cron", true);
+
+        assertThatThrownBy(() -> service.doStart()).isInstanceOf(IllegalArgumentException.class);
+
+        verify(scheduler, never()).schedule(any(Runnable.class), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_refuse_a_meaningless_backoff_configuration() {
+        assertThatThrownBy(() ->
+            new ScheduledPerformanceTargetEvaluationService(scheduler, CRON, true, 0, 60, 288, useCase, clusterManager)
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_evaluate_the_due_targets_with_the_configured_schedule() {
+        givenPrimaryNode(true);
+        when(useCase.execute(any())).thenReturn(new EvaluateDuePerformanceTargetsUseCase.Output(3, List.of()));
+
+        service.run();
+
+        verify(useCase).execute(
+            new EvaluateDuePerformanceTargetsUseCase.Input(new PerformanceTargetSchedule(3, Duration.ofMinutes(60), 288))
+        );
+    }
+
+    @Test
+    void should_not_propagate_a_failure_of_the_whole_run() {
+        givenPrimaryNode(true);
+        when(useCase.execute(any())).thenThrow(new RuntimeException("analytics backend unreachable"));
+
+        assertThatCode(() -> service.run()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_skip_the_run_when_the_node_is_not_primary() {
+        givenPrimaryNode(false);
+
+        service.run();
+
+        verifyNoInteractions(useCase);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -38,6 +38,7 @@
         <module>gravitee-apim-rest-api-services-audit</module>
         <module>gravitee-apim-rest-api-services-auto-fetch</module>
         <module>gravitee-apim-rest-api-services-portal-auto-fetch</module>
+        <module>gravitee-apim-rest-api-services-performance-targets</module>
         <module>gravitee-apim-rest-api-services-dictionary</module>
         <module>gravitee-apim-rest-api-services-dynamic-properties</module>
         <module>gravitee-apim-rest-api-services-events</module>


### PR DESCRIPTION
## Issue

[AIAM-511](https://gravitee.atlassian.net/browse/AIAM-511) — part of epic [AIAM-436](https://gravitee.atlassian.net/browse/AIAM-436). Builds on AIAM-508 (model, repositories), AIAM-509 (REST) and AIAM-510 (evaluation engine), already on `amp_demo`.

## Description

Scheduled evaluator for performance targets: jittered scheduling, per-window batching, count-first and backoff.

**Scheduled service** (`gravitee-apim-rest-api-services-performance-targets`, new plugin)
- `ScheduledPerformanceTargetEvaluationService` ticks on a cron (default every minute) on the primary node only, like the other scheduled services. Bundled in the standalone REST API distribution.
- Configuration under `services.performance-targets` in `gravitee.yml`: `enabled`, `cron`, `concurrency`, `backoff.after`, `backoff.cap` (minutes), `retention`. Disabling it leaves evaluate-on-demand working: that path is a distinct use case behind the REST API.

**Scheduling** (`PerformanceTargetSchedule`, `EvaluateDuePerformanceTargetsUseCase`, core)
- Each target owns the slots `k × effectiveInterval + jitter` of the epoch, where the jitter is a stable hash of its id spread across its declared interval; a target is due once a slot has started since its last evaluation. Load spreads over the ticks and a restart or a bulk import does not make everything due at once. A target never evaluated is due at once.
- Backoff: from `backoff.after` consecutive `NOT_EVALUABLE` evaluations on, every further miss doubles the interval up to `backoff.cap`; the first evaluable window brings the declared interval back.
- The use case keeps the schedule state (last evaluation, consecutive misses) in memory and seeds it from the stored evaluations the first time a target is seen, reading only as many as the backoff can use. Deleted targets are forgotten each tick. A target the evaluator leaves out is retried at its next slot, not at every tick.
- Stores each result as the target's latest evaluation and prunes to the configured retention.
- Scheduled evaluations carry a deterministic id derived from the target and the slot start. Without a cluster manager every Management API node reports itself as primary and evaluates the same slot; the first insert wins and the others are rejected on the primary key (`createIfAbsent`), so history and the "consecutive windows" signal stay clean. The analytics queries are still multiplied by the node count in that setup; `gravitee.yml` now says so and points to `cluster.type: hazelcast`. Evaluate-on-demand keeps random ids.

**Batching** (`PerformanceTargetEvaluatorImpl.evaluateAll`, infra)
- Targets whose every rule resolves to one API and carries no filter are grouped per environment and window into facets requests grouped by API, one bucket per API, at most 500 targets per request. A cheap request-count query comes first; the aggregation only covers the APIs with enough samples, so idle targets cost one count query.
- Any other target (a rule spanning several APIs, a rule with `filters`, an Edge API whose analytics cannot be grouped by API) is evaluated on its own with the existing measures path. A target that fails on its own is logged and left out; the others are still evaluated.
- A semaphore caps the analytics queries in flight per node (`concurrency`, default 2), shared by the scheduler and evaluate-on-demand.

**Repository**
- `PerformanceTargetRepository.findAll()` (API, Mongo, JDBC with a single query for the api ids, shared test).
- `PerformanceTargetEvaluationRepository.create` now inserts before unflagging the previous latest evaluation and throws the repository `DuplicateKeyException` on an existing id, leaving the stored evaluation and its flag untouched (shared test on Mongo and JDBC).

**Deviations from the ticket text, on purpose**
- Due-ness is slot-aligned rather than `lastEvaluatedAt + interval + jitter`: the literal formula makes a 5-minute target run every 5 to 10 minutes. Slot alignment keeps the period exactly the declared interval while still spreading targets across ticks.
- The analytics engine has no `filters`-style facet, so the shared query groups by the existing API facet. Single-API targets and agent targets whose rules are scoped per API type batch; a rule spanning several APIs falls back to a per-target request.

## Verification

| Suite | Result |
| --- | --- |
| Service unit tests (schedule, use case, evaluator batching and concurrency, existing) | 60 pass |
| `PerformanceTargetRepositoryTest` on JDBC and on MongoDB | 14 pass each |
| `PerformanceTargetEvaluationRepositoryTest` on JDBC and on MongoDB | 19 pass each |
| Management v2 REST performance target resources | 34 pass |
| New service module | 7 pass, plugin zip bundled in the distribution |

Acceptance criteria: 1 000 single-API targets on one window cost at most 4 facets requests and no measures request (asserted on a recording `AnalyticsEngineQueryService`); restart seeding, spreading, backoff to the cap and recovery within one interval are asserted in the use case test over simulated ticks; disabling the service schedules nothing.

Live smoke on a local distribution (Mongo + Elasticsearch, real traffic through the gateway): a 2-minute target was evaluated at :02, :04, :06, :08, :10, :12 (`PASS`, 41 samples); evaluate-now returned 429 against the scheduled run; after a restart of the Management API at :10:16 the :11 tick stayed silent and :12 evaluated, so the schedule was seeded from history.

## Compatibility-sensitive

- New configuration keys under `services.performance-targets`.
- `PerformanceTargetRepository` (repository API) gains `findAll`; any external implementation must add it.
- `PerformanceTargetEvaluationRepository.create` documents `DuplicateKeyException` on an existing id; `PerformanceTargetEvaluationCrudService` gains `createIfAbsent`.
- New plugin `gravitee-apim-rest-api-services-performance-targets` in the REST API distribution.

## Security-sensitive

- As in AIAM-510, the scheduler evaluates analytics **without a caller permission context**; scope is bounded server-side to the target's validated API ids.

## Additional context

- `retention` from the configuration drives the scheduler's pruning; evaluate-on-demand still prunes to the constant 288, and the scheduler re-prunes at the next slot.
- Formatted with `mvn prettier:write` on every changed module.
- Automation API sync: no mirror needed (no OpenAPI or CRD change).


[AIAM-511]: https://gravitee.atlassian.net/browse/AIAM-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIAM-436]: https://gravitee.atlassian.net/browse/AIAM-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ