### PR TITLE
feat(gamma): api metadata

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -60,6 +60,7 @@ import { ApiHealthCheckDashboardPage } from '../features/apis/pages/detail/endpo
 import { ApiEntrypointsPage } from '../features/apis/pages/detail/entrypoints/ApiEntrypointsPage';
 import { ApiFailoverPage } from '../features/apis/pages/detail/failover/ApiFailoverPage';
 import { ApiGeneralPage } from '../features/apis/pages/detail/general/ApiGeneralPage';
+import { ApiMetadataPage } from '../features/apis/pages/detail/metadata/ApiMetadataPage';
 import { ApiNotificationFormPage } from '../features/apis/pages/detail/notifications/ApiNotificationFormPage';
 import { ApiNotificationsPage } from '../features/apis/pages/detail/notifications/ApiNotificationsPage';
 import { ApiPlanFormPage } from '../features/apis/pages/detail/plans/ApiPlanFormPage';
@@ -231,6 +232,7 @@ export function AppRoutes() {
                                 </Route>
                                 <Route path="entrypoints" element={<ApiEntrypointsPage />} />
                                 <Route path="cors" element={<ApiCorsPage />} />
+                                <Route path="metadata" element={<ApiMetadataPage />} />
                                 <Route path="endpoints">
                                     <Route index element={<Navigate to="list" replace />} />
                                     <Route path="list" element={<ApiEndpointsPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
@@ -107,6 +107,7 @@ jest.mock('./ApiDetailSidebarNav', () => ({
     API_PROXY_NAV_GROUPS: [],
     ApiDetailSidebarNav: () => <div />,
     withTcpRestrictions: (groups: unknown[]) => groups,
+    withMetadataPermission: (groups: unknown[]) => groups,
 }));
 
 import { ApiDetailIndexRedirect, ApiDetailLayout } from './ApiDetailLayout';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -40,7 +40,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useId, useState } from 'react';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withTcpRestrictions } from './ApiDetailSidebarNav';
+import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withMetadataPermission, withTcpRestrictions } from './ApiDetailSidebarNav';
 import { useDetailBasePath } from '../../../../shared/hooks/useDetailBasePath';
 import { ApiDetailContext } from '../../context/ApiDetailContext';
 import { useApiDetail } from '../../hooks/useApiDetail';
@@ -253,6 +253,7 @@ export function ApiDetailLayout() {
     const { data: api, isLoading, isError } = useApiDetail(apiId);
     const { permissionsReady } = useApiPermissions(apiId);
     const canDeploy = useHasPermission({ anyOf: ['api-definition-u'] });
+    const canReadMetadata = useHasPermission({ anyOf: ['api-metadata-r'] });
     const queryClient = useQueryClient();
     const [contextExpanded, setContextExpanded] = useState(true);
     const [showDeployDialog, setShowDeployDialog] = useState(false);
@@ -271,7 +272,7 @@ export function ApiDetailLayout() {
     });
 
     const showDeployBanner = !isError && api?.deploymentState === 'NEED_REDEPLOY' && canDeploy;
-    const navGroups = withTcpRestrictions(API_PROXY_NAV_GROUPS, hasTcpListeners(api));
+    const navGroups = withMetadataPermission(withTcpRestrictions(API_PROXY_NAV_GROUPS, hasTcpListeners(api)), canReadMetadata);
 
     useLayoutConfig(
         {
@@ -292,7 +293,7 @@ export function ApiDetailLayout() {
             ) : null,
             bannerSticky: true,
         },
-        [contextExpanded, api, isLoading, basePath, permissionsReady, showDeployBanner, deployMutation.isPending],
+        [contextExpanded, api, isLoading, basePath, permissionsReady, showDeployBanner, deployMutation.isPending, canReadMetadata],
     );
 
     if (isError) {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { DatabaseIcon } from '@gravitee/graphene-core/icons';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withTcpRestrictions } from './ApiDetailSidebarNav';
+import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withMetadataPermission, withTcpRestrictions } from './ApiDetailSidebarNav';
 
 const GROUPS = API_PROXY_NAV_GROUPS;
 const BASE = '/env/apis/abc-123';
@@ -56,6 +57,17 @@ describe('API_PROXY_NAV_GROUPS', () => {
         expect(deployment.children).toHaveLength(2);
         expect(deployment.children!.map(c => c.path)).toEqual(['configuration', 'history']);
     });
+
+    it('places Metadata immediately after CORS in the General group', () => {
+        const general = GROUPS.find(g => g.label === 'General')!;
+        const visiblePaths = general.items.filter(item => !item.comingSoon).map(item => item.path);
+        expect(visiblePaths[visiblePaths.indexOf('cors') + 1]).toBe('metadata');
+    });
+
+    it('uses the same Metadata icon as Platform Environment metadata', () => {
+        const metadata = GROUPS.find(g => g.label === 'General')!.items.find(item => item.path === 'metadata')!;
+        expect(metadata.icon).toBe(DatabaseIcon);
+    });
 });
 
 // ─── Flat nav links ───────────────────────────────────────────────────────────
