### PR TITLE
feat(gamma): add environment-scoped SMTP settings

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -248,6 +248,10 @@ jest.mock('../pages/SmtpSettingsPage', () => ({
     SmtpSettingsPage: () => <div data-testid="smtp-settings-page" />,
 }));
 
+jest.mock('../pages/EnvironmentSmtpSettingsPage', () => ({
+    EnvironmentSmtpSettingsPage: () => <div data-testid="environment-smtp-settings-page" />,
+}));
+
 jest.mock('../pages/NotificationTemplatesPage', () => ({
     NotificationTemplatesPage: () => <div data-testid="notification-templates-page" />,
 }));
@@ -1553,6 +1557,30 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('cors-settings-page')).not.toBeNull();
         renderPlatform('/smtp');
         expect(screen.getByTestId('smtp-settings-page')).not.toBeNull();
+    });
+
+    it('routes to environment-scoped SMTP settings', () => {
+        renderPlatform('/environment/smtp');
+        expect(screen.getByTestId('environment-smtp-settings-page')).not.toBeNull();
+    });
+
+    it('blocks environment-scoped SMTP without environment-settings-r', () => {
+        denyPermissions('environment-settings-r');
+        renderPlatform('/environment/smtp');
+        expect(screen.queryByTestId('environment-smtp-settings-page')).toBeNull();
+        expect(screen.getByTestId('applications-page')).not.toBeNull();
+    });
+
+    it('shows environment SMTP in the Environment nav section', () => {
+        mockUseModuleRouting.mockReturnValue({
+            activeNavKey: 'environment-smtp',
+            navigateToKey: jest.fn(),
+            rootPath: '/platform',
+        });
+        renderPlatform('/environment/smtp');
+
+        expect(visibleNavKeys()).toContain('environment-smtp');
+        expect(visibleNavKeys()).not.toContain('smtp');
     });
 
     it('routes to organization notification templates', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -76,6 +76,7 @@ import { EditIdentityProviderPage } from '../pages/EditIdentityProviderPage';
 import { EntrypointsAndShardingTagsPage } from '../pages/EntrypointsAndShardingTagsPage';
 import { EnvAuditLogsPage } from '../pages/EnvAuditLogsPage';
 import { EnvironmentNotificationSettingsPage } from '../pages/EnvironmentNotificationSettingsPage';
+import { EnvironmentSmtpSettingsPage } from '../pages/EnvironmentSmtpSettingsPage';
 import { GatewayInstanceEnvironmentPage } from '../pages/GatewayInstanceEnvironmentPage';
 import { GatewayInstanceMonitoringPage } from '../pages/GatewayInstanceMonitoringPage';
 import { GatewayInstancesPage } from '../pages/GatewayInstancesPage';
@@ -517,6 +518,14 @@ export function AppRoutes() {
                                 element={
                                     <NavPermissionGuard itemKey="smtp">
                                         <SmtpSettingsPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
+                            <Route
+                                path="environment/smtp"
+                                element={
+                                    <NavPermissionGuard itemKey="environment-smtp">
+                                        <EnvironmentSmtpSettingsPage />
                                     </NavPermissionGuard>
                                 }
                             />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -196,6 +196,7 @@ describe('platform nav visibility', () => {
                 'gateways',
                 'alerts',
                 'notification-settings',
+                'environment-smtp',
                 'security-plan-types',
                 'environment-audit',
                 'access-management',
@@ -364,6 +365,10 @@ describe('platform nav visibility', () => {
         expect(modulePathFor('/environments/dev/platform/applications/app-1/subscriptions/sub-1', 'groups')).toBe(
             '/environments/dev/platform/groups',
         );
+        expect(modulePathFor('/environments/dev/platform/environment/smtp', 'applications')).toBe(
+            '/environments/dev/platform/applications',
+        );
+        expect(modulePathFor('/environments/dev/platform/environment/smtp', 'smtp')).toBe('/environments/dev/platform/smtp');
         expect(modulePathFor('/environments/dev/platform', 'no-access')).toBe('/environments/dev/platform/no-access');
         expect(modulePathFor('/', 'no-access')).toBe('/no-access');
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
@@ -17,7 +17,7 @@
 import type { License } from '@gravitee/gamma-modules-sdk/types';
 
 import { filterNavSections, firstNavItemKey, NAV_SECTIONS, type PlatformNavSection } from './navigation';
-import { DEFAULT_ROUTE_KEY, ROUTE_KEYS } from './routes';
+import { DEFAULT_ROUTE_KEY, ROUTES, ROUTE_KEYS, type RouteKey } from './routes';
 import { ENVIRONMENT_ALERT_READ_PERMISSION } from '../features/alerts/utils/alertPermissions';
 import { ENVIRONMENT_AUDIT_READ_PERMISSION, ORGANIZATION_AUDIT_READ_PERMISSION } from '../features/audit-logs/utils/auditPermissions';
 import { ENVIRONMENT_GROUP_READ_PERMISSION } from '../features/groups/utils/groupPermissions';
@@ -85,14 +85,13 @@ export const NAV_ITEM_PERMISSIONS: Readonly<Record<string, readonly string[]>> =
     gateways: ['environment-instance-r'],
     alerts: [ENVIRONMENT_ALERT_READ_PERMISSION],
     'notification-settings': ['environment-notification-r'],
+    'environment-smtp': [ENVIRONMENT_SETTINGS_READ_PERMISSION],
     'security-plan-types': [ENVIRONMENT_SETTINGS_READ_PERMISSION],
     'environment-audit': [ENVIRONMENT_AUDIT_READ_PERMISSION],
     users: ORGANIZATION_USER_ACCESS_PERMISSIONS,
     groups: [ENVIRONMENT_GROUP_READ_PERMISSION],
     roles: [ORGANIZATION_ROLE_READ_PERMISSION],
 };
-
-const MODULE_LEAF_KEYS: ReadonlySet<string> = new Set(ROUTE_KEYS);
 
 export interface NavVisibilityInput {
     readonly permissionsReady: boolean;
@@ -220,16 +219,26 @@ export function landingNavItemKey(visibility: NavVisibilityInput): string | unde
     return keys[0];
 }
 
-/** Replace the module leaf (a platform route key) with `itemKey`, keeping host prefixes. */
+/** Preserve host prefixes while replacing the longest matched nested route with `itemKey`'s path. */
 export function modulePathFor(pathname: string, itemKey: string): string {
+    const routePath = ROUTES[itemKey as RouteKey]?.path ?? itemKey;
     const segments = pathname.split('/').filter(Boolean);
-    let leafIndex = -1;
-    for (let index = segments.length - 1; index >= 0; index--) {
-        if (MODULE_LEAF_KEYS.has(segments[index]!)) {
-            leafIndex = index;
-            break;
+    const routeSegments = routePath.split('/');
+
+    let leafStart = -1;
+    let bestLength = 0;
+    for (const key of ROUTE_KEYS) {
+        const candidate = ROUTES[key].path.split('/');
+        if (segments.length < candidate.length) continue;
+        for (let start = 0; start <= segments.length - candidate.length; start++) {
+            const matches = candidate.every((segment, index) => segments[start + index] === segment);
+            if (matches && candidate.length > bestLength) {
+                bestLength = candidate.length;
+                leafStart = start;
+            }
         }
     }
-    const prefix = leafIndex >= 0 ? segments.slice(0, leafIndex) : segments;
-    return `/${[...prefix, itemKey].join('/')}`;
+
+    const prefix = leafStart >= 0 ? segments.slice(0, leafStart) : segments;
+    return `/${[...prefix, ...routeSegments].join('/')}`;
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -19,6 +19,7 @@ import {
     GlobeIcon,
     MailIcon,
     MessageSquareIcon,
+    SettingsIcon,
     ShieldIcon,
     UsersIcon,
     UsersRoundIcon,
@@ -86,19 +87,21 @@ describe('platform navigation config', () => {
         expect(assetItems.find(item => item.key === 'broadcasts')?.title).toBe('Broadcasts');
     });
 
-    it('places Access Management, Gateways, Alerts, Notifications, Security Plan Types, and Audit under Environment / System & Security', () => {
-        const systemItems =
-            NAV_SECTIONS.find(section => section.key === 'environment')?.groups.find(group => group.label === 'System & Security')?.items ??
-            [];
+    it('places Access Management, Gateways, Alerts, Notification settings, SMTP, Security Plan Types, and Audit under Environment / System & Security', () => {
         expect(sectionKeys('Environment', 'System & Security')).toEqual([
             'access-management',
             'gateways',
             'alerts',
             'notification-settings',
+            'environment-smtp',
             'security-plan-types',
             'environment-audit',
         ]);
+        const systemItems =
+            NAV_SECTIONS.find(section => section.key === 'environment')?.groups.find(group => group.label === 'System & Security')?.items ??
+            [];
         expect(systemItems.find(item => item.key === 'notification-settings')?.title).toBe('Notifications');
+        expect(systemItems.find(item => item.key === 'environment-smtp')?.icon).toBe(SettingsIcon);
     });
 
     it('places Users, Groups, and Roles under Team', () => {
@@ -216,6 +219,11 @@ describe('platform navigation config', () => {
         expect(ROUTES.cors).toEqual({ path: 'cors', label: 'CORS' });
         expect(ROUTES.smtp).toEqual({ path: 'smtp', label: 'SMTP' });
         expect(ROUTES.templates).toEqual({ path: 'templates', label: 'Templates' });
+    });
+
+    it('declares the environment-smtp route in platform routing config', () => {
+        expect(PLATFORM_ROUTE_CONFIG.routeKeys).toContain('environment-smtp');
+        expect(ROUTES['environment-smtp']).toEqual({ path: 'environment/smtp', label: 'SMTP' });
     });
 
     it('declares the authentication route in platform routing config', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -112,6 +112,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                     { key: 'gateways', title: ROUTES.gateways.label, icon: ServerIcon },
                     { key: 'alerts', title: ROUTES.alerts.label, icon: BellIcon },
                     { key: 'notification-settings', title: ROUTES['notification-settings'].label, icon: MailIcon },
+                    { key: 'environment-smtp', title: ROUTES['environment-smtp'].label, icon: SettingsIcon },
                     { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
                     { key: 'environment-audit', title: ROUTES['environment-audit'].label, icon: ScrollTextIcon },
                 ],

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -38,6 +38,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'environment-audit',
     'management-and-schedulers',
     'cors',
+    'environment-smtp',
     'smtp',
     'templates',
     'no-access',
@@ -70,6 +71,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'management-and-schedulers': { path: 'management-and-schedulers', label: 'Management & Schedulers' },
     cors: { path: 'cors', label: 'CORS' },
     smtp: { path: 'smtp', label: 'SMTP' },
+    'environment-smtp': { path: 'environment/smtp', label: 'SMTP' },
     templates: { path: 'templates', label: 'Templates' },
     'no-access': { path: 'no-access', label: 'No access' },
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/hooks/useResetEnvironmentBrandedSenders.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/hooks/useResetEnvironmentBrandedSenders.ts
@@ -18,25 +18,20 @@ import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { notify } from '../../../shared/notify';
-import type { PortalSettings } from '../services/portalSettings';
-import { savePortalSettings } from '../services/portalSettings';
-import { portalSettingsKeys } from '../utils/queryKeys';
+import { portalSettingsKeys } from '../../security-plan-types/utils/queryKeys';
+import { resetEnvironmentBrandedSenders } from '../services/environmentConsoleSettings';
 
-interface SavePortalSettingsOptions {
-    readonly successMessage?: string;
-    readonly errorMessage?: string;
-}
-
-export function useSavePortalSettings(options?: SavePortalSettingsOptions) {
+export function useResetEnvironmentBrandedSenders() {
     const env = useEnvironment();
+    const environmentId = env?.id ?? '';
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (payload: PortalSettings) => savePortalSettings(env!.id, payload),
+        mutationFn: () => resetEnvironmentBrandedSenders(environmentId),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: portalSettingsKeys.env(env?.id ?? '') });
-            notify.success(options?.successMessage ?? 'Security plan types saved successfully.');
+            queryClient.invalidateQueries({ queryKey: portalSettingsKeys.env(environmentId) });
+            notify.success('Branded senders reset to the organization configuration.');
         },
-        onError: error => notify.error(error, options?.errorMessage ?? 'Failed to save security plan types.'),
+        onError: error => notify.error(error, 'An error occurred while resetting the branded senders.'),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/services/environmentConsoleSettings.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/services/environmentConsoleSettings.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resetEnvironmentBrandedSenders } from './environmentConsoleSettings';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ConsoleSettings } from '../../organization-settings/types/consoleSettings';
+
+jest.mock('../../../shared/api/apimClient', () => ({ apimFetchJsonV1Env: jest.fn() }));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('environment console settings service', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('POSTs to the branded-senders reset resource', async () => {
+        const response: ConsoleSettings = { email: { brandedSendersInherited: true } };
+        mockApimFetchJsonV1Env.mockResolvedValue(response);
+
+        const result = await resetEnvironmentBrandedSenders('DEFAULT');
+
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/settings/email/branded-senders/reset', {
+            method: 'POST',
+        });
+        expect(result).toEqual(response);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/services/environmentConsoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-settings/services/environmentConsoleSettings.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ConsoleSettings } from '../../organization-settings/types/consoleSettings';
+
+/**
+ * Drops the environment-level branded-senders override so it falls back to the organization (or system)
+ * value. Sending an empty list via the portal settings POST would instead persist an empty override
+ * that shadows the organization value — Classic's `portal-settings.service.ts` has the same note.
+ */
+export async function resetEnvironmentBrandedSenders(environmentId: string): Promise<ConsoleSettings> {
+    return apimFetchJsonV1Env<ConsoleSettings>(environmentId, '/settings/email/branded-senders/reset', {
+        method: 'POST',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/BrandedSendersSection.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/BrandedSendersSection.spec.tsx
@@ -32,8 +32,8 @@ describe('BrandedSendersSection', () => {
                 onChange={jest.fn()}
             />,
         );
-        expect(screen.getByLabelText('From *').closest('[data-slot="card"]')).not.toBeNull();
-        expect(screen.getByLabelText('Recipient domains *').closest('[data-slot="card"]')).not.toBeNull();
+        expect(screen.getByLabelText('From', { selector: '#branded-from-0' }).closest('[data-slot="card"]')).not.toBeNull();
+        expect(screen.getByLabelText('Recipient domains').closest('[data-slot="card"]')).not.toBeNull();
     });
 
     it('previews default from/subject and lists branded rules', () => {
@@ -49,7 +49,9 @@ describe('BrandedSendersSection', () => {
         expect((screen.getByLabelText('Default From') as HTMLInputElement).value).toBe('noreply@example.com');
         expect((screen.getByLabelText('Default From') as HTMLInputElement).readOnly).toBe(true);
         expect(screen.getByText('partners.example.com')).not.toBeNull();
-        expect((screen.getByLabelText('From *') as HTMLInputElement).value).toBe('Partners <partners@example.com>');
+        expect((screen.getByLabelText('From', { selector: '#branded-from-0' }) as HTMLInputElement).value).toBe(
+            'Partners <partners@example.com>',
+        );
     });
 
     it('adds and removes branded sender rules', () => {
@@ -63,9 +65,9 @@ describe('BrandedSendersSection', () => {
                 onChange={onChange}
             />,
         );
-        fireEvent.click(screen.getByRole('button', { name: /Add rule/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Add configuration/i }));
         expect(onChange).toHaveBeenCalledWith([...SENDERS, { domains: [], from: '', subject: '' }]);
-        fireEvent.click(screen.getByRole('button', { name: /Delete branded sender 1/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete configuration 1' }));
         expect(onChange).toHaveBeenCalledWith([]);
     });
 
@@ -88,8 +90,8 @@ describe('BrandedSendersSection', () => {
             />,
         );
 
-        const domains = screen.getByLabelText('Recipient domains *');
-        const from = screen.getByLabelText('From *');
+        const domains = screen.getByLabelText('Recipient domains');
+        const from = screen.getByLabelText('From', { selector: '#branded-from-0' });
         const subject = screen.getByLabelText('Subject prefix');
 
         expect(screen.getByText('Invalid domain(s): localhost')).not.toBeNull();
@@ -103,5 +105,53 @@ describe('BrandedSendersSection', () => {
         expect(domains.getAttribute('aria-describedby')).toContain('branded-domains-0-error');
         expect(from.getAttribute('aria-describedby')).toBe('branded-from-0-error');
         expect(subject.getAttribute('aria-describedby')).toBe('branded-subject-0-error');
+    });
+
+    it('does not render a reset action by default', () => {
+        render(
+            <BrandedSendersSection
+                defaultFrom="noreply@example.com"
+                defaultSubject="[gravitee] %s"
+                senders={SENDERS}
+                disabled={false}
+                onChange={jest.fn()}
+            />,
+        );
+        expect(screen.queryByRole('button', { name: /Reset to Org settings/i })).toBeNull();
+    });
+
+    it('renders a reset action when canReset and onReset are provided, and calls it on click', () => {
+        const onReset = jest.fn();
+        render(
+            <BrandedSendersSection
+                defaultFrom="noreply@example.com"
+                defaultSubject="[gravitee] %s"
+                senders={SENDERS}
+                disabled={false}
+                onChange={jest.fn()}
+                canReset
+                onReset={onReset}
+            />,
+        );
+        const resetButton = screen.getByRole('button', { name: 'Reset to Org settings' });
+        fireEvent.click(resetButton);
+        expect(onReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the reset action while resetting', () => {
+        render(
+            <BrandedSendersSection
+                defaultFrom="noreply@example.com"
+                defaultSubject="[gravitee] %s"
+                senders={SENDERS}
+                disabled={false}
+                onChange={jest.fn()}
+                canReset
+                isResetting
+                onReset={jest.fn()}
+            />,
+        );
+        const resetButton = screen.getByRole('button', { name: /Resetting…/i }) as HTMLButtonElement;
+        expect(resetButton.disabled).toBe(true);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/BrandedSendersSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/BrandedSendersSection.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Button, Card, CardContent, Input } from '@gravitee/graphene-core';
-import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { PlusIcon, RefreshCwIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 
 import { ChipInput } from '../../shared/components/ChipInput';
 import type { BrandedSender } from '../types/consoleSettings';
@@ -34,6 +34,9 @@ export function BrandedSendersSection({
     senderErrors = [],
     listError,
     onChange,
+    canReset = false,
+    isResetting = false,
+    onReset,
 }: Readonly<{
     defaultFrom: string;
     defaultSubject: string;
@@ -42,6 +45,10 @@ export function BrandedSendersSection({
     senderErrors?: readonly BrandedSenderFieldErrors[];
     listError?: string;
     onChange: (next: BrandedSender[]) => void;
+    /** Environment-scoped settings only: shows a "Reset to Org settings" action next to "Add configuration". */
+    canReset?: boolean;
+    isResetting?: boolean;
+    onReset?: () => void;
 }>) {
     function updateAt(index: number, patch: Partial<BrandedSender>) {
         onChange(senders.map((sender, senderIndex) => (senderIndex === index ? { ...sender, ...patch } : sender)));
@@ -51,7 +58,7 @@ export function BrandedSendersSection({
         <div className="space-y-6">
             <section className="space-y-3">
                 <div>
-                    <h3 className="text-sm font-semibold">Default notification email</h3>
+                    <h2 className="text-sm font-semibold">Default notification email</h2>
                     <p className="text-xs text-muted-foreground">{"Used when no branded rule matches the recipient's email domain."}</p>
                 </div>
                 <div className="space-y-1.5">
@@ -59,36 +66,45 @@ export function BrandedSendersSection({
                         Default From
                     </label>
                     <Input id="smtp-default-from" value={defaultFrom} readOnly disabled />
-                    <p className="text-xs text-muted-foreground">Read-only preview of the from configured above.</p>
+                    <p className="text-xs text-muted-foreground">Read-only preview of the From configured above.</p>
                 </div>
                 <div className="space-y-1.5">
                     <label htmlFor="smtp-default-subject" className="text-sm font-medium">
                         Default subject prefix
                     </label>
                     <Input id="smtp-default-subject" value={defaultSubject} readOnly disabled />
+                    <p className="text-xs text-muted-foreground">{"%s is replaced with the email's subject."}</p>
                 </div>
             </section>
 
             <section className="space-y-3">
                 <div className="flex items-start justify-between gap-4">
                     <div>
-                        <h3 className="text-sm font-semibold">Branded notification email</h3>
+                        <h2 className="text-sm font-semibold">Branded notification email</h2>
                         <p className="text-xs text-muted-foreground">
                             {
-                                "Add one or more rules. When a recipient's domain matches a rule, that rule's From and Subject prefix are used instead of the default above."
+                                "Add one or more rules. When a recipient's domain matches a rule, that rule's From and Subject prefix are used instead of the defaults above."
                             }
                         </p>
                     </div>
                     {disabled ? null : (
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => onChange([...senders, { domains: [], from: '', subject: '' }])}
-                        >
-                            <PlusIcon className="size-4" aria-hidden />
-                            Add rule
-                        </Button>
+                        <div className="flex items-center gap-2">
+                            {canReset && onReset ? (
+                                <Button type="button" variant="ghost" size="sm" onClick={onReset} disabled={isResetting}>
+                                    <RefreshCwIcon className="size-4" aria-hidden />
+                                    {isResetting ? 'Resetting…' : 'Reset to Org settings'}
+                                </Button>
+                            ) : null}
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => onChange([...senders, { domains: [], from: '', subject: '' }])}
+                            >
+                                <PlusIcon className="size-4" aria-hidden />
+                                Add configuration
+                            </Button>
+                        </div>
                     )}
                 </div>
 
@@ -105,13 +121,14 @@ export function BrandedSendersSection({
                     return (
                         <Card key={`branded-sender-${index}`}>
                             <CardContent className="space-y-3 relative">
+                                <p className="text-sm font-medium">Configuration {index + 1}</p>
                                 {disabled ? null : (
                                     <Button
                                         type="button"
                                         variant="ghost"
                                         size="icon"
                                         className="absolute right-2 top-2"
-                                        aria-label={`Delete branded sender ${index + 1}`}
+                                        aria-label={`Delete configuration ${index + 1}`}
                                         onClick={() => onChange(senders.filter((_, senderIndex) => senderIndex !== index))}
                                     >
                                         <Trash2Icon className="size-4" aria-hidden />
@@ -119,7 +136,7 @@ export function BrandedSendersSection({
                                 )}
                                 <div className="space-y-1.5 pr-10">
                                     <label htmlFor={`branded-domains-${index}`} className="text-sm font-medium">
-                                        Recipient domains *
+                                        Recipient domains
                                     </label>
                                     <ChipInput
                                         id={`branded-domains-${index}`}
@@ -142,13 +159,14 @@ export function BrandedSendersSection({
                                 </div>
                                 <div className="space-y-1.5">
                                     <label htmlFor={`branded-from-${index}`} className="text-sm font-medium">
-                                        From *
+                                        From
                                     </label>
                                     <Input
                                         id={`branded-from-${index}`}
                                         value={sender.from}
                                         onChange={e => updateAt(index, { from: e.target.value })}
                                         disabled={disabled}
+                                        placeholder="noreply@example.com"
                                         aria-invalid={Boolean(fieldErrors.from)}
                                         aria-describedby={fieldErrors.from ? fromErrorId : undefined}
                                     />
@@ -167,6 +185,7 @@ export function BrandedSendersSection({
                                         value={sender.subject}
                                         onChange={e => updateAt(index, { subject: e.target.value })}
                                         disabled={disabled}
+                                        placeholder="[Example] %s"
                                         aria-invalid={Boolean(fieldErrors.subject)}
                                         aria-describedby={fieldErrors.subject ? subjectErrorId : undefined}
                                     />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.spec.tsx
@@ -88,4 +88,12 @@ describe('OrgSettingsFormShell', () => {
         expect(screen.getByRole('button', { name: /Save changes/i })).toHaveProperty('disabled', true);
         expect(screen.getByRole('button', { name: 'Discard' })).toHaveProperty('disabled', false);
     });
+
+    it('hides the architecture override banner when showArchitectureOverrideWarning is false', () => {
+        renderShell({ showArchitectureOverrideWarning: false });
+
+        expect(
+            screen.queryByText(/Depending on your architecture, this configuration may be overridden by a local configuration file/),
+        ).toBeNull();
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/OrgSettingsFormShell.tsx
@@ -30,6 +30,7 @@ export function OrgSettingsFormShell({
     onSave,
     onDiscard,
     children,
+    showArchitectureOverrideWarning = true,
 }: Readonly<{
     title: string;
     description: string;
@@ -42,6 +43,8 @@ export function OrgSettingsFormShell({
     onSave: () => void;
     onDiscard: () => void;
     children: ReactNode;
+    /** Organization console settings only — portal/environment settings omit this banner. */
+    showArchitectureOverrideWarning?: boolean;
 }>) {
     if (isLoading) {
         return (
@@ -74,13 +77,15 @@ export function OrgSettingsFormShell({
                     <p className="text-sm text-muted-foreground">{description}</p>
                 </div>
 
-                <Alert>
-                    <InfoIcon className="size-4" />
-                    <AlertDescription>
-                        Depending on your architecture, this configuration may be overridden by a local configuration file. See
-                        documentation for more information.
-                    </AlertDescription>
-                </Alert>
+                {showArchitectureOverrideWarning ? (
+                    <Alert>
+                        <InfoIcon className="size-4" />
+                        <AlertDescription>
+                            Depending on your architecture, this configuration may be overridden by a local configuration file. See
+                            documentation for more information.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
 
                 {!canEdit ? (
                     <Alert>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/SmtpSection.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/SmtpSection.spec.tsx
@@ -57,7 +57,7 @@ describe('SmtpSection', () => {
     it('wraps SMTP blocks in Graphene Cards', () => {
         render(<Harness />);
         expect(screen.getByLabelText('Enable Emailing').closest('[data-slot="card"]')).not.toBeNull();
-        expect(screen.getByText('Mail Properties').closest('[data-slot="card-title"]')).not.toBeNull();
+        expect(screen.getByText('Mail properties').closest('[data-slot="card-title"]')).not.toBeNull();
         expect(screen.getByText('Branded notification email').closest('[data-slot="card"]')).toBeNull();
     });
 
@@ -68,12 +68,14 @@ describe('SmtpSection', () => {
         expect(screen.getByText('Enter a valid email address, optionally with a display name.')).not.toBeNull();
         expect(screen.getByLabelText('Host').getAttribute('aria-invalid')).toBe('true');
         expect(screen.getByLabelText('Port').getAttribute('aria-invalid')).toBe('true');
-        expect(screen.getByLabelText('From').getAttribute('aria-invalid')).toBe('true');
+        expect(screen.getByLabelText('From', { selector: '#smtp-from' }).getAttribute('aria-invalid')).toBe('true');
     });
 
-    it('hides mail fields when emailing is disabled', () => {
+    it('keeps mail fields visible but disables most of them when emailing is off', () => {
         render(<Harness initial={{ ...ENABLED, enabled: false }} />);
-        expect(screen.queryByLabelText('Host')).toBeNull();
+        expect(screen.getByLabelText('Host')).not.toBeNull();
+        expect((screen.getByLabelText('Host') as HTMLInputElement).disabled).toBe(false);
+        expect((screen.getByLabelText('Password') as HTMLInputElement).disabled).toBe(true);
         expect(screen.getByLabelText('Enable Emailing')).not.toBeNull();
     });
 
@@ -90,8 +92,8 @@ describe('SmtpSection', () => {
             />,
         );
         expect(screen.getByText('Branded notification email')).not.toBeNull();
-        expect(screen.queryByRole('button', { name: /Add rule/i })).toBeNull();
-        expect((screen.getByLabelText('From *') as HTMLInputElement).disabled).toBe(true);
+        expect(screen.queryByRole('button', { name: /Add configuration/i })).toBeNull();
+        expect((screen.getByLabelText('From', { selector: '#smtp-from' }) as HTMLInputElement).disabled).toBe(true);
     });
 
     it('shows host, port, password sentinel, and mail properties when enabled', () => {
@@ -174,8 +176,8 @@ describe('SmtpSection', () => {
         );
         expect(screen.getByText('Invalid domain(s): localhost')).not.toBeNull();
         expect(screen.getByText('From is required.')).not.toBeNull();
-        expect(screen.getByLabelText('Recipient domains *').getAttribute('aria-invalid')).toBe('true');
-        expect(screen.getByLabelText('From *').getAttribute('aria-invalid')).toBe('true');
+        expect(screen.getByLabelText('Recipient domains').getAttribute('aria-invalid')).toBe('true');
+        expect(screen.getByLabelText('From', { selector: '#branded-from-0' }).getAttribute('aria-invalid')).toBe('true');
     });
 
     it('marks system-provided SMTP fields for the Classic tooltip', () => {
@@ -192,5 +194,11 @@ describe('SmtpSection', () => {
         fireEvent.click(enableSwitch);
         expect((screen.getByLabelText('Host') as HTMLInputElement).disabled).toBe(true);
         expect((screen.getByLabelText('Username') as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('disables Enable Emailing when email.enabled is system-provided', () => {
+        render(<Harness readonly={{ enabled: true }} />);
+        expect((screen.getByLabelText('Enable Emailing') as HTMLButtonElement).disabled).toBe(true);
+        expect(screen.getByLabelText('Enable Emailing').closest('[data-system-readonly="true"]')).not.toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/SmtpSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/components/SmtpSection.tsx
@@ -35,6 +35,24 @@ export interface SmtpFormState {
     brandedSenders: BrandedSender[];
 }
 
+export interface SmtpFieldReadonly {
+    enabled?: boolean;
+    host?: boolean;
+    port?: boolean;
+    username?: boolean;
+    password?: boolean;
+    protocol?: boolean;
+    subject?: boolean;
+    from?: boolean;
+    auth?: boolean;
+    startTlsEnable?: boolean;
+    sslTrust?: boolean;
+    brandedSenders?: boolean;
+}
+
+/** Classic portal-settings: host, port, and username stay editable when emailing is disabled. */
+const FIELDS_EDITABLE_WHEN_EMAILING_DISABLED = new Set<keyof SmtpFieldReadonly>(['host', 'port', 'username']);
+
 export function extractEmailAddress(from: string): string {
     const angled = from.match(/<([^>]+)>/);
     return (angled?.[1] ?? from).trim();
@@ -139,37 +157,32 @@ export function isSmtpFormValid(state: SmtpFormState): boolean {
     );
 }
 
-export interface SmtpFieldReadonly {
-    enabled?: boolean;
-    host?: boolean;
-    port?: boolean;
-    username?: boolean;
-    password?: boolean;
-    protocol?: boolean;
-    subject?: boolean;
-    from?: boolean;
-    auth?: boolean;
-    startTlsEnable?: boolean;
-    sslTrust?: boolean;
-    brandedSenders?: boolean;
-}
-
 export function SmtpSection({
     value,
     disabled,
     readonly = {},
     onChange,
+    canResetBrandedSenders = false,
+    isResettingBrandedSenders = false,
+    onResetBrandedSenders,
 }: Readonly<{
     value: SmtpFormState;
     disabled: boolean;
     readonly?: SmtpFieldReadonly;
     onChange: (next: SmtpFormState) => void;
+    /** Environment-scoped settings only: shows a "Reset to Org settings" action on the branded senders section. */
+    canResetBrandedSenders?: boolean;
+    isResettingBrandedSenders?: boolean;
+    onResetBrandedSenders?: () => void;
 }>) {
-    const fieldsOff = disabled || !value.enabled;
-
     function isFieldDisabled(key: keyof SmtpFieldReadonly): boolean {
-        return fieldsOff || Boolean(readonly[key]);
+        if (disabled || Boolean(readonly[key])) return true;
+        if (!value.enabled && !FIELDS_EDITABLE_WHEN_EMAILING_DISABLED.has(key)) return true;
+        return false;
     }
+
+    const brandedSendersDisabled = disabled || !value.enabled || Boolean(readonly.brandedSenders);
+    const showFieldErrors = value.enabled;
 
     return (
         <div className="space-y-6">
@@ -190,126 +203,120 @@ export function SmtpSection({
                         </SystemReadonlyHint>
                     </div>
 
-                    {value.enabled ? (
-                        <>
-                            <Field
-                                id="smtp-host"
-                                label="Host"
-                                value={value.host}
-                                disabled={isFieldDisabled('host')}
-                                systemReadonly={Boolean(readonly.host)}
-                                error={value.host.trim().length === 0 ? 'Host is required when emailing is enabled.' : undefined}
-                                onChange={host => onChange({ ...value, host })}
+                    <Field
+                        id="smtp-host"
+                        label="Host"
+                        value={value.host}
+                        disabled={isFieldDisabled('host')}
+                        systemReadonly={Boolean(readonly.host)}
+                        error={showFieldErrors && value.host.trim().length === 0 ? 'Host is required when emailing is enabled.' : undefined}
+                        onChange={host => onChange({ ...value, host })}
+                    />
+                    <Field
+                        id="smtp-port"
+                        label="Port"
+                        type="number"
+                        min={0}
+                        value={value.port}
+                        disabled={isFieldDisabled('port')}
+                        systemReadonly={Boolean(readonly.port)}
+                        error={showFieldErrors && parseSmtpPort(value.port) === null ? 'Enter a port between 0 and 65535.' : undefined}
+                        onChange={port => onChange({ ...value, port })}
+                    />
+                    <Field
+                        id="smtp-username"
+                        label="Username"
+                        value={value.username}
+                        disabled={isFieldDisabled('username')}
+                        systemReadonly={Boolean(readonly.username)}
+                        onChange={username => onChange({ ...value, username })}
+                    />
+                    <Field
+                        id="smtp-password"
+                        label="Password"
+                        type="password"
+                        value={value.password}
+                        disabled={isFieldDisabled('password')}
+                        systemReadonly={Boolean(readonly.password)}
+                        onChange={password => onChange({ ...value, password })}
+                    />
+                    <Field
+                        id="smtp-protocol"
+                        label="Protocol"
+                        value={value.protocol}
+                        disabled={isFieldDisabled('protocol')}
+                        systemReadonly={Boolean(readonly.protocol)}
+                        onChange={protocol => onChange({ ...value, protocol })}
+                    />
+                    <div className="space-y-1.5">
+                        <label htmlFor="smtp-subject" className="text-sm font-medium">
+                            Subject
+                        </label>
+                        <SystemReadonlyHint locked={Boolean(readonly.subject)}>
+                            <Input
+                                id="smtp-subject"
+                                value={value.subject}
+                                onChange={e => onChange({ ...value, subject: e.target.value })}
+                                disabled={isFieldDisabled('subject')}
                             />
-                            <Field
-                                id="smtp-port"
-                                label="Port"
-                                type="number"
-                                min={0}
-                                value={value.port}
-                                disabled={isFieldDisabled('port')}
-                                systemReadonly={Boolean(readonly.port)}
-                                error={parseSmtpPort(value.port) === null ? 'Enter a port between 0 and 65535.' : undefined}
-                                onChange={port => onChange({ ...value, port })}
-                            />
-                            <Field
-                                id="smtp-username"
-                                label="Username"
-                                value={value.username}
-                                disabled={isFieldDisabled('username')}
-                                systemReadonly={Boolean(readonly.username)}
-                                onChange={username => onChange({ ...value, username })}
-                            />
-                            <Field
-                                id="smtp-password"
-                                label="Password"
-                                type="password"
-                                value={value.password}
-                                disabled={isFieldDisabled('password')}
-                                systemReadonly={Boolean(readonly.password)}
-                                onChange={password => onChange({ ...value, password })}
-                            />
-                            <Field
-                                id="smtp-protocol"
-                                label="Protocol"
-                                value={value.protocol}
-                                disabled={isFieldDisabled('protocol')}
-                                systemReadonly={Boolean(readonly.protocol)}
-                                onChange={protocol => onChange({ ...value, protocol })}
-                            />
-                            <div className="space-y-1.5">
-                                <label htmlFor="smtp-subject" className="text-sm font-medium">
-                                    Subject
-                                </label>
-                                <SystemReadonlyHint locked={Boolean(readonly.subject)}>
-                                    <Input
-                                        id="smtp-subject"
-                                        value={value.subject}
-                                        onChange={e => onChange({ ...value, subject: e.target.value })}
-                                        disabled={isFieldDisabled('subject')}
-                                    />
-                                </SystemReadonlyHint>
-                                <p className="text-xs text-muted-foreground">{"%s is replaced with the email's subject."}</p>
-                            </div>
-                            <Field
-                                id="smtp-from"
-                                label="From"
-                                value={value.from}
-                                disabled={isFieldDisabled('from')}
-                                systemReadonly={Boolean(readonly.from)}
-                                error={smtpFromFieldError(value.from)}
-                                onChange={from => onChange({ ...value, from })}
-                            />
-                        </>
-                    ) : null}
+                        </SystemReadonlyHint>
+                        <p className="text-xs text-muted-foreground">{"%s is replaced with the email's subject."}</p>
+                    </div>
+                    <Field
+                        id="smtp-from"
+                        label="From"
+                        value={value.from}
+                        disabled={isFieldDisabled('from')}
+                        systemReadonly={Boolean(readonly.from)}
+                        error={showFieldErrors ? smtpFromFieldError(value.from) : undefined}
+                        onChange={from => onChange({ ...value, from })}
+                    />
                 </CardContent>
             </Card>
 
-            {value.enabled ? (
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Mail Properties</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                        <div className="flex items-center justify-between gap-4">
-                            <label htmlFor="smtp-auth" className="text-sm font-medium">
-                                Enable Auth
-                            </label>
-                            <SystemReadonlyHint locked={Boolean(readonly.auth)} className="inline-flex">
-                                <Switch
-                                    id="smtp-auth"
-                                    checked={value.auth}
-                                    onCheckedChange={checked => onChange({ ...value, auth: checked === true })}
-                                    disabled={isFieldDisabled('auth')}
-                                    aria-label="Enable Auth"
-                                />
-                            </SystemReadonlyHint>
-                        </div>
-                        <div className="flex items-center justify-between gap-4">
-                            <label htmlFor="smtp-starttls" className="text-sm font-medium">
-                                Enable Start TLS
-                            </label>
-                            <SystemReadonlyHint locked={Boolean(readonly.startTlsEnable)} className="inline-flex">
-                                <Switch
-                                    id="smtp-starttls"
-                                    checked={value.startTlsEnable}
-                                    onCheckedChange={checked => onChange({ ...value, startTlsEnable: checked === true })}
-                                    disabled={isFieldDisabled('startTlsEnable')}
-                                    aria-label="Enable Start TLS"
-                                />
-                            </SystemReadonlyHint>
-                        </div>
-                        <Field
-                            id="smtp-ssl-trust"
-                            label="SSL Trust"
-                            value={value.sslTrust}
-                            disabled={isFieldDisabled('sslTrust')}
-                            systemReadonly={Boolean(readonly.sslTrust)}
-                            onChange={sslTrust => onChange({ ...value, sslTrust })}
-                        />
-                    </CardContent>
-                </Card>
-            ) : null}
+            <Card>
+                <CardHeader>
+                    <CardTitle>Mail properties</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <label htmlFor="smtp-auth" className="text-sm font-medium">
+                            Enable Auth
+                        </label>
+                        <SystemReadonlyHint locked={Boolean(readonly.auth)} className="inline-flex">
+                            <Switch
+                                id="smtp-auth"
+                                checked={value.auth}
+                                onCheckedChange={checked => onChange({ ...value, auth: checked === true })}
+                                disabled={isFieldDisabled('auth')}
+                                aria-label="Enable Auth"
+                            />
+                        </SystemReadonlyHint>
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                        <label htmlFor="smtp-starttls" className="text-sm font-medium">
+                            Enable Start TLS
+                        </label>
+                        <SystemReadonlyHint locked={Boolean(readonly.startTlsEnable)} className="inline-flex">
+                            <Switch
+                                id="smtp-starttls"
+                                checked={value.startTlsEnable}
+                                onCheckedChange={checked => onChange({ ...value, startTlsEnable: checked === true })}
+                                disabled={isFieldDisabled('startTlsEnable')}
+                                aria-label="Enable Start TLS"
+                            />
+                        </SystemReadonlyHint>
+                    </div>
+                    <Field
+                        id="smtp-ssl-trust"
+                        label="SSL Trust"
+                        value={value.sslTrust}
+                        disabled={isFieldDisabled('sslTrust')}
+                        systemReadonly={Boolean(readonly.sslTrust)}
+                        onChange={sslTrust => onChange({ ...value, sslTrust })}
+                    />
+                </CardContent>
+            </Card>
 
             <div>
                 <SystemReadonlyHint locked={Boolean(readonly.brandedSenders)}>
@@ -317,10 +324,13 @@ export function SmtpSection({
                         defaultFrom={value.from}
                         defaultSubject={value.subject}
                         senders={value.brandedSenders}
-                        disabled={disabled || !value.enabled || Boolean(readonly.brandedSenders)}
+                        disabled={brandedSendersDisabled}
                         senderErrors={value.brandedSenders.map(getBrandedSenderFieldErrors)}
-                        listError={getBrandedSendersListError(value.brandedSenders)}
+                        listError={showFieldErrors ? getBrandedSendersListError(value.brandedSenders) : undefined}
                         onChange={brandedSenders => onChange({ ...value, brandedSenders })}
+                        canReset={canResetBrandedSenders}
+                        isResetting={isResettingBrandedSenders}
+                        onReset={onResetBrandedSenders}
                     />
                 </SystemReadonlyHint>
             </div>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/types/consoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/types/consoleSettings.ts
@@ -36,6 +36,12 @@ export interface ConsoleSettingsEmail extends DisableableFeature {
     subject?: string;
     from?: string;
     brandedSenders?: BrandedSender[];
+    /**
+     * Environment-scoped settings only: true when the environment has no branded-senders override of its
+     * own and is inheriting the organization's configuration. Absent (or on org-scoped settings) means
+     * "unknown" / not applicable — callers should treat that as "don't offer a reset".
+     */
+    brandedSendersInherited?: boolean;
     properties?: {
         auth?: boolean;
         startTlsEnable?: boolean;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildPortalSettingsEmailSavePayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildPortalSettingsEmailSavePayload.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildConsoleSettingsSavePayload } from './buildConsoleSettingsSavePayload';
+import type { PortalSettings } from '../../security-plan-types/services/portalSettings';
+import type { ConsoleSettings, ConsoleSettingsEmail } from '../types/consoleSettings';
+
+/** Overlays environment email settings onto the shared portal `/settings` document. */
+export function buildPortalSettingsEmailSavePayload(current: PortalSettings, email: ConsoleSettingsEmail): PortalSettings {
+    return buildConsoleSettingsSavePayload(current as ConsoleSettings, 'email', { email }) as PortalSettings;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/smtpFormState.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/smtpFormState.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildSmtpEmailPatch, buildSmtpFieldReadonly, buildSmtpFormState, canEnvironmentResetBrandedSenders } from './smtpFormState';
+import type { SmtpFormState } from '../components/SmtpSection';
+import { PASSWORD_SENTINEL, type ConsoleSettings } from '../types/consoleSettings';
+
+const SETTINGS: ConsoleSettings = {
+    email: {
+        enabled: true,
+        host: 'smtp.example.com',
+        port: 587,
+        username: 'admin',
+        password: PASSWORD_SENTINEL,
+        protocol: 'smtp',
+        subject: '[gravitee] %s',
+        from: 'noreply@example.com',
+        properties: { auth: true, startTlsEnable: true, sslTrust: '' },
+        brandedSenders: [],
+        brandedSendersInherited: false,
+    },
+    metadata: { readonly: ['email.host'] },
+};
+
+const LOCAL: SmtpFormState = {
+    enabled: true,
+    host: 'localhost',
+    port: '1025',
+    username: '',
+    password: PASSWORD_SENTINEL,
+    protocol: 'smtp',
+    subject: '[Gravitee.io] %s',
+    from: 'noreply@gravitee.local',
+    auth: false,
+    startTlsEnable: false,
+    sslTrust: '',
+    brandedSenders: [],
+};
+
+describe('smtpFormState', () => {
+    it('builds form state from console settings', () => {
+        expect(buildSmtpFormState(SETTINGS)).toEqual({
+            enabled: true,
+            host: 'smtp.example.com',
+            port: '587',
+            username: 'admin',
+            password: PASSWORD_SENTINEL,
+            protocol: 'smtp',
+            subject: '[gravitee] %s',
+            from: 'noreply@example.com',
+            auth: true,
+            startTlsEnable: true,
+            sslTrust: '',
+            brandedSenders: [],
+        });
+    });
+
+    it('maps metadata readonly keys to field flags', () => {
+        expect(buildSmtpFieldReadonly(SETTINGS)).toEqual({
+            enabled: false,
+            host: true,
+            port: false,
+            username: false,
+            password: false,
+            protocol: false,
+            subject: false,
+            from: false,
+            auth: false,
+            startTlsEnable: false,
+            sslTrust: false,
+            brandedSenders: false,
+        });
+    });
+
+    it('builds the email patch for save payloads', () => {
+        expect(buildSmtpEmailPatch(LOCAL)).toEqual({
+            enabled: true,
+            host: 'localhost',
+            port: 1025,
+            username: '',
+            password: PASSWORD_SENTINEL,
+            protocol: 'smtp',
+            subject: '[Gravitee.io] %s',
+            from: 'noreply@gravitee.local',
+            brandedSenders: [],
+            properties: { auth: false, startTlsEnable: false, sslTrust: '' },
+        });
+    });
+
+    it('offers branded-senders reset only for environment overrides', () => {
+        const readonly = buildSmtpFieldReadonly(SETTINGS);
+        expect(canEnvironmentResetBrandedSenders({ canEdit: true, localState: LOCAL, readonly, settings: SETTINGS })).toBe(true);
+        expect(
+            canEnvironmentResetBrandedSenders({
+                canEdit: true,
+                localState: LOCAL,
+                readonly,
+                settings: { ...SETTINGS, email: { ...SETTINGS.email!, brandedSendersInherited: true } },
+            }),
+        ).toBe(false);
+        expect(canEnvironmentResetBrandedSenders({ canEdit: false, localState: LOCAL, readonly, settings: SETTINGS })).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/smtpFormState.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/smtpFormState.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isConsoleSettingReadonly } from './isConsoleSettingReadonly';
+import { parseSmtpPort, type SmtpFieldReadonly, type SmtpFormState } from '../components/SmtpSection';
+import { PASSWORD_SENTINEL, type ConsoleSettings, type ConsoleSettingsEmail } from '../types/consoleSettings';
+
+export function buildSmtpFormState(settings: ConsoleSettings | undefined): SmtpFormState {
+    return {
+        enabled: settings?.email?.enabled ?? false,
+        host: settings?.email?.host ?? '',
+        port: settings?.email?.port !== undefined && settings?.email?.port !== null ? String(settings.email.port) : '',
+        username: settings?.email?.username ?? '',
+        password: settings?.email?.password ?? PASSWORD_SENTINEL,
+        protocol: settings?.email?.protocol ?? '',
+        subject: settings?.email?.subject ?? '',
+        from: settings?.email?.from ?? '',
+        auth: settings?.email?.properties?.auth ?? false,
+        startTlsEnable: settings?.email?.properties?.startTlsEnable ?? false,
+        sslTrust: settings?.email?.properties?.sslTrust ?? '',
+        brandedSenders: settings?.email?.brandedSenders ?? [],
+    };
+}
+
+export function buildSmtpFieldReadonly(settings: ConsoleSettings | undefined): SmtpFieldReadonly {
+    return {
+        enabled: isConsoleSettingReadonly(settings, 'email.enabled'),
+        host: isConsoleSettingReadonly(settings, 'email.host'),
+        port: isConsoleSettingReadonly(settings, 'email.port'),
+        username: isConsoleSettingReadonly(settings, 'email.username'),
+        password: isConsoleSettingReadonly(settings, 'email.password'),
+        protocol: isConsoleSettingReadonly(settings, 'email.protocol'),
+        subject: isConsoleSettingReadonly(settings, 'email.subject'),
+        from: isConsoleSettingReadonly(settings, 'email.from'),
+        auth: isConsoleSettingReadonly(settings, 'email.properties.auth'),
+        startTlsEnable: isConsoleSettingReadonly(settings, 'email.properties.starttls.enable'),
+        sslTrust: isConsoleSettingReadonly(settings, 'email.properties.ssl.trust'),
+        brandedSenders: isConsoleSettingReadonly(settings, 'email.branded_senders'),
+    };
+}
+
+export function buildSmtpEmailPatch(localState: SmtpFormState): ConsoleSettingsEmail {
+    return {
+        enabled: localState.enabled,
+        host: localState.host,
+        port: parseSmtpPort(localState.port) ?? undefined,
+        username: localState.username,
+        password: localState.password,
+        protocol: localState.protocol,
+        subject: localState.subject,
+        from: localState.from,
+        brandedSenders: localState.brandedSenders,
+        properties: {
+            auth: localState.auth,
+            startTlsEnable: localState.startTlsEnable,
+            sslTrust: localState.sslTrust,
+        },
+    };
+}
+
+/**
+ * Environment portal settings only — mirrors Classic `portal-settings.component.ts` `canResetBrandedSenders`.
+ */
+export function canEnvironmentResetBrandedSenders({
+    canEdit,
+    localState,
+    readonly,
+    settings,
+}: {
+    canEdit: boolean;
+    localState: SmtpFormState;
+    readonly: SmtpFieldReadonly;
+    settings: ConsoleSettings | undefined;
+}): boolean {
+    return canEdit && localState.enabled && !readonly.brandedSenders && settings?.email?.brandedSendersInherited === false;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentSmtpSettingsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentSmtpSettingsPage.spec.tsx
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { EnvironmentSmtpSettingsPage } from './EnvironmentSmtpSettingsPage';
+import { useResetEnvironmentBrandedSenders } from '../features/environment-settings/hooks/useResetEnvironmentBrandedSenders';
+import { PASSWORD_SENTINEL, type ConsoleSettings } from '../features/organization-settings/types/consoleSettings';
+import { usePortalSettings } from '../features/security-plan-types/hooks/usePortalSettings';
+import { useSavePortalSettings } from '../features/security-plan-types/hooks/useSavePortalSettings';
+import { ApimApiError } from '../shared/api/apimClient';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../shared/hooks/useForbiddenResourceRedirect');
+
+jest.mock('../features/security-plan-types/hooks/usePortalSettings', () => ({
+    usePortalSettings: jest.fn(),
+}));
+
+jest.mock('../features/security-plan-types/hooks/useSavePortalSettings', () => ({
+    useSavePortalSettings: jest.fn(),
+}));
+
+jest.mock('../features/environment-settings/hooks/useResetEnvironmentBrandedSenders', () => ({
+    useResetEnvironmentBrandedSenders: jest.fn(),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUsePortalSettings = jest.mocked(usePortalSettings);
+const mockUseSavePortalSettings = jest.mocked(useSavePortalSettings);
+const mockUseResetEnvironmentBrandedSenders = jest.mocked(useResetEnvironmentBrandedSenders);
+
+const SETTINGS: ConsoleSettings = {
+    email: {
+        enabled: true,
+        host: 'smtp.example.com',
+        port: 587,
+        username: 'admin',
+        password: PASSWORD_SENTINEL,
+        protocol: 'smtp',
+        subject: '[gravitee] %s',
+        from: 'noreply@example.com',
+        properties: { auth: true, startTlsEnable: true, sslTrust: '' },
+        brandedSenders: [{ domains: ['partners.example.com'], from: 'partners@example.com', subject: '[Partners] %s' }],
+        brandedSendersInherited: false,
+    },
+    trialInstance: { enabled: false },
+};
+
+function renderPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return render(<EnvironmentSmtpSettingsPage />, { wrapper: Wrapper });
+}
+
+describe('EnvironmentSmtpSettingsPage', () => {
+    beforeEach(() => {
+        jest.mocked(useForbiddenResourceRedirect).mockImplementation(() => undefined);
+        mockUseHasPermission.mockReturnValue(true);
+        mockUsePortalSettings.mockReturnValue({
+            data: SETTINGS,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof usePortalSettings>);
+        mockUseSavePortalSettings.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useSavePortalSettings>);
+        mockUseResetEnvironmentBrandedSenders.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetEnvironmentBrandedSenders>);
+    });
+
+    it('renders the environment-scoped SMTP fields and description', () => {
+        renderPage();
+        expect(screen.getByRole('heading', { name: 'SMTP' })).not.toBeNull();
+        expect(screen.getByText(/this environment uses/)).not.toBeNull();
+        expect((screen.getByLabelText('Host') as HTMLInputElement).value).toBe('smtp.example.com');
+        expect((screen.getByLabelText('Password') as HTMLInputElement).value).toBe(PASSWORD_SENTINEL);
+    });
+
+    it('does not show the organization architecture override banner', () => {
+        renderPage();
+        expect(
+            screen.queryByText(/Depending on your architecture, this configuration may be overridden by a local configuration file/),
+        ).toBeNull();
+    });
+
+    it('disables Enable Emailing only when email.enabled is system-provided', () => {
+        mockUsePortalSettings.mockReturnValue({
+            data: { ...SETTINGS, metadata: { readonly: ['email.enabled'] } },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof usePortalSettings>);
+        renderPage();
+        expect((screen.getByLabelText('Enable Emailing') as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByLabelText('Host') as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('disables the form when the user lacks environment-settings update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPage();
+        expect((screen.getByLabelText('Enable Emailing') as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByLabelText('Host') as HTMLInputElement).disabled).toBe(true);
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+    });
+
+    it('hides branded senders reset when the user lacks environment-settings update permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPage();
+        expect(screen.queryByRole('button', { name: /Reset to Org settings/i })).toBeNull();
+    });
+
+    it('hides SMTP on a trial instance', () => {
+        mockUsePortalSettings.mockReturnValue({
+            data: { ...SETTINGS, trialInstance: { enabled: true } },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof usePortalSettings>);
+        renderPage();
+        expect(screen.getByText('SMTP is not available on trial instances.')).not.toBeNull();
+        expect(screen.queryByLabelText('Host')).toBeNull();
+    });
+
+    it('posts email settings to the shared portal settings save mutation', () => {
+        const mutate = jest.fn();
+        mockUseSavePortalSettings.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useSavePortalSettings>);
+        renderPage();
+        fireEvent.change(screen.getByLabelText('Host'), { target: { value: 'smtp.acme.com' } });
+        fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+        expect(mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                email: expect.objectContaining({
+                    host: 'smtp.acme.com',
+                    password: PASSWORD_SENTINEL,
+                }),
+            }),
+            expect.any(Object),
+        );
+    });
+
+    it('offers "Reset to Org settings" when there is an environment override to drop', () => {
+        renderPage();
+        expect(screen.getByRole('button', { name: /Reset to Org settings/i })).not.toBeNull();
+    });
+
+    it('hides the reset action when branded senders are inherited from the organization', () => {
+        mockUsePortalSettings.mockReturnValue({
+            data: { ...SETTINGS, email: { ...SETTINGS.email, brandedSendersInherited: true } },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof usePortalSettings>);
+        renderPage();
+        expect(screen.queryByRole('button', { name: /Reset to Org settings/i })).toBeNull();
+    });
+
+    it('resets immediately when the page has no unsaved changes', () => {
+        const mutate = jest.fn();
+        mockUseResetEnvironmentBrandedSenders.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetEnvironmentBrandedSenders>);
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /Reset to Org settings/i }));
+        expect(mutate).toHaveBeenCalled();
+        expect(screen.queryByRole('heading', { name: 'Reset branded senders' })).toBeNull();
+    });
+
+    it('confirms before resetting when there are unsaved changes', () => {
+        const mutate = jest.fn();
+        mockUseResetEnvironmentBrandedSenders.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useResetEnvironmentBrandedSenders>);
+        renderPage();
+        fireEvent.change(screen.getByLabelText('Host'), { target: { value: 'smtp.acme.com' } });
+        fireEvent.click(screen.getByRole('button', { name: /Reset to Org settings/i }));
+        expect(mutate).not.toHaveBeenCalled();
+        expect(screen.getByRole('heading', { name: 'Reset branded senders' })).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+        expect(mutate).toHaveBeenCalled();
+    });
+
+    it('renders nothing while a forbidden response redirects away', () => {
+        mockUsePortalSettings.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            error: new ApimApiError(403, 'Forbidden'),
+        } as ReturnType<typeof usePortalSettings>);
+        renderPage();
+        expect(screen.queryByRole('heading', { name: 'SMTP' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentSmtpSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentSmtpSettingsPage.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useResetEnvironmentBrandedSenders } from '../features/environment-settings/hooks/useResetEnvironmentBrandedSenders';
+import { OrgSettingsFormShell } from '../features/organization-settings/components/OrgSettingsFormShell';
+import { isSmtpFormValid, SmtpSection, type SmtpFormState } from '../features/organization-settings/components/SmtpSection';
+import type { ConsoleSettings } from '../features/organization-settings/types/consoleSettings';
+import { buildPortalSettingsEmailSavePayload } from '../features/organization-settings/utils/buildPortalSettingsEmailSavePayload';
+import {
+    buildSmtpEmailPatch,
+    buildSmtpFieldReadonly,
+    buildSmtpFormState,
+    canEnvironmentResetBrandedSenders,
+} from '../features/organization-settings/utils/smtpFormState';
+import { usePortalSettings } from '../features/security-plan-types/hooks/usePortalSettings';
+import { useSavePortalSettings } from '../features/security-plan-types/hooks/useSavePortalSettings';
+import { ConfirmDialog } from '../shared/components/ConfirmDialog';
+import { useForbiddenResourceRedirect } from '../shared/hooks/useForbiddenResourceRedirect';
+import { isForbiddenApiError } from '../shared/utils/apiErrors';
+
+/**
+ * Environment-scoped SMTP settings: `platform > environment > SMTP`.
+ *
+ * Reuses the same form building blocks as the organization-scoped SMTP page ({@link SmtpSection},
+ * {@link OrgSettingsFormShell}) — the underlying `email` settings shape is identical, only the API scope
+ * differs (`/organizations/{orgId}/environments/{envId}/settings` instead of `/organizations/{orgId}/settings`).
+ * Unlike the organization page, this one also offers "Reset to Org settings" for branded senders, mirroring
+ * Classic's `portal-settings.component.ts`.
+ */
+export function EnvironmentSmtpSettingsPage() {
+    const canEdit = useHasPermission({ anyOf: ['environment-settings-u'] });
+    const { data: portalSettings, isLoading, isError, error } = usePortalSettings();
+    const settings = portalSettings as ConsoleSettings | undefined;
+    const saveMutation = useSavePortalSettings({
+        successMessage: 'Configuration successfully saved!',
+        errorMessage: 'An error occurred while saving the configuration.',
+    });
+    const resetMutation = useResetEnvironmentBrandedSenders();
+    const [localState, setLocalState] = useState<SmtpFormState>(() => buildSmtpFormState(settings));
+    const [savedState, setSavedState] = useState<SmtpFormState>(() => buildSmtpFormState(settings));
+    const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+
+    const isForbidden = isForbiddenApiError(isError, error);
+    useForbiddenResourceRedirect({
+        isForbidden,
+        navItemKey: 'environment-smtp',
+        permissionPrefix: 'environment-settings-',
+        redirectTo: '../applications',
+    });
+
+    const isDirty = JSON.stringify(localState) !== JSON.stringify(savedState);
+    const isDirtyRef = useRef(isDirty);
+    isDirtyRef.current = isDirty;
+
+    useEffect(() => {
+        if (!settings) return;
+        const next = buildSmtpFormState(settings);
+        setSavedState(next);
+        // Don't clobber in-progress edits when a background refetch (e.g. window refocus) delivers fresh data.
+        if (!isDirtyRef.current) {
+            setLocalState(next);
+        }
+    }, [settings]);
+
+    const trialHidesSmtp = Boolean(settings?.trialInstance?.enabled);
+    const readonly = useMemo(() => buildSmtpFieldReadonly(settings), [settings]);
+    const isValid = isSmtpFormValid(localState);
+    const canResetBrandedSenders = canEnvironmentResetBrandedSenders({ canEdit, localState, readonly, settings });
+
+    function handleSave() {
+        if (!settings) return;
+        if (!portalSettings) return;
+        if (!isDirty) return;
+        if (!isValid) return;
+        if (saveMutation.isPending) return;
+        const payload = buildPortalSettingsEmailSavePayload(portalSettings, buildSmtpEmailPatch(localState));
+        saveMutation.mutate(payload, { onSuccess: () => setSavedState(localState) });
+    }
+
+    function requestReset() {
+        // Reset re-fetches from the server, discarding any unsaved edits elsewhere on the page — confirm first
+        // when there's something to lose.
+        if (isDirty) {
+            setResetConfirmOpen(true);
+            return;
+        }
+        resetMutation.mutate();
+    }
+
+    function confirmReset() {
+        setResetConfirmOpen(false);
+        setLocalState(savedState);
+        resetMutation.mutate();
+    }
+
+    if (isForbidden) {
+        return null;
+    }
+
+    return (
+        <>
+            <OrgSettingsFormShell
+                title="SMTP"
+                description="Configure the mail server this environment uses for notifications, invitations, and other emails."
+                canEdit={canEdit}
+                isDirty={!trialHidesSmtp && isDirty}
+                isValid={isValid}
+                isSaving={saveMutation.isPending}
+                isLoading={isLoading}
+                isError={isError}
+                showArchitectureOverrideWarning={false}
+                onSave={handleSave}
+                onDiscard={() => setLocalState(savedState)}
+            >
+                {trialHidesSmtp ? (
+                    <p className="text-sm text-muted-foreground">SMTP is not available on trial instances.</p>
+                ) : (
+                    <SmtpSection
+                        value={localState}
+                        disabled={!canEdit}
+                        readonly={readonly}
+                        onChange={setLocalState}
+                        canResetBrandedSenders={canResetBrandedSenders}
+                        isResettingBrandedSenders={resetMutation.isPending}
+                        onResetBrandedSenders={requestReset}
+                    />
+                )}
+            </OrgSettingsFormShell>
+            <ConfirmDialog
+                open={resetConfirmOpen}
+                onOpenChange={setResetConfirmOpen}
+                title="Reset branded senders"
+                description="You have unsaved changes on this page that will be discarded. Do you want to reset the branded senders to the organization configuration?"
+                confirmLabel="Reset"
+                pendingLabel="Resetting…"
+                isPending={resetMutation.isPending}
+                onConfirm={confirmReset}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SmtpSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/SmtpSettingsPage.tsx
@@ -18,42 +18,18 @@ import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { OrgSettingsFormShell } from '../features/organization-settings/components/OrgSettingsFormShell';
-import {
-    isSmtpFormValid,
-    parseSmtpPort,
-    SmtpSection,
-    type SmtpFieldReadonly,
-    type SmtpFormState,
-} from '../features/organization-settings/components/SmtpSection';
+import { isSmtpFormValid, SmtpSection, type SmtpFormState } from '../features/organization-settings/components/SmtpSection';
 import { useOrgConsoleSettings } from '../features/organization-settings/hooks/useOrgConsoleSettings';
 import { useSaveOrgConsoleSettings } from '../features/organization-settings/hooks/useSaveOrgConsoleSettings';
-import { PASSWORD_SENTINEL, type ConsoleSettings } from '../features/organization-settings/types/consoleSettings';
 import { buildConsoleSettingsSavePayload } from '../features/organization-settings/utils/buildConsoleSettingsSavePayload';
-import { isConsoleSettingReadonly } from '../features/organization-settings/utils/isConsoleSettingReadonly';
-
-function buildState(settings: ConsoleSettings | undefined): SmtpFormState {
-    return {
-        enabled: settings?.email?.enabled ?? false,
-        host: settings?.email?.host ?? '',
-        port: settings?.email?.port !== undefined && settings?.email?.port !== null ? String(settings.email.port) : '',
-        username: settings?.email?.username ?? '',
-        password: settings?.email?.password ?? PASSWORD_SENTINEL,
-        protocol: settings?.email?.protocol ?? '',
-        subject: settings?.email?.subject ?? '',
-        from: settings?.email?.from ?? '',
-        auth: settings?.email?.properties?.auth ?? false,
-        startTlsEnable: settings?.email?.properties?.startTlsEnable ?? false,
-        sslTrust: settings?.email?.properties?.sslTrust ?? '',
-        brandedSenders: settings?.email?.brandedSenders ?? [],
-    };
-}
+import { buildSmtpEmailPatch, buildSmtpFieldReadonly, buildSmtpFormState } from '../features/organization-settings/utils/smtpFormState';
 
 export function SmtpSettingsPage() {
     const canEdit = useHasPermission({ anyOf: ['organization-settings-u'] });
     const { data: settings, isLoading, isError } = useOrgConsoleSettings();
     const saveMutation = useSaveOrgConsoleSettings();
-    const [localState, setLocalState] = useState<SmtpFormState>(() => buildState(settings));
-    const [savedState, setSavedState] = useState<SmtpFormState>(() => buildState(settings));
+    const [localState, setLocalState] = useState<SmtpFormState>(() => buildSmtpFormState(settings));
+    const [savedState, setSavedState] = useState<SmtpFormState>(() => buildSmtpFormState(settings));
 
     const isDirty = JSON.stringify(localState) !== JSON.stringify(savedState);
     const isDirtyRef = useRef(isDirty);
@@ -61,7 +37,7 @@ export function SmtpSettingsPage() {
 
     useEffect(() => {
         if (!settings) return;
-        const next = buildState(settings);
+        const next = buildSmtpFormState(settings);
         setSavedState(next);
         // Don't clobber in-progress edits when a background refetch (e.g. window refocus) delivers fresh data.
         if (!isDirtyRef.current) {
@@ -70,44 +46,13 @@ export function SmtpSettingsPage() {
     }, [settings]);
 
     const trialHidesSmtp = Boolean(settings?.trialInstance?.enabled);
-    const readonly = useMemo<SmtpFieldReadonly>(
-        () => ({
-            enabled: isConsoleSettingReadonly(settings, 'email.enabled'),
-            host: isConsoleSettingReadonly(settings, 'email.host'),
-            port: isConsoleSettingReadonly(settings, 'email.port'),
-            username: isConsoleSettingReadonly(settings, 'email.username'),
-            password: isConsoleSettingReadonly(settings, 'email.password'),
-            protocol: isConsoleSettingReadonly(settings, 'email.protocol'),
-            subject: isConsoleSettingReadonly(settings, 'email.subject'),
-            from: isConsoleSettingReadonly(settings, 'email.from'),
-            auth: isConsoleSettingReadonly(settings, 'email.properties.auth'),
-            startTlsEnable: isConsoleSettingReadonly(settings, 'email.properties.starttls.enable'),
-            sslTrust: isConsoleSettingReadonly(settings, 'email.properties.ssl.trust'),
-            brandedSenders: isConsoleSettingReadonly(settings, 'email.branded_senders'),
-        }),
-        [settings],
-    );
+    const readonly = useMemo(() => buildSmtpFieldReadonly(settings), [settings]);
     const isValid = isSmtpFormValid(localState);
 
     function handleSave() {
         if (!settings || !isDirty || !isValid || saveMutation.isPending) return;
         const payload = buildConsoleSettingsSavePayload(settings, 'email', {
-            email: {
-                enabled: localState.enabled,
-                host: localState.host,
-                port: parseSmtpPort(localState.port) ?? undefined,
-                username: localState.username,
-                password: localState.password,
-                protocol: localState.protocol,
-                subject: localState.subject,
-                from: localState.from,
-                brandedSenders: localState.brandedSenders,
-                properties: {
-                    auth: localState.auth,
-                    startTlsEnable: localState.startTlsEnable,
-                    sslTrust: localState.sslTrust,
-                },
-            },
+            email: buildSmtpEmailPatch(localState),
         });
         saveMutation.mutate(payload, { onSuccess: () => setSavedState(localState) });
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-216
## Description

Adds environment-scoped SMTP settings to Gamma at **Platform → Environment → SMTP** (`/environments/{envId}/platform/environment/smtp`), aligned with Classic Console portal SMTP behaviour (field-level readonly rules, system-config tooltips, branded senders reset).

Also refactors org and environment SMTP pages to share `smtpFormState` helpers and adds environment-page permission / 403 handling.

## Summary

- New route: **Environment → System & Security → SMTP** (distinct from org-level `/platform/smtp`)
- Same API as Classic: `GET/POST /organizations/{orgId}/environments/{envId}/settings`
- Permissions: `environment-settings-r` (view), `environment-settings-u` (edit/save/reset branded senders)
- Shared SMTP form state/build/patch utilities for org + environment pages
- No architecture override banner on the environment SMTP page

## Manual testing

Tested against local stack with **Mailpit** (SMTP `localhost:1025`, UI http://localhost:8025/). Top-level `email:` block in `gravitee.yml` left commented so settings are managed from the UI.


### Multi-tenant (`gravitee-multitenant` MongoDB)

| UI | URL |
|----|-----|
| Gamma | http://localhost:4200 |
| Classic Console | http://**{org}.{account}.apim-console.gravitee.io**:4000/#!/_login *(not `localhost:4000` — cookie cross-site issue)* |
| Rest API | Cockpit-linked multitenant run config on `:8083` |

- Per-environment SMTP must be configured in the **multitenant DB** (settings from standalone do not carry over)
- Fixed initial 500 on group invite (`Error while sending email notification`) caused by placeholder host `smtp.my.domain:587` — resolved by saving Mailpit settings per environment
- Group invite email delivery verified in Mailpit after environment SMTP configured

https://github.com/user-attachments/assets/30b4a0e4-e41f-42c6-988a-3b0a557edcd0

---

### UI field behaviour — Enable Emailing **ON**

When **Enable Emailing** is on (and fields are not system-locked via `gravitee.yml`), all SMTP fields on the environment page are editable:

| Field | Editable |
|-------|----------|
| Enable Emailing | Yes |
| Host / Port / Username / Password / Protocol / Subject / From | Yes |
| Mail properties (Auth, Start TLS, SSL Trust) | Yes |
| Branded senders | Yes |

---

### UI field behaviour — Enable Emailing **OFF**

Matches Classic Console:

| Field | Editable when emailing off |
|-------|----------------------------|
| Enable Emailing | Yes |
| Host / Port / Username | Yes |
| Password / Protocol / Subject / From / Mail properties / Branded senders | No |

https://github.com/user-attachments/assets/3d24a5c3-cb47-4750-a34e-e46960a0e397

---

### End-to-end email delivery (group invite)

**SMTP enabled → mail sent**

1. Environment SMTP: **Enable Emailing ON**, Mailpit (`localhost:1025`, auth/STARTTLS off)
2. Group → invite member by email
3. **Result:** `groupInvitation.html` in Mailpit

**SMTP disabled → no mail**

1. **Enable Emailing OFF**, save
2. Invite another member
3. **Result:** No new Mailpit message (backend skips send when `email.enabled` is false)

https://github.com/user-attachments/assets/f985b2dc-aaf0-40c5-ba5b-f1d3593468f5
