### PR TITLE
chore(deps): add gravitee-policy-ai-routing 1.0.0 to default bundle

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
@@ -2277,6 +2277,19 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-ai-routing</artifactId>
+                    <version>${gravitee-policy-ai-routing.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-pii-filtering</artifactId>
                     <version>${gravitee-policy-pii-filtering.version}</version>
                     <type>zip</type>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -250,6 +250,7 @@
     <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
     <gravitee-resource-ai-model-text-embedding.version>2.0.0</gravitee-resource-ai-model-text-embedding.version>
     <gravitee-policy-ai-semantic-caching.version>2.0.0</gravitee-policy-ai-semantic-caching.version>
+    <gravitee-policy-ai-routing.version>1.0.0</gravitee-policy-ai-routing.version>
     <gravitee-apim-repository-bridge.version>9.0.0</gravitee-apim-repository-bridge.version>
     <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
     <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Summary
- Adds `com.graviteesource.policy:gravitee-policy-ai-routing:1.0.0` to the standalone distribution's default bundle, following the same pattern as the existing `gravitee-policy-ai-semantic-caching` enterprise plugin.
- Declares the version property in `gravitee-apim-distribution/pom.xml` and the plugin dependency (zip, runtime scope) in `gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml`'s `bundle-default` profile.

Jira: AIAM-330

## Test plan
- [x] `xmllint --noout` on both modified poms
- [ ] CI distribution build picks up and bundles the plugin zip