### PR TITLE
fix(gateway): fail websocket writes on a closed connection

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocket.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocket.java
@@ -75,7 +75,7 @@ public class VertxWebSocket implements WebSocket {
             return webSocket.rxWrite(BufferInternal.buffer(buffer.getNativeBuffer()));
         }
 
-        return Completable.complete();
+        return closedOrComplete();
     }
 
     @Override
@@ -83,7 +83,7 @@ public class VertxWebSocket implements WebSocket {
         if (isValid()) {
             return webSocket.writePing(BufferInternal.buffer("ping_pong"));
         }
-        return Completable.complete();
+        return closedOrComplete();
     }
 
     public Completable writeFrame(io.gravitee.gateway.api.ws.WebSocketFrame frame) {
@@ -170,6 +170,17 @@ public class VertxWebSocket implements WebSocket {
 
     private boolean isValid() {
         return upgraded && !webSocket.isClosed();
+    }
+
+    /**
+     * Reporting a successful write on a websocket closed by the client makes the failure invisible to the caller: an
+     * async entrypoint keeps consuming from its endpoint and writing to nowhere, and its consumer is never released.
+     */
+    private Completable closedOrComplete() {
+        if (upgraded) {
+            return Completable.error(new HttpClosedException("WebSocket is closed"));
+        }
+        return Completable.complete();
     }
 
     private io.vertx.core.http.WebSocketFrame convert(io.gravitee.gateway.api.ws.WebSocketFrame frame) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocketTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocketTest.java
@@ -241,6 +241,17 @@ class VertxWebSocketTest {
             obs.assertComplete();
             verifyNoInteractions(webSocket);
         }
+
+        @Test
+        void should_fail_to_write_if_closed() {
+            ReflectionTestUtils.setField(cut, "upgraded", true);
+            ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+            when(webSocket.isClosed()).thenReturn(true);
+
+            final TestObserver<Void> obs = cut.write(io.gravitee.gateway.api.buffer.Buffer.buffer("test")).test();
+            obs.assertError(HttpClosedException.class);
+            verify(webSocket, never()).rxWrite(any(Buffer.class));
+        }
     }
 
     @Nested
@@ -304,6 +315,16 @@ class VertxWebSocketTest {
 
             cut.writePing().test().assertComplete();
             verifyNoInteractions(webSocket);
+        }
+
+        @Test
+        void should_fail_to_write_ping_frame_if_closed() {
+            ReflectionTestUtils.setField(cut, "upgraded", true);
+            ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+            when(webSocket.isClosed()).thenReturn(true);
+
+            cut.writePing().test().assertError(HttpClosedException.class);
+            verify(webSocket, never()).writePing(any(Buffer.class));
         }
     }
 


### PR DESCRIPTION
Fixes [APIM-15073](https://gravitee.atlassian.net/browse/APIM-15073).

## Problem

Closing a WebSocket connection did not release the Kafka consumer behind it. The consumer stayed in its group, kept polling, and kept committing offsets after the client was gone — so records produced afterwards were consumed by nobody, and every other client sharing that consumer group stopped receiving messages.

Reproduction: a v4 message API with a Kafka endpoint and both a WebSocket and an HTTP GET entrypoint, QoS `AUTO`. HTTP GET works; open and close a WebSocket; HTTP GET then returns nothing, while the consumer group offset still advances at the moment each message is published.

## Root cause

`VertxWebSocket.write(Buffer)` and `writePing()` returned `Completable.complete()` when the underlying socket was already closed, reporting success for a write that went nowhere.

An async entrypoint terminates its response pipeline only when the write flow or the heartbeat flow signals an error or completion. Both signals were silenced at once:

- the "successful" write kept the message stream alive, so it kept pulling records from the endpoint;
- that same write refreshed the last-frame timestamp, which suppressed the keep-alive ping — so the heartbeat, the one mechanism that would have noticed the dead connection, never fired either.

Nothing terminated, the endpoint `Flowable` was never cancelled, and the Kafka receiver was never disposed. QoS `AUTO` without the manual-ack capability consumes through `receiveAutoAck()`, so the orphaned consumer also committed the offsets it read.

## Change

`write()` and `writePing()` signal `HttpClosedException` when the socket has been upgraded and is closed. The entrypoint then tears down on the next write, or within one ping interval when the stream is idle, and the consumer is released.

Writing before the upgrade still completes, unchanged — there is no connection to fail against yet.

`writeFrame()` is deliberately left alone: it serves the legacy proxy path, which has its own close handling, and is not involved in this failure.

## Tests

Two tests in `VertxWebSocketTest` covering write and ping on an upgraded-then-closed socket.

Verified RED before the change — both failed with `No errors (… completions = 1)`, i.e. the write reported success on a closed socket. Green after. Full module: 146/146.

Also verified end-to-end in `gravitee-entrypoint-websocket` locally: with the pre-fix behaviour restored, the response message flow never completes and the consumer is never cancelled (`Not completed (latch = 1 …)`); with the fix, both terminate. Those entrypoint tests are not part of this PR — they live in the plugin repo.

## Backports

The defect is present on `master`, `4.12.x`, `4.11.x`, `4.10.x` and `4.9.x` — checked per branch against the actual source, all five carry the swallowing `write`/`writePing`. All five `apply-on-*` labels are set.

## Security-sensitive

None. No change to authentication, authorization, input parsing, redirects, secrets, or dependencies. The change makes a previously silent failure observable to the caller; it does not widen any surface.

[APIM-15073]: https://gravitee.atlassian.net/browse/APIM-15073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