### PR TITLE
fix(analytics): send http method names as the reported codes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.repository.analytics.engine.api.metric.Measure;
 import io.gravitee.repository.analytics.engine.api.metric.Metric;
@@ -184,7 +185,7 @@ public class AggregationAdapter {
 
             if (query.facets() != null && !query.facets().isEmpty()) {
                 var facets = new ArrayList<>(query.facets());
-                var facetBucketResults = toFacetBucketResults(metric, bucket, facets, aggNames, query.toFacetQuery());
+                var facetBucketResults = toFacetBucketResults(metric, bucket, null, facets, aggNames, query.toFacetQuery());
                 result.add(TimeSeriesBucketResult.ofBuckets(key, timestamp, facetBucketResults));
             } else {
                 var aggregations = toAggregations(bucket, aggNames);
@@ -197,9 +198,14 @@ public class AggregationAdapter {
         return result;
     }
 
+    /**
+     * @param bucketFacet the facet {@code bucket} belongs to; {@code null} for a date histogram bucket, whose key is
+     *                    never read here
+     */
     private static List<FacetBucketResult> toFacetBucketResults(
         Metric metric,
         JsonNode bucket,
+        Facet bucketFacet,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
@@ -208,8 +214,7 @@ public class AggregationAdapter {
             var aggregations = toAggregations(bucket, aggNames);
             var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
             var measures = getMeasuresWithDefaults(metric, metricAndMeasures, query);
-            var key = bucket.get(ES_KEY_PROP).asText();
-            return List.of(FacetBucketResult.ofMeasures(key, measures));
+            return List.of(FacetBucketResult.ofMeasures(bucketKey(bucketFacet, bucket), measures));
         }
 
         var nextFacets = new ArrayList<>(facets);
@@ -225,13 +230,12 @@ public class AggregationAdapter {
         var results = new ArrayList<FacetBucketResult>();
 
         for (var facetBucket : facetBuckets) {
-            var key = facetBucket.get(ES_KEY_PROP).asText();
-            var nestedResults = toFacetBucketResults(metric, facetBucket, new ArrayList<>(nextFacets), aggNames, query);
+            var nestedResults = toFacetBucketResults(metric, facetBucket, nextFacet, new ArrayList<>(nextFacets), aggNames, query);
 
             if (nextFacets.isEmpty()) {
                 results.addAll(nestedResults);
             } else {
-                results.add(FacetBucketResult.ofBuckets(key, nestedResults));
+                results.add(FacetBucketResult.ofBuckets(bucketKey(nextFacet, facetBucket), nestedResults));
             }
         }
 
@@ -251,19 +255,20 @@ public class AggregationAdapter {
         var agg = aggregations.get(aggName);
         var buckets = agg.getBuckets();
         for (var bucket : buckets) {
-            results.add(toFacetBucketResult(metric, bucket, facets, aggNames, query));
+            results.add(toFacetBucketResult(metric, facet, bucket, facets, aggNames, query));
         }
         return results;
     }
 
     private static FacetBucketResult toFacetBucketResult(
         Metric metric,
+        Facet facet,
         JsonNode bucket,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
     ) {
-        var key = bucket.get(ES_KEY_PROP).asText();
+        var key = bucketKey(facet, bucket);
         if (facets.isEmpty()) {
             var aggregations = toAggregations(bucket, aggNames);
             var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
@@ -275,12 +280,16 @@ public class AggregationAdapter {
         var nextAggName = adaptName(metric, nextFacet);
         var next = bucket.get(nextAggName);
         var buckets = next.get(ES_BUCKETS_PROP);
-        return FacetBucketResult.ofBuckets(key, toFacetBucketResults(metric, toBucketList(buckets), nextFacets, aggNames, query));
+        return FacetBucketResult.ofBuckets(
+            key,
+            toFacetBucketResults(metric, toBucketList(buckets), nextFacet, nextFacets, aggNames, query)
+        );
     }
 
     private static List<FacetBucketResult> toFacetBucketResults(
         Metric metric,
         List<JsonNode> buckets,
+        Facet bucketsFacet,
         List<Facet> facets,
         List<String> aggNames,
         FacetsQuery query
@@ -288,11 +297,10 @@ public class AggregationAdapter {
         var results = new ArrayList<FacetBucketResult>();
         if (facets.isEmpty()) {
             for (var bucket : buckets) {
-                var key = bucket.get(ES_KEY_PROP).asText();
                 var aggregations = toAggregations(bucket, aggNames);
                 var metricAndMeasures = toMetricsAndMeasures(aggregations, query);
                 var measures = getMeasuresWithDefaults(metric, metricAndMeasures, query);
-                results.add(FacetBucketResult.ofMeasures(key, measures));
+                results.add(FacetBucketResult.ofMeasures(bucketKey(bucketsFacet, bucket), measures));
             }
             return results;
         }
@@ -302,7 +310,7 @@ public class AggregationAdapter {
         var nextAggName = adaptName(metric, nextFacet);
 
         for (var bucket : buckets) {
-            var key = bucket.get(ES_KEY_PROP).asText();
+            var key = bucketKey(bucketsFacet, bucket);
             var next = bucket.get(nextAggName);
             if (next == null) {
                 continue;
@@ -311,12 +319,21 @@ public class AggregationAdapter {
             results.add(
                 FacetBucketResult.ofBuckets(
                     key,
-                    toFacetBucketResults(metric, toBucketList(nextBuckets), new ArrayList<>(nextFacets), aggNames, query)
+                    toFacetBucketResults(metric, toBucketList(nextBuckets), nextFacet, new ArrayList<>(nextFacets), aggNames, query)
                 )
             );
         }
 
         return results;
+    }
+
+    /** The gateway reports the HTTP method as its {@link HttpMethod#code()}; the catalog names it. */
+    private static String bucketKey(Facet facet, JsonNode bucket) {
+        var key = bucket.get(ES_KEY_PROP);
+        if (facet == Facet.HTTP_METHOD && key.canConvertToInt()) {
+            return ofNullable(HttpMethod.get(key.asInt())).map(HttpMethod::name).orElseGet(key::asText);
+        }
+        return key.asText();
     }
 
     private static Map<String, Aggregation> toAggregations(JsonNode bucket, List<String> aggNames) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
 import io.gravitee.repository.analytics.engine.api.query.ObservabilityEntrypoints;
 import io.gravitee.repository.analytics.engine.api.query.Query;
@@ -23,6 +24,7 @@ import io.gravitee.repository.elasticsearch.v4.shared.StatusCodeGroups;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
@@ -289,6 +291,9 @@ public class FilterAdapter {
         if (filter.name() == Filter.Name.HTTP_STATUS_CODE_GROUP) {
             return statusCodeGroupFilter(filter);
         }
+        if (filter.name() == Filter.Name.HTTP_METHOD) {
+            return httpMethodFilter(filter);
+        }
         if (filter.operator() == Filter.Operator.GTE || filter.operator() == Filter.Operator.LTE) {
             return rangeFilter(filter);
         }
@@ -309,6 +314,34 @@ public class FilterAdapter {
             case IN -> StatusCodeGroups.shouldForGroups(field, (Collection<String>) filter.value());
             default -> throw new IllegalArgumentException("Unsupported operator for HTTP_STATUS_CODE_GROUP filter: " + filter.operator());
         };
+    }
+
+    /** The catalog offers method names, the gateway reports the method as its {@link HttpMethod#code()}. */
+    private JsonObject httpMethodFilter(Filter filter) {
+        var field = fieldResolver.fromFilter(filter);
+        return switch (filter.operator()) {
+            case EQ -> JsonObject.of("term", JsonObject.of(field, httpMethodCode(filter.value())));
+            case IN -> JsonObject.of(
+                "terms",
+                JsonObject.of(field, new JsonArray(values(filter.value()).map(FilterAdapter::httpMethodCode).toList()))
+            );
+            default -> throw new IllegalArgumentException("Unsupported operator for HTTP_METHOD filter: " + filter.operator());
+        };
+    }
+
+    private static int httpMethodCode(Object value) {
+        if (value instanceof Number code) {
+            return code.intValue();
+        }
+        try {
+            return HttpMethod.valueOf(String.valueOf(value).toUpperCase(Locale.ROOT)).code();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown HTTP method: " + value, e);
+        }
+    }
+
+    private static Stream<?> values(Object value) {
+        return Objects.requireNonNull(value) instanceof Collection<?> collection ? collection.stream() : Stream.of(value);
     }
 
     private String filterName(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.withPrecision;
 
 import io.gravitee.common.http.HttpMethod;
@@ -1628,6 +1629,45 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                     assertThat(measure.measures().values()).hasSize(1);
                     assertThat(measure.measures().values().iterator().next()).satisfies(n -> assertThat(n.doubleValue()).isNotZero());
                 }
+            }
+        }
+
+        /**
+         * The fixture holds 22 documents on the HTTP entrypoints: 3 GET, 13 DELETE, 4 POST and 2 PUT. The gateway
+         * reports the method as its numeric code.
+         */
+        @Nested
+        class HTTPMethodFilters {
+
+            private static final MetricMeasuresQuery REQUESTS = new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT));
+
+            @Test
+            void should_count_the_requests_of_one_http_method() {
+                var filter = new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "POST");
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(4L);
+            }
+
+            @Test
+            void should_count_the_requests_of_several_http_methods() {
+                var filter = new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.IN, List.of("GET", "PUT"));
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(5L);
+            }
+
+            @Test
+            void should_bucket_the_requests_by_http_method_name() {
+                var query = new FacetsQuery(buildTimeRange(), List.of(), List.of(REQUESTS), List.of(Facet.HTTP_METHOD));
+
+                var result = cut.searchHTTPFacets(QUERY_CONTEXT, query);
+
+                assertThat(result.metrics().getFirst().buckets())
+                    .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+                    .containsExactlyInAnyOrder(tuple("GET", 3L), tuple("DELETE", 13L), tuple("POST", 4L), tuple("PUT", 2L));
             }
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/AggregationAdapterTest.java
@@ -115,6 +115,57 @@ class AggregationAdapterTest {
     }
 
     @Test
+    void should_name_http_method_buckets_after_the_method_rather_than_its_reported_code() {
+        var query = new FacetsQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT))),
+            List.of(Facet.HTTP_METHOD)
+        );
+
+        var get = JSON.createObjectNode().put("key", 3).put("doc_count", 30);
+        get.putObject("HTTP_REQUESTS#COUNT").put("value", 30);
+        var post = JSON.createObjectNode().put("key", 7).put("doc_count", 12);
+        post.putObject("HTTP_REQUESTS#COUNT").put("value", 12);
+
+        var facetAgg = new Aggregation();
+        facetAgg.setBuckets(List.of(get, post));
+
+        var result = AggregationAdapter.toMetricsAndBuckets(Map.of("HTTP_REQUESTS#HTTP_METHOD", facetAgg), query);
+
+        assertThat(result.get(0).buckets())
+            .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+            .containsExactly(org.assertj.core.groups.Tuple.tuple("GET", 30L), org.assertj.core.groups.Tuple.tuple("POST", 12L));
+    }
+
+    @Test
+    void should_name_http_method_buckets_nested_under_another_facet() {
+        var query = new FacetsQuery(
+            TIME_RANGE,
+            List.of(),
+            List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT))),
+            List.of(Facet.API, Facet.HTTP_METHOD)
+        );
+
+        var get = JSON.createObjectNode().put("key", 3).put("doc_count", 30);
+        get.putObject("HTTP_REQUESTS#COUNT").put("value", 30);
+        var api = JSON.createObjectNode().put("key", "api-1").put("doc_count", 30);
+        api.putObject("HTTP_REQUESTS#HTTP_METHOD").putArray("buckets").add(get);
+
+        var facetAgg = new Aggregation();
+        facetAgg.setBuckets(List.of(api));
+
+        var result = AggregationAdapter.toMetricsAndBuckets(Map.of("HTTP_REQUESTS#API", facetAgg), query);
+
+        var apiBucket = result.get(0).buckets().get(0);
+        assertThat(apiBucket.key()).isEqualTo("api-1");
+        assertThat(apiBucket.buckets())
+            .singleElement()
+            .extracting(bucket -> bucket.key())
+            .isEqualTo("GET");
+    }
+
+    @Test
     void should_return_zero_measures_without_fix_when_filter_agg_wraps_measures() {
         var query = new FacetsQuery(
             TIME_RANGE,

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -336,6 +336,48 @@ class FilterAdapterTest {
     }
 
     @Nested
+    class HttpMethodFilters {
+
+        @Test
+        void should_filter_on_the_reported_method_code_for_eq() throws JsonProcessingException {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "GET"));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var jsonQuery = JSON.readTree(measuresAdapter.adapt(query));
+
+            var term = jsonQuery.at("/query/bool/filter/1/term/http-method");
+            assertThat(term.isIntegralNumber()).isTrue();
+            assertThat(term.asInt()).isEqualTo(3);
+        }
+
+        @Test
+        void should_filter_on_the_reported_method_codes_for_in() throws JsonProcessingException {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.IN, List.of("POST", "put")));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var jsonQuery = JSON.readTree(measuresAdapter.adapt(query));
+
+            var terms = jsonQuery.at("/query/bool/filter/1/terms/http-method");
+            assertThat(terms.isArray()).isTrue();
+            assertThat(terms.get(0).asInt()).isEqualTo(7);
+            assertThat(terms.get(1).asInt()).isEqualTo(8);
+        }
+
+        @Test
+        void should_throw_for_an_unknown_http_method() {
+            var filters = List.of(new Filter(Filter.Name.HTTP_METHOD, Filter.Operator.EQ, "FETCH"));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            assertThatThrownBy(() -> measuresAdapter.adapt(query))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("FETCH");
+        }
+    }
+
+    @Nested
     class NumericRangeFilters {
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15071

## Description

Every analytics-engine request carrying an `HTTP_METHOD` filter failed with HTTP 500 (`number_format_exception` from Elasticsearch): the catalog offers method names (`GET`, `POST`, …) but the gateway reports `http-method` as the numeric `HttpMethod` code (`GET` = 3, `POST` = 7), and the adapter sent the name as-is to a `short` field. Facets by `HTTP_METHOD` returned the numeric codes as bucket keys.

- `FilterAdapter` translates method names to the reported code for `EQ` and `IN`, case-insensitively, and refuses an unknown method with a clear error.
- `AggregationAdapter` names `HTTP_METHOD` facet buckets after the method at every nesting level, so a dashboard grouped by method reads `GET` / `POST` instead of `3` / `7`.

Found while smoke-testing performance targets (AIAM-436): a rule filter on `HTTP_METHOD` passed validation and then failed at every evaluation. Same change already merged on `amp_demo` in #19656.

## Tests

- `FilterAdapterTest`: codes for `EQ` and `IN`, unknown method rejected.
- `AggregationAdapterTest`: bucket naming at the first and a nested level.
- `AnalyticsElasticsearchRepositoryTest` (Testcontainers): fixture counts per method (`POST` 4, `GET`+`PUT` 5) and method-named buckets.

## Compatibility-sensitive surfaces

Analytics query behaviour: `HTTP_METHOD` filters now match documents and `HTTP_METHOD` facet keys change from numeric codes to method names. No index mapping change.
