### PR TITLE
fix(gamma): deep-link message and native tasks to the esm module that serves them

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/components/TaskRow.tsx
@@ -32,6 +32,7 @@ const ICONS: Record<TaskIconKey, LucideIcon> = {
 
 const AREA_CLASS: Record<TaskAreaKey, string> = {
     apim: 'border-primary/30 text-primary',
+    esm: 'border-warning/30 text-warning',
     mcp: 'border-highlight/30 text-highlight',
     ai: 'border-highlight/30 text-highlight',
     llm: 'border-highlight/30 text-highlight',

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.spec.ts
@@ -77,6 +77,7 @@ describe('toTaskView', () => {
         'api-llm': { name: 'Concierge Agent', apiType: 'llm-proxy' },
         'api-a2a': { name: 'Dispatch Agent', apiType: 'a2a-proxy' },
         'api-kafka': { name: 'Orders Stream', apiType: 'native' },
+        'api-message': { name: 'Booking Events', apiType: 'message' },
         'product-1': { name: 'Travel Suite' },
     };
 
@@ -145,12 +146,21 @@ describe('toTaskView', () => {
         expect(a2a.to).toBe('/environments/prod/aim/agent-runtime/api-a2a');
     });
 
-    it('labels a native subscription as Kafka and routes it to the Event Stream Management module', () => {
+    // The esm module has no subscription *detail* route, so the deep link stops at the list.
+    it('labels a native subscription as Kafka and deep-links it to the esm subscriptions list', () => {
         const view = toTaskView(subscription('api-kafka'), metadata, resolveEnvHrid);
 
         expect(view.area).toEqual({ key: 'kafka', label: 'Kafka' });
         expect(view.toModuleId).toBe('esm');
-        expect(view.to).toBe('/environments/prod/esm');
+        expect(view.to).toBe('/environments/prod/esm/kafka-apis/api-kafka/subscriptions');
+    });
+
+    it('deep-links a message subscription to the esm subscriptions list, not to apim', () => {
+        const view = toTaskView(subscription('api-message'), metadata, resolveEnvHrid);
+
+        expect(view.area).toEqual({ key: 'esm', label: 'Event Stream Management' });
+        expect(view.toModuleId).toBe('esm');
+        expect(view.to).toBe('/environments/prod/esm/message-apis/api-message/subscriptions');
     });
 
     it('builds an API Product subscription with a deep link into the apim api-products area', () => {
@@ -189,6 +199,26 @@ describe('toTaskView', () => {
         expect(view.area.key).toBe('llm');
         expect(view.toModuleId).toBe('aim');
         expect(view.to).toBe('/environments/prod/aim/llm-proxy/api-llm');
+    });
+
+    // apim/apis/{id} renders a Message API as an HTTP proxy, with screens it does not have.
+    it('deep-links a message review task to the esm module instead of apim', () => {
+        const entity: TaskEntity = { type: 'IN_REVIEW', created_at: 1, data: { referenceId: 'api-message' } };
+
+        const view = toTaskView(entity, metadata, resolveEnvHrid);
+
+        expect(view.area.key).toBe('esm');
+        expect(view.toModuleId).toBe('esm');
+        expect(view.to).toBe('/environments/prod/esm/message-apis/api-message');
+    });
+
+    it('deep-links a native review task to the esm kafka-apis page', () => {
+        const entity: TaskEntity = { type: 'IN_REVIEW', created_at: 1, data: { referenceId: 'api-kafka' } };
+
+        const view = toTaskView(entity, metadata, resolveEnvHrid);
+
+        expect(view.toModuleId).toBe('esm');
+        expect(view.to).toBe('/environments/prod/esm/kafka-apis/api-kafka');
     });
 
     it('deep-links an MCP review task to the mcp-proxy API page', () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.mapping.ts
@@ -52,19 +52,38 @@ type ConsumerLevel = 'detail' | 'list' | 'none';
 interface ApiTypeConfig {
     readonly area: TaskArea;
     readonly moduleId: string;
-    readonly route?: { readonly section: string; readonly consumers: ConsumerLevel };
+    /**
+     * `consumersSegment` is the path segment the owning module serves its subscriptions under: `apim`
+     * and `aim` say `consumers`, `esm` says `subscriptions`. Defaults to `consumers`.
+     */
+    readonly route?: { readonly section: string; readonly consumers: ConsumerLevel; readonly consumersSegment?: string };
 }
 
 const API_MANAGEMENT_AREA: TaskArea = { key: 'apim', label: 'API Management' };
 const USERS_AREA: TaskArea = { key: 'users', label: 'Users' };
 
+const EVENT_STREAM_AREA: TaskArea = { key: 'esm', label: 'Event Stream Management' };
+
+/**
+ * `message` and `native` APIs are served by the `esm` module, not by `apim`: sending them to
+ * `apim/apis/{id}` renders a Message API as an HTTP proxy and offers screens it does not have. The
+ * esm module has no subscription *detail* route, so their subscription tasks land on the list.
+ */
 const API_TYPE_CONFIG: Record<string, ApiTypeConfig> = {
     proxy: { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } },
-    message: { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } },
+    message: {
+        area: EVENT_STREAM_AREA,
+        moduleId: 'esm',
+        route: { section: 'message-apis', consumers: 'list', consumersSegment: 'subscriptions' },
+    },
     'mcp-proxy': { area: { key: 'mcp', label: 'MCP' }, moduleId: 'aim', route: { section: 'mcp-proxy', consumers: 'detail' } },
     'llm-proxy': { area: { key: 'llm', label: 'LLM' }, moduleId: 'aim', route: { section: 'llm-proxy', consumers: 'detail' } },
     'a2a-proxy': { area: { key: 'ai', label: 'AI Agent' }, moduleId: 'aim', route: { section: 'agent-runtime', consumers: 'none' } },
-    native: { area: { key: 'kafka', label: 'Kafka' }, moduleId: 'esm' },
+    native: {
+        area: { key: 'kafka', label: 'Kafka' },
+        moduleId: 'esm',
+        route: { section: 'kafka-apis', consumers: 'list', consumersSegment: 'subscriptions' },
+    },
 };
 
 const DEFAULT_CONFIG: ApiTypeConfig = { area: API_MANAGEMENT_AREA, moduleId: 'apim', route: { section: 'apis', consumers: 'detail' } };
@@ -166,12 +185,12 @@ function resolveConsumerTarget(config: ApiTypeConfig, envHrid: string, refId: st
     if (!config.route || !refId) {
         return moduleRoot(envHrid, config.moduleId);
     }
-    const { section, consumers } = config.route;
+    const { section, consumers, consumersSegment = 'consumers' } = config.route;
     if (consumers === 'detail' && subscriptionId) {
-        return envPath(envHrid, config.moduleId, section, refId, 'consumers', subscriptionId);
+        return envPath(envHrid, config.moduleId, section, refId, consumersSegment, subscriptionId);
     }
     if (consumers === 'list') {
-        return envPath(envHrid, config.moduleId, section, refId, 'consumers');
+        return envPath(envHrid, config.moduleId, section, refId, consumersSegment);
     }
     return envPath(envHrid, config.moduleId, section, refId);
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.types.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/tasks/tasks.types.ts
@@ -31,7 +31,7 @@ export interface TasksResponse {
 
 export type TaskCategory = 'SUBSCRIPTION' | 'API_REVIEW' | 'CHANGES_REQUESTED' | 'USER_REGISTRATION' | 'API_PROMOTION';
 
-export type TaskAreaKey = 'apim' | 'mcp' | 'ai' | 'llm' | 'kafka' | 'users';
+export type TaskAreaKey = 'apim' | 'esm' | 'mcp' | 'ai' | 'llm' | 'kafka' | 'users';
 
 export interface TaskArea {
     readonly key: TaskAreaKey;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-195

## Description

Tasks & Approvals sent every Message API task to `apim/apis/{id}`, which renders a Message API as an HTTP proxy — "Gateway Endpoint", "Upstream Service", a backend-security checklist — and offers screens it does not have. `native` had the right module id but no `route` at all, so its tasks fell back to the esm module root and dropped the API.

Both now point at the sections esm actually serves (`message-apis`, `kafka-apis`), and message tasks are labelled Event Stream Management rather than API Management.

The subscription segment becomes part of the route config: `apim` and `aim` serve subscriptions under `consumers`, esm under `subscriptions` — and esm has no subscription *detail* route, so those tasks deep-link to the list rather than to a page that would 404.

## Additional context

Same class of bug as 2853b6f (`fix(gamma): deep-link LLM tasks to the llm-proxy route the aim module actually serves`, AIAM-480), and fixed the same way.

Found while working ESM-195: a reviewer clicking "Review API" on a Message API task landed in a module that has no review action at all.

Verified against a local stack — the target routes resolve without a sub-path, both `message-apis/:id` and `kafka-apis/:id` having an `index` route in the esm module. `TaskAreaKey` gained `esm`, and its only consumer (`TaskRow`'s `AREA_CLASS`) was updated alongside, or the badge would have rendered with an `undefined` class.

Four tests added; one existing test updated — it froze the old behaviour (a native subscription resolving to the bare esm module root).

Companion PR on `gravitee-gamma-module-esm`: https://github.com/gravitee-io/gravitee-gamma-module-esm/pull/78