@@ -77,6 +89,11 @@ describe('ApiDetailSidebarNav — flat links', () => {
     it('renders the Resources link with the correct href', () => {
         renderNav(`${BASE}/overview`);
         expect(screen.getByRole('link', { name: /^resources$/i })).toHaveAttribute('href', `${BASE}/resources`);
+    });
+
+    it('renders the Metadata link with the correct href', () => {
+        renderNav(`${BASE}/overview`);
+        expect(screen.getByRole('link', { name: /^metadata$/i })).toHaveAttribute('href', `${BASE}/metadata`);
     });
 
     it('renders "coming soon" items (API Score, Response Templates, Authorization) as disabled, non-navigable rows', () => {
@@ -130,6 +147,19 @@ describe('withTcpRestrictions', () => {
     it('keeps Failover and Health Check Dashboard in the Endpoints children for non-TCP APIs', () => {
         const endpoints = GROUPS.find(g => g.label === 'Gateway')!.items.find(i => i.path === 'endpoints')!;
         expect(endpoints.children!.map(c => c.path)).toEqual(['list', 'failover', 'health-check-dashboard']);
+    });
+});
+
+describe('withMetadataPermission', () => {
+    it('returns the groups unchanged when the user can read metadata', () => {
+        expect(withMetadataPermission(GROUPS, true)).toBe(GROUPS);
+    });
+
+    it('omits Metadata from the General group when the user lacks api-metadata-r', () => {
+        const restricted = withMetadataPermission(GROUPS, false);
+        const general = restricted.find(g => g.label === 'General')!;
+        expect(general.items.find(item => item.path === 'metadata')).toBeUndefined();
+        expect(general.items.find(item => item.path === 'cors')).toBeDefined();
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -19,6 +19,7 @@ import {
     BellIcon,
     ChevronDownIcon,
     ChevronRightIcon,
+    DatabaseIcon,
     FlaskConicalIcon,
     GlobeIcon,
     LayoutDashboardIcon,
@@ -87,6 +88,7 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
             { path: 'api-score', label: 'API Score', icon: SparklesIcon, comingSoon: true },
             { path: 'response-templates', label: 'Response Templates', icon: ScrollTextIcon, comingSoon: true },
             { path: 'cors', label: 'CORS', icon: ShieldCheckIcon },
+            { path: 'metadata', label: 'Metadata', icon: DatabaseIcon },
         ],
     },
     {
@@ -167,6 +169,14 @@ export function withTcpRestrictions(groups: DetailNavGroup[], apiHasTcpListeners
             if (!disabled.children) return disabled;
             return { ...disabled, children: disabled.children.filter(child => !TCP_OMITTED_CHILD_PATHS.has(child.path)) };
         }),
+    }));
+}
+
+export function withMetadataPermission(groups: DetailNavGroup[], canReadMetadata: boolean): DetailNavGroup[] {
+    if (canReadMetadata) return groups;
+    return groups.map(group => ({
+        ...group,
+        items: group.items.filter(item => item.path !== 'metadata'),
     }));
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiMetadata.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { createApiMetadata, deleteApiMetadata, searchApiMetadata, updateApiMetadata } from '../services/apiMetadata';
+import type { NewApiMetadataPayload, SearchApiMetadataParams, UpdateApiMetadataPayload } from '../types/metadata';
+import { apiMetadataKeys } from '../utils/queryKeys';
+
+export function useApiMetadata(apiId: string | undefined, params: SearchApiMetadataParams, enabled = true) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+
+    return useQuery({
+        queryKey: apiMetadataKeys.list(envId, apiId ?? '', params),
+        queryFn: () => searchApiMetadata(envId, apiId!, params),
+        enabled: Boolean(env && apiId && enabled),
+    });
+}
+
+function useApiMetadataMutation<TData>(apiId: string, mutationFn: (envId: string, apiId: string, data: TData) => Promise<unknown>) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: TData) => mutationFn(env!.id, apiId, data),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: apiMetadataKeys.all });
+        },
+    });
+}
+
+export function useCreateApiMetadata(apiId: string) {
+    return useApiMetadataMutation<NewApiMetadataPayload>(apiId, createApiMetadata);
+}
+
+export function useUpdateApiMetadata(apiId: string) {
+    return useApiMetadataMutation<UpdateApiMetadataPayload>(apiId, updateApiMetadata);
+}
+
+export function useDeleteApiMetadata(apiId: string) {
+    return useApiMetadataMutation<string>(apiId, deleteApiMetadata);
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataDeleteDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataDeleteDialog.spec.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ApiMetadataDeleteDialog } from './ApiMetadataDeleteDialog';
+import type { ApiMetadata } from '../../../types/metadata';
+
+const API_ONLY: ApiMetadata = { key: 'team', name: 'Team', format: 'STRING', value: 'Platform' };
+const GLOBAL_OVERRIDE: ApiMetadata = {
+    key: 'support-email',
+    name: 'Support Email',
+    format: 'MAIL',
+    value: 'api@example.com',
+    defaultValue: 'help@example.com',
+};
+
+function renderDialog(metadata: ApiMetadata, open = true) {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    render(<ApiMetadataDeleteDialog open={open} metadata={metadata} onClose={onClose} onConfirm={onConfirm} isDeleting={false} />);
+    return { onClose, onConfirm };
+}
+
+describe('ApiMetadataDeleteDialog', () => {
+    it('asks to delete API-only metadata', () => {
+        renderDialog(API_ONLY);
+        expect(screen.getByRole('heading', { name: 'Delete API metadata' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+    });
+
+    it('asks to reset inherited metadata that has an API override', () => {
+        renderDialog(GLOBAL_OVERRIDE);
+        expect(screen.getByRole('heading', { name: 'Reset global metadata' })).not.toBeNull();
+        expect(screen.getByText(/help@example.com/)).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Reset' })).not.toBeNull();
+    });
+
+    it('invokes onConfirm from the destructive action', () => {
+        const { onConfirm } = renderDialog(API_ONLY);
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataDeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataDeleteDialog.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { ApiMetadata } from '../../../types/metadata';
+import { isResettableMetadata } from '../../../utils/apiMetadata';
+
+export function ApiMetadataDeleteDialog({
+    open,
+    metadata,
+    onClose,
+    onConfirm,
+    isDeleting,
+}: Readonly<{
+    open: boolean;
+    metadata: ApiMetadata | undefined;
+    onClose: () => void;
+    onConfirm: () => void;
+    isDeleting: boolean;
+}>) {
+    const isReset = metadata ? isResettableMetadata(metadata) : false;
+    const title = isReset ? 'Reset global metadata' : 'Delete API metadata';
+    const confirmLabel = isReset ? 'Reset' : 'Delete';
+    const pendingLabel = isReset ? 'Resetting…' : 'Deleting…';
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>
+                        {isReset ? (
+                            <>
+                                Are you sure you want to reset <span className="font-medium text-foreground">{metadata?.name}</span> to its
+                                original value <span className="font-medium text-foreground">{metadata?.defaultValue}</span>?
+                            </>
+                        ) : (
+                            <>
+                                Are you sure you want to delete API metadata{' '}
+                                <span className="font-medium text-foreground">{metadata?.name}</span>
+                                {metadata?.key ? (
+                                    <>
+                                        {' '}
+                                        <span className="font-mono text-xs bg-muted px-1 py-0.5 rounded">{metadata.key}</span>
+                                    </>
+                                ) : null}
+                                ?
+                            </>
+                        )}
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || !metadata}>
+                        {isDeleting ? pendingLabel : confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataPage.spec.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ApiMetadataPage } from './ApiMetadataPage';
+import { useApiDetailContext } from '../../../context/ApiDetailContext';
+import { useApiMetadata, useCreateApiMetadata, useDeleteApiMetadata, useUpdateApiMetadata } from '../../../hooks/useApiMetadata';
+import type { ApiMetadata } from '../../../types/metadata';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('../../../context/ApiDetailContext', () => ({
+    useApiDetailContext: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useApiMetadata', () => ({
+    useApiMetadata: jest.fn(),
+    useCreateApiMetadata: jest.fn(),
+    useUpdateApiMetadata: jest.fn(),
+    useDeleteApiMetadata: jest.fn(),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseApiDetailContext = useApiDetailContext as jest.Mock;
+const mockUseApiMetadata = useApiMetadata as jest.Mock;
+const mockUseCreateApiMetadata = useCreateApiMetadata as jest.Mock;
+const mockUseUpdateApiMetadata = useUpdateApiMetadata as jest.Mock;
+const mockUseDeleteApiMetadata = useDeleteApiMetadata as jest.Mock;
+
+const TEAM: ApiMetadata = { key: 'team', name: 'Team', format: 'STRING', value: 'Platform Engineering' };
+
+function idleMutation() {
+    return { mutateAsync: jest.fn(), isPending: false };
+}
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/apis/api-1/metadata']}>
+            <Routes>
+                <Route path="apis/:apiId/metadata" element={<ApiMetadataPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+    mockUseApiDetailContext.mockReturnValue({
+        api: { id: 'api-1', definitionContext: { origin: 'MANAGEMENT' } },
+        isLoading: false,
+        permissionsReady: true,
+    });
+    mockUseApiMetadata.mockReturnValue({ data: { data: [TEAM], pagination: { totalCount: 1 } }, isLoading: false, isError: false });
+    mockUseCreateApiMetadata.mockReturnValue(idleMutation());
+    mockUseUpdateApiMetadata.mockReturnValue(idleMutation());
+    mockUseDeleteApiMetadata.mockReturnValue(idleMutation());
+});
+
+describe('ApiMetadataPage', () => {
+    it('renders the classic API metadata heading and create action', () => {
+        renderPage();
+        expect(screen.queryByRole('heading', { name: 'API metadata' })).not.toBeNull();
+        expect(
+            screen.queryByText('Set metadata information on the API that can be easily accessed through Markdown templating.'),
+        ).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /add api metadata/i })).not.toBeNull();
+        expect(screen.queryByRole('combobox', { name: 'Filter by source' })).not.toBeNull();
+    });
+
+    it('hides the add button when the user cannot create metadata', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-metadata-c'));
+        renderPage();
+        expect(screen.queryByRole('button', { name: /add api metadata/i })).toBeNull();
+    });
+
+    it('does not flash a permission denied message while API permissions are loading', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { id: 'api-1', definitionContext: { origin: 'MANAGEMENT' } },
+            isLoading: false,
+            permissionsReady: false,
+        });
+        mockUseHasPermission.mockReturnValue(false);
+        renderPage();
+        expect(screen.queryByText(/don't have permission to view API metadata/i)).toBeNull();
+        expect(screen.queryByRole('heading', { name: 'API metadata' })).toBeNull();
+        expect(mockUseApiMetadata).toHaveBeenCalledWith('api-1', expect.any(Object), false);
+    });
+
+    it('shows a permission denied message when the user lacks api-metadata-r', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-metadata-r'));
+        renderPage();
+        expect(screen.queryByText(/don't have permission to view API metadata/i)).not.toBeNull();
+        expect(screen.queryByRole('button', { name: /add api metadata/i })).toBeNull();
+        expect(mockUseApiMetadata).toHaveBeenCalledWith('api-1', expect.any(Object), false);
+    });
+
+    it('hides the add button and shows a read-only banner for Kubernetes APIs', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { id: 'api-1', definitionContext: { origin: 'KUBERNETES' } },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        expect(screen.queryByRole('button', { name: /add api metadata/i })).toBeNull();
+        expect(screen.queryByText(/managed by the Kubernetes operator/i)).not.toBeNull();
+    });
+
+    it('hides the header add button on first-use and keeps the empty-state CTA', () => {
+        mockUseApiMetadata.mockReturnValue({ data: { data: [], pagination: { totalCount: 0 } }, isLoading: false, isError: false });
+        renderPage();
+        expect(screen.queryByText('No API metadata')).not.toBeNull();
+        expect(screen.getAllByRole('button', { name: /add api metadata/i })).toHaveLength(1);
+        expect(screen.queryByRole('combobox', { name: 'Filter by source' })).toBeNull();
+    });
+
+    it('shows an error alert when the metadata query fails', () => {
+        mockUseApiMetadata.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+        renderPage();
+        expect(screen.queryByText('Failed to load metadata. Please refresh the page.')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataPage.tsx
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Alert, AlertDescription, Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { ApiMetadataDeleteDialog } from './ApiMetadataDeleteDialog';
+import { ApiMetadataSheet } from './ApiMetadataSheet';
+import { ApiMetadataTable } from './ApiMetadataTable';
+import { notify } from '../../../../../shared/notify';
+import { useApiDetailContext } from '../../../context/ApiDetailContext';
+import { useApiMetadata, useCreateApiMetadata, useDeleteApiMetadata, useUpdateApiMetadata } from '../../../hooks/useApiMetadata';
+import type { ApiMetadata, MetadataSource, NewApiMetadataPayload, UpdateApiMetadataPayload } from '../../../types/metadata';
+import { DEFAULT_METADATA_PAGE_SIZE, toMetadataSortBy } from '../../../utils/apiMetadata';
+
+type SheetState =
+    | { type: 'closed' }
+    | { type: 'create' }
+    | { type: 'edit'; metadata: ApiMetadata }
+    | { type: 'delete'; metadata: ApiMetadata };
+type TableSortingState = { id: string; desc: boolean }[];
+
+export function ApiMetadataPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+    const env = useEnvironment();
+    const { api, permissionsReady } = useApiDetailContext();
+
+    const canRead = useHasPermission({ anyOf: ['api-metadata-r'] });
+    const canCreate = useHasPermission({ anyOf: ['api-metadata-c'] });
+    const canEdit = useHasPermission({ anyOf: ['api-metadata-u'] });
+    const canDelete = useHasPermission({ anyOf: ['api-metadata-d'] });
+
+    const isKubernetesManaged = api?.definitionContext?.origin === 'KUBERNETES';
+    const readOnly = isKubernetesManaged;
+
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_METADATA_PAGE_SIZE);
+    const [sorting, setSorting] = useState<TableSortingState>([]);
+    const [source, setSource] = useState<MetadataSource | undefined>(undefined);
+    const [sheet, setSheet] = useState<SheetState>({ type: 'closed' });
+
+    const searchParams = useMemo(
+        () => ({
+            page,
+            perPage: pageSize,
+            source,
+            sortBy: toMetadataSortBy(sorting),
+        }),
+        [page, pageSize, source, sorting],
+    );
+
+    const { data, isLoading, isError } = useApiMetadata(apiId, searchParams, permissionsReady && canRead);
+    const createMutation = useCreateApiMetadata(apiId ?? '');
+    const updateMutation = useUpdateApiMetadata(apiId ?? '');
+    const deleteMutation = useDeleteApiMetadata(apiId ?? '');
+
+    const metadata = data?.data ?? [];
+    const totalCount = data?.pagination?.totalCount ?? metadata.length;
+    const isFirstUse = !isLoading && !isError && totalCount === 0 && source === undefined;
+    const showAddButton = canCreate && !readOnly && !isFirstUse;
+
+    function closeSheet() {
+        setSheet({ type: 'closed' });
+    }
+
+    function handleSourceChange(next: MetadataSource | undefined) {
+        setSource(next);
+        setPage(1);
+    }
+
+    function handleResetFilters() {
+        setSource(undefined);
+        setSorting([]);
+        setPage(1);
+    }
+
+    function handleSortingChange(updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) {
+        setSorting(prev => (typeof updater === 'function' ? updater(prev) : updater));
+        setPage(1);
+    }
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    async function handleCreate(payload: NewApiMetadataPayload | UpdateApiMetadataPayload) {
+        try {
+            await createMutation.mutateAsync(payload as NewApiMetadataPayload);
+            notify.success('Metadata created successfully');
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to create metadata');
+        }
+    }
+
+    async function handleUpdate(payload: NewApiMetadataPayload | UpdateApiMetadataPayload) {
+        try {
+            await updateMutation.mutateAsync(payload as UpdateApiMetadataPayload);
+            notify.success(`'${payload.name}' updated successfully`);
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to update metadata');
+        }
+    }
+
+    async function handleDelete() {
+        if (sheet.type !== 'delete') return;
+        try {
+            await deleteMutation.mutateAsync(sheet.metadata.key);
+            notify.success(`'${sheet.metadata.name}' deleted successfully`);
+            closeSheet();
+        } catch (error) {
+            notify.error(error, 'Failed to delete metadata');
+        }
+    }
+
+    if (!env || !apiId) {
+        return null;
+    }
+
+    if (!permissionsReady) {
+        return null;
+    }
+
+    if (!canRead) {
+        return (
+            <div className="space-y-6">
+                <h1 className="text-2xl font-semibold tracking-tight">API metadata</h1>
+                <p className="text-sm text-muted-foreground">You don&apos;t have permission to view API metadata.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">API metadata</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Set metadata information on the API that can be easily accessed through Markdown templating.
+                    </p>
+                </div>
+                {showAddButton ? (
+                    <Button className="shrink-0" onClick={() => setSheet({ type: 'create' })}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Add API Metadata
+                    </Button>
+                ) : null}
+            </div>
+
+            {isKubernetesManaged ? (
+                <Alert>
+                    <AlertDescription>This API is managed by the Kubernetes operator. Metadata is read-only.</AlertDescription>
+                </Alert>
+            ) : null}
+
+            {isError ? (
+                <Alert variant="destructive">
+                    <AlertDescription>Failed to load metadata. Please refresh the page.</AlertDescription>
+                </Alert>
+            ) : (
+                <ApiMetadataTable
+                    metadata={metadata}
+                    totalCount={totalCount}
+                    page={page}
+                    pageSize={pageSize}
+                    sorting={sorting}
+                    source={source}
+                    isLoading={isLoading}
+                    canCreate={canCreate}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
+                    readOnly={readOnly}
+                    isMutating={createMutation.isPending || updateMutation.isPending || deleteMutation.isPending}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                    onSortingChange={handleSortingChange}
+                    onSourceChange={handleSourceChange}
+                    onResetFilters={handleResetFilters}
+                    onCreate={() => setSheet({ type: 'create' })}
+                    onEdit={m => setSheet({ type: 'edit', metadata: m })}
+                    onDelete={m => setSheet({ type: 'delete', metadata: m })}
+                />
+            )}
+
+            <ApiMetadataSheet
+                open={sheet.type === 'create' || sheet.type === 'edit'}
+                mode={sheet.type === 'edit' ? 'edit' : 'create'}
+                metadata={sheet.type === 'edit' ? sheet.metadata : undefined}
+                readOnly={readOnly}
+                onClose={closeSheet}
+                onSubmit={sheet.type === 'edit' ? handleUpdate : handleCreate}
+                isSaving={createMutation.isPending || updateMutation.isPending}
+            />
+
+            <ApiMetadataDeleteDialog
+                open={sheet.type === 'delete'}
+                metadata={sheet.type === 'delete' ? sheet.metadata : undefined}
+                onClose={closeSheet}
+                onConfirm={handleDelete}
+                isDeleting={deleteMutation.isPending}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataSheet.spec.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ApiMetadataSheet } from './ApiMetadataSheet';
+import type { ApiMetadata } from '../../../types/metadata';
+
+const EXISTING: ApiMetadata = { key: 'support-email', name: 'Support Email', format: 'MAIL', value: 'help@example.com' };
+
+function renderSheet({
+    open = true,
+    mode,
+    metadata,
+    isSaving = false,
+    readOnly = false,
+}: {
+    open?: boolean;
+    mode: 'create' | 'edit';
+    metadata?: ApiMetadata;
+    isSaving?: boolean;
+    readOnly?: boolean;
+}) {
+    const onClose = jest.fn();
+    const onSubmit = jest.fn();
+    render(
+        <ApiMetadataSheet
+            open={open}
+            mode={mode}
+            metadata={metadata}
+            readOnly={readOnly}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            isSaving={isSaving}
+        />,
+    );
+    return { onClose, onSubmit };
+}
+
+describe('ApiMetadataSheet', () => {
+    it('does not show sheet content when closed', () => {
+        renderSheet({ open: false, mode: 'create' });
+        expect(screen.queryByRole('heading', { name: 'Add API Metadata' })).toBeNull();
+    });
+
+    it('shows create title when mode is create', () => {
+        renderSheet({ mode: 'create' });
+        expect(screen.getByRole('heading', { name: 'Add API Metadata' })).not.toBeNull();
+    });
+
+    it('keeps Add disabled until name and value are filled', () => {
+        renderSheet({ mode: 'create' });
+        const addBtn = screen.getByRole('button', { name: 'Add' }) as HTMLButtonElement;
+        expect(addBtn.disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Team' } });
+        expect(addBtn.disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'Platform' } });
+        expect(addBtn.disabled).toBe(false);
+    });
+
+    it('submits a create payload', () => {
+        const { onSubmit } = renderSheet({ mode: 'create' });
+        fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Team' } });
+        fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: 'Platform' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+        expect(onSubmit).toHaveBeenCalledWith({ name: 'Team', format: 'STRING', value: 'Platform' });
+    });
+
+    it('shows the key as read-only in edit mode', () => {
+        renderSheet({ mode: 'edit', metadata: EXISTING });
+        expect((screen.getByLabelText('Key') as HTMLInputElement).value).toBe('support-email');
+        expect((screen.getByLabelText('Key') as HTMLInputElement).disabled).toBe(true);
+    });
+
+    it('hides the submit button in read-only mode', () => {
+        renderSheet({ mode: 'edit', metadata: EXISTING, readOnly: true });
+        expect(screen.queryByRole('button', { name: 'Update' })).toBeNull();
+        expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0);
+    });
+
+    it('shows a mail example on the value field', () => {
+        renderSheet({ mode: 'edit', metadata: EXISTING });
+        expect(screen.getByLabelText(/Value/i)).toHaveAttribute('placeholder', 'e.g. john@doe.com');
+        expect(screen.queryByText('e.g. john@doe.com')).toBeNull();
+    });
+
+    it('shows a url example on the value field', () => {
+        renderSheet({
+            mode: 'edit',
+            metadata: { key: 'docs', name: 'Docs', format: 'URL', value: 'https://docs.example.com' },
+        });
+        expect(screen.getByLabelText(/Value/i)).toHaveAttribute('placeholder', 'e.g. https://gravitee.io');
+        expect(screen.queryByText('e.g. https://gravitee.io')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataSheet.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Button,
+    Field,
+    FieldLabel,
+    Input,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from '@gravitee/graphene-core';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+
+import type { ApiMetadata, MetadataFormat, NewApiMetadataPayload, UpdateApiMetadataPayload } from '../../../types/metadata';
+import {
+    editMetadataValue,
+    getMetadataValueFormatError,
+    getMetadataValueInputType,
+    getMetadataValuePlaceholder,
+    isMetadataValueValid,
+    METADATA_FORMAT_LABELS,
+    METADATA_FORMATS,
+} from '../../../utils/apiMetadata';
+
+interface MetadataForm {
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}
+
+const EMPTY_FORM: MetadataForm = { name: '', format: 'STRING', value: '' };
+
+export type ApiMetadataSheetMode = 'create' | 'edit';
+
+export function ApiMetadataSheet({
+    open,
+    mode,
+    metadata,
+    readOnly = false,
+    onClose,
+    onSubmit,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    mode: ApiMetadataSheetMode;
+    metadata?: ApiMetadata;
+    readOnly?: boolean;
+    onClose: () => void;
+    onSubmit: (data: NewApiMetadataPayload | UpdateApiMetadataPayload) => void;
+    isSaving: boolean;
+}>) {
+    const [form, setForm] = useState<MetadataForm>(EMPTY_FORM);
+    const [initialForm, setInitialForm] = useState<MetadataForm | null>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        if (mode === 'edit' && metadata) {
+            const initial = { name: metadata.name, format: metadata.format, value: editMetadataValue(metadata) };
+            setForm(initial);
+            setInitialForm(initial);
+        } else {
+            setForm(EMPTY_FORM);
+            setInitialForm(null);
+        }
+    }, [open, mode, metadata]);
+
+    const handleOpenChange = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    function setField<K extends keyof MetadataForm>(key: K, value: MetadataForm[K]) {
+        setForm(prev => ({ ...prev, [key]: value }));
+    }
+
+    function handleFormatChange(newFormat: MetadataFormat) {
+        setForm(prev => ({ ...prev, format: newFormat, value: newFormat === 'BOOLEAN' ? 'false' : '' }));
+    }
+
+    const fieldsDisabled = isSaving || readOnly;
+    const isValid = form.name.trim() !== '' && isMetadataValueValid(form.format, form.value);
+    const valueFormatError = getMetadataValueFormatError(form.format, form.value);
+
+    const hasChanged = useMemo(() => {
+        if (mode === 'create') return true;
+        if (!initialForm) return false;
+        return form.name !== initialForm.name || form.value !== initialForm.value;
+    }, [mode, form, initialForm]);
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault();
+        if (readOnly || !isValid || !hasChanged) return;
+        const base = { name: form.name.trim(), format: form.format, value: form.value.trim() };
+        if (mode === 'edit' && metadata) {
+            onSubmit({ ...base, key: metadata.key, defaultValue: metadata.defaultValue } satisfies UpdateApiMetadataPayload);
+        } else {
+            onSubmit(base satisfies NewApiMetadataPayload);
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={handleOpenChange}>
+            <SheetContent side="right" className="flex max-h-full flex-col" style={{ maxWidth: '480px' }}>
+                <SheetHeader>
+                    <SheetTitle>{mode === 'create' ? 'Add API Metadata' : 'Edit Metadata'}</SheetTitle>
+                    <SheetDescription>
+                        {mode === 'create'
+                            ? 'Define metadata on this API that can be accessed through Markdown templating.'
+                            : 'Update the metadata value. Format cannot be changed after creation.'}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <ScrollArea className="flex-1 min-h-0">
+                    <form id="api-metadata-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-1 py-4">
+                        {mode === 'edit' && metadata && (
+                            <Field orientation="vertical" className="gap-1.5">
+                                <FieldLabel htmlFor="api-metadata-key">Key</FieldLabel>
+                                <Input id="api-metadata-key" value={metadata.key} disabled readOnly />
+                            </Field>
+                        )}
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="api-metadata-name">
+                                Name{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Input
+                                id="api-metadata-name"
+                                value={form.name}
+                                onChange={e => setField('name', e.target.value)}
+                                placeholder="e.g. Support Email"
+                                disabled={fieldsDisabled}
+                                required
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="api-metadata-format">
+                                Format{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            <Select
+                                value={form.format}
+                                onValueChange={val => handleFormatChange(val as MetadataFormat)}
+                                disabled={mode === 'edit' || fieldsDisabled}
+                            >
+                                <SelectTrigger id="api-metadata-format">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {METADATA_FORMATS.map(fmt => (
+                                        <SelectItem key={fmt} value={fmt}>
+                                            {METADATA_FORMAT_LABELS[fmt]}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            {mode === 'edit' && <p className="text-xs text-muted-foreground">Format cannot be changed after creation.</p>}
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-1.5">
+                            <FieldLabel htmlFor="api-metadata-value">
+                                Value{' '}
+                                <span className="text-destructive" aria-hidden>
+                                    *
+                                </span>
+                            </FieldLabel>
+                            {form.format === 'BOOLEAN' ? (
+                                <Select value={form.value} onValueChange={val => setField('value', val)} disabled={fieldsDisabled}>
+                                    <SelectTrigger id="api-metadata-value">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="true">true</SelectItem>
+                                        <SelectItem value="false">false</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            ) : (
+                                <Input
+                                    id="api-metadata-value"
+                                    value={form.value}
+                                    onChange={e => setField('value', e.target.value)}
+                                    type={getMetadataValueInputType(form.format)}
+                                    placeholder={getMetadataValuePlaceholder(form.format)}
+                                    disabled={fieldsDisabled}
+                                    required
+                                    aria-invalid={valueFormatError !== null}
+                                    aria-describedby={valueFormatError ? 'api-metadata-value-error' : undefined}
+                                />
+                            )}
+                            {valueFormatError ? (
+                                <p id="api-metadata-value-error" className="text-sm text-destructive" role="alert">
+                                    {valueFormatError}
+                                </p>
+                            ) : null}
+                        </Field>
+                    </form>
+                </ScrollArea>
+
+                <SheetFooter className="shrink-0 flex-row justify-end gap-2 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        {readOnly ? 'Close' : 'Cancel'}
+                    </Button>
+                    {!readOnly && (
+                        <Button type="submit" form="api-metadata-form" disabled={!isValid || !hasChanged || isSaving}>
+                            {isSaving ? (mode === 'create' ? 'Adding…' : 'Updating…') : mode === 'create' ? 'Add' : 'Update'}
+                        </Button>
+                    )}
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.spec.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+import { ApiMetadataTable } from './ApiMetadataTable';
+import type { ApiMetadata, MetadataSource } from '../../../types/metadata';
+
+const API_ONLY: ApiMetadata = { key: 'team', name: 'Team', format: 'STRING', value: 'Platform Engineering' };
+const GLOBAL_INHERITED: ApiMetadata = {
+    key: 'support-email',
+    name: 'Support Email',
+    format: 'MAIL',
+    defaultValue: 'help@example.com',
+};
+const GLOBAL_OVERRIDE: ApiMetadata = {
+    key: 'docs-url',
+    name: 'Documentation URL',
+    format: 'URL',
+    value: 'https://docs.example.com',
+    defaultValue: 'https://docs.acme.io',
+};
+
+function renderTable(
+    overrides: Partial<{
+        metadata: ApiMetadata[];
+        canCreate: boolean;
+        canEdit: boolean;
+        canDelete: boolean;
+        readOnly: boolean;
+        source: 'GLOBAL' | 'API';
+        totalCount: number;
+    }> = {},
+) {
+    const onCreate = jest.fn();
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+    const onResetFilters = jest.fn();
+    const onSourceChange = jest.fn();
+    const metadata = overrides.metadata ?? [API_ONLY, GLOBAL_INHERITED, GLOBAL_OVERRIDE];
+    render(
+        <ApiMetadataTable
+            metadata={metadata}
+            totalCount={overrides.totalCount ?? metadata.length}
+            page={1}
+            pageSize={10}
+            sorting={[]}
+            source={overrides.source}
+            isLoading={false}
+            canCreate={overrides.canCreate ?? true}
+            canEdit={overrides.canEdit ?? true}
+            canDelete={overrides.canDelete ?? true}
+            readOnly={overrides.readOnly ?? false}
+            isMutating={false}
+            onPageChange={jest.fn()}
+            onPageSizeChange={jest.fn()}
+            onSortingChange={jest.fn()}
+            onSourceChange={onSourceChange}
+            onResetFilters={onResetFilters}
+            onCreate={onCreate}
+            onEdit={onEdit}
+            onDelete={onDelete}
+        />,
+    );
+    return { onCreate, onEdit, onDelete, onResetFilters, onSourceChange };
+}
+
+describe('ApiMetadataTable', () => {
+    it('renders key, name, format, and value columns', () => {
+        renderTable();
+        expect(screen.queryByRole('columnheader', { name: 'Key' })).not.toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Name' })).not.toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Format' })).not.toBeNull();
+        expect(screen.queryByRole('columnheader', { name: 'Value' })).not.toBeNull();
+        expect(screen.queryByText('Team')).not.toBeNull();
+        expect(screen.queryByText('Platform Engineering')).not.toBeNull();
+    });
+
+    it('shows a Global badge for inherited metadata and falls back to the default value', () => {
+        renderTable();
+        expect(screen.getAllByText('Global').length).toBe(2);
+        expect(screen.queryByText('help@example.com')).not.toBeNull();
+    });
+
+    it('renders the source filter without Reset when no source is selected', () => {
+        renderTable();
+        expect(screen.queryByRole('combobox', { name: 'Filter by source' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reset filters' })).toBeNull();
+    });
+
+    it('shows Reset filters only when a source is selected', () => {
+        renderTable({ source: 'API' });
+        expect(screen.queryByRole('button', { name: 'Reset filters' })).not.toBeNull();
+    });
+
+    it('invokes onResetFilters from the toolbar button', () => {
+        const { onResetFilters } = renderTable({ source: 'API' });
+        fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+        expect(onResetFilters).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the selected source when Reset filters is clicked', () => {
+        function Harness() {
+            const [source, setSource] = useState<MetadataSource | undefined>('API');
+            return (
+                <ApiMetadataTable
+                    metadata={[API_ONLY]}
+                    totalCount={1}
+                    page={1}
+                    pageSize={10}
+                    sorting={[]}
+                    source={source}
+                    isLoading={false}
+                    canCreate={false}
+                    canEdit={false}
+                    canDelete={false}
+                    readOnly={false}
+                    isMutating={false}
+                    onPageChange={jest.fn()}
+                    onPageSizeChange={jest.fn()}
+                    onSortingChange={jest.fn()}
+                    onSourceChange={setSource}
+                    onResetFilters={() => setSource(undefined)}
+                    onCreate={jest.fn()}
+                    onEdit={jest.fn()}
+                    onDelete={jest.fn()}
+                />
+            );
+        }
+
+        render(<Harness />);
+        expect(screen.getByRole('combobox', { name: 'Filter by source' })).toHaveTextContent('API');
+        fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+        expect(screen.getByRole('combobox', { name: 'Filter by source' })).toHaveTextContent('All sources');
+        expect(screen.queryByRole('button', { name: 'Reset filters' })).toBeNull();
+    });
+
+    it('hides mutating actions for inherited rows without an API override', () => {
+        renderTable({ metadata: [GLOBAL_INHERITED], canEdit: false, canDelete: true });
+        expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /reset .* metadata/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /actions for/i })).toBeNull();
+    });
+
+    it('uses a reset action for inherited metadata that has an API override', () => {
+        renderTable({ metadata: [GLOBAL_OVERRIDE], canEdit: false, canDelete: true });
+        expect(screen.queryByRole('button', { name: /reset documentation url metadata/i })).not.toBeNull();
+    });
+
+    it('hides the actions column when the user cannot edit or delete', () => {
+        renderTable({ canEdit: false, canDelete: false });
+        expect(screen.queryByRole('button', { name: /actions for/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
+    });
+
+    it('hides mutating actions when the API is Kubernetes-managed even if the user can edit', () => {
+        renderTable({ canEdit: true, canDelete: true, readOnly: true });
+        expect(screen.queryByRole('button', { name: /edit .* metadata/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /reset .* metadata/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /actions for/i })).toBeNull();
+    });
+
+    it('shows a first-use empty state when there is no metadata and no source filter', () => {
+        const { onCreate } = renderTable({ metadata: [], totalCount: 0 });
+        expect(screen.queryByText('No API metadata')).not.toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: /add api metadata/i }));
+        expect(onCreate).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('combobox', { name: 'Filter by source' })).toBeNull();
+    });
+
+    it('shows a no-results empty state when a source filter matches nothing', () => {
+        renderTable({ metadata: [], source: 'API', totalCount: 0 });
+        expect(screen.queryByText('No metadata matches the selected source filter.')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.tsx
@@ -1,0 +1,353 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Badge,
+    Button,
+    DataTable,
+    DataTableColumnHeader,
+    type DataTableColumnHeaderProps,
+    DataTableEmptyState,
+    type DataTableProps,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { DatabaseIcon, MoreVerticalIcon, PencilIcon, PlusIcon, RefreshCwIcon, SearchIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+
+import { MetadataFormatBadge } from './MetadataFormatBadge';
+import type { ApiMetadata, MetadataSource } from '../../../types/metadata';
+import {
+    canDeleteOrResetMetadata,
+    DEFAULT_METADATA_PAGE_SIZE,
+    displayMetadataValue,
+    isInheritedGlobal,
+    isResettableMetadata,
+    METADATA_PAGE_SIZE_OPTIONS,
+    METADATA_SOURCE_FILTER_ALL,
+} from '../../../utils/apiMetadata';
+
+type ColCell<T> = { row: { original: T } };
+type ColHeader<T> = { column: DataTableColumnHeaderProps<T, unknown>['column'] };
+type TableSortingState = { id: string; desc: boolean }[];
+
+function GlobalBadge() {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Badge variant="secondary">Global</Badge>
+            </TooltipTrigger>
+            <TooltipContent>Inherited global metadata</TooltipContent>
+        </Tooltip>
+    );
+}
+
+function buildColumns({
+    canEdit,
+    canDelete,
+    readOnly,
+    isMutating,
+    onEdit,
+    onDelete,
+}: {
+    canEdit: boolean;
+    canDelete: boolean;
+    readOnly: boolean;
+    isMutating: boolean;
+    onEdit: (metadata: ApiMetadata) => void;
+    onDelete: (metadata: ApiMetadata) => void;
+}): DataTableProps<ApiMetadata>['columns'] {
+    const columns: DataTableProps<ApiMetadata>['columns'] = [
+        {
+            id: 'key',
+            accessorKey: 'key',
+            header: ({ column }: ColHeader<ApiMetadata>) => <DataTableColumnHeader column={column} title="Key" />,
+            cell: ({ row }: ColCell<ApiMetadata>) => (
+                <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{row.original.key}</span>
+                    {isInheritedGlobal(row.original) ? <GlobalBadge /> : null}
+                </div>
+            ),
+        },
+        {
+            id: 'name',
+            accessorKey: 'name',
+            header: ({ column }: ColHeader<ApiMetadata>) => <DataTableColumnHeader column={column} title="Name" />,
+            cell: ({ row }: ColCell<ApiMetadata>) => <span className="text-sm font-medium">{row.original.name}</span>,
+        },
+        {
+            id: 'format',
+            accessorKey: 'format',
+            header: ({ column }: ColHeader<ApiMetadata>) => <DataTableColumnHeader column={column} title="Format" />,
+            cell: ({ row }: ColCell<ApiMetadata>) => <MetadataFormatBadge format={row.original.format} />,
+        },
+        {
+            id: 'value',
+            accessorFn: (row: ApiMetadata) => displayMetadataValue(row),
+            header: ({ column }: ColHeader<ApiMetadata>) => <DataTableColumnHeader column={column} title="Value" />,
+            cell: ({ row }: ColCell<ApiMetadata>) => {
+                const value = displayMetadataValue(row.original);
+                return value ? <span className="text-sm">{value}</span> : <span className="text-sm text-muted-foreground">—</span>;
+            },
+        },
+    ];
+
+    if ((canEdit || canDelete) && !readOnly) {
+        columns.push({
+            id: 'actions',
+            header: () => <span className="sr-only">Actions</span>,
+            size: 56,
+            enableSorting: false,
+            enableHiding: false,
+            cell: ({ row }: ColCell<ApiMetadata>) => {
+                const item = row.original;
+                const canEditItem = canEdit && !readOnly;
+                const canRemoveItem = canDelete && !readOnly && canDeleteOrResetMetadata(item);
+                const isReset = isResettableMetadata(item);
+                const actionCount = (canEditItem ? 1 : 0) + (canRemoveItem ? 1 : 0);
+
+                if (actionCount === 0) return null;
+
+                if (actionCount === 1) {
+                    return (
+                        <div className="flex justify-end">
+                            {canEditItem ? (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-8"
+                                    aria-label={`Edit ${item.name} metadata`}
+                                    disabled={isMutating}
+                                    onClick={() => onEdit(item)}
+                                >
+                                    <PencilIcon className="size-4" aria-hidden />
+                                </Button>
+                            ) : (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-8 text-destructive hover:text-destructive"
+                                    aria-label={isReset ? `Reset ${item.name} metadata` : `Delete ${item.name} metadata`}
+                                    disabled={isMutating}
+                                    onClick={() => onDelete(item)}
+                                >
+                                    {isReset ? (
+                                        <RefreshCwIcon className="size-4" aria-hidden />
+                                    ) : (
+                                        <Trash2Icon className="size-4" aria-hidden />
+                                    )}
+                                </Button>
+                            )}
+                        </div>
+                    );
+                }
+
+                return (
+                    <div className="flex justify-end">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-8"
+                                    aria-label={`Actions for ${item.name} metadata`}
+                                    disabled={isMutating}
+                                >
+                                    <MoreVerticalIcon className="size-4" aria-hidden />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="min-w-48">
+                                <DropdownMenuItem onSelect={() => onEdit(item)} disabled={isMutating}>
+                                    <PencilIcon className="size-4" aria-hidden />
+                                    Edit
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem variant="destructive" onSelect={() => onDelete(item)} disabled={isMutating}>
+                                    {isReset ? (
+                                        <RefreshCwIcon className="size-4" aria-hidden />
+                                    ) : (
+                                        <Trash2Icon className="size-4" aria-hidden />
+                                    )}
+                                    {isReset ? 'Reset' : 'Delete'}
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                );
+            },
+        });
+    }
+
+    return columns;
+}
+
+export function ApiMetadataTable({
+    metadata,
+    totalCount,
+    page,
+    pageSize,
+    sorting,
+    source,
+    isLoading,
+    canCreate,
+    canEdit,
+    canDelete,
+    readOnly,
+    isMutating,
+    onPageChange,
+    onPageSizeChange,
+    onSortingChange,
+    onSourceChange,
+    onResetFilters,
+    onCreate,
+    onEdit,
+    onDelete,
+}: Readonly<{
+    metadata: ApiMetadata[];
+    totalCount: number;
+    page: number;
+    pageSize: number;
+    sorting: TableSortingState;
+    source: MetadataSource | undefined;
+    isLoading: boolean;
+    canCreate: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
+    readOnly: boolean;
+    isMutating: boolean;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (size: number) => void;
+    onSortingChange: (updater: TableSortingState | ((prev: TableSortingState) => TableSortingState)) => void;
+    onSourceChange: (source: MetadataSource | undefined) => void;
+    onResetFilters: () => void;
+    onCreate: () => void;
+    onEdit: (metadata: ApiMetadata) => void;
+    onDelete: (metadata: ApiMetadata) => void;
+}>) {
+    const columns = useMemo(
+        () => buildColumns({ canEdit, canDelete, readOnly, isMutating, onEdit, onDelete }),
+        [canEdit, canDelete, readOnly, isMutating, onEdit, onDelete],
+    );
+
+    const hasSourceFilter = source !== undefined;
+    const isFirstUse = !isLoading && totalCount === 0 && !hasSourceFilter;
+    const isNoResults = !isLoading && metadata.length === 0 && hasSourceFilter;
+
+    if (isFirstUse) {
+        return (
+            <div className="rounded-lg border">
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<DatabaseIcon className="size-8" aria-hidden />}
+                    title="No API metadata"
+                    description="Add metadata to this API for Markdown templating and portal display."
+                    primaryAction={
+                        canCreate && !readOnly ? (
+                            <Button type="button" onClick={onCreate}>
+                                <PlusIcon className="size-4" aria-hidden />
+                                Add API Metadata
+                            </Button>
+                        ) : undefined
+                    }
+                />
+            </div>
+        );
+    }
+
+    return (
+        <TooltipProvider delayDuration={200}>
+            <DataTable
+                aria-label="API metadata"
+                columns={columns}
+                data={metadata}
+                sorting={sorting}
+                onSortingChange={onSortingChange}
+                serverSide
+                loading={isLoading}
+                skeletonCount={pageSize || DEFAULT_METADATA_PAGE_SIZE}
+                toolbar={
+                    <div className="flex flex-wrap items-center gap-2">
+                        <Select
+                            value={source ?? METADATA_SOURCE_FILTER_ALL}
+                            onValueChange={value =>
+                                onSourceChange(value === METADATA_SOURCE_FILTER_ALL ? undefined : (value as MetadataSource))
+                            }
+                        >
+                            <SelectTrigger className="w-48" aria-label="Filter by source">
+                                <SelectValue placeholder="Filter by source" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={METADATA_SOURCE_FILTER_ALL}>All sources</SelectItem>
+                                <SelectItem value="GLOBAL">Global</SelectItem>
+                                <SelectItem value="API">API</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        {hasSourceFilter ? (
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="gap-1.5 text-muted-foreground"
+                                onClick={onResetFilters}
+                            >
+                                <RefreshCwIcon className="size-4" aria-hidden />
+                                Reset filters
+                            </Button>
+                        ) : null}
+                    </div>
+                }
+                pagination={{
+                    page,
+                    pageSize,
+                    totalCount,
+                    pageSizeOptions: [...METADATA_PAGE_SIZE_OPTIONS],
+                    onPageChange,
+                    onPageSizeChange,
+                }}
+                emptyMessage={
+                    isNoResults ? (
+                        <DataTableEmptyState
+                            variant="no-results"
+                            icon={<SearchIcon className="size-8" aria-hidden />}
+                            title="No metadata found"
+                            description="No metadata matches the selected source filter."
+                            action={
+                                <Button type="button" variant="outline" size="sm" onClick={onResetFilters}>
+                                    Clear filters
+                                </Button>
+                            }
+                        />
+                    ) : undefined
+                }
+            />
+        </TooltipProvider>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/MetadataFormatBadge.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/MetadataFormatBadge.spec.tsx
@@ -13,18 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { render, screen } from '@testing-library/react';
 
-export * from './alert';
-export * from './analytics';
-export * from './api';
-export * from './apiCreation';
-export * from './apiImport';
-export * from './auditLogs.types';
-export * from './broadcast';
-export * from './healthCheck';
-export * from './members.types';
-export * from './metadata';
-export * from './notification';
-export * from './plan';
-export * from './resource';
-export * from './subscription';
+import { MetadataFormatBadge } from './MetadataFormatBadge';
+import type { MetadataFormat } from '../../../types/metadata';
+
+describe('MetadataFormatBadge', () => {
+    it.each<[MetadataFormat, string]>([
+        ['STRING', 'String'],
+        ['NUMERIC', 'Numeric'],
+        ['BOOLEAN', 'Boolean'],
+        ['DATE', 'Date'],
+        ['MAIL', 'Mail'],
+        ['URL', 'URL'],
+    ])('renders %s as %s', (format, expectedLabel) => {
+        render(<MetadataFormatBadge format={format} />);
+        expect(screen.queryByText(expectedLabel)).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/MetadataFormatBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/MetadataFormatBadge.tsx
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-export * from './alert';
-export * from './analytics';
-export * from './api';
-export * from './apiCreation';
-export * from './apiImport';
-export * from './auditLogs.types';
-export * from './broadcast';
-export * from './healthCheck';
-export * from './members.types';
-export * from './metadata';
-export * from './notification';
-export * from './plan';
-export * from './resource';
-export * from './subscription';
+import { Badge } from '@gravitee/graphene-core';
+
+import type { MetadataFormat } from '../../../types/metadata';
+import { METADATA_FORMAT_LABELS } from '../../../utils/apiMetadata';
+
+export function MetadataFormatBadge({ format }: Readonly<{ format: MetadataFormat }>) {
+    return <Badge variant="default">{METADATA_FORMAT_LABELS[format] ?? format}</Badge>;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiMetadata.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiMetadata.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createApiMetadata, deleteApiMetadata, searchApiMetadata, updateApiMetadata } from './apiMetadata';
+import { apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+    apimFetchJsonV2: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+const mockApimFetchJsonV2 = jest.mocked(apimFetchJsonV2);
+
+describe('apiMetadata service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+        mockApimFetchJsonV2.mockResolvedValue({ data: [] });
+    });
+
+    describe('searchApiMetadata', () => {
+        it('calls the v2 metadata search with default pagination', async () => {
+            await searchApiMetadata('env-1', 'api-1');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata?page=1&perPage=10');
+        });
+
+        it('appends source and sortBy when provided', async () => {
+            await searchApiMetadata('env-1', 'api-1', { page: 2, perPage: 25, source: 'GLOBAL', sortBy: '-name' });
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata?page=2&perPage=25&source=GLOBAL&sortBy=-name');
+        });
+
+        it('normalizes a missing data array to an empty list', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({} as Awaited<ReturnType<typeof searchApiMetadata>>);
+            const result = await searchApiMetadata('env-1', 'api-1');
+            expect(result.data).toEqual([]);
+        });
+
+        it('URL-encodes the API id', async () => {
+            await searchApiMetadata('env-1', 'api/with spaces');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api%2Fwith%20spaces/metadata?page=1&perPage=10');
+        });
+    });
+
+    describe('createApiMetadata', () => {
+        it('POSTs the payload to the v1 metadata collection', async () => {
+            const payload = { name: 'Team', format: 'STRING' as const, value: 'Platform' };
+            await createApiMetadata('env-1', 'api-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata/', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('updateApiMetadata', () => {
+        it('PUTs the payload to the keyed v1 resource', async () => {
+            const payload = { key: 'team', name: 'Team', format: 'STRING' as const, value: 'Platform' };
+            await updateApiMetadata('env-1', 'api-1', payload);
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata/team', {
+                method: 'PUT',
+                body: JSON.stringify(payload),
+            });
+        });
+    });
+
+    describe('deleteApiMetadata', () => {
+        it('DELETEs the keyed v1 resource', async () => {
+            await deleteApiMetadata('env-1', 'api-1', 'team');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata/team', {
+                method: 'DELETE',
+            });
+        });
+
+        it('URL-encodes the metadata key', async () => {
+            await deleteApiMetadata('env-1', 'api-1', 'key with spaces');
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/apis/api-1/metadata/key%20with%20spaces', {
+                method: 'DELETE',
+            });
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiMetadata.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type {
+    ApiMetadata,
+    ApiMetadataListResponse,
+    NewApiMetadataPayload,
+    SearchApiMetadataParams,
+    UpdateApiMetadataPayload,
+} from '../types/metadata';
+
+const apiPath = (apiId: string) => `/apis/${encodeURIComponent(apiId)}`;
+
+export async function searchApiMetadata(
+    environmentId: string,
+    apiId: string,
+    params: SearchApiMetadataParams = {},
+): Promise<ApiMetadataListResponse> {
+    const searchParams = new URLSearchParams({
+        page: String(params.page ?? 1),
+        perPage: String(params.perPage ?? 10),
+    });
+    if (params.source) searchParams.set('source', params.source);
+    if (params.sortBy) searchParams.set('sortBy', params.sortBy);
+
+    const response = await apimFetchJsonV2<ApiMetadataListResponse>(environmentId, `${apiPath(apiId)}/metadata?${searchParams.toString()}`);
+    return { data: response.data ?? [], pagination: response.pagination };
+}
+
+export async function createApiMetadata(environmentId: string, apiId: string, payload: NewApiMetadataPayload): Promise<ApiMetadata> {
+    return apimFetchJsonV1Env<ApiMetadata>(environmentId, `${apiPath(apiId)}/metadata/`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function updateApiMetadata(environmentId: string, apiId: string, payload: UpdateApiMetadataPayload): Promise<ApiMetadata> {
+    return apimFetchJsonV1Env<ApiMetadata>(environmentId, `${apiPath(apiId)}/metadata/${encodeURIComponent(payload.key)}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function deleteApiMetadata(environmentId: string, apiId: string, metadataKey: string): Promise<void> {
+    return apimFetchJsonV1Env<void>(environmentId, `${apiPath(apiId)}/metadata/${encodeURIComponent(metadataKey)}`, {
+        method: 'DELETE',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/metadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/metadata.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MetadataFormat = 'STRING' | 'NUMERIC' | 'BOOLEAN' | 'DATE' | 'MAIL' | 'URL';
+
+export type MetadataSource = 'GLOBAL' | 'API';
+
+export interface ApiMetadata {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value?: string;
+    defaultValue?: string;
+}
+
+export interface NewApiMetadataPayload {
+    name: string;
+    format: MetadataFormat;
+    value: string;
+}
+
+export interface UpdateApiMetadataPayload {
+    key: string;
+    name: string;
+    format: MetadataFormat;
+    value: string;
+    defaultValue?: string;
+}
+
+export interface SearchApiMetadataParams {
+    page?: number;
+    perPage?: number;
+    source?: MetadataSource;
+    sortBy?: string;
+}
+
+export interface ApiMetadataListResponse {
+    data: ApiMetadata[];
+    pagination?: {
+        page?: number;
+        perPage?: number;
+        pageCount?: number;
+        pageItemsCount?: number;
+        totalCount?: number;
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    canDeleteOrResetMetadata,
+    displayMetadataValue,
+    getMetadataValuePlaceholder,
+    isInheritedGlobal,
+    isMetadataValueValid,
+    isResettableMetadata,
+    toMetadataSortBy,
+} from './apiMetadata';
+import type { ApiMetadata } from '../types/metadata';
+
+const API_ONLY: ApiMetadata = { key: 'team', name: 'Team', format: 'STRING', value: 'Platform' };
+const GLOBAL_INHERITED: ApiMetadata = {
+    key: 'support-email',
+    name: 'Support Email',
+    format: 'MAIL',
+    defaultValue: 'help@example.com',
+};
+const GLOBAL_OVERRIDE: ApiMetadata = {
+    key: 'support-email',
+    name: 'Support Email',
+    format: 'MAIL',
+    value: 'api@example.com',
+    defaultValue: 'help@example.com',
+};
+
+describe('apiMetadata helpers', () => {
+    describe('displayMetadataValue', () => {
+        it('returns the API value when set', () => {
+            expect(displayMetadataValue(API_ONLY)).toBe('Platform');
+            expect(displayMetadataValue(GLOBAL_OVERRIDE)).toBe('api@example.com');
+        });
+
+        it('falls back to the global default when the API value is missing', () => {
+            expect(displayMetadataValue(GLOBAL_INHERITED)).toBe('help@example.com');
+        });
+    });
+
+    describe('inheritance flags', () => {
+        it('marks rows with a defaultValue as inherited global metadata', () => {
+            expect(isInheritedGlobal(API_ONLY)).toBe(false);
+            expect(isInheritedGlobal(GLOBAL_INHERITED)).toBe(true);
+            expect(isInheritedGlobal(GLOBAL_OVERRIDE)).toBe(true);
+        });
+
+        it('allows delete only when an API-level value exists', () => {
+            expect(canDeleteOrResetMetadata(API_ONLY)).toBe(true);
+            expect(canDeleteOrResetMetadata(GLOBAL_INHERITED)).toBe(false);
+            expect(canDeleteOrResetMetadata(GLOBAL_OVERRIDE)).toBe(true);
+        });
+
+        it('treats inherited rows with an override as resettable', () => {
+            expect(isResettableMetadata(API_ONLY)).toBe(false);
+            expect(isResettableMetadata(GLOBAL_INHERITED)).toBe(false);
+            expect(isResettableMetadata(GLOBAL_OVERRIDE)).toBe(true);
+        });
+    });
+
+    describe('toMetadataSortBy', () => {
+        it('serializes ascending and descending sort for the v2 query param', () => {
+            expect(toMetadataSortBy([{ id: 'name', desc: false }])).toBe('name');
+            expect(toMetadataSortBy([{ id: 'key', desc: true }])).toBe('-key');
+        });
+
+        it('returns undefined when no sort is active', () => {
+            expect(toMetadataSortBy([])).toBeUndefined();
+            expect(toMetadataSortBy(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('getMetadataValuePlaceholder', () => {
+        it('returns format examples for numeric, mail, and url values', () => {
+            expect(getMetadataValuePlaceholder('NUMERIC')).toBe('e.g. 123');
+            expect(getMetadataValuePlaceholder('MAIL')).toBe('e.g. john@doe.com');
+            expect(getMetadataValuePlaceholder('URL')).toBe('e.g. https://gravitee.io');
+        });
+
+        it('omits a placeholder for string, boolean, and date values', () => {
+            expect(getMetadataValuePlaceholder('STRING')).toBeUndefined();
+            expect(getMetadataValuePlaceholder('BOOLEAN')).toBeUndefined();
+            expect(getMetadataValuePlaceholder('DATE')).toBeUndefined();
+        });
+    });
+
+    describe('isMetadataValueValid', () => {
+        it('accepts boolean literals only', () => {
+            expect(isMetadataValueValid('BOOLEAN', 'true')).toBe(true);
+            expect(isMetadataValueValid('BOOLEAN', 'false')).toBe(true);
+            expect(isMetadataValueValid('BOOLEAN', 'yes')).toBe(false);
+        });
+
+        it('rejects empty non-boolean values', () => {
+            expect(isMetadataValueValid('STRING', '')).toBe(false);
+            expect(isMetadataValueValid('NUMERIC', '3')).toBe(true);
+            expect(isMetadataValueValid('NUMERIC', 'nope')).toBe(false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ApiMetadata, MetadataFormat } from '../types/metadata';
+
+export const METADATA_FORMATS: MetadataFormat[] = ['STRING', 'NUMERIC', 'BOOLEAN', 'DATE', 'MAIL', 'URL'];
+
+export const METADATA_FORMAT_LABELS: Record<MetadataFormat, string> = {
+    STRING: 'String',
+    NUMERIC: 'Numeric',
+    BOOLEAN: 'Boolean',
+    DATE: 'Date',
+    MAIL: 'Mail',
+    URL: 'URL',
+};
+
+export const METADATA_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+export const DEFAULT_METADATA_PAGE_SIZE = 10;
+
+/** Default source-filter option. Graphene Select is controlled and requires a value for every item. */
+export const METADATA_SOURCE_FILTER_ALL = 'ALL';
+
+export function getMetadataValuePlaceholder(format: MetadataFormat): string | undefined {
+    if (format === 'NUMERIC') return 'e.g. 123';
+    if (format === 'MAIL') return 'e.g. john@doe.com';
+    if (format === 'URL') return 'e.g. https://gravitee.io';
+    return undefined;
+}
+
+/** Allows FreeMarker/templated values (`${...}`) as well as literal emails. */
+export const MAIL_PATTERN =
+    /^((\${.+})|(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,})))$/;
+
+export const URL_PATTERN = /^((\$\{.+\})|(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})\b([-a-zA-Z0-9()@:%_+.~#?&//=!]*))$/;
+
+export function displayMetadataValue(metadata: ApiMetadata): string {
+    if (metadata.defaultValue && !metadata.value) {
+        return metadata.defaultValue;
+    }
+    return metadata.value ?? '';
+}
+
+export function isInheritedGlobal(metadata: ApiMetadata): boolean {
+    return Boolean(metadata.defaultValue);
+}
+
+/** API-level override exists, so the row can be deleted or reset to the global default. */
+export function canDeleteOrResetMetadata(metadata: ApiMetadata): boolean {
+    return metadata.value !== undefined;
+}
+
+export function isResettableMetadata(metadata: ApiMetadata): boolean {
+    return Boolean(metadata.defaultValue) && metadata.value !== undefined;
+}
+
+export function toMetadataSortBy(sorting: { id: string; desc: boolean }[] | undefined): string | undefined {
+    const sort = sorting?.[0];
+    if (!sort?.id) return undefined;
+    return sort.desc ? `-${sort.id}` : sort.id;
+}
+
+export function isMetadataValueValid(format: MetadataFormat, value: string): boolean {
+    if (format === 'BOOLEAN') return value === 'true' || value === 'false';
+    if (!value.trim()) return false;
+    if (format === 'NUMERIC') return !Number.isNaN(Number(value));
+    if (format === 'MAIL') return MAIL_PATTERN.test(value);
+    if (format === 'URL') return URL_PATTERN.test(value);
+    return true;
+}
+
+export function getMetadataValueFormatError(format: MetadataFormat, value: string): string | null {
+    if (!value.trim()) return null;
+    if (format === 'MAIL' && !MAIL_PATTERN.test(value)) return 'Invalid email';
+    if (format === 'URL' && !URL_PATTERN.test(value)) return 'Invalid URL';
+    return null;
+}
+
+export function getMetadataValueInputType(format: MetadataFormat): 'number' | 'date' | 'email' | 'url' | 'text' {
+    if (format === 'NUMERIC') return 'number';
+    if (format === 'DATE') return 'date';
+    if (format === 'MAIL') return 'email';
+    if (format === 'URL') return 'url';
+    return 'text';
+}
+
+export function editMetadataValue(metadata: ApiMetadata): string {
+    const value = displayMetadataValue(metadata);
+    if (metadata.format === 'DATE') {
+        return value.slice(0, 10);
+    }
+    return value;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
@@ -118,6 +118,11 @@ export const apiNotificationKeys = {
     hooks: (envId: string) => [...apiNotificationKeys.all, 'hooks', envId] as const,
 };
 
+export const apiMetadataKeys = {
+    all: ['api-metadata'] as const,
+    list: (envId: string, apiId: string, params: object) => [...apiMetadataKeys.all, 'list', envId, apiId, params] as const,
+};
+
 export const apiPlanKeys = {
     all: ['api-plans'] as const,
     list: (envId: string, ctx: PlanContext, statuses: PlanStatus[], page: number, perPage: number) =>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-15074

## Description
Adds an API Metadata screen to Gamma under API Proxies → API detail → General  with classic Console parity.
- Sidebar **Metadata** entry and `/metadata` route
- Server-side list via Management API v2 (`GET /apis/{id}/metadata`) with source filter + sort/pagination
- Create / update / delete via Management API v1 metadata endpoints
- Permissions: `api-metadata-c` / `api-metadata-u` / `api-metadata-d`

https://github.com/user-attachments/assets/9e955897-3435-4834-9d9c-8ea40f7686bb

