### PR TITLE
fix(analytics): read the http path from path-info

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
@@ -58,7 +58,8 @@ public class HTTPFieldResolver implements FieldResolver {
             case Filter.Name.ZONE -> "zone";
             case Filter.Name.HTTP_METHOD -> "http-method";
             case Filter.Name.HTTP_STATUS_CODE_GROUP, HTTP_STATUS -> "status";
-            case Filter.Name.HTTP_PATH -> "path";
+            // the gateway reports the path after the context path as path-info; `path` is declared but never written
+            case Filter.Name.HTTP_PATH -> "path-info.keyword";
             case Filter.Name.HTTP_PATH_MAPPING -> "mapped-path";
             case Filter.Name.GEO_IP_COUNTRY -> "geoip.country_iso_code";
             case Filter.Name.GEO_IP_REGION -> "geoip.region_name";
@@ -104,7 +105,7 @@ public class HTTPFieldResolver implements FieldResolver {
             case ZONE -> "zone";
             case HTTP_METHOD -> "http-method";
             case HTTP_STATUS_CODE_GROUP, HTTP_STATUS -> "status";
-            case HTTP_PATH -> "path";
+            case HTTP_PATH -> "path-info.keyword";
             case HTTP_PATH_MAPPING -> "mapped-path";
             case GEO_IP_COUNTRY -> "geoip.country_iso_code";
             case GEO_IP_REGION -> "geoip.region_name";

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.withPrecision;
 
 import io.gravitee.common.http.HttpMethod;
@@ -1679,6 +1680,33 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
                     bucket -> assertThat(bucket.key()).isEqualTo("400-499"),
                     bucket -> assertThat(bucket.key()).isEqualTo("500-599")
                 );
+            }
+        }
+
+        /** The fixture holds 22 documents on the HTTP entrypoints, two of them on {@code /tools/call}, reported as {@code path-info}. */
+        @Nested
+        class HTTPPathFilters {
+
+            private static final MetricMeasuresQuery REQUESTS = new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT));
+
+            @Test
+            void should_count_the_requests_of_one_path() {
+                var filter = new Filter(Filter.Name.HTTP_PATH, Filter.Operator.EQ, "/tools/call");
+
+                var result = cut.searchHTTPMeasures(QUERY_CONTEXT, new MeasuresQuery(buildTimeRange(), List.of(filter), List.of(REQUESTS)));
+
+                assertThat(result.measures().getFirst().measures().get(Measure.COUNT).longValue()).isEqualTo(2L);
+            }
+
+            @Test
+            void should_bucket_the_requests_by_path() {
+                var query = new FacetsQuery(buildTimeRange(), List.of(), List.of(REQUESTS), List.of(Facet.HTTP_PATH));
+
+                var result = cut.searchHTTPFacets(QUERY_CONTEXT, query);
+
+                assertThat(result.metrics().getFirst().buckets())
+                    .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
+                    .contains(tuple("/tools/call", 2L), tuple("/chat", 2L), tuple("/", 13L));
             }
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolverTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolverTest.java
@@ -64,6 +64,14 @@ class HTTPFieldResolverTest {
         assertThrows(UnsupportedOperationException.class, () -> fieldResolver.fromMetric(Metric.MESSAGE_ERRORS));
     }
 
+    @Test
+    void should_resolve_http_path_to_the_path_info_the_gateway_reports() {
+        assertThat(fieldResolver.fromFilter(new Filter(Filter.Name.HTTP_PATH, Filter.Operator.EQ, "/tools/call"))).isEqualTo(
+            "path-info.keyword"
+        );
+        assertThat(fieldResolver.fromFacet(Facet.HTTP_PATH)).isEqualTo("path-info.keyword");
+    }
+
     @ParameterizedTest
     @EnumSource(
         value = Filter.Name.class,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15072

## Description

An `HTTP_PATH` filter or facet on the analytics engine always matched nothing: `HTTPFieldResolver` resolved it to the `path` field, which the v4 metrics index template declares but the gateway never writes. Documents carry the path after the context path as `path-info` (and the full request URI as `uri`, already served by the `URI` filter).

`HTTP_PATH` now resolves to `path-info.keyword` for filters, facets and filter value listing. The `path-info` field is dynamically mapped as text with a keyword sub-field in every existing index, so no mapping change is needed and existing data is queryable immediately.

Found while smoke-testing performance targets (AIAM-436): a rule filter on `HTTP_PATH` silently evaluated over an empty set. Same change already merged on `amp_demo` in #19656.

## Tests

- `HTTPFieldResolverTest`: filter and facet resolve to `path-info.keyword`.
- `AnalyticsElasticsearchRepositoryTest` (Testcontainers): the two fixture requests on `/tools/call` are counted, and facets by path return `/tools/call`, `/chat` and `/` with the fixture counts.

## Compatibility-sensitive surfaces

Analytics query behaviour: `HTTP_PATH` filters and facets now return data; the values are the path after the API context path (`/tools/call`), not the full URI. No index mapping change.
