### PR TITLE
feat(rest-api): batch multi-API performance targets and fix HTTP method/path analytics filters

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/GroupedMeasuresQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/GroupedMeasuresQuery.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.query;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The same measures computed once per group of documents, in a single request. Each group is named by the caller
+ * and selects its documents with its own filters, on top of the query filters shared by every group; a group whose
+ * filters match no document still comes back, with no measure.
+ *
+ * @param groups the filters of each group, by group key; the insertion order is the order of the answer
+ */
+public record GroupedMeasuresQuery(
+    TimeRange timeRange,
+    List<Filter> filters,
+    List<MetricMeasuresQuery> metrics,
+    Map<String, List<Filter>> groups
+) implements Query {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/result/GroupedMeasuresResult.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/result/GroupedMeasuresResult.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.result;
+
+import java.util.Map;
+
+/**
+ * The measures of each group of a grouped measures query, by group key. A group that matched no document has every
+ * requested measure at zero, like an unfiltered measures query over an empty window.
+ */
+public record GroupedMeasuresResult(Map<String, MeasuresResult> groups) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -16,9 +16,11 @@
 package io.gravitee.repository.log.v4.api;
 
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
 import io.gravitee.repository.analytics.query.events.EventAnalyticsAggregate;
@@ -65,6 +67,12 @@ public interface AnalyticsRepository {
     Optional<EventAnalyticsAggregate> searchEventAnalytics(QueryContext queryContext, HistogramQuery query);
 
     MeasuresResult searchHTTPMeasures(QueryContext queryContext, MeasuresQuery query);
+
+    /**
+     * The same HTTP measures computed once per group of documents in a single request, each group selecting its
+     * documents with its own filters. Answers every requested group, with zeroed measures when nothing matched.
+     */
+    GroupedMeasuresResult searchHTTPGroupedMeasures(QueryContext queryContext, GroupedMeasuresQuery query);
 
     FacetsResult searchHTTPFacets(QueryContext queryContext, FacetsQuery query);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -18,10 +18,12 @@ package io.gravitee.repository.elasticsearch.v4.analytics;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
 import io.gravitee.repository.analytics.query.events.EventAnalyticsAggregate;
@@ -52,6 +54,8 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         new SearchResponseStatusOverTimeAdapter();
 
     private final HTTPMeasuresQueryAdapter httpMeasuresQueryAdapter = new HTTPMeasuresQueryAdapter();
+    private final HTTPGroupedMeasuresQueryAdapter httpGroupedMeasuresQueryAdapter = new HTTPGroupedMeasuresQueryAdapter();
+    private final GroupedMeasuresResponseAdapter groupedMeasuresResponseAdapter = new GroupedMeasuresResponseAdapter();
     private final HTTPFacetsQueryAdapter httpFacetsQueryAdapter = new HTTPFacetsQueryAdapter();
     private final NativeFacetsQueryAdapter nativeFacetsQueryAdapter = new NativeFacetsQueryAdapter();
     private final HTTPTimeSeriesQueryAdapter httpTimeSeriesQueryAdapter = new HTTPTimeSeriesQueryAdapter();
@@ -278,6 +282,19 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         return client
             .search(index, null, esQuery)
             .map(response -> measuresResponseAdapter.adapt(response, query))
+            .blockingGet();
+    }
+
+    @Override
+    public GroupedMeasuresResult searchHTTPGroupedMeasures(QueryContext queryContext, GroupedMeasuresQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+        var esQuery = httpGroupedMeasuresQueryAdapter.adapt(query);
+
+        log.debug("HTTP grouped measures query: {}", esQuery);
+
+        return client
+            .search(index, null, esQuery)
+            .map(response -> groupedMeasuresResponseAdapter.adapt(response, query))
             .blockingGet();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
@@ -27,7 +27,9 @@ import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
 import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetBucketResult;
+import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MetricFacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.MetricMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MetricTimeSeriesResult;
 import io.gravitee.repository.analytics.engine.api.result.TimeSeriesBucketResult;
 import java.util.ArrayList;
@@ -67,6 +69,16 @@ public class AggregationAdapter {
      */
     public static String adaptName(Metric metric, Measure measure) {
         return metric.name() + AGG_NAME_SEPARATOR + measure.name();
+    }
+
+    /** The measures of one bucket whose sub-aggregations are the metrics of {@code query}, zero for a metric it lacks. */
+    public static MeasuresResult toBucketMeasures(JsonNode bucket, Query query) {
+        var metricAndMeasures = toMetricsAndMeasures(toAggregations(bucket, adaptNames(query)), query);
+        var results = new ArrayList<MetricMeasuresResult>();
+        for (var metric : query.metrics()) {
+            results.add(new MetricMeasuresResult(metric.metric(), getMeasuresWithDefaults(metric.metric(), metricAndMeasures, query)));
+        }
+        return new MeasuresResult(results);
     }
 
     public static String adaptName(Metric metric, Facet facet) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.repository.analytics.engine.api.metric.Measure;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
@@ -184,7 +185,7 @@ public class AggregationAdapter {
 
             if (query.facets() != null && !query.facets().isEmpty()) {
                 var facets = new ArrayList<>(query.facets());
-                var facetBucketResults = toFacetBucketResults(metric, bucket, facets, aggNames, query.toFacetQuery());
+                var facetBucketResults = toFacetBucketResults(metric, bucket, null, facets, aggNames, query.toFacetQuery());
                 result.add(TimeSeriesBucketResult.ofBuckets(key, timestamp, facetBucketResults));
             } else {
                 var aggregations = toAggregations(bucket, aggNames);
@@ -197,9 +198,14 @@ public class AggregationAdapter {
         return result;
     }
 
+    /**
+     * @param bucketFacet the facet {@code bucket} belongs to; {@code null} for a date histogram bucket, whose key is
+     *                    never read here
+     */
     private static List<FacetBucketResult> toFacetBucketResults(
         Metric metric,
         JsonNode bucket,
+        Facet bucketFacet,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
@@ -208,8 +214,7 @@ public class AggregationAdapter {
             var aggregations = toAggregations(bucket, aggNames);
             var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
             var measures = getMeasuresWithDefaults(metric, metricAndMeasures, query);
-            var key = bucket.get(ES_KEY_PROP).asText();
-            return List.of(FacetBucketResult.ofMeasures(key, measures));
+            return List.of(FacetBucketResult.ofMeasures(bucketKey(bucketFacet, bucket), measures));
         }
 
         var nextFacets = new ArrayList<>(facets);
@@ -225,13 +230,12 @@ public class AggregationAdapter {
         var results = new ArrayList<FacetBucketResult>();
 
         for (var facetBucket : facetBuckets) {
-            var key = facetBucket.get(ES_KEY_PROP).asText();
-            var nestedResults = toFacetBucketResults(metric, facetBucket, new ArrayList<>(nextFacets), aggNames, query);
+            var nestedResults = toFacetBucketResults(metric, facetBucket, nextFacet, new ArrayList<>(nextFacets), aggNames, query);
 
             if (nextFacets.isEmpty()) {
                 results.addAll(nestedResults);
             } else {
-                results.add(FacetBucketResult.ofBuckets(key, nestedResults));
+                results.add(FacetBucketResult.ofBuckets(bucketKey(nextFacet, facetBucket), nestedResults));
             }
         }
 
@@ -251,19 +255,20 @@ public class AggregationAdapter {
         var agg = aggregations.get(aggName);
         var buckets = agg.getBuckets();
         for (var bucket : buckets) {
-            results.add(toFacetBucketResult(metric, bucket, facets, aggNames, query));
+            results.add(toFacetBucketResult(metric, facet, bucket, facets, aggNames, query));
         }
         return results;
     }
 
     private static FacetBucketResult toFacetBucketResult(
         Metric metric,
+        Facet facet,
         JsonNode bucket,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
     ) {
-        var key = bucket.get(ES_KEY_PROP).asText();
+        var key = bucketKey(facet, bucket);
         if (facets.isEmpty()) {
             var aggregations = toAggregations(bucket, aggNames);
             var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
@@ -275,12 +280,16 @@ public class AggregationAdapter {
         var nextAggName = adaptName(metric, nextFacet);
         var next = bucket.get(nextAggName);
         var buckets = next.get(ES_BUCKETS_PROP);
-        return FacetBucketResult.ofBuckets(key, toFacetBucketResults(metric, toBucketList(buckets), nextFacets, aggNames, query));
+        return FacetBucketResult.ofBuckets(
+            key,
+            toFacetBucketResults(metric, toBucketList(buckets), nextFacet, nextFacets, aggNames, query)
+        );
     }
 
     private static List<FacetBucketResult> toFacetBucketResults(
         Metric metric,
         List<JsonNode> buckets,
+        Facet bucketsFacet,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
@@ -288,11 +297,10 @@ public class AggregationAdapter {
         var results = new ArrayList<FacetBucketResult>();
         if (facets.isEmpty()) {
             for (var bucket : buckets) {
-                var key = bucket.get(ES_KEY_PROP).asText();
                 var aggregations = toAggregations(bucket, aggNames);
                 var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
                 var measures = getMeasuresWithDefaults(metric, metricAndMeasures, query);
-                results.add(FacetBucketResult.ofMeasures(key, measures));
+                results.add(FacetBucketResult.ofMeasures(bucketKey(bucketsFacet, bucket), measures));
             }
             return results;
         }
@@ -302,7 +310,7 @@ public class AggregationAdapter {
         var nextAggName = adaptName(metric, nextFacet);
 
         for (var bucket : buckets) {
-            var key = bucket.get(ES_KEY_PROP).asText();
+            var key = bucketKey(bucketsFacet, bucket);
             var next = bucket.get(nextAggName);
             if (next == null) {
                 continue;
@@ -311,12 +319,21 @@ public class AggregationAdapter {
             results.add(
                 FacetBucketResult.ofBuckets(
                     key,
-                    toFacetBucketResults(metric, toBucketList(nextBuckets), new ArrayList<>(nextFacets), aggNames, query)
+                    toFacetBucketResults(metric, toBucketList(nextBuckets), nextFacet, new ArrayList<>(nextFacets), aggNames, query)
                 )
             );
         }
 
         return results;
+    }
+
+    /** The gateway reports the HTTP method as its {@link HttpMethod#code()}; the catalog names it. */
+    private static String bucketKey(Facet facet, JsonNode bucket) {
+        var key = bucket.get(ES_KEY_PROP);
+        if (facet == Facet.HTTP_METHOD && key.canConvertToInt()) {
+            return ofNullable(HttpMethod.get(key.asInt())).map(HttpMethod::name).orElseGet(key::asText);
+        }
+        return key.asText();
     }
 
     private static Map<String, Aggregation> toAggregations(JsonNode bucket, List<String> aggNames) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
 import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.api.FieldResolver;
@@ -22,6 +23,7 @@ import io.gravitee.repository.elasticsearch.v4.shared.StatusCodeGroups;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
@@ -305,6 +307,9 @@ public class FilterAdapter {
         if (filter.name() == Filter.Name.HTTP_STATUS_CODE_GROUP) {
             return statusCodeGroupFilter(filter);
         }
+        if (filter.name() == Filter.Name.HTTP_METHOD) {
+            return httpMethodFilter(filter);
+        }
         if (filter.operator() == Filter.Operator.GTE || filter.operator() == Filter.Operator.LTE) {
             return rangeFilter(filter);
         }
@@ -325,6 +330,34 @@ public class FilterAdapter {
             case IN -> StatusCodeGroups.shouldForGroups(field, (Collection<String>) filter.value());
             default -> throw new IllegalArgumentException("Unsupported operator for HTTP_STATUS_CODE_GROUP filter: " + filter.operator());
         };
+    }
+
+    /** The catalog offers method names, the gateway reports the method as its {@link HttpMethod#code()}. */
+    private JsonObject httpMethodFilter(Filter filter) {
+        var field = fieldResolver.fromFilter(filter);
+        return switch (filter.operator()) {
+            case EQ -> JsonObject.of("term", JsonObject.of(field, httpMethodCode(filter.value())));
+            case IN -> JsonObject.of(
+                "terms",
+                JsonObject.of(field, new JsonArray(values(filter.value()).map(FilterAdapter::httpMethodCode).toList()))
+            );
+            default -> throw new IllegalArgumentException("Unsupported operator for HTTP_METHOD filter: " + filter.operator());
+        };
+    }
+
+    private static int httpMethodCode(Object value) {
+        if (value instanceof Number code) {
+            return code.intValue();
+        }
+        try {
+            return HttpMethod.valueOf(String.valueOf(value).toUpperCase(Locale.ROOT)).code();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown HTTP method: " + value, e);
+        }
+    }
+
+    private static Stream<?> values(Object value) {
+        return Objects.requireNonNull(value) instanceof Collection<?> collection ? collection.stream() : Stream.of(value);
     }
 
     private String filterName(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/GroupedMeasuresResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/GroupedMeasuresResponseAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
+import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/** Reads one measures result per group bucket; a group Elasticsearch did not answer gets the zeroed measures. */
+public class GroupedMeasuresResponseAdapter extends AbstractResponseAdapter {
+
+    private final MeasuresResponseAdapter measuresResponseAdapter = new MeasuresResponseAdapter();
+
+    public GroupedMeasuresResult adapt(SearchResponse esResponse, GroupedMeasuresQuery query) {
+        var buckets = lookupForAggregations(esResponse)
+            .map(aggregations -> aggregations.get(HTTPGroupedMeasuresQueryAdapter.GROUPS_AGG_NAME))
+            .map(Aggregation::getBuckets)
+            .orElse(List.of());
+        var answered = new HashMap<String, MeasuresResult>();
+        for (var bucket : buckets) {
+            answered.put(bucket.get(AggregationAdapter.ES_KEY_PROP).asText(), AggregationAdapter.toBucketMeasures(bucket, query));
+        }
+        var empty = measuresResponseAdapter.empty(new MeasuresQuery(query.timeRange(), query.filters(), query.metrics()));
+        var groups = new LinkedHashMap<String, MeasuresResult>();
+        for (var key : query.groups().keySet()) {
+            groups.put(key, answered.getOrDefault(key, empty));
+        }
+        return new GroupedMeasuresResult(groups);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
@@ -58,7 +58,8 @@ public class HTTPFieldResolver implements FieldResolver {
             case Filter.Name.ZONE -> "zone";
             case Filter.Name.HTTP_METHOD -> "http-method";
             case Filter.Name.HTTP_STATUS_CODE_GROUP, HTTP_STATUS -> "status";
-            case Filter.Name.HTTP_PATH -> "path";
+            // the gateway reports the path after the context path as path-info; `path` is declared but never written
+            case Filter.Name.HTTP_PATH -> "path-info.keyword";
             case Filter.Name.HTTP_PATH_MAPPING -> "mapped-path";
             case Filter.Name.GEO_IP_COUNTRY -> "geoip.country_iso_code";
             case Filter.Name.GEO_IP_REGION -> "geoip.region_name";
@@ -104,7 +105,7 @@ public class HTTPFieldResolver implements FieldResolver {
             case ZONE -> "zone";
             case HTTP_METHOD -> "http-method";
             case HTTP_STATUS_CODE_GROUP, HTTP_STATUS -> "status";
-            case HTTP_PATH -> "path";
+            case HTTP_PATH -> "path-info.keyword";
             case HTTP_PATH_MAPPING -> "mapped-path";
             case GEO_IP_COUNTRY -> "geoip.country_iso_code";
             case GEO_IP_REGION -> "geoip.region_name";

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPGroupedMeasuresQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPGroupedMeasuresQueryAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * One {@code filters} aggregation with a named bucket per group, each bucket carrying the measure aggregations of
+ * every metric. The buckets come back as an array, in the order the groups were declared, each with its key.
+ */
+public class HTTPGroupedMeasuresQueryAdapter {
+
+    static final String GROUPS_AGG_NAME = "GROUPS";
+
+    private final FilterAdapter filterAdapter = new FilterAdapter(new HTTPFieldResolver());
+    private final BoolQueryAdapter boolAdapter = new BoolQueryAdapter(filterAdapter);
+    private final HTTPMeasuresQueryAdapter measuresAdapter = new HTTPMeasuresQueryAdapter();
+
+    public String adapt(GroupedMeasuresQuery query) {
+        var groupFilters = new JsonObject();
+        query.groups().forEach((key, filters) -> groupFilters.put(key, filterAdapter.adaptMetricFilters(filters)));
+        var groups = new JsonObject()
+            .put("filters", new JsonObject().put("keyed", false).put("filters", groupFilters))
+            .put("aggs", measuresAdapter.adaptMetrics(query.metrics(), HTTPMeasuresQueryAdapter.rateWindow(query.timeRange())));
+        return new JsonObject()
+            .put("size", 0)
+            .put("query", boolAdapter.adaptForHTTP(query))
+            .put("aggs", new JsonObject().put(GROUPS_AGG_NAME, groups))
+            .toString();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -1598,6 +1598,61 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         }
 
         @Nested
+        class HTTPGroupedMeasures {
+
+            private static final String FIRST_API = "4a6895d5-a1bc-4041-a895-d5a1bce041ae";
+            private static final String SECOND_API = "llm-api-001";
+            private static final MetricMeasuresQuery REQUESTS = new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT));
+
+            @Test
+            void should_measure_each_group_over_the_union_of_its_apis_in_one_request() {
+                var groups = new java.util.LinkedHashMap<String, List<Filter>>();
+                groups.put("first", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of(FIRST_API))));
+                groups.put("pair", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of(FIRST_API, SECOND_API))));
+                groups.put("nothing", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of("no-such-api"))));
+                var query = new io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery(
+                    buildTimeRange(),
+                    List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of(FIRST_API, SECOND_API, "no-such-api"))),
+                    List.of(REQUESTS, new MetricMeasuresQuery(Metric.HTTP_GATEWAY_RESPONSE_TIME, Set.of(Measure.MAX))),
+                    groups
+                );
+
+                var result = cut.searchHTTPGroupedMeasures(QUERY_CONTEXT, query);
+
+                var first = count(cut.searchHTTPMeasures(QUERY_CONTEXT, measuresOf(FIRST_API)));
+                var second = count(cut.searchHTTPMeasures(QUERY_CONTEXT, measuresOf(SECOND_API)));
+                assertThat(first).isPositive();
+                assertThat(second).isPositive();
+                assertThat(result.groups().keySet()).containsExactly("first", "pair", "nothing");
+                assertThat(count(result.groups().get("first"))).isEqualTo(first);
+                assertThat(count(result.groups().get("pair"))).isEqualTo(first + second);
+                assertThat(count(result.groups().get("nothing"))).isZero();
+                assertThat(result.groups().get("pair").measures())
+                    .filteredOn(metric -> metric.metric() == Metric.HTTP_GATEWAY_RESPONSE_TIME)
+                    .singleElement()
+                    .satisfies(max -> assertThat(max.measures().get(Measure.MAX).doubleValue()).isPositive());
+            }
+
+            private static MeasuresQuery measuresOf(String apiId) {
+                return new MeasuresQuery(
+                    buildTimeRange(),
+                    List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of(apiId))),
+                    List.of(REQUESTS)
+                );
+            }
+
+            private static long count(io.gravitee.repository.analytics.engine.api.result.MeasuresResult result) {
+                return result
+                    .measures()
+                    .stream()
+                    .filter(metric -> metric.metric() == Metric.HTTP_REQUESTS)
+                    .map(metric -> metric.measures().get(Measure.COUNT).longValue())
+                    .findFirst()
+                    .orElseThrow();
+            }
+        }
+
+        @Nested
         class HTTPMeasures {
 
             static MeasuresQuery buildQuery() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.withPrecision;
 
 import io.gravitee.common.http.HttpMethod;
@@ -1684,6 +1685,65 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                     .measures()
                     .get(measure)
                     .doubleValue();
+            }
+        }
+
+        /**
+         * The fixture holds 22 documents on the HTTP entrypoints: 3 GET, 13 DELETE, 4 POST and 2 PUT, two of them on
+         * {@code /tools/call}. The gateway reports the method as its numeric code and the path as {@code path-info}.
+         */
+        @Nested
+        class HTTPMethodAndPathFilters {
+
+            private static final MetricMeasuresQuery REQUESTS = new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT));
+
+            @Test
+            void should_count_the_requests_of_one_http_method() {
+                var filter = new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "POST");
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(4L);
+            }
+
+            @Test
+            void should_count_the_requests_of_several_http_methods() {
+                var filter = new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.IN, List.of("GET", "PUT"));
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(5L);
+            }
+
+            @Test
+            void should_bucket_the_requests_by_http_method_name() {
+                var query = new FacetsQuery(buildTimeRange(), List.of(), List.of(REQUESTS), List.of(Facet.HTTP_METHOD));
+
+                var result = cut.searchHTTPFacets(QUERY_CONTEXT, query);
+
+                assertThat(result.metrics().getFirst().buckets())
+                    .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+                    .containsExactlyInAnyOrder(tuple("GET", 3L), tuple("DELETE", 13L), tuple("POST", 4L), tuple("PUT", 2L));
+            }
+
+            @Test
+            void should_count_the_requests_of_one_path() {
+                var filter = new Filter(Filter.Name.HTTP_PATH, Filter.Operator.EQ, "/tools/call");
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(2L);
+            }
+
+            @Test
+            void should_bucket_the_requests_by_path() {
+                var query = new FacetsQuery(buildTimeRange(), List.of(), List.of(REQUESTS), List.of(Facet.HTTP_PATH));
+
+                var result = cut.searchHTTPFacets(QUERY_CONTEXT, query);
+
+                assertThat(result.metrics().getFirst().buckets())
+                    .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+                    .contains(tuple("/tools/call", 2L), tuple("/chat", 2L), tuple("/", 13L));
             }
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
@@ -115,6 +115,57 @@ class AggregationAdapterTest {
     }
 
     @Test
+    void should_name_http_method_buckets_after_the_method_rather_than_its_reported_code() {
+        var query = new FacetsQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT))),
+            List.of(Facet.HTTP_METHOD)
+        );
+
+        var get = JSON.createObjectNode().put("key", 3).put("doc_count", 30);
+        get.putObject("HTTP_REQUESTS#COUNT").put("value", 30);
+        var post = JSON.createObjectNode().put("key", 7).put("doc_count", 12);
+        post.putObject("HTTP_REQUESTS#COUNT").put("value", 12);
+
+        var facetAgg = new Aggregation();
+        facetAgg.setBuckets(List.of(get, post));
+
+        var result = AggregationAdapter.toMetricsAndBuckets(Map.of("HTTP_REQUESTS#HTTP_METHOD", facetAgg), query);
+
+        assertThat(result.get(0).buckets())
+            .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+            .containsExactly(org.assertj.core.groups.Tuple.tuple("GET", 30L), org.assertj.core.groups.Tuple.tuple("POST", 12L));
+    }
+
+    @Test
+    void should_name_http_method_buckets_nested_under_another_facet() {
+        var query = new FacetsQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT))),
+            List.of(Facet.API, Facet.HTTP_METHOD)
+        );
+
+        var get = JSON.createObjectNode().put("key", 3).put("doc_count", 30);
+        get.putObject("HTTP_REQUESTS#COUNT").put("value", 30);
+        var api = JSON.createObjectNode().put("key", "api-1").put("doc_count", 30);
+        api.putObject("HTTP_REQUESTS#HTTP_METHOD").putArray("buckets").add(get);
+
+        var facetAgg = new Aggregation();
+        facetAgg.setBuckets(List.of(api));
+
+        var result = AggregationAdapter.toMetricsAndBuckets(Map.of("HTTP_REQUESTS#API", facetAgg), query);
+
+        var apiBucket = result.get(0).buckets().get(0);
+        assertThat(apiBucket.key()).isEqualTo("api-1");
+        assertThat(apiBucket.buckets())
+            .singleElement()
+            .extracting(bucket -> bucket.key())
+            .isEqualTo("GET");
+    }
+
+    @Test
     void should_return_zero_measures_without_fix_when_filter_agg_wraps_measures() {
         var query = new FacetsQuery(
             TIME_RANGE,

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -336,6 +336,48 @@ class FilterAdapterTest {
     }
 
     @Nested
+    class HttpMethodFilters {
+
+        @Test
+        void should_filter_on_the_reported_method_code_for_eq() throws JsonProcessingException {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "GET"));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var jsonQuery = JSON.readTree(measuresAdapter.adapt(query));
+
+            var term = jsonQuery.at("/query/bool/filter/1/term/http-method");
+            assertThat(term.isIntegralNumber()).isTrue();
+            assertThat(term.asInt()).isEqualTo(3);
+        }
+
+        @Test
+        void should_filter_on_the_reported_method_codes_for_in() throws JsonProcessingException {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.IN, List.of("POST", "put")));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var jsonQuery = JSON.readTree(measuresAdapter.adapt(query));
+
+            var terms = jsonQuery.at("/query/bool/filter/1/terms/http-method");
+            assertThat(terms.isArray()).isTrue();
+            assertThat(terms.get(0).asInt()).isEqualTo(7);
+            assertThat(terms.get(1).asInt()).isEqualTo(8);
+        }
+
+        @Test
+        void should_throw_for_an_unknown_http_method() {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "FETCH"));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            assertThatThrownBy(() -> measuresAdapter.adapt(query))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("FETCH");
+        }
+    }
+
+    @Nested
     class NumericRangeFilters {
 
         @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/GroupedMeasuresResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/GroupedMeasuresResponseAdapterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.analytics.engine.api.metric.Measure;
+import io.gravitee.repository.analytics.engine.api.metric.Metric;
+import io.gravitee.repository.analytics.engine.api.query.Filter;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.TimeRange;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class GroupedMeasuresResponseAdapterTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final GroupedMeasuresResponseAdapter adapter = new GroupedMeasuresResponseAdapter();
+
+    private static GroupedMeasuresQuery aQuery() {
+        var groups = new LinkedHashMap<String, List<Filter>>();
+        groups.put("busy", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of("api-a"))));
+        groups.put("idle", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of("api-b"))));
+        return new GroupedMeasuresQuery(
+            new TimeRange(Instant.now().minusSeconds(3600), Instant.now()),
+            List.of(),
+            List.of(
+                new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)),
+                new MetricMeasuresQuery(Metric.HTTP_GATEWAY_RESPONSE_TIME, Set.of(Measure.P95))
+            ),
+            groups
+        );
+    }
+
+    @Test
+    void should_read_the_measures_of_each_group_bucket_by_its_key() throws Exception {
+        var response = JSON.readValue(
+            """
+            {"took": 3, "timed_out": false, "aggregations": {"GROUPS": {"buckets": [
+              {"key": "busy", "doc_count": 5, "HTTP_REQUESTS#COUNT": {"value": 5}, "HTTP_GATEWAY_RESPONSE_TIME#P95": {"values": {"95.0": 120.0}}},
+              {"key": "idle", "doc_count": 0, "HTTP_REQUESTS#COUNT": {"value": 0}, "HTTP_GATEWAY_RESPONSE_TIME#P95": {"values": {"95.0": null}}}
+            ]}}}
+            """,
+            SearchResponse.class
+        );
+
+        var result = adapter.adapt(response, aQuery());
+
+        assertThat(result.groups().keySet()).containsExactly("busy", "idle");
+        assertThat(measure(result.groups().get("busy").measures(), Metric.HTTP_REQUESTS, Measure.COUNT)).isEqualTo(5.0);
+        assertThat(measure(result.groups().get("busy").measures(), Metric.HTTP_GATEWAY_RESPONSE_TIME, Measure.P95)).isEqualTo(120.0);
+        assertThat(measure(result.groups().get("idle").measures(), Metric.HTTP_REQUESTS, Measure.COUNT)).isZero();
+    }
+
+    @Test
+    void should_answer_every_group_with_zeroed_measures_when_elasticsearch_returns_no_aggregation() throws Exception {
+        var response = JSON.readValue("{\"took\": 1, \"timed_out\": false}", SearchResponse.class);
+
+        var result = adapter.adapt(response, aQuery());
+
+        assertThat(result.groups().keySet()).containsExactly("busy", "idle");
+        assertThat(result.groups().get("busy").measures()).allSatisfy(metric ->
+            assertThat(metric.measures().values()).allSatisfy(value -> assertThat(value.doubleValue()).isZero())
+        );
+    }
+
+    private static double measure(
+        List<io.gravitee.repository.analytics.engine.api.result.MetricMeasuresResult> measures,
+        Metric metric,
+        Measure measure
+    ) {
+        return measures
+            .stream()
+            .filter(m -> m.metric() == metric)
+            .map(m -> m.measures().get(measure))
+            .map(Number::doubleValue)
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolverTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolverTest.java
@@ -65,6 +65,14 @@ class HTTPFieldResolverTest {
         assertThrows(UnsupportedOperationException.class, () -> fieldResolver.fromMetric(Metric.MESSAGE_ERRORS));
     }
 
+    @Test
+    void should_resolve_http_path_to_the_path_info_the_gateway_reports() {
+        assertThat(fieldResolver.fromFilter(new Filter(Filter.Name.HTTP_PATH, Filter.Operator.EQ, "/tools/call"))).isEqualTo(
+            "path-info.keyword"
+        );
+        assertThat(fieldResolver.fromFacet(Facet.HTTP_PATH)).isEqualTo("path-info.keyword");
+    }
+
     @ParameterizedTest
     @EnumSource(
         value = Filter.Name.class,

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPGroupedMeasuresQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPGroupedMeasuresQueryAdapterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.repository.analytics.engine.api.metric.Measure;
+import io.gravitee.repository.analytics.engine.api.metric.Metric;
+import io.gravitee.repository.analytics.engine.api.query.Filter;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class HTTPGroupedMeasuresQueryAdapterTest extends AbstractQueryAdapterTest {
+
+    final HTTPGroupedMeasuresQueryAdapter adapter = new HTTPGroupedMeasuresQueryAdapter();
+
+    @Test
+    void should_build_one_filters_aggregation_with_a_named_bucket_per_group() throws JsonProcessingException {
+        var groups = new LinkedHashMap<String, List<Filter>>();
+        groups.put("alone", List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of("api-a"))));
+        groups.put(
+            "pair-search",
+            List.of(
+                new Filter(Filter.Name.API, Filter.Operator.IN, List.of("api-b", "api-c")),
+                new Filter(Filter.Name.MCP_PROXY_TOOL, Filter.Operator.EQ, "search")
+            )
+        );
+        var metrics = List.of(
+            new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)),
+            new MetricMeasuresQuery(Metric.HTTP_GATEWAY_RESPONSE_TIME, Set.of(Measure.P95))
+        );
+        var query = new GroupedMeasuresQuery(
+            buildTimeRange(),
+            List.of(new Filter(Filter.Name.API, Filter.Operator.IN, List.of("api-a", "api-b", "api-c"))),
+            metrics,
+            groups
+        );
+
+        var jsonQuery = JSON.readTree(adapter.adapt(query));
+
+        assertThat(jsonQuery.at("/size").asInt()).isZero();
+        assertThat(jsonQuery.at("/query/bool/filter/0/range/@timestamp/gte").asLong()).isEqualTo(FROM);
+        assertThat(jsonQuery.at("/query/bool/filter/1/terms/api-id")).hasSize(3);
+
+        var filters = jsonQuery.at("/aggs/GROUPS/filters");
+        assertThat(filters.at("/keyed").asBoolean()).isFalse();
+        assertThat(filters.at("/filters/alone/bool/must/0/terms/api-id/0").asText()).isEqualTo("api-a");
+        assertThat(filters.at("/filters/pair-search/bool/must/0/terms/api-id")).hasSize(2);
+        assertThat(filters.at("/filters/pair-search/bool/must/1/term/additional-metrics.keyword_mcp-proxy_tools~1call").asText()).isEqualTo(
+            "search"
+        );
+
+        var aggs = jsonQuery.at("/aggs/GROUPS/aggs");
+        assertThat(aggs.at("/HTTP_REQUESTS#COUNT/value_count/field").asText()).isEqualTo("@timestamp");
+        assertThat(aggs.at("/HTTP_GATEWAY_RESPONSE_TIME#P95/percentiles/percents/0").asDouble()).isEqualTo(95.0);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
@@ -16,9 +16,11 @@
 package io.gravitee.repository.noop.log.v4;
 
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
 import io.gravitee.repository.analytics.query.events.EventAnalyticsAggregate;
