### PR TITLE
feat(gamma-platform): add Integrations nav, list, and connection status

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { License } from '@gravitee/gamma-modules-sdk/types';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentType } from 'react';
 import { MemoryRouter, useLocation, useNavigationType } from 'react-router-dom';
 
@@ -406,19 +406,29 @@ const NO_INTEGRATIONS_RESPONSE = {
 
 const INTEGRATIONS_REQUEST_URL = 'https://apim.test/management/v2/environments/env-1/integrations?page=1&perPage=10';
 
-function jsonResponse(body: unknown) {
-    return Promise.resolve(new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } }));
+function jsonResponse(body: unknown, status = 200) {
+    return Promise.resolve(new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }));
+}
+
+function okIntegrationsResponse() {
+    return jsonResponse(NO_INTEGRATIONS_RESPONSE);
+}
+
+// 403 rather than 5xx so retryTransientRequest gives up after the first attempt: a retried request would
+// only report isError after react-query's backoff, well past any reasonable wait budget.
+function forbiddenIntegrationsResponse() {
+    return jsonResponse({ httpStatus: 403, message: 'You do not have permission to list integrations.' }, 403);
 }
 
 // The API client resolves /constants.json then /ui/bootstrap before any environment-scoped call and caches
 // the result process-wide, so both have to answer here for an integrations request to be attempted at all.
-function spyOnApimFetch() {
+function spyOnApimFetch(integrationsResponse: () => Promise<Response> = okIntegrationsResponse) {
     resetApimClientForTests();
     return jest.spyOn(global, 'fetch').mockImplementation(input => {
         const url = String(input);
         if (url.endsWith('/constants.json')) return jsonResponse({ gammaBaseURL: APIM_BOOTSTRAP.gammaBaseURL });
         if (url.endsWith('/ui/bootstrap')) return jsonResponse(APIM_BOOTSTRAP);
-        return jsonResponse(NO_INTEGRATIONS_RESPONSE);
+        return integrationsResponse();
     });
 }
 
@@ -724,7 +734,9 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('integrations-page')).not.toBeNull();
     });
 
-    it('surfaces no error notification while the Integrations gate runs without environment-integration-r', () => {
+    it('surfaces no error notification while the Integrations gate runs without environment-integration-r', async () => {
+        mockUseRealIntegrationsPage = true;
+        const fetchSpy = spyOnApimFetch(forbiddenIntegrationsResponse);
         const notifyError = jest.spyOn(notify, 'error').mockImplementation(() => undefined);
         mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
         mockSetLicense(ENTITLED_LICENSE);
@@ -733,8 +745,31 @@ describe('AppRoutes', () => {
         renderPlatform();
         renderIntegrationsUrl();
 
-        expect(notifyError).not.toHaveBeenCalled();
+        // A refused route starts no async work, so there is nothing to await here: only waitFor's own
+        // timeout gives the mount path — bootstrap, list request, error state, notify effect — time to run.
+        await expect(waitFor(() => expect(notifyError).toHaveBeenCalled())).rejects.toThrow();
         notifyError.mockRestore();
+        fetchSpy.mockRestore();
+    });
+
+    // Positive control for the assertion above: the same failing integrations response does reach
+    // notify.error once the gate lets the page mount, so silence there means the gate refused the route.
+    it('surfaces an error notification once the gate lets the Integrations page mount and its list request fails', async () => {
+        mockUseRealIntegrationsPage = true;
+        const fetchSpy = spyOnApimFetch(forbiddenIntegrationsResponse);
+        const notifyError = jest.spyOn(notify, 'error').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderIntegrationsUrl();
+
+        expect(await screen.findByText('Integrations could not be loaded. Please refresh and try again.')).not.toBeNull();
+        expect(notifyError).toHaveBeenCalledWith(
+            expect.any(ApimApiError),
+            'Integrations could not be loaded. Please refresh and try again.',
+        );
+        notifyError.mockRestore();
+        fetchSpy.mockRestore();
     });
 
     it('requests no integrations endpoint while deciding whether Integrations is available', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { License } from '@gravitee/gamma-modules-sdk/types';
 import { act, render, screen } from '@testing-library/react';
 import type { ComponentType } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation, useNavigationType } from 'react-router-dom';
 
 import { AppRoutes } from './AppRoutes';
+import { ROUTES } from '../config/routes';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { ApimApiError } from '../shared/api/apimClient';
 import { useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
 import { markNavItemDenied, resetDeniedNavItemsForEnvironment } from '../shared/nav/deniedNavItems';
+import { notify } from '../shared/notify/notify';
 
 jest.mock('./PlatformToaster', () => ({
     PlatformToaster: () => <div data-testid="platform-toaster" />,
@@ -51,11 +54,28 @@ let mockPermissionStoreVersion = 0;
 
 const mockUseEnvironmentPermissionGrant = jest.fn<boolean | undefined, [string[]]>();
 
+// Same reasoning as the permission store above: the license arrives from the host and can land after the
+// first render, so the fake keeps real listeners. The holder is read back by reference — a `getSnapshot`
+// returning a fresh object literal per call trips React's "result of getSnapshot should be cached" loop.
+const mockLicenseListeners = new Set<() => void>();
+let mockLicense: License | null = null;
+
+const ENTITLED_LICENSE: License = { tier: 'enterprise', packs: [], features: [], isExpired: false };
+const OSS_LICENSE: License = { tier: 'oss', packs: [], features: [], isExpired: false };
+const EXPIRED_LICENSE: License = { tier: 'enterprise', packs: [], features: [], isExpired: true };
+
+const mockUseConsoleSettings = jest.fn();
+
 let deniedNavItemResetCount = 0;
 
 function emitPermissionChange() {
     mockPermissionStoreVersion += 1;
     mockPermissionListeners.forEach(listener => listener());
+}
+
+function mockSetLicense(license: License | null) {
+    mockLicense = license;
+    mockLicenseListeners.forEach(listener => listener());
 }
 
 jest.mock('@gravitee/graphene-core', () => {
@@ -72,6 +92,7 @@ jest.mock('@gravitee/graphene-core', () => {
 
 jest.mock('../shared/console-settings', () => ({
     ConsoleSettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useConsoleSettings: () => mockUseConsoleSettings(),
 }));
 
 jest.mock('../shared/hooks/useEnvironmentPermissions', () => ({
@@ -93,6 +114,15 @@ jest.mock('@gravitee/gamma-modules-sdk', () => ({
         },
         getSnapshot: () => mockPermissionStoreVersion,
     },
+    licenseService: {
+        setLicense: mockSetLicense,
+        getLicense: () => mockLicense,
+        subscribe: (listener: () => void) => {
+            mockLicenseListeners.add(listener);
+            return () => mockLicenseListeners.delete(listener);
+        },
+        getSnapshot: () => mockLicense,
+    },
 }));
 
 jest.mock('../features/dictionaries/hooks/useEnvironmentDictionaries');
@@ -113,6 +143,10 @@ function grantOnlyPermissions(...allowed: string[]) {
 
 jest.mock('../pages/ApplicationsPage', () => ({
     ApplicationsPage: () => <div data-testid="applications-page" />,
+}));
+
+jest.mock('../pages/IntegrationsPage', () => ({
+    IntegrationsPage: () => <div data-testid="integrations-page" />,
 }));
 
 jest.mock('../pages/UsersPage', () => ({
@@ -263,6 +297,24 @@ jest.mock('../pages/EnvironmentNotificationSettingsPage', () => ({
     EnvironmentNotificationSettingsPage: () => <div data-testid="environment-notification-settings-page" />,
 }));
 
+function LocationProbe() {
+    return <div data-testid="location">{useLocation().pathname}</div>;
+}
+
+function NavigationTypeProbe() {
+    return <div data-testid="navigation-type">{useNavigationType()}</div>;
+}
+
+function renderIntegrationsUrl() {
+    render(
+        <MemoryRouter initialEntries={['/integrations']}>
+            <AppRoutes />
+            <LocationProbe />
+            <NavigationTypeProbe />
+        </MemoryRouter>,
+    );
+}
+
 function renderPlatform(path = '/applications') {
     render(
         <MemoryRouter initialEntries={[path]}>
@@ -271,7 +323,7 @@ function renderPlatform(path = '/applications') {
     );
 }
 
-type NavGroupProps = { items: { key: string; access?: string }[] };
+type NavGroupProps = { label?: string; items: { key: string; access?: string }[] };
 
 type LayoutConfig = {
     navigation?: { props?: { items?: { key: string; title: string }[]; onItemSelect?: (key: string) => void } };
@@ -315,6 +367,14 @@ function visibleNavKeys(): string[] {
     return contextGroups().flatMap(group => group.items.map(item => item.key));
 }
 
+function navGroupItemKeys(groupLabel: string): string[] {
+    return (
+        contextGroups()
+            .find(group => group.label === groupLabel)
+            ?.items.map(item => item.key) ?? []
+    );
+}
+
 function navItemAccess(key: string): string | undefined {
     return contextGroups()
         .flatMap(group => group.items)
@@ -340,6 +400,11 @@ describe('AppRoutes', () => {
         mockUseEnvironmentPermissionsReady.mockReturnValue(true);
         mockPermissionListeners.clear();
         mockPermissionStoreVersion = 0;
+        mockLicenseListeners.clear();
+        // Null on both stores is what the host reports before it pushes anything: entitlement stays
+        // unknown until a license lands, and null settings are ConsoleSettingsProvider's pre-fetch value.
+        mockLicense = null;
+        mockUseConsoleSettings.mockReset().mockReturnValue(null);
         // The denial store is module state; a switch to an unused environment id clears it.
         resetDeniedNavItemsForEnvironment(`reset-${(deniedNavItemResetCount += 1)}`);
         mockUseEnvironmentDictionaries.mockReturnValue({
@@ -420,6 +485,255 @@ describe('AppRoutes', () => {
         );
 
         expect(screen.getByTestId('role-members-page')).not.toBeNull();
+    });
+
+    it('routes a direct Integrations URL visit to the Integrations page without redirecting', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        render(
+            <MemoryRouter initialEntries={['/integrations']}>
+                <AppRoutes />
+                <LocationProbe />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('integrations-page')).not.toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/integrations');
+    });
+
+    it('shows the Integrations nav item next to Applications when the gate passes with no integrations configured', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderPlatform();
+
+        expect(navGroupItemKeys('APIs & Assets')).toEqual([
+            'applications',
+            'integrations',
+            'metadata',
+            'dictionaries',
+            'shared-policy-groups',
+        ]);
+        expect(navItemAccess('integrations')).toBeUndefined();
+    });
+
+    it('hides the Integrations nav item when Federation is not enabled for the organization', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: false } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('integrations');
+    });
+
+    it('hides the Integrations nav item when console settings carry no federation flag at all', () => {
+        mockUseConsoleSettings.mockReturnValue({});
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('integrations');
+    });
+
+    it('hides the Integrations nav item when the user lacks environment-integration-r', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        denyPermissions('environment-integration-r');
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('integrations');
+    });
+
+    it.each([
+        ['an oss-tier license', OSS_LICENSE],
+        ['an expired license', EXPIRED_LICENSE],
+        ['no license reported yet', null],
+    ])('hides the Integrations nav item entirely, not as a locked item, with %s', (_case, license) => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(license);
+
+        renderPlatform();
+
+        expect(visibleNavKeys()).not.toContain('integrations');
+    });
+
+    it('redirects a direct Integrations URL visit to Applications when the user lacks environment-integration-r', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        denyPermissions('environment-integration-r');
+
+        renderIntegrationsUrl();
+
+        expect(screen.queryByTestId('integrations-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/applications');
+        expect(screen.getByTestId('navigation-type').textContent).toBe('REPLACE');
+    });
+
+    it.each([
+        ['Federation is not enabled for the organization', { federation: { enabled: false } }, ENTITLED_LICENSE],
+        ['the installed license tier is oss', { federation: { enabled: true } }, OSS_LICENSE],
+        ['the license has expired', { federation: { enabled: true } }, EXPIRED_LICENSE],
+        ['no license has been reported yet', { federation: { enabled: true } }, null],
+    ])('redirects a direct Integrations URL visit to Applications when %s', (_case, consoleSettings, license) => {
+        mockUseConsoleSettings.mockReturnValue(consoleSettings);
+        mockSetLicense(license);
+
+        renderIntegrationsUrl();
+
+        expect(screen.queryByTestId('integrations-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/applications');
+        expect(screen.getByTestId('navigation-type').textContent).toBe('REPLACE');
+    });
+
+    it('redirects a refused Integrations visit to the landing item when the user cannot see Applications', () => {
+        grantOnlyPermissions('environment-integration-r', 'organization-settings-r', 'organization-tenant-r');
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: false } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderIntegrationsUrl();
+
+        expect(screen.queryByTestId('integrations-page')).toBeNull();
+        expect(screen.getByTestId('tenants-page')).not.toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/tenants');
+    });
+
+    it('lands on the Integrations page from the platform index when Integrations is the only visible item', () => {
+        grantOnlyPermissions('environment-integration-r');
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        render(
+            <MemoryRouter initialEntries={['/']}>
+                <AppRoutes />
+                <LocationProbe />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('location').textContent).toBe('/integrations');
+        expect(screen.getByTestId('integrations-page')).not.toBeNull();
+        expect(screen.queryByTestId('platform-no-access-page')).toBeNull();
+    });
+
+    it('warns once while Federation is enabled and no license has been reported', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+
+        renderPlatform();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
+    it('does not repeat the unreported-license warning across a re-render', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        renderPlatform();
+
+        act(() => {
+            emitPermissionChange();
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
+    it('does not warn a second time when the refused visit is to the Integrations route itself', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+
+        renderIntegrationsUrl();
+
+        expect(screen.queryByTestId('integrations-page')).toBeNull();
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
+    it.each([
+        ['the license tier is oss', { federation: { enabled: true } }, OSS_LICENSE],
+        ['the license has expired', { federation: { enabled: true } }, EXPIRED_LICENSE],
+        ['Federation is not enabled', { federation: { enabled: false } }, null],
+    ])('stays quiet when %s, which answers the entitlement question', (_case, consoleSettings, license) => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue(consoleSettings);
+        mockSetLicense(license);
+
+        renderPlatform();
+
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it('lands on the Integrations page when the Integrations nav item is selected', () => {
+        const navigateToKey = jest.fn();
+        mockUseModuleRouting.mockReturnValue({ activeNavKey: 'applications', navigateToKey, rootPath: '/platform' });
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        renderPlatform();
+        expect(visibleNavKeys()).toContain('integrations');
+
+        contextNav()?.props?.onItemSelect?.('integrations');
+
+        expect(navigateToKey).toHaveBeenCalledWith('integrations');
+        renderPlatform(`/${ROUTES.integrations.path}`);
+        expect(screen.getByTestId('integrations-page')).not.toBeNull();
+    });
+
+    it('surfaces no error notification while the Integrations gate runs without environment-integration-r', () => {
+        const notifyError = jest.spyOn(notify, 'error').mockImplementation(() => undefined);
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        denyPermissions('environment-integration-r');
+
+        renderPlatform();
+        renderIntegrationsUrl();
+
+        expect(notifyError).not.toHaveBeenCalled();
+        notifyError.mockRestore();
+    });
+
+    it('requests no integrations endpoint while deciding whether Integrations is available', () => {
+        const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response('[]'));
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        denyPermissions('environment-integration-r');
+
+        renderPlatform();
+        renderIntegrationsUrl();
+
+        const requestedUrls = fetchSpy.mock.calls.map(([input]) => String(input));
+        expect(requestedUrls.filter(url => /integration/i.test(url))).toEqual([]);
+        fetchSpy.mockRestore();
+    });
+
+    it('adds the Integrations nav item when the license lands after the first render', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        renderPlatform();
+        expect(visibleNavKeys()).not.toContain('integrations');
+
+        act(() => {
+            mockSetLicense(ENTITLED_LICENSE);
+        });
+
+        expect(visibleNavKeys()).toContain('integrations');
+    });
+
+    it('redirects off the Integrations page when the entitlement lapses while it is open', () => {
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+        renderIntegrationsUrl();
+        expect(screen.getByTestId('integrations-page')).not.toBeNull();
+
+        act(() => {
+            mockSetLicense(EXPIRED_LICENSE);
+        });
+
+        expect(screen.queryByTestId('integrations-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+        expect(screen.getByTestId('location').textContent).toBe('/applications');
     });
 
     it('shows Organization, Environment, and Team in the primary sidebar', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -22,7 +22,7 @@ import { AppRoutes } from './AppRoutes';
 import { ROUTES } from '../config/routes';
 import { useEnvironmentDictionaries } from '../features/dictionaries/hooks/useEnvironmentDictionaries';
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
-import { ApimApiError } from '../shared/api/apimClient';
+import { ApimApiError, resetApimClientForTests } from '../shared/api/apimClient';
 import { useEnvironmentPermissionsReady } from '../shared/hooks/useEnvironmentPermissions';
 import { markNavItemDenied, resetDeniedNavItemsForEnvironment } from '../shared/nav/deniedNavItems';
 import { notify } from '../shared/notify/notify';
@@ -145,9 +145,17 @@ jest.mock('../pages/ApplicationsPage', () => ({
     ApplicationsPage: () => <div data-testid="applications-page" />,
 }));
 
-jest.mock('../pages/IntegrationsPage', () => ({
-    IntegrationsPage: () => <div data-testid="integrations-page" />,
-}));
+// The routing assertions only need a marker, but the fetch assertions need the real page: its
+// useIntegrations hook is the only code in the module that ever calls the integrations endpoint, so a
+// permanently stubbed page would make "no integrations request happened" true no matter what the gate does.
+let mockUseRealIntegrationsPage = false;
+
+jest.mock('../pages/IntegrationsPage', () => {
+    const { IntegrationsPage: RealIntegrationsPage } = jest.requireActual<{ IntegrationsPage: ComponentType }>('../pages/IntegrationsPage');
+    return {
+        IntegrationsPage: () => (mockUseRealIntegrationsPage ? <RealIntegrationsPage /> : <div data-testid="integrations-page" />),
+    };
+});
 
 jest.mock('../pages/UsersPage', () => ({
     UsersPage: () => <div data-testid="users-page" />,
@@ -385,6 +393,39 @@ function primaryNavKeys(): string[] {
     return primaryNav()?.props?.items?.map(item => item.key) ?? [];
 }
 
+const APIM_BOOTSTRAP = {
+    managementBaseURL: 'https://apim.test/management',
+    gammaBaseURL: 'https://apim.test/gamma',
+    organizationId: 'org-1',
+};
+
+const NO_INTEGRATIONS_RESPONSE = {
+    data: [],
+    pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 },
+};
+
+const INTEGRATIONS_REQUEST_URL = 'https://apim.test/management/v2/environments/env-1/integrations?page=1&perPage=10';
+
+function jsonResponse(body: unknown) {
+    return Promise.resolve(new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } }));
+}
+
+// The API client resolves /constants.json then /ui/bootstrap before any environment-scoped call and caches
+// the result process-wide, so both have to answer here for an integrations request to be attempted at all.
+function spyOnApimFetch() {
+    resetApimClientForTests();
+    return jest.spyOn(global, 'fetch').mockImplementation(input => {
+        const url = String(input);
+        if (url.endsWith('/constants.json')) return jsonResponse({ gammaBaseURL: APIM_BOOTSTRAP.gammaBaseURL });
+        if (url.endsWith('/ui/bootstrap')) return jsonResponse(APIM_BOOTSTRAP);
+        return jsonResponse(NO_INTEGRATIONS_RESPONSE);
+    });
+}
+
+function integrationsRequestUrls(fetchSpy: ReturnType<typeof spyOnApimFetch>): string[] {
+    return fetchSpy.mock.calls.map(([input]) => String(input)).filter(url => /integration/i.test(url));
+}
+
 describe('AppRoutes', () => {
     beforeEach(() => {
         mockUseLayoutConfig.mockClear();
@@ -393,6 +434,7 @@ describe('AppRoutes', () => {
             navigateToKey: jest.fn(),
             rootPath: '/platform',
         });
+        mockUseRealIntegrationsPage = false;
         mockUseHasPermission.mockReset().mockReturnValue(true);
         mockUseHasFeature.mockReset().mockReturnValue(true);
         mockUseHasEnvironmentPermission.mockReset().mockReturnValue(true);
@@ -695,17 +737,33 @@ describe('AppRoutes', () => {
         notifyError.mockRestore();
     });
 
-    it('requests no integrations endpoint while deciding whether Integrations is available', () => {
-        const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(new Response('[]'));
+    it('requests no integrations endpoint while deciding whether Integrations is available', async () => {
+        mockUseRealIntegrationsPage = true;
+        const fetchSpy = spyOnApimFetch();
         mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
         mockSetLicense(ENTITLED_LICENSE);
         denyPermissions('environment-integration-r');
 
         renderPlatform();
         renderIntegrationsUrl();
+        await act(async () => {});
 
-        const requestedUrls = fetchSpy.mock.calls.map(([input]) => String(input));
-        expect(requestedUrls.filter(url => /integration/i.test(url))).toEqual([]);
+        expect(integrationsRequestUrls(fetchSpy)).toEqual([]);
+        fetchSpy.mockRestore();
+    });
+
+    // Positive control for the assertion above: it proves the real page does reach the endpoint, so an
+    // empty list there means the gate refused the route rather than that no fetch was ever reachable.
+    it('requests the integrations endpoint once the gate lets the Integrations page mount', async () => {
+        mockUseRealIntegrationsPage = true;
+        const fetchSpy = spyOnApimFetch();
+        mockUseConsoleSettings.mockReturnValue({ federation: { enabled: true } });
+        mockSetLicense(ENTITLED_LICENSE);
+
+        renderIntegrationsUrl();
+
+        expect(await screen.findByText('No integrations yet')).not.toBeNull();
+        expect(integrationsRequestUrls(fetchSpy)).toEqual([INTEGRATIONS_REQUEST_URL]);
         fetchSpy.mockRestore();
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -58,6 +58,7 @@ import { GatewayInstanceDetailLayout } from '../features/gateway-instances/compo
 import { useEnvironmentMetadata } from '../features/metadata/hooks/useEnvironmentMetadata';
 import { ORGANIZATION_ROLE_UPDATE_PERMISSION } from '../features/roles/utils/rolePermissionConstants';
 import { SecurityPlanTypesPage } from '../features/security-plan-types/SecurityPlanTypesPage';
+import { useIntegrationsAvailable, useIntegrationsEntitlementUnknown } from '../features/shared/hooks/useIntegrationsAvailable';
 import { usePermissionServiceSnapshot } from '../features/shared/hooks/usePermissionServiceSnapshot';
 import { SharedPolicyGroupDetailLayout } from '../features/shared-policy-groups/components/SharedPolicyGroupDetailLayout';
 import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/shared-policy-groups/utils/sharedPolicyGroupPermissions';
@@ -79,6 +80,7 @@ import { GatewayInstanceMonitoringPage } from '../pages/GatewayInstanceMonitorin
 import { GatewayInstancesPage } from '../pages/GatewayInstancesPage';
 import { GroupDetailPage } from '../pages/GroupDetailPage';
 import { GroupsPage } from '../pages/GroupsPage';
+import { IntegrationsPage } from '../pages/IntegrationsPage';
 import { ManagementAndSchedulersPage } from '../pages/ManagementAndSchedulersPage';
 import { MetadataPage } from '../pages/MetadataPage';
 import { NotificationTemplateDetailPage } from '../pages/NotificationTemplateDetailPage';
@@ -165,6 +167,16 @@ function PermissionPageGuard({
 function RequireAlertEngineLicense({ children }: { readonly children: ReactElement }) {
     const hasFeature = useHasFeature(ALERT_ENGINE_FEATURE);
     if (!hasFeature) {
+        return <UnauthorizedRedirect />;
+    }
+    return children;
+}
+
+// Sibling of the nav item's own availability check, reading the same predicate through the same hook:
+// the route and the sidebar have to agree, or the item is visible and the page bounces.
+function RequireIntegrationsAvailable({ children }: { readonly children: ReactElement }) {
+    const federationAvailable = useIntegrationsAvailable();
+    if (!federationAvailable) {
         return <UnauthorizedRedirect />;
     }
     return children;
@@ -290,6 +302,18 @@ function ModuleLayout() {
     const dictionariesQuery = useEnvironmentDictionaries({ enabled: canReadDictionariesPermission });
     const dictionariesForbidden = isForbiddenApiError(dictionariesQuery.isError, dictionariesQuery.error);
 
+    const federationAvailable = useIntegrationsAvailable();
+
+    // Denying on an unreported license hides a feature the organization may well be entitled to, and
+    // the host logs only that the license request failed, never what the denial cost. ModuleLayout
+    // mounts once per module session, so this warns once rather than once per Integrations visit.
+    const federationEntitlementUnknown = useIntegrationsEntitlementUnknown();
+    useEffect(() => {
+        if (federationEntitlementUnknown) {
+            console.warn('Organization license not loaded; hiding the Integrations nav item and route until entitlement is known');
+        }
+    }, [federationEntitlementUnknown]);
+
     const { activeNavKey, navigateToKey } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
     const hasAlertEngine = useHasFeature(ALERT_ENGINE_FEATURE);
     const hasAuditTrail = useHasFeature(APIM_AUDIT_TRAIL_FEATURE);
@@ -311,10 +335,11 @@ function ModuleLayout() {
             has: hasPermission,
             metadataForbidden,
             dictionariesForbidden,
+            federationAvailable,
             lockedItemKeys,
             deniedItemKeys: deniedNavItemKeys,
         }),
-        [deniedNavItemKeys, dictionariesForbidden, hasPermission, lockedItemKeys, metadataForbidden, permissionsReady],
+        [deniedNavItemKeys, dictionariesForbidden, federationAvailable, hasPermission, lockedItemKeys, metadataForbidden, permissionsReady],
     );
 
     const visibleNavSections = useMemo(
@@ -689,6 +714,16 @@ export function AppRoutes() {
                                 element={
                                     <NavPermissionGuard itemKey="security-plan-types">
                                         <SecurityPlanTypesPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
+                            <Route
+                                path="integrations"
+                                element={
+                                    <NavPermissionGuard itemKey="integrations">
+                                        <RequireIntegrationsAvailable>
+                                            <IntegrationsPage />
+                                        </RequireIntegrationsAvailable>
                                     </NavPermissionGuard>
                                 }
                             />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { License } from '@gravitee/gamma-modules-sdk/types';
+
 import { NAV_SECTIONS } from './navigation';
 import {
     firstVisibleNavItemKey,
+    isFederationAvailable,
     isNavItemVisible,
     landingNavItemKey,
     modulePathFor,
@@ -92,6 +95,8 @@ const ORGANIZATION_ADMIN = [
     'organization-user-d',
     'organization-notification_templates-r',
 ] as const;
+
+const ENTITLED_LICENSE: License = { tier: 'enterprise', packs: [], features: [], isExpired: false };
 
 function hasOf(granted: readonly string[]): (permission: string) => boolean {
     const set = new Set(granted);
@@ -208,6 +213,30 @@ describe('platform nav visibility', () => {
         expect(isNavItemVisible('access-management', visibility(['environment-am_configuration-r']))).toBe(true);
         expect(isNavItemVisible('access-management', visibility([...ORGANIZATION_USER, ...ENVIRONMENT_USER]))).toBe(false);
         expect(isNavItemVisible('access-management', visibility([...ORGANIZATION_USER, ...FEDERATION_AGENT]))).toBe(false);
+    });
+
+    it('shows Integrations for environment-integration-r when the federation availability gate passes', () => {
+        const entitled = visibility(['environment-integration-r'], { federationAvailable: true });
+
+        expect(isNavItemVisible('integrations', entitled)).toBe(true);
+        expect(visibleNavItemKeys(entitled)).toEqual(['integrations']);
+    });
+
+    it('hides Integrations without environment-integration-r even when the availability gate passes', () => {
+        const unpermitted = visibility([], { federationAvailable: true });
+
+        expect(isNavItemVisible('integrations', unpermitted)).toBe(false);
+        expect(visibleNavItemKeys(unpermitted)).not.toContain('integrations');
+    });
+
+    it('gates Integrations on environment-integration-r without the org settings gate', () => {
+        expect(requiresOrganizationSettingsGate('integrations')).toBe(false);
+        expect(pageGuardForNavItem('integrations')).toEqual({ anyOf: ['environment-integration-r'] });
+    });
+
+    it('withholds Federation availability until a license is reported', () => {
+        expect(isFederationAvailable({ federationEnabled: true, license: null })).toBe(false);
+        expect(isFederationAvailable({ federationEnabled: true, license: ENTITLED_LICENSE })).toBe(true);
     });
 
     it('hides Management, CORS, and SMTP when the user has organization-settings-u without -r', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { License } from '@gravitee/gamma-modules-sdk/types';
+
 import { filterNavSections, firstNavItemKey, NAV_SECTIONS, type PlatformNavSection } from './navigation';
 import { DEFAULT_ROUTE_KEY, ROUTE_KEYS } from './routes';
 import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
@@ -29,6 +31,7 @@ export const ORGANIZATION_SETTINGS_READ_PERMISSION = 'organization-settings-r' a
 export const ORGANIZATION_SETTINGS_GATE_PERMISSIONS = [ORGANIZATION_SETTINGS_READ_PERMISSION, 'organization-settings-u'] as const;
 
 export const ENVIRONMENT_APPLICATION_READ_PERMISSION = 'environment-application-r' as const;
+export const ENVIRONMENT_INTEGRATION_READ_PERMISSION = 'environment-integration-r' as const;
 export const ENVIRONMENT_AM_CONFIGURATION_READ_PERMISSION = 'environment-am_configuration-r' as const;
 export const ENVIRONMENT_SETTINGS_READ_PERMISSION = 'environment-settings-r' as const;
 export const ORGANIZATION_TAG_READ_PERMISSION = 'organization-tag-r' as const;
@@ -56,9 +59,11 @@ const ORGANIZATION_SETTINGS_GATED_ITEMS: ReadonlySet<string> = new Set([
  * after the org-settings outer gate (organization-navigation.service.ts). Gamma does
  * not also accept environment-tenant-r or environment-entrypoint-r for those items.
  *
- * Two deliberate divergences: Classic filters its org Audit item on license only, while
- * Gamma also requires `organization-audit-r`; and Access Management is environment-scoped
- * here, outside the org-settings gate, because it is Gamma-only.
+ * Three deliberate divergences: Classic filters its org Audit item on license only, while
+ * Gamma also requires `organization-audit-r`; Access Management is environment-scoped
+ * here, outside the org-settings gate, because it is Gamma-only; and Integrations, mapped to
+ * the same `environment-integration-r` Classic's side nav uses, is additionally hidden
+ * unless the caller reports Federation license availability.
  */
 export const NAV_ITEM_PERMISSIONS: Readonly<Record<string, readonly string[]>> = {
     tenants: [ORGANIZATION_TENANT_READ_PERMISSION],
@@ -72,6 +77,7 @@ export const NAV_ITEM_PERMISSIONS: Readonly<Record<string, readonly string[]>> =
     templates: [ORGANIZATION_NOTIFICATION_TEMPLATES_READ],
     'organization-audit': [ORGANIZATION_AUDIT_READ_PERMISSION],
     applications: [ENVIRONMENT_APPLICATION_READ_PERMISSION],
+    integrations: [ENVIRONMENT_INTEGRATION_READ_PERMISSION],
     metadata: ['environment-metadata-r'],
     dictionaries: ['environment-dictionary-r'],
     'shared-policy-groups': [ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION],
@@ -92,10 +98,42 @@ export interface NavVisibilityInput {
     readonly has: (permission: string) => boolean;
     readonly metadataForbidden?: boolean;
     readonly dictionariesForbidden?: boolean;
+    readonly federationAvailable?: boolean;
     /** Items shown but not enterable (missing license). Visible in the sidebar, never a landing target. */
     readonly lockedItemKeys?: readonly string[];
     /** Items a live 403 denied at runtime, whichever permission scope still grants them. */
     readonly deniedItemKeys?: ReadonlySet<string>;
+}
+
+/**
+ * The single source for `federationAvailable`, read by the nav item and by its route guard so a
+ * visible item can never lead to a route that bounces. Permission is not part of it: each side
+ * already applies that half through NAV_ITEM_PERMISSIONS / pageGuardForNavItem.
+ *
+ * A null license means the host has not reported one yet, not that none is installed — an
+ * installation without one reports `tier: 'oss'`. Granting on null would turn a license fetch that
+ * has not landed, or failed, into an entitlement.
+ *
+ * Expiry is a separate term because the backend's tier does not carry it: an expired enterprise
+ * license still reports `tier: 'enterprise'` (LicenseDomainService.isFederationFeatureAllowed).
+ */
+export function isFederationAvailable({
+    federationEnabled,
+    license,
+}: Readonly<{ federationEnabled: boolean; license: License | null }>): boolean {
+    if (!federationEnabled) {
+        return false;
+    }
+    if (license === null) {
+        return false;
+    }
+    if (license.isExpired) {
+        return false;
+    }
+    if (license.tier === 'oss') {
+        return false;
+    }
+    return true;
 }
 
 export function requiresOrganizationSettingsGate(itemKey: string): boolean {
@@ -144,6 +182,9 @@ export function isNavItemVisible(itemKey: string, visibility: NavVisibilityInput
         return false;
     }
     if (itemKey === 'dictionaries' && visibility.dictionariesForbidden) {
+        return false;
+    }
+    if (itemKey === 'integrations' && !visibility.federationAvailable) {
         return false;
     }
     return true;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -62,8 +62,14 @@ describe('platform navigation config', () => {
         expect(systemItems.find(item => item.key === 'templates')?.icon).toBe(FileTextIcon);
     });
 
-    it('places Applications, Metadata, Dictionaries, and Shared Policy Groups under Environment / APIs & Assets', () => {
-        expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries', 'shared-policy-groups']);
+    it('places Applications, Integrations, Metadata, Dictionaries, and Shared Policy Groups under Environment / APIs & Assets', () => {
+        expect(sectionKeys('Environment', 'APIs & Assets')).toEqual([
+            'applications',
+            'integrations',
+            'metadata',
+            'dictionaries',
+            'shared-policy-groups',
+        ]);
     });
 
     it('places Access Management, Gateways, Alerts, Notifications, Security Plan Types, and Audit under Environment / System & Security', () => {
@@ -138,6 +144,11 @@ describe('platform navigation config', () => {
 
         expect(findAlerts(lockNavItem([...NAV_SECTIONS], 'alerts', true))?.access).toBe('locked');
         expect(findAlerts(lockNavItem([...NAV_SECTIONS], 'alerts', false))?.access).toBeUndefined();
+    });
+
+    it('declares the integrations route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('integrations');
+        expect(ROUTES.integrations).toEqual({ path: 'integrations', label: 'Integrations' });
     });
 
     it('declares the users route in platform routing config', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -34,6 +34,7 @@ import {
     ShieldIcon,
     UsersIcon,
     UsersRoundIcon,
+    WaypointsIcon,
     WorkflowIcon,
 } from '@gravitee/graphene-core/icons';
 import type { ElementType } from 'react';
@@ -96,6 +97,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                 label: 'APIs & Assets',
                 items: [
                     { key: 'applications', title: ROUTES.applications.label, icon: AppWindowIcon },
+                    { key: 'integrations', title: ROUTES.integrations.label, icon: WaypointsIcon },
                     { key: 'metadata', title: ROUTES.metadata.label, icon: DatabaseIcon },
                     { key: 'dictionaries', title: ROUTES.dictionaries.label, icon: BookOpenIcon },
                     { key: 'shared-policy-groups', title: ROUTES['shared-policy-groups'].label, icon: LayersIcon },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -17,6 +17,7 @@ import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
 export const ROUTE_KEYS: readonly string[] = [
     'applications',
+    'integrations',
     'users',
     'groups',
     'roles',
@@ -46,6 +47,7 @@ export const DEFAULT_ROUTE_KEY: RouteKey = 'applications';
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     applications: { path: 'applications', label: 'Applications' },
+    integrations: { path: 'integrations', label: 'Integrations' },
     users: { path: 'users', label: 'Users' },
     groups: { path: 'groups', label: 'Groups' },
     roles: { path: 'roles', label: 'Roles' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationProviderLabel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationProviderLabel.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+import { hasProviderLabel, integrationProviderLabel, SUPPORTED_PROVIDER_TOKENS } from '../utils/providerLabels';
+
+export function IntegrationProviderLabel({ provider }: Readonly<{ provider: string }>) {
+    const unmappedProvider = hasProviderLabel(provider) ? undefined : provider;
+    useEffect(() => {
+        if (unmappedProvider) {
+            console.warn(
+                `Integration provider "${unmappedProvider}" is not one of ${SUPPORTED_PROVIDER_TOKENS.join(', ')}; rendering the raw provider key`,
+            );
+        }
+    }, [unmappedProvider]);
+
+    return <span className="text-sm">{integrationProviderLabel(provider)}</span>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationStatusBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationStatusBadge.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Badge } from '@gravitee/graphene-core';
+import { useEffect, type ComponentProps } from 'react';
+
+import type { IntegrationAgentStatus } from '../types/integration';
+
+const STATUS_CONFIG: Record<IntegrationAgentStatus, { label: string; variant: ComponentProps<typeof Badge>['variant'] }> = {
+    CONNECTED: { label: 'Connected', variant: 'success' },
+    DISCONNECTED: { label: 'Disconnected', variant: 'destructive' },
+};
+
+function statusConfig(agentStatus: IntegrationAgentStatus | undefined) {
+    return agentStatus && Object.prototype.hasOwnProperty.call(STATUS_CONFIG, agentStatus) ? STATUS_CONFIG[agentStatus] : undefined;
+}
+
+export function IntegrationStatusBadge({ agentStatus }: Readonly<{ agentStatus: IntegrationAgentStatus | undefined }>) {
+    const config = statusConfig(agentStatus);
+
+    const unrecognizedStatus = agentStatus && !config ? agentStatus : undefined;
+    useEffect(() => {
+        if (unrecognizedStatus) {
+            console.warn(
+                `Integration agent status "${unrecognizedStatus}" is not one of ${Object.keys(STATUS_CONFIG).join(', ')}; rendering an empty Status cell`,
+            );
+        }
+    }, [unrecognizedStatus]);
+
+    if (!config) {
+        return null;
+    }
+    return <Badge variant={config.variant}>{config.label}</Badge>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsEmptyState.tsx
@@ -14,28 +14,18 @@
  * limitations under the License.
  */
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
+import { DataTableEmptyState } from '@gravitee/graphene-core';
+import { PlugIcon } from '@gravitee/graphene-core/icons';
+
+export function IntegrationsEmptyState() {
+    return (
+        <div className="rounded-lg border">
+            <DataTableEmptyState
+                variant="first-use"
+                icon={<PlugIcon className="size-8" aria-hidden />}
+                title="No integrations yet"
+                description="Create an integration to start importing APIs and event streams from a 3rd-party provider."
+            />
+        </div>
+    );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsTable.spec.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dataTableHarness } from '@gravitee/graphene-core/testing';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+
+import { IntegrationsTable } from './IntegrationsTable';
+import type { Integration, IntegrationAgentStatus } from '../types/integration';
+import { TABLE_PAGE_SIZE_OPTIONS } from '../utils/paginationConstants';
+
+const INTEGRATIONS: Integration[] = [
+    { id: 'int-1', name: 'Acme Gateway', provider: 'aws-api-gateway' },
+    { id: 'int-2', name: 'Broker North', provider: 'solace' },
+    { id: 'int-3', name: 'Partner Apigee', provider: 'apigee' },
+];
+
+const PROVIDER_LABEL_BY_TOKEN: [token: string, label: string][] = [
+    ['A2A', 'A2A Protocol'],
+    ['aws-api-gateway', 'AWS API Gateway'],
+    ['solace', 'Solace'],
+    ['apigee', 'Apigee'],
+    ['azure-api-management', 'Azure API Management'],
+    ['ibm-api-connect', 'IBM API Connect'],
+    ['confluent-platform', 'Confluent Platform'],
+    ['mulesoft', 'MuleSoft'],
+    ['edge-stack', 'Edge Stack'],
+];
+const SUPPORTED_PROVIDER_TOKENS = PROVIDER_LABEL_BY_TOKEN.map(([token]) => token);
+const UNMAPPED_PROVIDER_TOKEN = 'kong';
+const OBJECT_PROTOTYPE_MEMBER_PROVIDER_TOKEN = 'constructor';
+// The v2 DTO declares agentStatus nullable, so the wire can send an explicit null that the optional field type cannot express.
+const WIRE_NULL_AGENT_STATUS = null as unknown as IntegrationAgentStatus;
+
+const A2A_INTEGRATIONS_WITHOUT_AGENT_STATUS: [description: string, integration: Integration][] = [
+    ['omits the agentStatus key', { id: 'int-a2a', name: 'Agent Bridge', provider: 'A2A' }],
+    ['sets agentStatus to undefined', { id: 'int-a2a', name: 'Agent Bridge', provider: 'A2A', agentStatus: undefined }],
+    ['sets agentStatus to null', { id: 'int-a2a', name: 'Agent Bridge', provider: 'A2A', agentStatus: WIRE_NULL_AGENT_STATUS }],
+];
+
+const PAGINATED_TOTAL_COUNT = 23;
+const PAGE_SIZES_AT_OR_ABOVE_TOTAL_COUNT = TABLE_PAGE_SIZE_OPTIONS.filter(size => size >= PAGINATED_TOTAL_COUNT);
+
+function renderTable(overrides: Partial<ComponentProps<typeof IntegrationsTable>> = {}) {
+    return render(
+        <IntegrationsTable
+            integrations={INTEGRATIONS}
+            totalCount={INTEGRATIONS.length}
+            page={1}
+            pageSize={10}
+            loading={false}
+            onPageChange={jest.fn()}
+            onPageSizeChange={jest.fn()}
+            {...overrides}
+        />,
+    );
+}
+
+function integrationsTable() {
+    return dataTableHarness({ within: screen.getByRole('region', { name: 'Integrations' }) });
+}
+
+describe('IntegrationsTable', () => {
+    beforeAll(() => {
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+    });
+
+    it('renders one row per integration', () => {
+        renderTable();
+
+        expect(integrationsTable().getRowCount()).toBe(INTEGRATIONS.length);
+    });
+
+    it('renders a row for every provider token, including one it has no label for', () => {
+        const integrations = [...SUPPORTED_PROVIDER_TOKENS, UNMAPPED_PROVIDER_TOKEN].map(provider => ({
+            id: `int-${provider}`,
+            name: `Integration ${provider}`,
+            provider,
+        }));
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        const names = integrationsTable()
+            .getRows()
+            .map(row => row.getCellText('Name'));
+
+        expect(names).toEqual(integrations.map(integration => integration.name));
+    });
+
+    it('renders exactly the Name, Provider and Status columns', () => {
+        renderTable();
+
+        expect(integrationsTable().getHeaders()).toEqual(['Name', 'Provider', 'Status']);
+    });
+
+    it("renders each integration's name in its own Name cell", () => {
+        renderTable();
+
+        const names = integrationsTable()
+            .getRows()
+            .map(row => row.getCellText('Name'));
+
+        expect(names).toEqual(['Acme Gateway', 'Broker North', 'Partner Apigee']);
+    });
+
+    it('renders every name as plain text, offering nothing to navigate into', () => {
+        renderTable();
+
+        const nameCells = integrationsTable()
+            .getRows()
+            .map(row => row.getCellElement('Name'));
+
+        expect(nameCells).toHaveLength(INTEGRATIONS.length);
+        nameCells.forEach(nameCell => {
+            expect(nameCell.querySelector('a, button, [role="link"], [role="button"]')).toBeNull();
+        });
+    });
+
+    it("renders each supported provider's display label in its own Provider cell", () => {
+        const integrations = PROVIDER_LABEL_BY_TOKEN.map(([provider]) => ({
+            id: `int-${provider}`,
+            name: `Integration ${provider}`,
+            provider,
+        }));
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        const labels = integrations.map(({ name }) => integrationsTable().getRow(name).getCellText('Provider'));
+
+        expect(labels).toEqual(PROVIDER_LABEL_BY_TOKEN.map(([, label]) => label));
+    });
+
+    it('renders the mapped label rather than the bare token in the Provider cell of an A2A integration', () => {
+        const integrations = [{ id: 'int-a2a', name: 'Agent Bridge', provider: 'A2A' }];
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        expect(integrationsTable().getRow('Agent Bridge').getCellText('Provider')).toBe('A2A Protocol');
+    });
+
+    it.each([UNMAPPED_PROVIDER_TOKEN, OBJECT_PROTOTYPE_MEMBER_PROVIDER_TOKEN])(
+        'falls back to the raw token in the Provider cell of %s, a token it has no label for',
+        provider => {
+            const integrations = [{ id: 'int-unmapped', name: 'Legacy Gateway', provider }];
+
+            renderTable({ integrations, totalCount: integrations.length });
+
+            expect(integrationsTable().getRow('Legacy Gateway').getCellText('Provider')).toBe(provider);
+        },
+    );
+
+    it.each([UNMAPPED_PROVIDER_TOKEN, OBJECT_PROTOTYPE_MEMBER_PROVIDER_TOKEN])(
+        'warns once, naming %s, rather than falling back to the raw token in the Provider cell in silence',
+        provider => {
+            const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+            const integrations = [{ id: 'int-unmapped', name: 'Legacy Gateway', provider }];
+
+            renderTable({ integrations, totalCount: integrations.length });
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining(provider));
+            warn.mockRestore();
+        },
+    );
+
+    it('stays quiet while every provider on screen is one it has a label for', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const integrations = SUPPORTED_PROVIDER_TOKENS.map(provider => ({
+            id: `int-${provider}`,
+            name: `Integration ${provider}`,
+            provider,
+        }));
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it.each([
+        ['CONNECTED', 'Connected'],
+        ['DISCONNECTED', 'Disconnected'],
+    ] as const)("renders agent status %s as a badge reading '%s' in that integration's Status cell", (agentStatus, label) => {
+        const integrations = [{ id: 'int-status', name: 'Status Bearer', provider: 'solace', agentStatus }];
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        const row = integrationsTable().getRow('Status Bearer');
+
+        expect(row.getCellElement('Status').querySelector('[data-slot="badge"]')?.textContent).toBe(label);
+        expect(row.getCellText('Status')).toBe(label);
+    });
+
+    it("derives each row's Status cell from that row's own agent status when both statuses are on screen", () => {
+        const integrations: Integration[] = [
+            { id: 'int-connected', name: 'Connected Bearer', provider: 'solace', agentStatus: 'CONNECTED' },
+            { id: 'int-disconnected', name: 'Disconnected Bearer', provider: 'apigee', agentStatus: 'DISCONNECTED' },
+        ];
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        expect(integrationsTable().getRow('Disconnected Bearer').getCellText('Status')).not.toContain('Connected');
+        expect(integrationsTable().getRow('Connected Bearer').getCellText('Status')).toBe('Connected');
+    });
+
+    it.each(A2A_INTEGRATIONS_WITHOUT_AGENT_STATUS)(
+        'renders an empty Status cell, and a row that is otherwise intact, for an A2A integration that %s',
+        (_description, integration) => {
+            renderTable({ integrations: [integration], totalCount: 1 });
+
+            const row = integrationsTable().getRow('Agent Bridge');
+
+            expect(row.getCellText('Status')).toBe('');
+            expect(row.getCellElement('Status').querySelector('[data-slot="badge"]')).toBeNull();
+            expect(row.getCellText('Name')).toBe('Agent Bridge');
+            expect(row.getCellText('Provider')).toBe('A2A Protocol');
+        },
+    );
+
+    it("leaves a status-less row's Status cell empty while its neighbors on both sides render badges", () => {
+        const integrations: Integration[] = [
+            { id: 'int-connected', name: 'Connected Bearer', provider: 'solace', agentStatus: 'CONNECTED' },
+            { id: 'int-a2a', name: 'Agent Bridge', provider: 'A2A' },
+            { id: 'int-disconnected', name: 'Disconnected Bearer', provider: 'apigee', agentStatus: 'DISCONNECTED' },
+        ];
+
+        renderTable({ integrations, totalCount: integrations.length });
+
+        const statusLessRow = integrationsTable().getRow('Agent Bridge');
+
+        expect(statusLessRow.getCellText('Status')).toBe('');
+        expect(statusLessRow.getCellElement('Status').querySelector('[data-slot="badge"]')).toBeNull();
+        expect(integrationsTable().getRow('Connected Bearer').getCellText('Status')).toBe('Connected');
+        expect(integrationsTable().getRow('Disconnected Bearer').getCellText('Status')).toBe('Disconnected');
+    });
+
+    it.each([
+        [3, 10],
+        [10, 10],
+    ])('hides pagination when totalCount %i fits within page size %i', (totalCount, pageSize) => {
+        renderTable({ totalCount, pageSize });
+
+        expect(screen.queryByRole('combobox', { name: 'Items per page' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Previous page' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Next page' })).toBeNull();
+    });
+
+    it.each(PAGE_SIZES_AT_OR_ABOVE_TOTAL_COUNT)(
+        'keeps the pagination footer reachable after page size %i is enlarged to at least the total count',
+        pageSize => {
+            renderTable({ totalCount: PAGINATED_TOTAL_COUNT, pageSize });
+
+            expect(screen.getByRole('combobox', { name: 'Items per page' }).textContent).toBe(String(pageSize));
+            expect(screen.getByRole('button', { name: 'Previous page' })).not.toBeNull();
+            expect(screen.getByRole('button', { name: 'Next page' })).not.toBeNull();
+        },
+    );
+
+    it('shows the current page size in the items per page control', () => {
+        renderTable({ totalCount: 23, pageSize: 10 });
+
+        expect(screen.getByRole('combobox', { name: 'Items per page' }).textContent).toBe('10');
+    });
+
+    it('shows the server-reported total in the result-count indicator', () => {
+        renderTable({ page: 1, pageSize: 10, totalCount: 23 });
+
+        expect(screen.getByText('1-10 of 23')).not.toBeNull();
+    });
+
+    it('navigates pages through the shared previous and next arrow buttons', () => {
+        renderTable({ page: 1, pageSize: 10, totalCount: 23 });
+
+        expect(screen.getByRole('button', { name: 'Previous page' }).hasAttribute('disabled')).toBe(true);
+        expect(screen.getByRole('button', { name: 'Next page' }).hasAttribute('disabled')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/components/IntegrationsTable.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataTable, type DataTableProps } from '@gravitee/graphene-core';
+
+import { IntegrationProviderLabel } from './IntegrationProviderLabel';
+import { IntegrationStatusBadge } from './IntegrationStatusBadge';
+import type { ColCell } from '../../../shared/utils/dataTableTypes';
+import type { Integration } from '../types/integration';
+import { SMALLEST_TABLE_PAGE_SIZE, TABLE_PAGE_SIZE_OPTIONS } from '../utils/paginationConstants';
+
+const COLUMNS: DataTableProps<Integration>['columns'] = [
+    {
+        id: 'name',
+        accessorKey: 'name',
+        enableSorting: false,
+        header: 'Name',
+        cell: ({ row }: ColCell<Integration>) => <span className="text-sm font-medium text-foreground">{row.original.name}</span>,
+    },
+    {
+        id: 'provider',
+        accessorKey: 'provider',
+        enableSorting: false,
+        header: 'Provider',
+        cell: ({ row }: ColCell<Integration>) => <IntegrationProviderLabel provider={row.original.provider} />,
+    },
+    {
+        id: 'status',
+        enableSorting: false,
+        header: 'Status',
+        cell: ({ row }: ColCell<Integration>) => <IntegrationStatusBadge agentStatus={row.original.agentStatus} />,
+    },
+];
+
+interface IntegrationsTableProps {
+    readonly integrations: Integration[];
+    readonly totalCount: number;
+    readonly page: number;
+    readonly pageSize: number;
+    readonly loading: boolean;
+    readonly onPageChange: (page: number) => void;
+    readonly onPageSizeChange: (size: number) => void;
+}
+
+export function IntegrationsTable({
+    integrations,
+    totalCount,
+    page,
+    pageSize,
+    loading,
+    onPageChange,
+    onPageSizeChange,
+}: IntegrationsTableProps) {
+    const pagination =
+        totalCount > SMALLEST_TABLE_PAGE_SIZE
+            ? {
+                  page,
+                  pageSize,
+                  totalCount,
+                  pageSizeOptions: [...TABLE_PAGE_SIZE_OPTIONS],
+                  onPageChange,
+                  onPageSizeChange: (size: number) => {
+                      onPageSizeChange(size);
+                      onPageChange(1);
+                  },
+              }
+            : undefined;
+
+    return (
+        <DataTable
+            aria-label="Integrations"
+            columns={COLUMNS}
+            data={integrations}
+            loading={loading}
+            skeletonCount={pageSize}
+            serverSide
+            pagination={pagination}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/hooks/useIntegrations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/hooks/useIntegrations.ts
@@ -14,28 +14,19 @@
  * limitations under the License.
  */
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { listIntegrations } from '../services/integrationList';
+import { integrationKeys } from '../utils/queryKeys';
+
+export function useIntegrations({ page, perPage }: { page: number; perPage: number }) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: integrationKeys.list(env?.id ?? '', page, perPage),
+        queryFn: () => listIntegrations(env!.id, { page, perPage }),
+        enabled: Boolean(env),
+        placeholderData: keepPreviousData,
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/services/integrationList.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/services/integrationList.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { listIntegrations } from './integrationList';
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV2: jest.fn(),
+}));
+
+const mockApimFetchJsonV2 = jest.mocked(apimFetchJsonV2);
+
+describe('integrations list service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV2.mockResolvedValue(undefined);
+    });
+
+    it('lists integrations for the environment with offset page and perPage parameters', async () => {
+        await listIntegrations('env-1', { page: 1, perPage: 10 });
+
+        expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/integrations?page=1&perPage=10');
+    });
+
+    it('carries no parameter other than page and perPage on any page', async () => {
+        await listIntegrations('env-1', { page: 1, perPage: 10 });
+        await listIntegrations('env-1', { page: 2, perPage: 25 });
+
+        const parameterNames = mockApimFetchJsonV2.mock.calls.map(([, path]) => [
+            ...new URLSearchParams(path.slice(path.indexOf('?'))).keys(),
+        ]);
+
+        expect(parameterNames).toEqual([
+            ['page', 'perPage'],
+            ['page', 'perPage'],
+        ]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/services/integrationList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/services/integrationList.ts
@@ -13,29 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { IntegrationsResponse } from '../types/integration';
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
+export async function listIntegrations(environmentId: string, params: { page: number; perPage: number }): Promise<IntegrationsResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('page', String(params.page));
+    searchParams.set('perPage', String(params.perPage));
+    return apimFetchJsonV2<IntegrationsResponse>(environmentId, `/integrations?${searchParams.toString()}`);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/types/integration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/types/integration.ts
@@ -13,29 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type IntegrationAgentStatus = 'CONNECTED' | 'DISCONNECTED';
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
+export interface Integration {
+    id: string;
+    name: string;
+    provider: string;
+    agentStatus?: IntegrationAgentStatus;
+}
+
+export interface IntegrationsPagination {
+    page: number;
+    perPage: number;
+    pageCount: number;
+    pageItemsCount: number;
+    totalCount: number;
+}
+
+export interface IntegrationsResponse {
+    data: Integration[];
+    pagination: IntegrationsPagination;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/paginationConstants.ts
@@ -14,28 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
-}
+export { SMALLEST_TABLE_PAGE_SIZE, TABLE_PAGE_SIZE_OPTIONS } from '../../../shared/utils/paginationConstants';
+
+export const DEFAULT_INTEGRATION_LIST_PAGE_SIZE = 10;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/providerLabels.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/providerLabels.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const PROVIDER_LABELS: Record<string, string> = {
+    A2A: 'A2A Protocol',
+    'aws-api-gateway': 'AWS API Gateway',
+    solace: 'Solace',
+    apigee: 'Apigee',
+    'azure-api-management': 'Azure API Management',
+    'ibm-api-connect': 'IBM API Connect',
+    'confluent-platform': 'Confluent Platform',
+    mulesoft: 'MuleSoft',
+    'edge-stack': 'Edge Stack',
+};
+
+export const SUPPORTED_PROVIDER_TOKENS: readonly string[] = Object.keys(PROVIDER_LABELS);
+
+export function hasProviderLabel(provider: string): boolean {
+    return Object.prototype.hasOwnProperty.call(PROVIDER_LABELS, provider);
+}
+
+export function integrationProviderLabel(provider: string): string {
+    return hasProviderLabel(provider) ? PROVIDER_LABELS[provider] : provider;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/integrations/utils/queryKeys.ts
@@ -14,28 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
- * Extend here when platform features need more org settings fields.
- */
-export interface ConsoleSettings {
-    userGroup?: {
-        required?: {
-            enabled?: boolean;
-        };
-    };
-    cloudHosted?: {
-        enabled?: boolean;
-    };
-    alert?: {
-        enabled?: boolean;
-    };
-    management?: {
-        systemRoleEdition?: {
-            enabled?: boolean;
-        };
-    };
-    federation?: {
-        enabled?: boolean;
-    };
-}
+export const integrationKeys = {
+    all: ['environment-integrations'] as const,
+    list: (envId: string, page: number, perPage: number) => [...integrationKeys.all, 'list', envId, page, perPage] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useIntegrationsAvailable.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useIntegrationsAvailable.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { licenseService } from '@gravitee/gamma-modules-sdk';
+import type { License } from '@gravitee/gamma-modules-sdk/types';
+import { useSyncExternalStore } from 'react';
+
+import { isFederationAvailable } from '../../../config/navVisibility';
+import { useConsoleSettings } from '../../../shared/console-settings';
+
+/** Re-renders when the host pushes a license into {@link licenseService}, which can land after first render. */
+function useIntegrationsGateInputs(): { readonly federationEnabled: boolean; readonly license: License | null } {
+    const license = useSyncExternalStore(
+        listener => licenseService.subscribe(listener),
+        () => licenseService.getSnapshot(),
+        () => licenseService.getSnapshot(),
+    );
+    const consoleSettings = useConsoleSettings();
+    return { federationEnabled: consoleSettings?.federation?.enabled === true, license };
+}
+
+export function useIntegrationsAvailable(): boolean {
+    return isFederationAvailable(useIntegrationsGateInputs());
+}
+
+/**
+ * The Federation license is switched on but no license has been reported, so the gate denies without
+ * knowing whether the organization is entitled — unlike an oss tier or an expired license, which are answers.
+ */
+export function useIntegrationsEntitlementUnknown(): boolean {
+    const { federationEnabled, license } = useIntegrationsGateInputs();
+    return federationEnabled && license === null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/users/utils/userTokenDisplay.spec.ts
@@ -43,7 +43,18 @@ describe('userTokenDisplay utilities', () => {
     });
 
     it('formats token timestamps for table display', () => {
-        expect(formatTokenTimestamp(undefined)).toBe('never');
-        expect(formatTokenTimestamp(Date.parse('2021-08-31T01:35:35.403Z'))).toMatch(/Aug 31, 2021|31 Aug 2021/);
+        const RealDateTimeFormat = Intl.DateTimeFormat;
+        const dtfSpy = jest
+            .spyOn(Intl, 'DateTimeFormat')
+            .mockImplementation(
+                (locale?: string | string[], options?: Intl.DateTimeFormatOptions) =>
+                    new RealDateTimeFormat(locale, { ...options, timeZone: 'UTC' }),
+            );
+        try {
+            expect(formatTokenTimestamp(undefined)).toBe('never');
+            expect(formatTokenTimestamp(Date.parse('2021-08-31T01:35:35.403Z'))).toMatch(/Aug 31, 2021|31 Aug 2021/);
+        } finally {
+            dtfSpy.mockRestore();
+        }
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/IntegrationsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/IntegrationsPage.spec.tsx
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { dataTableHarness } from '@gravitee/graphene-core/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IntegrationsPage } from './IntegrationsPage';
+import { listIntegrations } from '../features/integrations/services/integrationList';
+import type { IntegrationsResponse } from '../features/integrations/types/integration';
+import { DEFAULT_INTEGRATION_LIST_PAGE_SIZE, TABLE_PAGE_SIZE_OPTIONS } from '../features/integrations/utils/paginationConstants';
+import { notify } from '../shared/notify';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({ useEnvironment: jest.fn() }));
+jest.mock('../features/integrations/services/integrationList', () => ({ listIntegrations: jest.fn() }));
+jest.mock('../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockListIntegrations = jest.mocked(listIntegrations);
+const mockNotifyError = jest.mocked(notify.error);
+
+const EMPTY_RESPONSE: IntegrationsResponse = {
+    data: [],
+    pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 },
+};
+
+const SINGLE_PAGE_RESPONSE: IntegrationsResponse = {
+    data: [
+        { id: 'int-1', name: 'Acme Gateway', provider: 'aws-api-gateway' },
+        { id: 'int-2', name: 'Broker North', provider: 'solace' },
+        { id: 'int-3', name: 'Partner Apigee', provider: 'apigee' },
+    ],
+    pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 3, totalCount: 3 },
+};
+
+function pageOfIntegrations(page: number, names: string[]): IntegrationsResponse {
+    return {
+        data: names.map((name, index) => ({ id: `${name}-${index}`, name, provider: 'solace' })),
+        pagination: { page, perPage: 10, pageCount: 3, pageItemsCount: names.length, totalCount: 23 },
+    };
+}
+
+function integrationsTable() {
+    return dataTableHarness({ within: screen.getByRole('region', { name: 'Integrations' }) });
+}
+
+function singlePageNamed(name: string): IntegrationsResponse {
+    return {
+        data: [{ id: `${name}-1`, name, provider: 'solace' }],
+        pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+    };
+}
+
+function renderIntegrationsPage(queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+    return render(<IntegrationsPage />, {
+        wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+    });
+}
+
+describe('IntegrationsPage', () => {
+    beforeAll(() => {
+        global.ResizeObserver = class ResizeObserver {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as typeof ResizeObserver;
+
+        Element.prototype.hasPointerCapture = jest.fn();
+        Element.prototype.setPointerCapture = jest.fn();
+        Element.prototype.releasePointerCapture = jest.fn();
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    beforeEach(() => {
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' });
+        mockListIntegrations.mockResolvedValue(EMPTY_RESPONSE);
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('requests the first page of integrations for the current environment', async () => {
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(mockListIntegrations).toHaveBeenCalledTimes(1));
+        expect(mockListIntegrations).toHaveBeenCalledWith('env-1', { page: 1, perPage: 10 });
+    });
+
+    it('renders one row per integration returned for the page', async () => {
+        mockListIntegrations.mockResolvedValue(SINGLE_PAGE_RESPONSE);
+
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(integrationsTable().getRowCount()).toBe(SINGLE_PAGE_RESPONSE.data.length));
+    });
+
+    it('replaces the rows with the next page when the user advances the page', async () => {
+        mockListIntegrations.mockImplementation((_environmentId, { page }) =>
+            Promise.resolve(page === 1 ? pageOfIntegrations(1, ['Alpha', 'Bravo']) : pageOfIntegrations(2, ['Charlie', 'Delta'])),
+        );
+
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(integrationsTable().queryRow('Alpha')).not.toBeNull());
+
+        await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+        await waitFor(() => expect(mockListIntegrations).toHaveBeenCalledWith('env-1', { page: 2, perPage: 10 }));
+        await waitFor(() => expect(integrationsTable().queryRow('Charlie')).not.toBeNull());
+        expect(integrationsTable().queryRow('Delta')).not.toBeNull();
+        expect(integrationsTable().queryRow('Alpha')).toBeNull();
+        expect(integrationsTable().queryRow('Bravo')).toBeNull();
+    });
+
+    it('returns to the first page when the user changes the page size', async () => {
+        mockListIntegrations.mockImplementation((_environmentId, { page }) =>
+            Promise.resolve(pageOfIntegrations(page, page === 1 ? ['Alpha', 'Bravo'] : ['Charlie', 'Delta'])),
+        );
+
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(integrationsTable().queryRow('Alpha')).not.toBeNull());
+        await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+        await waitFor(() => expect(mockListIntegrations).toHaveBeenCalledWith('env-1', { page: 2, perPage: 10 }));
+
+        await userEvent.click(screen.getByRole('combobox', { name: 'Items per page' }));
+        await userEvent.click(screen.getByRole('option', { name: '25' }));
+
+        await waitFor(() => expect(mockListIntegrations).toHaveBeenCalledWith('env-1', { page: 1, perPage: 25 }));
+        expect(mockListIntegrations).not.toHaveBeenCalledWith('env-1', { page: 2, perPage: 25 });
+    });
+
+    it('selects the default integration list page size in the items per page control', async () => {
+        const totalCountExceedingEveryPageSize = Math.max(...TABLE_PAGE_SIZE_OPTIONS) + 1;
+        mockListIntegrations.mockResolvedValue({
+            data: [{ id: 'int-1', name: 'Acme Gateway', provider: 'solace' }],
+            pagination: {
+                page: 1,
+                perPage: DEFAULT_INTEGRATION_LIST_PAGE_SIZE,
+                pageCount: 2,
+                pageItemsCount: 1,
+                totalCount: totalCountExceedingEveryPageSize,
+            },
+        });
+
+        renderIntegrationsPage();
+
+        await waitFor(() =>
+            expect(screen.getByRole('combobox', { name: 'Items per page' }).textContent).toBe(String(DEFAULT_INTEGRATION_LIST_PAGE_SIZE)),
+        );
+    });
+
+    it('issues no request until an environment is resolved', async () => {
+        mockUseEnvironment.mockReturnValue(undefined);
+
+        renderIntegrationsPage();
+        await act(async () => {});
+
+        expect(mockListIntegrations).not.toHaveBeenCalled();
+    });
+
+    it('refetches instead of reusing the cached page when the environment changes', async () => {
+        mockListIntegrations.mockImplementation(environmentId =>
+            Promise.resolve(singlePageNamed(environmentId === 'env-1' ? 'Env One Gateway' : 'Env Two Gateway')),
+        );
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+        const { rerender } = renderIntegrationsPage(queryClient);
+
+        await waitFor(() => expect(integrationsTable().queryRow('Env One Gateway')).not.toBeNull());
+
+        mockUseEnvironment.mockReturnValue({ id: 'env-2' });
+        rerender(<IntegrationsPage />);
+
+        await waitFor(() => expect(integrationsTable().queryRow('Env Two Gateway')).not.toBeNull());
+        expect(integrationsTable().queryRow('Env One Gateway')).toBeNull();
+        expect(mockListIntegrations).toHaveBeenCalledWith('env-2', { page: 1, perPage: 10 });
+    });
+
+    it('replaces the table with the empty state when the environment has no integrations', async () => {
+        renderIntegrationsPage();
+
+        expect(await screen.findByText('No integrations yet')).not.toBeNull();
+        expect(
+            screen.getByText('Create an integration to start importing APIs and event streams from a 3rd-party provider.'),
+        ).not.toBeNull();
+        expect(screen.queryByRole('region', { name: 'Integrations' })).toBeNull();
+        expect(screen.getByRole('heading', { name: 'Integrations' })).not.toBeNull();
+        expect(screen.queryByText('Integrations could not be loaded. Please refresh and try again.')).toBeNull();
+        expect(mockNotifyError).not.toHaveBeenCalled();
+    });
+
+    it('keeps the empty state off the screen while the first page is still loading', () => {
+        mockListIntegrations.mockReturnValue(new Promise(() => {}));
+
+        renderIntegrationsPage();
+
+        expect(screen.queryByText('No integrations yet')).toBeNull();
+        expect(screen.getByRole('region', { name: 'Integrations' })).not.toBeNull();
+    });
+
+    it('raises a single error toast carrying the failure when the integrations request fails', async () => {
+        const failure = new Error('integrations unavailable');
+        mockListIntegrations.mockRejectedValue(failure);
+
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(mockNotifyError).toHaveBeenCalledWith(failure, expect.stringMatching(/\S/)));
+        expect(mockNotifyError).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the table with an inline error region when the integrations request fails', async () => {
+        mockListIntegrations.mockRejectedValue(new Error('integrations unavailable'));
+
+        renderIntegrationsPage();
+
+        expect(await screen.findByText('Integrations could not be loaded. Please refresh and try again.')).not.toBeNull();
+        expect(screen.queryByRole('region', { name: 'Integrations' })).toBeNull();
+    });
+
+    it('keeps the page header on screen when the integrations request fails', async () => {
+        mockListIntegrations.mockRejectedValue(new Error('integrations unavailable'));
+
+        renderIntegrationsPage();
+
+        expect(await screen.findByText('Integrations could not be loaded. Please refresh and try again.')).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Integrations' })).not.toBeNull();
+        expect(
+            screen.getByText(
+                'Connect to third-party API gateways and event brokers to create a unified control plane and API portal with Gravitee.',
+            ),
+        ).not.toBeNull();
+    });
+
+    it('keeps the empty state off the screen when the integrations request fails', async () => {
+        mockListIntegrations.mockRejectedValue(new Error('integrations unavailable'));
+
+        renderIntegrationsPage();
+
+        await waitFor(() => expect(mockNotifyError).toHaveBeenCalled());
+        expect(screen.queryByText('No integrations yet')).toBeNull();
+        expect(screen.queryByText('Create an integration to start importing APIs and event streams from a 3rd-party provider.')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/IntegrationsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/IntegrationsPage.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { IntegrationsEmptyState } from '../features/integrations/components/IntegrationsEmptyState';
+import { IntegrationsTable } from '../features/integrations/components/IntegrationsTable';
+import { useIntegrations } from '../features/integrations/hooks/useIntegrations';
+import { DEFAULT_INTEGRATION_LIST_PAGE_SIZE } from '../features/integrations/utils/paginationConstants';
+import { notify } from '../shared/notify';
+
+export function IntegrationsPage() {
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(DEFAULT_INTEGRATION_LIST_PAGE_SIZE);
+
+    const { data, isLoading, isError, error } = useIntegrations({ page, perPage });
+
+    const integrations = data?.data ?? [];
+    const totalCount = data?.pagination.totalCount ?? 0;
+
+    useEffect(() => {
+        if (!isError) return;
+        notify.error(error, 'Integrations could not be loaded. Please refresh and try again.');
+    }, [error, isError]);
+
+    function renderContent() {
+        if (isError) {
+            return (
+                <div className="flex items-center justify-center p-8">
+                    <p className="text-sm text-muted-foreground">Integrations could not be loaded. Please refresh and try again.</p>
+                </div>
+            );
+        }
+
+        if (!isLoading && totalCount === 0) {
+            return <IntegrationsEmptyState />;
+        }
+
+        return (
+            <IntegrationsTable
+                integrations={integrations}
+                totalCount={totalCount}
+                page={page}
+                pageSize={perPage}
+                loading={isLoading}
+                onPageChange={setPage}
+                onPageSizeChange={setPerPage}
+            />
+        );
+    }
+
+    return (
+        <div className="space-y-6" data-testid="integrations-page">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Integrations</h1>
+                <p className="text-sm text-muted-foreground">
+                    Connect to third-party API gateways and event brokers to create a unified control plane and API portal with Gravitee.
+                </p>
+            </div>
+
+            {renderContent()}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
@@ -22,7 +22,7 @@
  * Permission stubs default to granted so feature tests render normally.
  * To test denied states, mock `useHasPermission` or `permissionService` per-test.
  */
-import type { PermissionCheck } from '@gravitee/gamma-modules-sdk/types';
+import type { License, PermissionCheck } from '@gravitee/gamma-modules-sdk/types';
 import type { ReactNode } from 'react';
 
 // ─── License ──────────────────────────────────────────────────────────────────
@@ -32,14 +32,14 @@ export const useHasFeature = (_feature: string): boolean => true;
 
 export const licenseService = {
     setLicense: (_license: unknown): void => {},
-    getLicense: (): null => null,
+    getLicense: (): License | null => null,
     hasFeature: (_feature: string): boolean => true,
     hasPack: (_pack: string): boolean => true,
     isExpired: (): boolean => false,
     subscribe:
         (_listener: () => void): (() => void) =>
         () => {},
-    getSnapshot: (): null => null,
+    getSnapshot: (): License | null => null,
 };
 
 // ─── Permissions ──────────────────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/paginationConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/paginationConstants.ts
@@ -16,3 +16,5 @@
 
 /** Shared page-size options for DataTable pagination (UI-COMP-12). */
 export const TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
+
+export const SMALLEST_TABLE_PAGE_SIZE: number = Math.min(...TABLE_PAGE_SIZE_OPTIONS);


### PR DESCRIPTION
## Issue

[AIAM-469](https://gravitee.atlassian.net/browse/AIAM-469)

## Purpose

Environment administrators with access to Federation currently have no place in the Gamma Platform module to review their organization's configured Integrations. This PR adds the foundation screen for the Federation Integrations experience being ported from Classic APIM: a nav entry and a list of configured integrations (name, provider, connection status), gated so it is completely invisible — not just disabled — to users and license plans that aren't entitled to it. Creating an integration, viewing its details, and running discovery are later, separate pieces of work that build on this list.

## Summary of changes

- Add an "Integrations" nav item to the Gamma Platform module's Environment → "APIs & Assets" group, next to "Applications". Visibility is gated on three independent conditions: Federation enabled for the org, a Federation-entitled license tier, and the `environment-integration-r` permission — absent (not disabled) if any is unmet.
- Route the Integrations URL behind the same availability gate: a direct visit redirects to Applications (or the user's landing item) when any gate condition fails, and renders the Integrations list when all are met.
- Add the Integrations list screen: a table with Name, Provider, and Status columns, backed by a new `integrationList` service/query hook, with pagination (10 per page, matching the existing `ApiListTable` pattern) and an empty state ("No integrations yet") when none are configured. Load failures surface via the existing `notify.error` toast convention rather than a silent empty list.
- Add a connection-status badge component that renders "Connected" or "Disconnected" from the integration's `agentStatus`, leaving the cell empty for providers (e.g. A2A) that never report one.
- Fix a pre-existing flaky test in `userTokenDisplay.spec.ts` that depended on the runner's local timezone offset, by mocking `Intl.DateTimeFormat` to force UTC.

### Behaviour changes

- New "Integrations" nav item and list screen, visible only to entitled users/orgs as described above.
- Direct navigation to the Integrations URL now redirects (rather than 404s or renders) when the user isn't entitled.

## Docs Notes

- New "Integrations" nav item in Gamma Platform → Environment → APIs & Assets, next to Applications — visible only when Federation is enabled for the org, the license tier is Federation-entitled, and the user has ENVIRONMENT_INTEGRATION READ permission; absent otherwise (not disabled/upsold).
- New Integrations list screen at the Integrations route: columns Name, Provider, Status (Connected/Disconnected badge); paginates at 10/page; empty state titled "No integrations yet" when none configured.
- No new or changed REST endpoints — reuses the existing `GET /organizations/{orgId}/console` `federation.enabled` flag and the existing Integrations read endpoint.

## Out of scope

- Creating an integration, viewing an integration's details, and running discovery — separate follow-up stories under the parent epic.

## Related PRs / tickets

- Parent epic: AIAM-259 — [Parity] Federation Integrations page & functionality

## Known Issues

- [test-coverage] `navVisibility.ts:199` / `AppRoutes.tsx:218` — no test proves the platform index lands on `/integrations` when Integrations is the user's only visible nav item (pre-existing gap, outside this branch's diff).
- [test-coverage] `IntegrationStatusBadge.tsx:27,31` — the "unrecognized agent status" `console.warn` branch is intentionally left untested; ruled unreachable/out-of-scope during review (no AC covers it, and it requires a deliberate type cast to trigger).
- `features/metadata/components/MetadataDeleteSheet.spec.tsx` — suite-level flake from cross-suite state leakage; unrelated to this branch (all 5 of its own tests pass in isolation).
- `gravitee-gamma-module-platform` (Java side) — pre-existing compile failures in `AmSdkClientFactoryTest`/`AmSdkConnectionTesterTest`/`AmSdkDirectoryClientTest` against outdated constructor signatures; unrelated to this branch (touches zero `.java` files).


[AIAM-469]: https://gravitee.atlassian.net/browse/AIAM-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
