### PR TITLE
fix(gamma): Notification's table, creation, sidenav title

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.spec.tsx
@@ -802,7 +802,7 @@ describe('AppRoutes', () => {
         expect(visibleNavKeys()).not.toContain('alerts');
     });
 
-    it('routes to the Notification settings page under the platform module', () => {
+    it('routes to the Notifications page under the platform module', () => {
         render(
             <MemoryRouter initialEntries={['/notification-settings']}>
                 <AppRoutes />
@@ -812,13 +812,13 @@ describe('AppRoutes', () => {
         expect(screen.getByTestId('environment-notification-settings-page')).not.toBeNull();
     });
 
-    it('shows the Notification settings nav item when the user has read permission', () => {
+    it('shows the Notifications nav item when the user has read permission', () => {
         renderPlatform();
 
         expect(visibleNavKeys()).toContain('notification-settings');
     });
 
-    it('hides the Notification settings nav item when the user lacks environment-notification-r', () => {
+    it('hides the Notifications nav item when the user lacks environment-notification-r', () => {
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-notification-r'));
 
         renderPlatform();
@@ -826,7 +826,7 @@ describe('AppRoutes', () => {
         expect(visibleNavKeys()).not.toContain('notification-settings');
     });
 
-    it('redirects away from Notification settings when the user lacks environment-notification-r', () => {
+    it('redirects away from Notifications when the user lacks environment-notification-r', () => {
         mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('environment-notification-r'));
 
         render(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -39,6 +39,11 @@ describe('applicationDetailNavigation permissions', () => {
     const hasDefinitionRead = (permissions: string[]) => permissions.includes('application-definition-r');
     const hasMemberRead = (permissions: string[]) => permissions.includes('application-member-r');
 
+    it('labels the notifications tab Notifications', () => {
+        const settings = APPLICATION_NAV_GROUPS.find(group => group.label === 'Settings');
+        expect(settings?.items.find(item => item.path === 'notifications')?.label).toBe('Notifications');
+    });
+
     it('maps general tab to application-definition-r', () => {
         expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
     });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
@@ -53,7 +53,7 @@ export const APPLICATION_NAV_GROUPS: ApplicationDetailNavGroup[] = [
         items: [
             {
                 path: 'notifications',
-                label: 'Notification settings',
+                label: 'Notifications',
                 icon: BellIcon,
                 permissions: ['application-notification-r', 'application-alert-r'],
             },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -292,7 +292,7 @@ describe('platform nav visibility', () => {
         });
     });
 
-    it('gates Notification settings on environment-notification-r without the org settings gate', () => {
+    it('gates Notifications on environment-notification-r without the org settings gate', () => {
         expect(requiresOrganizationSettingsGate('notification-settings')).toBe(false);
         expect(pageGuardForNavItem('notification-settings')).toEqual({ anyOf: ['environment-notification-r'] });
         expect(isNavItemVisible('notification-settings', visibility(['environment-notification-r']))).toBe(true);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -66,7 +66,10 @@ describe('platform navigation config', () => {
         expect(sectionKeys('Environment', 'APIs & Assets')).toEqual(['applications', 'metadata', 'dictionaries', 'shared-policy-groups']);
     });
 
-    it('places Access Management, Gateways, Alerts, Notification settings, Security Plan Types, and Audit under Environment / System & Security', () => {
+    it('places Access Management, Gateways, Alerts, Notifications, Security Plan Types, and Audit under Environment / System & Security', () => {
+        const systemItems =
+            NAV_SECTIONS.find(section => section.key === 'environment')?.groups.find(group => group.label === 'System & Security')?.items ??
+            [];
         expect(sectionKeys('Environment', 'System & Security')).toEqual([
             'access-management',
             'gateways',
@@ -75,6 +78,7 @@ describe('platform navigation config', () => {
             'security-plan-types',
             'environment-audit',
         ]);
+        expect(systemItems.find(item => item.key === 'notification-settings')?.title).toBe('Notifications');
     });
 
     it('places Users, Groups, and Roles under Team', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -60,7 +60,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'entrypoints-and-sharding-tags': { path: 'entrypoints-and-sharding-tags', label: 'Entrypoints & Sharding Tags' },
     'policy-studio': { path: 'policy-studio', label: 'Policy Studio' },
     alerts: { path: 'alerts', label: 'Alerts' },
-    'notification-settings': { path: 'notification-settings', label: 'Notification settings' },
+    'notification-settings': { path: 'notification-settings', label: 'Notifications' },
     'organization-audit': { path: 'organization-audit', label: 'Audit' },
     'environment-audit': { path: 'environment-audit', label: 'Audit' },
     'management-and-schedulers': { path: 'management-and-schedulers', label: 'Management & Schedulers' },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationSheet.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationSheet.spec.tsx
@@ -79,13 +79,34 @@ describe('EditNotificationSheet', () => {
                 onCreate={jest.fn()}
             />,
         );
-        expect(querySheetHeading('Edit Console Notification')).toBeNull();
+        expect(querySheetHeading('Add notification')).toBeNull();
+        expect(querySheetHeading('Edit Subscription alerts')).toBeNull();
     });
 
-    it('shows sheet title and description when row is set', () => {
+    it('shows the GENERIC row name in the edit title', () => {
         renderSheet();
-        expect(screen.getByRole('heading', { name: 'Edit Console Notification' })).not.toBeNull();
+        expect(screen.getByRole('heading', { name: 'Edit Subscription alerts' })).not.toBeNull();
         expect(screen.getByText(/Configure notifier settings and subscribed events for Subscription alerts/i)).not.toBeNull();
+    });
+
+    it('shows Edit Console Notification for the PORTAL row', () => {
+        renderSheet({
+            row: {
+                key: 'PORTAL',
+                name: 'Console Notification',
+                subscribedEvents: 0,
+                notifierName: 'Console',
+                notification: {
+                    name: 'Console Notification',
+                    referenceType: 'ENVIRONMENT',
+                    referenceId: 'env-1',
+                    config_type: 'PORTAL',
+                    hooks: [],
+                },
+                isReadonly: false,
+            },
+        });
+        expect(screen.getByRole('heading', { name: 'Edit Console Notification' })).not.toBeNull();
     });
 
     it('invokes onCancel when Cancel is clicked', () => {
@@ -145,6 +166,7 @@ describe('EditNotificationSheet', () => {
 
     it('shows name and notifier fields in create mode', () => {
         renderSheet({ row: buildNewNotificationRow('app-1', notifiers) });
+        expect(screen.getByRole('heading', { name: 'Add notification' })).not.toBeNull();
         expect(screen.getByLabelText(/^Name/)).not.toBeNull();
         expect(screen.getByLabelText(/^Notifier/)).not.toBeNull();
         expect(screen.getByRole('button', { name: 'Add notification' })).not.toBeNull();

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationSheet.tsx
@@ -34,7 +34,7 @@ import {
 } from '@gravitee/graphene-core';
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { isCreateNotificationRow, notificationNotifierOptions } from './notificationHelpers';
+import { isCreateNotificationRow, notificationNotifierOptions, notificationSheetTitle } from './notificationHelpers';
 import { NotificationHookCategorySection } from './NotificationHookCategorySection';
 import type {
     ApplicationNotificationHookCategory,
@@ -182,7 +182,7 @@ export function EditNotificationSheet({
         <Sheet open={row !== null} onOpenChange={handleOpenChange}>
             <SheetContent side="right" className="flex max-h-full flex-col" style={sheetWidthStyle}>
                 <SheetHeader>
-                    <SheetTitle>Edit Console Notification</SheetTitle>
+                    <SheetTitle>{notificationSheetTitle(row)}</SheetTitle>
                     <SheetDescription>Configure notifier settings and subscribed events for {sheetSubject}.</SheetDescription>
                 </SheetHeader>
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.spec.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 import {
+    buildNewNotificationRow,
     groupHooksByCategory,
     mapApplicationNotificationsToRows,
     notificationNotifierOptions,
+    notificationSheetTitle,
     notifierTypeLabel,
     resolveNotifierName,
 } from './notificationHelpers';
@@ -110,6 +112,57 @@ describe('notificationHelpers', () => {
             );
             expect(rows[0].isReadonly).toBe(true);
             expect(rows[0].notifierName).toBe('Console');
+        });
+    });
+
+    describe('notificationSheetTitle', () => {
+        const notifiers: ApplicationNotifier[] = [{ id: 'email-notifier', type: 'EMAIL', name: 'Email' }];
+
+        it('uses Add notification for create', () => {
+            expect(notificationSheetTitle(buildNewNotificationRow('app-1', notifiers))).toBe('Add notification');
+        });
+
+        it('does not treat a closed sheet as create', () => {
+            expect(notificationSheetTitle(null)).toBe('');
+        });
+
+        it('uses Edit Console Notification for the PORTAL row', () => {
+            expect(
+                notificationSheetTitle({
+                    key: 'PORTAL',
+                    name: 'Console Notification',
+                    subscribedEvents: 0,
+                    notifierName: 'Console',
+                    notification: {
+                        name: 'Console Notification',
+                        referenceType: 'ENVIRONMENT',
+                        referenceId: 'env-1',
+                        config_type: 'PORTAL',
+                        hooks: [],
+                    },
+                    isReadonly: false,
+                }),
+            ).toBe('Edit Console Notification');
+        });
+
+        it('uses the GENERIC row name for other edits', () => {
+            expect(
+                notificationSheetTitle({
+                    key: 'n1',
+                    name: 'Subscription alerts',
+                    subscribedEvents: 1,
+                    notifierName: 'Email',
+                    notification: {
+                        id: 'n1',
+                        name: 'Subscription alerts',
+                        referenceType: 'APPLICATION',
+                        referenceId: 'app-1',
+                        config_type: 'GENERIC',
+                        hooks: [],
+                    },
+                    isReadonly: false,
+                }),
+            ).toBe('Edit Subscription alerts');
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.ts
@@ -43,6 +43,16 @@ export function isCreateNotificationRow(row: ApplicationNotificationRow | null):
     return row?.key === NOTIFICATION_CREATE_ROW_KEY;
 }
 
+export function notificationSheetTitle(row: ApplicationNotificationRow | null): string {
+    if (!row) {
+        return '';
+    }
+    if (isCreateNotificationRow(row)) {
+        return 'Add notification';
+    }
+    return `Edit ${row.name}`;
+}
+
 export function buildNewNotificationRow(applicationId: string, notifiers: ApplicationNotifier[]): ApplicationNotificationRow {
     const defaultNotifier = notifiers.find(item => item.id);
     const notifierId = defaultNotifier?.id ?? '';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.spec.tsx
@@ -80,7 +80,7 @@ describe('EnvironmentNotificationsTable', () => {
 
         expect(screen.getByText('Console')).not.toBeNull();
         expect(screen.getByText('None')).not.toBeNull();
-        expect(screen.getByText('—')).not.toBeNull();
+        expect(screen.getByText('—').getAttribute('title')).toBeNull();
     });
 
     it('shows the Email channel badge, event count, and config target on GENERIC rows', () => {
@@ -88,7 +88,24 @@ describe('EnvironmentNotificationsTable', () => {
 
         expect(screen.getByText('Email')).not.toBeNull();
         expect(screen.getByText('2 events')).not.toBeNull();
-        expect(screen.getByText('ops@example.com')).not.toBeNull();
+        expect(screen.getByText('ops@example.com').getAttribute('title')).toBe('ops@example.com');
+    });
+
+    it('keeps the full target in the cell and exposes it on title for CSS truncation', () => {
+        const longTarget = 'https://webhook.site/e389f278-aaaa,https://webhook.site/e389f278-bbbb,https://webhook.site/e389f278-cccc';
+        render(
+            <EnvironmentNotificationsTable
+                {...baseProps}
+                rows={[buildRow({ notification: { ...buildRow().notification, config: longTarget } })]}
+                canUpdate={() => true}
+            />,
+        );
+
+        const target = screen.getByText(longTarget);
+        expect(target.className).toContain('truncate');
+        expect(target.className).toContain('min-w-0');
+        expect(target.className).toContain('max-w-full');
+        expect(target.getAttribute('title')).toBe(longTarget);
     });
 
     it('puts row actions behind a three-dot menu, not inline edit/delete icons', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.tsx
@@ -66,6 +66,18 @@ function EventCountBadge({ count }: Readonly<{ count: number }>) {
     );
 }
 
+function NotificationTargetCell({ row }: Readonly<{ row: ApplicationNotificationRow }>) {
+    const target = notificationTarget(row);
+    return (
+        <span
+            className="block min-w-0 max-w-full truncate font-mono text-xs text-muted-foreground"
+            title={target === '—' ? undefined : target}
+        >
+            {target}
+        </span>
+    );
+}
+
 function rowActionVisibility(
     row: ApplicationNotificationRow,
     canUpdate: (row: ApplicationNotificationRow) => boolean,
@@ -159,10 +171,10 @@ function buildColumns({
         {
             id: 'target',
             header: 'Target',
+            size: 288,
+            maxSize: 288,
             enableSorting: false,
-            cell: ({ row }: ColCell<ApplicationNotificationRow>) => (
-                <span className="block max-w-72 truncate font-mono text-xs text-muted-foreground">{notificationTarget(row.original)}</span>
-            ),
+            cell: ({ row }: ColCell<ApplicationNotificationRow>) => <NotificationTargetCell row={row.original} />,
         },
     ];
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
@@ -191,7 +191,7 @@ export function ApplicationNotificationSettingsPage() {
     return (
         <div className="space-y-6 p-6">
             <div className="space-y-1">
-                <h1 className="text-2xl font-semibold tracking-tight">Notification settings</h1>
+                <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
                 <p className="text-sm text-muted-foreground">Hooks and metadata used in notification templates.</p>
             </div>
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentNotificationSettingsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentNotificationSettingsPage.spec.tsx
@@ -190,7 +190,7 @@ describe('EnvironmentNotificationSettingsPage', () => {
 
     it('renders the page title', () => {
         renderPage();
-        expect(screen.queryByRole('heading', { name: 'Notification settings' })).not.toBeNull();
+        expect(screen.queryByRole('heading', { name: 'Notifications' })).not.toBeNull();
     });
 
     it('renders both the Console Notification row and GENERIC rows', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentNotificationSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/EnvironmentNotificationSettingsPage.tsx
@@ -164,7 +164,7 @@ export function EnvironmentNotificationSettingsPage() {
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-4">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">Notification settings</h1>
+                    <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
                     <p className="text-sm text-muted-foreground">Configure how this environment notifies you and your team about events.</p>
                 </div>
                 {canAddNotification ? (


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-60

## Description

Fixes three issues on Gamma environment Notifications.

- The add/edit sheet now uses the correct title (`Add notification`, `Edit Console Notification`, or `Edit {name}`) instead of always showing “Edit Console Notification”. 

- The env sidebar and page heading are renamed from “Notification settings” to “Notifications” (path stays `notification-settings`). 

- Long Target values are capped in a fixed-width column with an ellipsis, and the full email/webhook list is shown in a tooltip on hover.

## Additional context

With Fix :

Sidenav title : "Notification"
Top tip & truncate on target column

<img width="1710" height="965" alt="image" src="https://github.com/user-attachments/assets/d1c35c74-d106-42c2-9150-69c8de78478b" />

Add Notification text on "new notification creation"

<img width="1710" height="965" alt="image" src="https://github.com/user-attachments/assets/e6b036e9-f02f-41b7-8a63-9cf1676bed02" />