@@ -118,6 +120,11 @@ public class NoOpAnalyticsRepository implements AnalyticsRepository {
 
     @Override
     public MeasuresResult searchHTTPMeasures(QueryContext queryContext, MeasuresQuery query) {
+        return null;
+    }
+
+    @Override
+    public GroupedMeasuresResult searchHTTPGroupedMeasures(QueryContext queryContext, GroupedMeasuresQuery query) {
         return null;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/GroupedMeasuresRequest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/GroupedMeasuresRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The same measures computed once per group of documents, in a single request. Each group selects its documents
+ * with its own filters on top of the request filters, and is answered under its key.
+ *
+ * @param groups the filters of each group, by group key; the insertion order is kept in the answer
+ */
+public record GroupedMeasuresRequest(
+    TimeRange timeRange,
+    List<Filter> filters,
+    List<MetricMeasuresRequest> metrics,
+    Map<String, List<Filter>> groups
+) {
+    public GroupedMeasuresRequest emptyMetrics() {
+        return new GroupedMeasuresRequest(timeRange, filters, new ArrayList<>(), groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/GroupedMeasuresResponse.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/GroupedMeasuresResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** The measures of each group of a {@link GroupedMeasuresRequest}, by group key. */
+public record GroupedMeasuresResponse(Map<String, MeasuresResponse> groups) {
+    /** Joins the answers of several engines to one request: a group carries the metrics every engine returned for it. */
+    public static GroupedMeasuresResponse merge(List<GroupedMeasuresResponse> responses) {
+        var metricsByGroup = new LinkedHashMap<String, List<MetricMeasuresResponse>>();
+        responses
+            .stream()
+            .filter(Objects::nonNull)
+            .forEach(response ->
+                response
+                    .groups()
+                    .forEach((group, measures) ->
+                        metricsByGroup.computeIfAbsent(group, key -> new ArrayList<>()).addAll(measures.metrics())
+                    )
+            );
+        var groups = new LinkedHashMap<String, MeasuresResponse>();
+        metricsByGroup.forEach((group, metrics) -> groups.put(group, new MeasuresResponse(metrics)));
+        return new GroupedMeasuresResponse(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/query_service/AnalyticsEngineQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/query_service/AnalyticsEngineQueryService.java
@@ -17,6 +17,8 @@ package io.gravitee.apim.core.analytics_engine.query_service;
 
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
@@ -37,4 +39,14 @@ public interface AnalyticsEngineQueryService {
     FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request);
 
     TimeSeriesResponse searchTimeSeries(ExecutionContext context, TimeSeriesRequest request);
+
+    /** Whether {@link #searchGroupedMeasures} is implemented for the metrics of this engine. */
+    default boolean supportsGroupedMeasures() {
+        return false;
+    }
+
+    /** The same measures computed once per group of documents, in a single request; see {@link GroupedMeasuresRequest}. */
+    default GroupedMeasuresResponse searchGroupedMeasures(ExecutionContext context, GroupedMeasuresRequest request) {
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " does not compute measures per group");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/service_provider/AnalyticsQueryContextProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/service_provider/AnalyticsQueryContextProvider.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.analytics_engine.service_provider;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.analytics_engine.exception.UnsupportedMetricException;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
@@ -49,6 +50,16 @@ public class AnalyticsQueryContextProvider {
         for (var metric : measureRequest.metrics()) {
             var service = resolve(metric.name());
             var request = context.computeIfAbsent(service, s -> measureRequest.emptyMetrics());
+            request.metrics().add(metric);
+        }
+        return context;
+    }
+
+    public Map<AnalyticsEngineQueryService, GroupedMeasuresRequest> resolve(GroupedMeasuresRequest groupedRequest) {
+        var context = new HashMap<AnalyticsEngineQueryService, GroupedMeasuresRequest>();
+        for (var metric : groupedRequest.metrics()) {
+            var service = resolve(metric.name());
+            var request = context.computeIfAbsent(service, s -> groupedRequest.emptyMetrics());
             request.metrics().add(metric);
         }
         return context;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
@@ -18,6 +18,8 @@ package io.gravitee.apim.infra.adapter;
 import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.Measure;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
@@ -30,14 +32,17 @@ import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
 import io.gravitee.repository.analytics.engine.api.query.FacetsQuery;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.MetricMeasuresQuery;
 import io.gravitee.repository.analytics.engine.api.query.TimeSeriesQuery;
 import io.gravitee.repository.analytics.engine.api.result.FacetsResult;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MetricMeasuresResult;
 import io.gravitee.repository.analytics.engine.api.result.MetricTimeSeriesResult;
 import io.gravitee.repository.analytics.engine.api.result.TimeSeriesResult;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.mapstruct.Mapper;
@@ -72,6 +77,32 @@ public interface AnalyticsMeasuresAdapter {
 
     @Mapping(source = "name", target = "metric")
     MetricMeasuresQuery fromRequest(MetricMeasuresRequest request);
+
+    Filter fromRequest(io.gravitee.apim.core.analytics_engine.model.Filter filter);
+
+    io.gravitee.repository.analytics.engine.api.query.TimeRange fromRequest(
+        io.gravitee.apim.core.analytics_engine.model.TimeRange timeRange
+    );
+
+    default GroupedMeasuresQuery fromRequest(GroupedMeasuresRequest request) {
+        var groups = new LinkedHashMap<String, List<Filter>>();
+        request.groups().forEach((key, filters) -> groups.put(key, filters.stream().map(this::fromRequest).toList()));
+        return new GroupedMeasuresQuery(
+            fromRequest(request.timeRange()),
+            request.filters().stream().map(this::fromRequest).toList(),
+            request.metrics().stream().map(this::fromRequest).toList(),
+            groups
+        );
+    }
+
+    default GroupedMeasuresResponse fromResult(GroupedMeasuresResult result) {
+        if (result == null) {
+            return null;
+        }
+        var groups = new LinkedHashMap<String, MeasuresResponse>();
+        result.groups().forEach((key, measures) -> groups.put(key, fromResult(measures)));
+        return new GroupedMeasuresResponse(groups);
+    }
 
     default MeasuresResponse fromResult(MeasuresResult result) {
         if (result == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImpl.java
@@ -15,17 +15,14 @@
  */
 package io.gravitee.apim.infra.performance_target;
 
-import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
-import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
-import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
-import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.Measure;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
-import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.service_provider.AnalyticsQueryContextProvider;
@@ -49,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -61,15 +59,15 @@ import org.springframework.stereotype.Service;
  * Evaluates targets through the analytics engine query services the dashboards use, with the same
  * {@code API IN [...]} filter a single-API dashboard applies, so a breach shows the number the chart shows.
  *
- * <p>One target: rules sharing a filter set (resolved API ids plus rule filters) are answered by one measures request
+ * <p>One target: rules sharing a scope (resolved API ids plus rule filters) are answered by one measures request
  * that also carries the request-count metric of the subject's API family; that count is the sample size every rule
- * of the set is judged on.
+ * of the scope is judged on.
  *
- * <p>Many targets: those whose every rule resolves to a single API and carries no filter are answered per
- * environment and window by facets requests grouped by API, one bucket per API, so a thousand targets cost a
- * handful of requests. A cheap request-count query comes first and the aggregation only covers the APIs with enough
- * samples. Any other target is evaluated on its own. Analytics calls from the scheduler and from evaluate-on-demand
- * share a cap on the queries in flight.
+ * <p>Many targets: those whose subject belongs to the HTTP API family are answered per environment and window by
+ * grouped measures requests, one group per distinct scope shared by every rule that reads it, so a thousand targets
+ * cost a handful of requests whatever the number of APIs a subject holds. A cheap request-count request comes first
+ * and the measures request only covers the scopes with enough samples. A target of another API family is evaluated
+ * on its own. Analytics calls from the scheduler and from evaluate-on-demand share a cap on the queries in flight.
  *
  * <p>The engine is called without a caller context on purpose: a target is validated against its environment when
  * it is written, and the scheduler evaluates it with no user at hand.
@@ -81,8 +79,8 @@ import org.springframework.stereotype.Service;
 @CustomLog
 public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluator {
 
-    /** Targets per facets request, which bounds the number of buckets a single response carries. */
-    static final int MAX_TARGETS_PER_REQUEST = 500;
+    /** Scopes per grouped request, which bounds the number of buckets a single response carries. */
+    static final int MAX_GROUPS_PER_REQUEST = 500;
 
     private static final int DEFAULT_CONCURRENCY = 2;
 
@@ -109,6 +107,18 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         new MetricMeasuresRequest(MetricSpec.Name.EDGE_DETECTION_COUNT, List.of(MetricSpec.Measure.COUNT)),
         ApiType.AUTHZ,
         new MetricMeasuresRequest(MetricSpec.Name.AUTHZ_OPERATIONS, List.of(MetricSpec.Measure.COUNT))
+    );
+
+    /**
+     * The API types whose documents share the HTTP analytics indices and can be measured per group; Edge lives
+     * behind another entrypoint filter and the other families have engines of their own.
+     */
+    private static final Set<ApiType> GROUPABLE_API_TYPES = Set.of(
+        ApiType.PROXY,
+        ApiType.LLM_PROXY,
+        ApiType.MCP_PROXY,
+        ApiType.A2A_PROXY,
+        ApiType.MESSAGE
     );
 
     private final ApiCrudService apiCrudService;
@@ -165,12 +175,9 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
             }
         }
         batches.forEach((batch, indexes) -> {
-            for (int from = 0; from < indexes.size(); from += MAX_TARGETS_PER_REQUEST) {
-                var chunk = indexes.subList(from, Math.min(from + MAX_TARGETS_PER_REQUEST, indexes.size()));
-                var evaluations = evaluateBatch(batch, chunk.stream().map(targets::get).toList(), now, apiTypesById);
-                for (int k = 0; k < chunk.size(); k++) {
-                    results[chunk.get(k)] = evaluations.get(k);
-                }
+            var evaluations = evaluateBatch(batch, indexes.stream().map(targets::get).toList(), now, apiTypesById);
+            for (int k = 0; k < indexes.size(); k++) {
+                results[indexes.get(k)] = evaluations.get(k);
             }
         });
         return Arrays.stream(results).filter(Objects::nonNull).toList();
@@ -199,12 +206,11 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         var results = new PerformanceTargetEvaluation.RuleResult[rules.size()];
         var ruleIndexesByScope = new LinkedHashMap<Scope, List<Integer>>();
         for (int i = 0; i < rules.size(); i++) {
-            var rule = rules.get(i);
-            var apiIds = scopeApiIds(target, rule, apiTypesById);
-            if (apiIds.isEmpty()) {
-                results[i] = rule.evaluate(null, 0, target.minSampleSize());
+            var scope = scopeOf(target, rules.get(i), apiTypesById);
+            if (scope == null) {
+                results[i] = rules.get(i).evaluate(null, 0, target.minSampleSize());
             } else {
-                ruleIndexesByScope.computeIfAbsent(new Scope(apiIds, rule.filters()), scope -> new ArrayList<>()).add(i);
+                ruleIndexesByScope.computeIfAbsent(scope, s -> new ArrayList<>()).add(i);
             }
         }
 
@@ -232,21 +238,18 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
     }
 
     /**
-     * A target is batchable when every rule can be read from an API bucket: one API, no rule filter, and an API
-     * family whose analytics can be grouped by API, which excludes Edge.
+     * A target is batchable when its subject belongs to the HTTP family and every rule metric is served by an engine
+     * that computes measures per group.
      */
-    private static boolean isBatchable(PerformanceTarget target, Map<String, ApiType> knownApiTypes) {
+    private boolean isBatchable(PerformanceTarget target, Map<String, ApiType> knownApiTypes) {
         var apiTypesById = subjectApiTypes(target, knownApiTypes);
-        for (var rule : target.rules()) {
-            if (!rule.filters().isEmpty()) {
-                return false;
-            }
-            var apiIds = scopeApiIds(target, rule, apiTypesById);
-            if (apiIds.size() > 1 || (apiIds.size() == 1 && apiTypesById.get(apiIds.getFirst()) == ApiType.EDGE)) {
-                return false;
-            }
-        }
-        return true;
+        return (
+            GROUPABLE_API_TYPES.containsAll(apiTypesById.values()) &&
+            target
+                .rules()
+                .stream()
+                .allMatch(rule -> queryContextProvider.resolve(rule.metric()).supportsGroupedMeasures())
+        );
     }
 
     private List<PerformanceTargetEvaluation> evaluateBatch(
@@ -258,67 +261,71 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         var window = new TimeRange(now.minus(batch.window()), now);
         var executionContext = executionContext(batch.environmentId());
 
-        var subjects = targets.stream().collect(Collectors.toMap(PerformanceTarget::id, target -> subjectApiTypes(target, knownApiTypes)));
-        // the API each rule reads its bucket from, by target then rule position; null when the rule has no API
-        var ruleApiIds = new HashMap<String, List<String>>();
-        var apiIds = new LinkedHashSet<String>();
-        for (var target : targets) {
-            var perRule = new ArrayList<String>();
-            for (var rule : target.rules()) {
-                var scope = scopeApiIds(target, rule, subjects.get(target.id()));
-                perRule.add(scope.isEmpty() ? null : scope.getFirst());
-                apiIds.addAll(scope);
-            }
-            ruleApiIds.put(target.id(), perRule);
-        }
-
-        var countMetrics = apiIds
+        var subjects = targets
             .stream()
-            .map(apiId -> SAMPLE_COUNT_METRICS.get(knownApiTypes.get(apiId)))
-            .distinct()
+            .map(target -> subjectApiTypes(target, knownApiTypes))
             .toList();
-        var counts = apiIds.isEmpty()
-            ? Map.<String, MeasuresResponse>of()
-            : searchFacetsByApi(executionContext, window, List.copyOf(apiIds), countMetrics);
-        var sampleCounts = new HashMap<String, Long>();
-        for (var apiId : apiIds) {
-            var countMetric = SAMPLE_COUNT_METRICS.get(knownApiTypes.get(apiId));
-            sampleCounts.put(apiId, counts.containsKey(apiId) ? sampleCount(counts.get(apiId), countMetric) : 0L);
+        // one group per distinct scope, shared by every rule that reads it; null when the rule has no API
+        var groupKeys = new LinkedHashMap<Scope, String>();
+        var ruleScopes = new ArrayList<List<Scope>>();
+        for (int t = 0; t < targets.size(); t++) {
+            var target = targets.get(t);
+            var scopes = new ArrayList<Scope>();
+            for (var rule : target.rules()) {
+                var scope = scopeOf(target, rule, subjects.get(t));
+                if (scope != null) {
+                    groupKeys.computeIfAbsent(scope, s -> "scope-" + groupKeys.size());
+                }
+                scopes.add(scope);
+            }
+            ruleScopes.add(scopes);
         }
 
-        var measuredApiIds = new LinkedHashSet<String>();
+        var scopesByCountMetric = new LinkedHashMap<MetricMeasuresRequest, List<Scope>>();
+        for (var scope : groupKeys.keySet()) {
+            scopesByCountMetric.computeIfAbsent(sampleCountMetric(scope.apiIds(), knownApiTypes), metric -> new ArrayList<>()).add(scope);
+        }
+        var sampleCounts = new HashMap<Scope, Long>();
+        scopesByCountMetric.forEach((countMetric, scopes) ->
+            searchGroupedMeasures(executionContext, window, scopes, groupKeys, List.of(countMetric)).forEach((scope, measures) ->
+                sampleCounts.put(scope, sampleCount(measures, countMetric))
+            )
+        );
+
+        var measuredScopes = new LinkedHashSet<Scope>();
         var measuresByMetric = new LinkedHashMap<MetricSpec.Name, LinkedHashSet<MetricSpec.Measure>>();
-        for (var target : targets) {
-            var rules = target.rules();
-            for (int i = 0; i < rules.size(); i++) {
-                var apiId = ruleApiIds.get(target.id()).get(i);
-                if (apiId != null && sampleCounts.get(apiId) >= target.minSampleSize()) {
-                    measuredApiIds.add(apiId);
-                    measuresByMetric.computeIfAbsent(rules.get(i).metric(), metric -> new LinkedHashSet<>()).add(rules.get(i).measure());
+        for (int t = 0; t < targets.size(); t++) {
+            var target = targets.get(t);
+            for (int i = 0; i < target.rules().size(); i++) {
+                var scope = ruleScopes.get(t).get(i);
+                if (scope != null && sampleCounts.get(scope) >= target.minSampleSize()) {
+                    var rule = target.rules().get(i);
+                    measuredScopes.add(scope);
+                    measuresByMetric.computeIfAbsent(rule.metric(), metric -> new LinkedHashSet<>()).add(rule.measure());
                 }
             }
         }
-        var measures = measuredApiIds.isEmpty()
-            ? Map.<String, MeasuresResponse>of()
-            : searchFacetsByApi(executionContext, window, List.copyOf(measuredApiIds), metrics(measuresByMetric));
+        var measures = measuredScopes.isEmpty()
+            ? Map.<Scope, MeasuresResponse>of()
+            : searchGroupedMeasures(executionContext, window, List.copyOf(measuredScopes), groupKeys, metrics(measuresByMetric));
 
         var evaluations = new ArrayList<PerformanceTargetEvaluation>();
-        for (var target : targets) {
-            var rules = target.rules();
+        for (int t = 0; t < targets.size(); t++) {
+            var target = targets.get(t);
             var results = new ArrayList<PerformanceTargetEvaluation.RuleResult>();
-            for (int i = 0; i < rules.size(); i++) {
-                var rule = rules.get(i);
-                var apiId = ruleApiIds.get(target.id()).get(i);
-                if (apiId == null) {
+            for (int i = 0; i < target.rules().size(); i++) {
+                var rule = target.rules().get(i);
+                var scope = ruleScopes.get(t).get(i);
+                if (scope == null) {
                     results.add(rule.evaluate(null, 0, target.minSampleSize()));
                 } else {
-                    var observed = Optional.ofNullable(measures.get(apiId))
+                    var observed = Optional.ofNullable(measures.get(scope))
                         .flatMap(m -> value(m, rule.metric(), rule.measure()))
                         .orElse(null);
-                    results.add(rule.evaluate(observed, sampleCounts.get(apiId), target.minSampleSize()));
+                    results.add(rule.evaluate(observed, sampleCounts.get(scope), target.minSampleSize()));
                 }
             }
-            evaluations.add(evaluation(target, window, results, subjects.get(target.id()), now));
+            evaluations.add(evaluation(target, window, results, subjects.get(t), now));
         }
         return evaluations;
     }
@@ -370,8 +377,10 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         return apiTypesById;
     }
 
-    private static List<String> scopeApiIds(PerformanceTarget target, PerformanceTarget.Rule rule, Map<String, ApiType> apiTypesById) {
-        return target.apiIdsFor(rule, apiTypesById).stream().filter(apiTypesById::containsKey).toList();
+    /** The documents a rule is measured on, or {@code null} when none of its API types is in the subject. */
+    private static Scope scopeOf(PerformanceTarget target, PerformanceTarget.Rule rule, Map<String, ApiType> apiTypesById) {
+        var apiIds = target.apiIdsFor(rule, apiTypesById).stream().filter(apiTypesById::containsKey).toList();
+        return apiIds.isEmpty() ? null : new Scope(apiIds, rule.filters());
     }
 
     private static MetricMeasuresRequest sampleCountMetric(List<String> apiIds, Map<String, ApiType> apiTypesById) {
@@ -414,11 +423,7 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
             measuresByMetric.computeIfAbsent(rule.metric(), metric -> new LinkedHashSet<>()).add(rule.measure());
         }
 
-        var filters = new ArrayList<Filter>();
-        filters.add(apiIn(scope.apiIds()));
-        filters.addAll(scope.filters());
-
-        var request = new MeasuresRequest(window, filters, metrics(measuresByMetric));
+        var request = new MeasuresRequest(window, scope.filters(), metrics(measuresByMetric));
         return MeasuresResponse.merge(
             queryContextProvider
                 .resolve(request)
@@ -429,44 +434,40 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
         );
     }
 
-    /** One facets request grouped by API; the answer is read back as one measures response per API id. */
-    private Map<String, MeasuresResponse> searchFacetsByApi(
+    /**
+     * The measures of every scope, {@value #MAX_GROUPS_PER_REQUEST} scopes per request. The request is pre-filtered
+     * on the union of the scopes' API ids so a group only has to narrow it down.
+     */
+    private Map<Scope, MeasuresResponse> searchGroupedMeasures(
         ExecutionContext executionContext,
         TimeRange window,
-        List<String> apiIds,
+        List<Scope> scopes,
+        Map<Scope, String> groupKeys,
         List<MetricMeasuresRequest> metrics
     ) {
-        var request = new FacetsRequest(
-            window,
-            List.of(apiIn(apiIds)),
-            metrics
-                .stream()
-                .map(metric -> new FacetMetricMeasuresRequest(metric.name(), metric.measures(), List.of()))
-                .toList(),
-            List.of(FacetSpec.Name.API),
-            apiIds.size(),
-            List.of()
-        );
-        var response = FacetsResponse.merge(
-            queryContextProvider
-                .resolve(request)
-                .entrySet()
-                .stream()
-                .map(entry -> withPermit(() -> entry.getKey().searchFacets(executionContext, entry.getValue())))
-                .toList()
-        );
-
-        var metricsByApi = new HashMap<String, List<MetricMeasuresResponse>>();
-        for (var metric : response.metrics()) {
-            for (var bucket : metric.buckets()) {
-                metricsByApi
-                    .computeIfAbsent(bucket.key(), apiId -> new ArrayList<>())
-                    .add(new MetricMeasuresResponse(metric.metric(), metric.unit(), bucket.measures()));
+        var byScope = new HashMap<Scope, MeasuresResponse>();
+        for (int from = 0; from < scopes.size(); from += MAX_GROUPS_PER_REQUEST) {
+            var chunk = scopes.subList(from, Math.min(from + MAX_GROUPS_PER_REQUEST, scopes.size()));
+            var groups = new LinkedHashMap<String, List<Filter>>();
+            var apiIds = new LinkedHashSet<String>();
+            for (var scope : chunk) {
+                groups.put(groupKeys.get(scope), scope.filters());
+                apiIds.addAll(scope.apiIds());
+            }
+            var request = new GroupedMeasuresRequest(window, List.of(apiIn(List.copyOf(apiIds))), metrics, groups);
+            var response = GroupedMeasuresResponse.merge(
+                queryContextProvider
+                    .resolve(request)
+                    .entrySet()
+                    .stream()
+                    .map(entry -> withPermit(() -> entry.getKey().searchGroupedMeasures(executionContext, entry.getValue())))
+                    .toList()
+            );
+            for (var scope : chunk) {
+                byScope.put(scope, response.groups().getOrDefault(groupKeys.get(scope), new MeasuresResponse(List.of())));
             }
         }
-        var byApi = new HashMap<String, MeasuresResponse>();
-        metricsByApi.forEach((apiId, apiMetrics) -> byApi.put(apiId, new MeasuresResponse(apiMetrics)));
-        return byApi;
+        return byScope;
     }
 
     private <T> T withPermit(Supplier<T> query) {
@@ -501,8 +502,16 @@ public class PerformanceTargetEvaluatorImpl implements PerformanceTargetEvaluato
     }
 
     /** The documents a set of rules is measured on: the API ids they resolve to, narrowed by their own filters. */
-    private record Scope(List<String> apiIds, List<Filter> filters) {}
+    private record Scope(List<String> apiIds, List<Filter> ruleFilters) {
+        /** The API filter first, then the rule filters, the order the single-target requests have always used. */
+        List<Filter> filters() {
+            var filters = new ArrayList<Filter>();
+            filters.add(apiIn(apiIds));
+            filters.addAll(ruleFilters);
+            return filters;
+        }
+    }
 
-    /** Targets answered by one facets request: same environment, hence same indices, and same window. */
+    /** Targets answered by the same grouped requests: same environment, hence same indices, and same window. */
     private record Batch(String environmentId, Duration window) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/HTTPDataPlaneAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/HTTPDataPlaneAnalyticsQueryService.java
@@ -20,6 +20,8 @@ import static io.gravitee.apim.core.analytics_engine.model.MetricSpec.Name.HTTP_
 
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec.Name;
@@ -79,6 +81,18 @@ public class HTTPDataPlaneAnalyticsQueryService implements AnalyticsEngineQueryS
     public MeasuresResponse searchMeasures(ExecutionContext context, MeasuresRequest request) {
         var query = AnalyticsMeasuresAdapter.INSTANCE.fromRequest(request);
         var result = analyticsRepository.searchHTTPMeasures(context.getQueryContext(), query);
+        return AnalyticsMeasuresAdapter.INSTANCE.fromResult(result);
+    }
+
+    @Override
+    public boolean supportsGroupedMeasures() {
+        return true;
+    }
+
+    @Override
+    public GroupedMeasuresResponse searchGroupedMeasures(ExecutionContext context, GroupedMeasuresRequest request) {
+        var query = AnalyticsMeasuresAdapter.INSTANCE.fromRequest(request);
+        var result = analyticsRepository.searchHTTPGroupedMeasures(context.getQueryContext(), query);
         return AnalyticsMeasuresAdapter.INSTANCE.fromResult(result);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/performance_target/PerformanceTargetEvaluatorImplTest.java
@@ -26,17 +26,15 @@ import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.PerformanceTargetFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
-import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
-import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
-import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.Measure;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
-import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
@@ -57,6 +55,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +63,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -347,13 +347,7 @@ class PerformanceTargetEvaluatorImplTest {
     @Test
     void should_count_samples_with_the_metric_of_the_subject_api_family() {
         apiCrudService.initWith(List.of(ApiFixtures.aNativeApi().toBuilder().id("kafka-api").build()));
-        var throughput = PerformanceTarget.Rule.builder()
-            .metric(MetricSpec.Name.NATIVE_OPERATION_BROKER_DURATION)
-            .measure(MetricSpec.Measure.AVG)
-            .operator(PerformanceTarget.Operator.LTE)
-            .threshold(50)
-            .build();
-        var target = anAgentTarget(throughput)
+        var target = anAgentTarget(BROKER_DURATION)
             .toBuilder()
             .subject(new PerformanceTarget.Subject(List.of("kafka-api"), "kafka-api"))
             .build();
@@ -370,13 +364,34 @@ class PerformanceTargetEvaluatorImplTest {
             );
     }
 
+    private static final PerformanceTarget.Rule BROKER_DURATION = PerformanceTarget.Rule.builder()
+        .metric(MetricSpec.Name.NATIVE_OPERATION_BROKER_DURATION)
+        .measure(MetricSpec.Measure.AVG)
+        .operator(PerformanceTarget.Operator.LTE)
+        .threshold(50)
+        .build();
+
     private static PerformanceTarget anAgentTarget(PerformanceTarget.Rule... rules) {
-        return PerformanceTargetFixtures.aTarget()
+        return aTarget("target-id", List.of(A2A_API_ID, LLM_API_ID), "agent-42", WINDOW, rules);
+    }
+
+    private static PerformanceTarget aTarget(
+        String id,
+        List<String> apiIds,
+        String reference,
+        Duration window,
+        PerformanceTarget.Rule... rules
+    ) {
+        return PerformanceTargetFixtures.aTarget(id)
             .toBuilder()
-            .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID, LLM_API_ID), "agent-42"))
-            .window(WINDOW)
+            .subject(new PerformanceTarget.Subject(apiIds, reference))
+            .window(window)
             .rules(List.of(rules))
             .build();
+    }
+
+    private static PerformanceTarget aSingleApiTarget(String apiId, Duration window, PerformanceTarget.Rule... rules) {
+        return aTarget(apiId, List.of(apiId), apiId, window, rules);
     }
 
     private static Filter apiIn(String... apiIds) {
@@ -395,6 +410,14 @@ class PerformanceTargetEvaluatorImplTest {
     class EvaluateAll {
 
         private static final PerformanceTarget.Rule LATENCY = PerformanceTargetFixtures.aLatencyRule();
+        private static final MetricMeasuresRequest REQUEST_COUNT = new MetricMeasuresRequest(
+            MetricSpec.Name.HTTP_REQUESTS,
+            List.of(MetricSpec.Measure.COUNT)
+        );
+        private static final MetricMeasuresRequest LATENCY_P95 = new MetricMeasuresRequest(
+            MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
+            List.of(MetricSpec.Measure.P95)
+        );
 
         @Test
         void should_evaluate_a_thousand_single_api_targets_of_one_window_with_a_bounded_number_of_requests() {
@@ -418,7 +441,7 @@ class PerformanceTargetEvaluatorImplTest {
             var evaluations = evaluator.evaluateAll(targets, NOW);
 
             assertThat(analytics.requests).isEmpty();
-            assertThat(analytics.facetsRequests).hasSizeLessThanOrEqualTo(4);
+            assertThat(analytics.groupedRequests).hasSizeLessThanOrEqualTo(4);
             assertThat(evaluations)
                 .hasSize(1000)
                 .allSatisfy(evaluation -> {
@@ -433,7 +456,54 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         @Test
-        void should_count_first_and_aggregate_only_the_targets_with_enough_samples() {
+        void should_evaluate_a_thousand_targets_half_of_them_on_two_apis_with_a_bounded_number_of_requests() {
+            var apiIds = IntStream.range(0, 1000)
+                .mapToObj(i -> "api-" + i)
+                .toList();
+            apiCrudService.initWith(
+                apiIds
+                    .stream()
+                    .<Api>map(id -> ApiFixtures.aProxyApiV4().toBuilder().id(id).build())
+                    .toList()
+            );
+            var targets = new ArrayList<PerformanceTarget>();
+            for (int i = 0; i < apiIds.size(); i += 2) {
+                var first = apiIds.get(i);
+                var second = apiIds.get(i + 1);
+                analytics.given(
+                    Set.of(first),
+                    requests(50),
+                    measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1000)
+                );
+                analytics.given(
+                    Set.of(first, second),
+                    requests(120),
+                    measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 1800)
+                );
+                targets.add(aSingleApiTarget(first, WINDOW, LATENCY));
+                targets.add(aTarget("agent-" + i, List.of(first, second), "agent-" + i, WINDOW, LATENCY));
+            }
+
+            var evaluations = evaluator.evaluateAll(targets, NOW);
+
+            assertThat(analytics.requests).isEmpty();
+            assertThat(analytics.groupedRequests).hasSizeLessThanOrEqualTo(4);
+            assertThat(evaluations)
+                .hasSize(1000)
+                .allSatisfy(evaluation -> assertThat(evaluation.status()).isEqualTo(PASS));
+            assertThat(evaluations)
+                .filteredOn(evaluation -> evaluation.coveredApiIds().size() == 2)
+                .hasSize(500)
+                .allSatisfy(evaluation ->
+                    assertThat(evaluation.rules())
+                        .singleElement()
+                        .extracting(PerformanceTargetEvaluation.RuleResult::sampleCount, PerformanceTargetEvaluation.RuleResult::observed)
+                        .containsExactly(120L, 1800.0)
+                );
+        }
+
+        @Test
+        void should_count_first_and_measure_only_the_scopes_with_enough_samples() {
             analytics.givenApi(A2A_API_ID, requests(63), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 4810));
             analytics.givenApi(LLM_API_ID, requests(5), measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 100));
 
@@ -443,29 +513,18 @@ class PerformanceTargetEvaluatorImplTest {
             );
 
             assertThat(analytics.contexts).containsOnly(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID));
-            assertThat(analytics.facetsRequests)
-                .allSatisfy(request -> {
-                    assertThat(request.timeRange()).isEqualTo(new TimeRange(NOW.minus(WINDOW), NOW));
-                    assertThat(request.facets()).containsExactly(FacetSpec.Name.API);
-                })
+            assertThat(analytics.groupedRequests)
+                .allSatisfy(request -> assertThat(request.timeRange()).isEqualTo(new TimeRange(NOW.minus(WINDOW), NOW)))
                 .satisfiesExactly(
                     count -> {
                         assertThat(count.filters()).containsExactly(apiIn(A2A_API_ID, LLM_API_ID));
-                        assertThat(count.limit()).isEqualTo(2);
-                        assertThat(count.metrics()).containsExactly(
-                            new FacetMetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT), List.of())
-                        );
+                        assertThat(count.groups().values()).containsExactly(List.of(apiIn(A2A_API_ID)), List.of(apiIn(LLM_API_ID)));
+                        assertThat(count.metrics()).containsExactly(REQUEST_COUNT);
                     },
-                    aggregation -> {
-                        assertThat(aggregation.filters()).containsExactly(apiIn(A2A_API_ID));
-                        assertThat(aggregation.limit()).isEqualTo(1);
-                        assertThat(aggregation.metrics()).containsExactly(
-                            new FacetMetricMeasuresRequest(
-                                MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME,
-                                List.of(MetricSpec.Measure.P95),
-                                List.of()
-                            )
-                        );
+                    measures -> {
+                        assertThat(measures.filters()).containsExactly(apiIn(A2A_API_ID));
+                        assertThat(measures.groups().values()).containsExactly(List.of(apiIn(A2A_API_ID)));
+                        assertThat(measures.metrics()).containsExactly(LATENCY_P95);
                     }
                 );
             assertThat(evaluations)
@@ -482,7 +541,7 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         @Test
-        void should_skip_the_aggregation_when_no_target_has_enough_samples() {
+        void should_skip_the_measures_when_no_scope_has_enough_samples() {
             analytics.givenApi(A2A_API_ID, requests(3));
 
             var evaluations = evaluator.evaluateAll(
@@ -490,7 +549,7 @@ class PerformanceTargetEvaluatorImplTest {
                 NOW
             );
 
-            assertThat(analytics.facetsRequests).hasSize(1);
+            assertThat(analytics.groupedRequests).hasSize(1);
             assertThat(evaluations)
                 .flatExtracting(PerformanceTargetEvaluation::rules)
                 .extracting(PerformanceTargetEvaluation.RuleResult::sampleCount, PerformanceTargetEvaluation.RuleResult::status)
@@ -525,8 +584,8 @@ class PerformanceTargetEvaluatorImplTest {
                 NOW
             );
 
-            assertThat(analytics.facetsRequests)
-                .extracting(FacetsRequest::timeRange, FacetsRequest::filters)
+            assertThat(analytics.groupedRequests)
+                .extracting(GroupedMeasuresRequest::timeRange, GroupedMeasuresRequest::filters)
                 .containsExactlyInAnyOrder(
                     tuple(new TimeRange(NOW.minus(WINDOW), NOW), List.of(apiIn(A2A_API_ID, LLM_API_ID))),
                     tuple(new TimeRange(NOW.minus(hour), NOW), List.of(apiIn("hourly-api"))),
@@ -540,7 +599,7 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         @Test
-        void should_fall_back_to_a_per_target_evaluation_when_a_rule_spans_several_apis_or_carries_filters() {
+        void should_batch_targets_whose_rules_span_several_apis_or_carry_filters() {
             var searchTool = new Filter(FilterSpec.Name.MCP_PROXY_TOOL, FilterOperator.EQ, "search");
             var filtered = aSingleApiTarget(A2A_API_ID, WINDOW, ERROR_RATE.toBuilder().filters(List.of(searchTool)).build());
 
@@ -549,10 +608,17 @@ class PerformanceTargetEvaluatorImplTest {
                 NOW
             );
 
-            assertThat(analytics.requests)
-                .extracting(MeasuresRequest::filters)
-                .containsExactly(List.of(apiIn(A2A_API_ID, LLM_API_ID)), List.of(apiIn(A2A_API_ID), searchTool));
-            assertThat(analytics.facetsRequests).singleElement().extracting(FacetsRequest::filters).isEqualTo(List.of(apiIn(LLM_API_ID)));
+            assertThat(analytics.requests).isEmpty();
+            assertThat(analytics.groupedRequests)
+                .singleElement()
+                .satisfies(count -> {
+                    assertThat(count.filters()).containsExactly(apiIn(A2A_API_ID, LLM_API_ID));
+                    assertThat(count.groups().values()).containsExactly(
+                        List.of(apiIn(A2A_API_ID, LLM_API_ID)),
+                        List.of(apiIn(A2A_API_ID), searchTool),
+                        List.of(apiIn(LLM_API_ID))
+                    );
+                });
             assertThat(evaluations)
                 .extracting(PerformanceTargetEvaluation::targetId)
                 .containsExactly("target-id", filtered.id(), LLM_API_ID);
@@ -570,7 +636,7 @@ class PerformanceTargetEvaluatorImplTest {
             var evaluations = evaluator.evaluateAll(List.of(anAgentTarget(A2A_LATENCY, LLM_COST)), NOW);
 
             assertThat(analytics.requests).isEmpty();
-            assertThat(analytics.facetsRequests).hasSize(2);
+            assertThat(analytics.groupedRequests).hasSize(2);
             assertThat(evaluations)
                 .singleElement()
                 .satisfies(evaluation -> {
@@ -587,6 +653,59 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         @Test
+        void should_evaluate_a_target_in_a_batch_like_on_its_own() {
+            analytics.given(
+                Set.of(A2A_API_ID),
+                requests(63),
+                measure(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 4810)
+            );
+            analytics.given(
+                Set.of(A2A_API_ID, LLM_API_ID),
+                requests(91),
+                measure(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 1.5)
+            );
+            analytics.given(
+                Set.of(LLM_API_ID),
+                requests(40),
+                measure(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, MetricSpec.Measure.AVG, 0.02)
+            );
+            var target = anAgentTarget(A2A_LATENCY, ERROR_RATE, LLM_COST);
+
+            var alone = evaluator.evaluate(target, NOW);
+            var batched = evaluator.evaluateAll(List.of(target), NOW);
+
+            assertThat(batched).singleElement().isEqualTo(alone);
+            assertThat(alone.status()).isEqualTo(BREACH);
+            assertThat(alone.rules())
+                .extracting(
+                    PerformanceTargetEvaluation.RuleResult::observed,
+                    PerformanceTargetEvaluation.RuleResult::sampleCount,
+                    PerformanceTargetEvaluation.RuleResult::status
+                )
+                .containsExactly(tuple(4810.0, 63L, BREACH), tuple(1.5, 91L, PASS), tuple(0.02, 40L, BREACH));
+        }
+
+        @Test
+        void should_evaluate_a_target_of_another_api_family_on_its_own() {
+            apiCrudService.initWith(
+                List.of(
+                    ApiFixtures.anA2AProxyApiV4().toBuilder().id(A2A_API_ID).build(),
+                    ApiFixtures.aNativeApi().toBuilder().id("kafka-api").build()
+                )
+            );
+            var kafka = aTarget("kafka-target", List.of("kafka-api"), "kafka-api", WINDOW, BROKER_DURATION);
+
+            var evaluations = evaluator.evaluateAll(List.of(kafka, aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY)), NOW);
+
+            assertThat(analytics.requests).singleElement().extracting(MeasuresRequest::filters).isEqualTo(List.of(apiIn("kafka-api")));
+            assertThat(analytics.groupedRequests)
+                .singleElement()
+                .extracting(GroupedMeasuresRequest::filters)
+                .isEqualTo(List.of(apiIn(A2A_API_ID)));
+            assertThat(evaluations).extracting(PerformanceTargetEvaluation::targetId).containsExactly("kafka-target", A2A_API_ID);
+        }
+
+        @Test
         void should_keep_the_input_order_and_leave_out_a_target_that_cannot_be_evaluated() {
             apiCrudService.initWith(
                 List.of(
@@ -594,11 +713,7 @@ class PerformanceTargetEvaluatorImplTest {
                     ApiFixtures.aNativeApi().toBuilder().id("kafka-api").build()
                 )
             );
-            var mixedFamilies = PerformanceTargetFixtures.aTarget("mixed")
-                .toBuilder()
-                .subject(new PerformanceTarget.Subject(List.of(A2A_API_ID, "kafka-api"), "mixed"))
-                .rules(List.of(ERROR_RATE))
-                .build();
+            var mixedFamilies = aTarget("mixed", List.of(A2A_API_ID, "kafka-api"), "mixed", WINDOW, ERROR_RATE);
 
             var evaluations = evaluator.evaluateAll(
                 List.of(aSingleApiTarget(A2A_API_ID, WINDOW, LATENCY), mixedFamilies, anAgentTarget(ERROR_RATE)),
@@ -611,7 +726,7 @@ class PerformanceTargetEvaluatorImplTest {
         @Test
         void should_return_nothing_for_no_target() {
             assertThat(evaluator.evaluateAll(List.of(), NOW)).isEmpty();
-            assertThat(analytics.facetsRequests).isEmpty();
+            assertThat(analytics.groupedRequests).isEmpty();
             assertThat(analytics.requests).isEmpty();
         }
     }
@@ -659,28 +774,18 @@ class PerformanceTargetEvaluatorImplTest {
         }
     }
 
-    private static PerformanceTarget aSingleApiTarget(String apiId, Duration window, PerformanceTarget.Rule... rules) {
-        return PerformanceTargetFixtures.aTarget(apiId)
-            .toBuilder()
-            .subject(new PerformanceTarget.Subject(List.of(apiId), apiId))
-            .window(window)
-            .rules(List.of(rules))
-            .build();
-    }
-
     /**
-     * Answers a measures request with the metrics configured for the API ids it filters on, merging several
-     * configured responses for the same metric, and a facets request with one API bucket per API id that has
-     * configured metrics, the way Elasticsearch returns no bucket for an API without documents. Records what it was
-     * asked so tests can assert the query shape.
+     * Answers a measures request, or each group of a grouped request, with the metrics configured for the API ids it
+     * filters on, restricted to the metrics asked for, the way the engine answers only what it is asked. A group with
+     * nothing configured comes back without metrics, which reads as zero samples. Records what it was asked so tests
+     * can assert the query shape.
      */
     static class RecordingAnalyticsEngineQueryService implements AnalyticsEngineQueryService {
 
         final List<ExecutionContext> contexts = new ArrayList<>();
         final List<MeasuresRequest> requests = new ArrayList<>();
-        final List<FacetsRequest> facetsRequests = new ArrayList<>();
+        final List<GroupedMeasuresRequest> groupedRequests = new ArrayList<>();
         private final Map<Set<String>, List<MetricMeasuresResponse>> responsesByApiIds = new HashMap<>();
-        private final Map<String, List<MetricMeasuresResponse>> responsesByApi = new HashMap<>();
 
         void given(Set<String> apiIds, MetricMeasuresResponse... metrics) {
             for (var metric : metrics) {
@@ -689,9 +794,7 @@ class PerformanceTargetEvaluatorImplTest {
         }
 
         void givenApi(String apiId, MetricMeasuresResponse... metrics) {
-            for (var metric : metrics) {
-                responsesByApi.computeIfAbsent(apiId, id -> new ArrayList<>()).add(metric);
-            }
+            given(Set.of(apiId), metrics);
         }
 
         @Override
@@ -703,9 +806,30 @@ class PerformanceTargetEvaluatorImplTest {
         public MeasuresResponse searchMeasures(ExecutionContext context, MeasuresRequest request) {
             contexts.add(context);
             requests.add(request);
+            return response(apiIdsOf(request.filters()), request.metrics());
+        }
+
+        @Override
+        public boolean supportsGroupedMeasures() {
+            return true;
+        }
+
+        @Override
+        public GroupedMeasuresResponse searchGroupedMeasures(ExecutionContext context, GroupedMeasuresRequest request) {
+            contexts.add(context);
+            groupedRequests.add(request);
+            var groups = new LinkedHashMap<String, MeasuresResponse>();
+            request.groups().forEach((key, filters) -> groups.put(key, response(apiIdsOf(filters), request.metrics())));
+            return new GroupedMeasuresResponse(groups);
+        }
+
+        private MeasuresResponse response(Set<String> apiIds, List<MetricMeasuresRequest> metrics) {
+            var requested = metrics.stream().map(MetricMeasuresRequest::name).collect(Collectors.toSet());
             var byMetric = new HashMap<MetricSpec.Name, List<Measure>>();
-            for (var response : responsesByApiIds.getOrDefault(apiIdsOf(request.filters()), List.of())) {
-                byMetric.computeIfAbsent(response.name(), name -> new ArrayList<>()).addAll(response.measures());
+            for (var response : responsesByApiIds.getOrDefault(apiIds, List.of())) {
+                if (requested.contains(response.name())) {
+                    byMetric.computeIfAbsent(response.name(), name -> new ArrayList<>()).addAll(response.measures());
+                }
             }
             return new MeasuresResponse(
                 new TreeSet<>(byMetric.keySet())
@@ -713,40 +837,6 @@ class PerformanceTargetEvaluatorImplTest {
                     .map(name -> new MetricMeasuresResponse(name, null, byMetric.get(name)))
                     .toList()
             );
-        }
-
-        @Override
-        public FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request) {
-            contexts.add(context);
-            facetsRequests.add(request);
-            var apiIds = new TreeSet<>(apiIdsOf(request.filters()));
-            return new FacetsResponse(
-                request
-                    .metrics()
-                    .stream()
-                    .map(metric ->
-                        new MetricFacetsResponse(
-                            metric.name(),
-                            null,
-                            apiIds
-                                .stream()
-                                .map(apiId -> new FacetBucketResponse(apiId, null, null, measuresOf(apiId, metric)))
-                                .filter(bucket -> !bucket.measures().isEmpty())
-                                .toList()
-                        )
-                    )
-                    .toList()
-            );
-        }
-
-        private List<Measure> measuresOf(String apiId, FacetMetricMeasuresRequest metric) {
-            return responsesByApi
-                .getOrDefault(apiId, List.of())
-                .stream()
-                .filter(response -> response.name() == metric.name())
-                .flatMap(response -> response.measures().stream())
-                .filter(measure -> metric.measures().contains(measure.name()))
-                .toList();
         }
 
         @SuppressWarnings("unchecked")
@@ -757,6 +847,11 @@ class PerformanceTargetEvaluatorImplTest {
                 .findFirst()
                 .map(filter -> Set.copyOf((Collection<String>) filter.value()))
                 .orElse(Set.of());
+        }
+
+        @Override
+        public FacetsResponse searchFacets(ExecutionContext context, FacetsRequest request) {
+            throw new UnsupportedOperationException("targets are no longer evaluated through facets");
         }
 
         @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/HTTPDataPlaneAnalyticsQueryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/HTTPDataPlaneAnalyticsQueryServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.analytics_engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.GroupedMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeRange;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.repository.analytics.engine.api.metric.Metric;
+import io.gravitee.repository.analytics.engine.api.query.GroupedMeasuresQuery;
+import io.gravitee.repository.analytics.engine.api.result.GroupedMeasuresResult;
+import io.gravitee.repository.analytics.engine.api.result.MeasuresResult;
+import io.gravitee.repository.analytics.engine.api.result.MetricMeasuresResult;
+import io.gravitee.repository.log.v4.api.AnalyticsRepository;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class HTTPDataPlaneAnalyticsQueryServiceTest {
+
+    private final AnalyticsRepository repository = mock(AnalyticsRepository.class);
+    private final HTTPDataPlaneAnalyticsQueryService service = new HTTPDataPlaneAnalyticsQueryService(repository);
+
+    @Test
+    void should_compute_measures_per_group_through_the_repository() {
+        var context = new ExecutionContext("org", "env");
+        var groups = new LinkedHashMap<String, List<Filter>>();
+        groups.put("a", List.of(new Filter(FilterSpec.Name.API, FilterOperator.IN, List.of("api-a"))));
+        groups.put("b", List.of(new Filter(FilterSpec.Name.API, FilterOperator.IN, List.of("api-b"))));
+        var request = new GroupedMeasuresRequest(
+            new TimeRange(Instant.parse("2021-06-01T09:00:00Z"), Instant.parse("2021-06-01T10:00:00Z")),
+            List.of(new Filter(FilterSpec.Name.API, FilterOperator.IN, List.of("api-a", "api-b"))),
+            List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT))),
+            groups
+        );
+        when(repository.searchHTTPGroupedMeasures(eq(context.getQueryContext()), any())).thenReturn(
+            new GroupedMeasuresResult(
+                Map.of(
+                    "a",
+                    new MeasuresResult(
+                        List.of(
+                            new MetricMeasuresResult(
+                                Metric.HTTP_REQUESTS,
+                                Map.of(io.gravitee.repository.analytics.engine.api.metric.Measure.COUNT, 5)
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        var response = service.searchGroupedMeasures(context, request);
+
+        var query = ArgumentCaptor.forClass(GroupedMeasuresQuery.class);
+        verify(repository).searchHTTPGroupedMeasures(eq(context.getQueryContext()), query.capture());
+        assertThat(query.getValue().timeRange().from()).isEqualTo(Instant.parse("2021-06-01T09:00:00Z"));
+        assertThat(query.getValue().filters())
+            .singleElement()
+            .satisfies(filter -> {
+                assertThat(filter.name()).isEqualTo(io.gravitee.repository.analytics.engine.api.query.Filter.Name.API);
+                assertThat(filter.value()).isEqualTo(List.of("api-a", "api-b"));
+            });
+        assertThat(query.getValue().metrics())
+            .singleElement()
+            .satisfies(metric -> {
+                assertThat(metric.metric()).isEqualTo(Metric.HTTP_REQUESTS);
+                assertThat(metric.measures()).isEqualTo(Set.of(io.gravitee.repository.analytics.engine.api.metric.Measure.COUNT));
+            });
+        assertThat(query.getValue().groups().keySet()).containsExactly("a", "b");
+        assertThat(query.getValue().groups().get("b"))
+            .singleElement()
+            .extracting(f -> f.value())
+            .isEqualTo(List.of("api-b"));
+        assertThat(response.groups().get("a").metrics()).containsExactly(
+            new MetricMeasuresResponse(MetricSpec.Name.HTTP_REQUESTS, null, List.of(new Measure(MetricSpec.Measure.COUNT, 5)))
+        );
+    }
+
+    @Test
+    void should_advertise_grouped_measures() {
+        assertThat(service.supportsGroupedMeasures()).isTrue();
+    }
+}


### PR DESCRIPTION
## Issues

- https://gravitee.atlassian.net/browse/AIAM-554 — batch the scheduled evaluation of multi-API performance targets
- https://gravitee.atlassian.net/browse/APIM-15071 — analytics engine: `HTTP_METHOD` filter fails with `number_format_exception`
- https://gravitee.atlassian.net/browse/APIM-15072 — analytics engine: `HTTP_PATH` filter queries the unpopulated `path` field

Follow-ups of the AIAM-436 smoke test (see the epic comment of 2026-09-05).

## Description

### Performance targets: one analytics request per window, whatever the subjects hold (AIAM-554)

The scheduled evaluator batched targets by API through a facets request, so only single-API, filter-free targets were batched; an agent target (A2A proxy plus the LLM proxy it calls) cost one request each. Measured locally: 314 targets with 75 two-API subjects → ~90 Elasticsearch searches per tick.

The analytics engine gains a **grouped measures** query: the same measures computed once per named group of documents, each group selecting its documents with its own filters, in a single request (an Elasticsearch `filters` aggregation, one bucket per group, measure aggregations underneath). It runs through the whole engine stack:

- `repository-api`: `GroupedMeasuresQuery` / `GroupedMeasuresResult`, `AnalyticsRepository.searchHTTPGroupedMeasures`.
- `repository-elasticsearch`: `HTTPGroupedMeasuresQueryAdapter`, `GroupedMeasuresResponseAdapter`, `AggregationAdapter.toBucketMeasures`.
- `rest-api-service` core: `GroupedMeasuresRequest` / `GroupedMeasuresResponse`, `AnalyticsEngineQueryService.searchGroupedMeasures` (default throws; `supportsGroupedMeasures()` is `false` unless the engine implements it — the HTTP data plane does), `AnalyticsQueryContextProvider.resolve`.
- `rest-api-service` infra: MapStruct mapping and the HTTP data plane query service.

The evaluator now batches by **scope** (the API ids a rule resolves to plus its filters) instead of by API: one group per distinct scope shared by every rule that reads it, count-first, then one measures request per 500 groups for the scopes with enough samples. Multi-API subjects and rules with filters join the batch; only targets of other API families (Native, Edge, Authz) are still evaluated one at a time. The facets-by-API path is removed.

Same instance after the change: 300 mixed targets (75 per subject shape, 75 with two APIs) → **4 searches per tick**, 5–9 ms of Elasticsearch time, every target evaluated each tick; a two-API target evaluated by the batch and on its own gives the same result.

### `HTTP_METHOD` and `HTTP_PATH` analytics filters (APIM-15071, APIM-15072)

Pre-existing engine bugs that performance-target rules inherit (a rule filter on either passed validation and then failed or matched nothing):

- The gateway reports `http-method` as its `HttpMethod` code (`GET` = 3) while the catalog and the adapter used the name, so every `HTTP_METHOD` filter failed with `number_format_exception`. `FilterAdapter` now translates names to codes for `EQ` and `IN` (and refuses unknown methods), and `AggregationAdapter` names `HTTP_METHOD` facet buckets after the method at every nesting level.
- `HTTP_PATH` resolved to the `path` field, declared in the index template but never written; documents carry `path-info`. It now resolves to `path-info.keyword` for filters, facets and value listing.

Verified live on the same instance: `HTTP_METHOD EQ GET` → 200 with the right count, facets by `HTTP_METHOD` → `GET` / `POST` buckets, `HTTP_PATH EQ /status/503` → exactly the 120 calls sent, and rule filters on both evaluate.

## Tests

- `FilterAdapterTest`, `AggregationAdapterTest`, `HTTPFieldResolverTest`: method code translation, bucket naming, path field.
- `HTTPGroupedMeasuresQueryAdapterTest`, `GroupedMeasuresResponseAdapterTest`: query shape and bucket reading.
- `AnalyticsElasticsearchRepositoryTest` (Testcontainers): fixture counts per method and path, method-named buckets, a two-API group equal to the sum of its APIs.
- `HTTPDataPlaneAnalyticsQueryServiceTest`: request and result mapping.
- `PerformanceTargetEvaluatorImplTest`: 1000 targets (all single-API, then half two-API) in ≤ 4 requests, count-first, per-window batching, filtered rules batched, batch equal to evaluate-alone, other families evaluated alone.

## Compatibility-sensitive surfaces

- `AnalyticsRepository` (repository interface) gains `searchHTTPGroupedMeasures`; `AnalyticsEngineQueryService` gains two default methods.
- Analytics query behaviour change: `HTTP_METHOD` filters and facets now work, `HTTP_PATH` reads `path-info.keyword`. No index mapping change.
