### PR TITLE
[4.9.x] feat(helm): render gateway http2 flow-control windows

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -86,6 +86,17 @@ secrets:
 #  requestTimeoutGraceDelay: 30
 #  secured: false
 #  alpn: false
+#  HTTP/2 flow control. A client may only send this many bytes of request body before waiting for the gateway to
+#  acknowledge them, so upload throughput is bounded by window size / round-trip time. The 65535 bytes protocol
+#  default throttles large uploads as soon as there is real network latency, where HTTP/1.1 is unaffected.
+#  Both are left at the protocol default unless set, and both have to be set: the initial settings the gateway sends
+#  reach streams only, never the connection, so raising streamWindowSize alone leaves the connection window at
+#  65535 bytes and it stays the bottleneck. Keep connectionWindowSize >= streamWindowSize.
+#  Raising them costs gateway memory per connection and per concurrent request respectively, so size them against
+#  the payloads you actually accept and the concurrency you expect, not against a single upload. Neither is capped.
+#  http2:
+#    streamWindowSize: 20971520 # per-request window, in bytes
+#    connectionWindowSize: 20971520 # per-connection window, in bytes
 #  ssl:
 #    clientAuth: none # Supports none, request, required
 #    The following allows to configure a header to extract the certificate from. Only works for header processed by NGINX in the front of the Gateway.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -95,8 +95,8 @@ secrets:
 #  Raising them costs gateway memory per connection and per concurrent request respectively, so size them against
 #  the payloads you actually accept and the concurrency you expect, not against a single upload. Neither is capped.
 #  http2:
-#    streamWindowSize: 20971520 # per-request window, in bytes
 #    connectionWindowSize: 20971520 # per-connection window, in bytes
+#    streamWindowSize: 20971520 # per-request window, in bytes
 #  ssl:
 #    clientAuth: none # Supports none, request, required
 #    The following allows to configure a header to extract the certificate from. Only works for header processed by NGINX in the front of the Gateway.

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 ### 4.9.35
 - Expose the gateway HTTP/2 flow-control windows through `gateway.http.http2.connectionWindowSize` and `gateway.http.http2.streamWindowSize` (also per server under `gateway.servers[]`), unset by default so the 65535 bytes protocol default is kept (APIM-15040). Upload throughput over HTTP/2 is bounded by window size / round-trip time, so the default throttles large request bodies as soon as there is real network latency, where HTTP/1.1 is unaffected. Set both or neither: the initial settings the gateway sends reach streams only, never the connection, so raising `streamWindowSize` alone leaves the connection window at 65535 bytes and it stays the bottleneck. They cost gateway memory per connection and per concurrent request respectively, and neither is capped.
+- Bump the Gravitee node Hazelcast cache and cluster plugins to 7.28.1, to stay consistent with `gravitee-node.version` in the APIM `pom.xml`.
 
 ### 4.9.25
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.9.35
+- Expose the gateway HTTP/2 flow-control windows through `gateway.http.http2.connectionWindowSize` and `gateway.http.http2.streamWindowSize` (also per server under `gateway.servers[]`), unset by default so the 65535 bytes protocol default is kept (APIM-15040). Upload throughput over HTTP/2 is bounded by window size / round-trip time, so the default throttles large request bodies as soon as there is real network latency, where HTTP/1.1 is unaffected. Set both or neither: the initial settings the gateway sends reach streams only, never the connection, so raising `streamWindowSize` alone leaves the connection window at 65535 bytes and it stays the bottleneck. They cost gateway memory per connection and per concurrent request respectively, and neither is capped.
+
 ### 4.9.25
 - fix gateway requestTimeout ignored when gateway.servers is configured (APIM-14276)
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,9 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: "`gateway.http.http2.connectionWindowSize` and `gateway.http.http2.streamWindowSize` (also per server under `gateway.servers[]`) set the gateway HTTP/2 flow-control windows, unset by default so the 65535 bytes protocol default is kept. Set both or neither: raising the stream window alone leaves the connection window as the bottleneck"
+      links:
+        - name: Github PR
+          url: https://github.com/gravitee-io/gravitee-api-management/pull/19688

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -106,6 +106,9 @@ data:
         {{- if $server.haproxy }}
         haproxy: {{ toYaml $server.haproxy | nindent 10 }}
         {{- end }}
+        {{- if $server.http2 }}
+        http2: {{ toYaml $server.http2 | nindent 10 }}
+        {{- end }}
     {{- end }}
     http:
       requestTimeout: {{ include "gateway.httpRequestTimeout" . }}
@@ -164,6 +167,9 @@ data:
         enabled: {{ .Values.gateway.websocket }}
       {{- if .Values.gateway.haproxy }}
       haproxy: {{ toYaml .Values.gateway.haproxy | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateway.http.http2 }}
+      http2: {{ toYaml .Values.gateway.http.http2 | nindent 8 }}
       {{- end }}
     {{- end }}
     {{- if hasKey .Values.gateway "kafka" }}

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.27.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.27.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.27.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.27.0.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.28.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.28.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.28.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.28.1.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/tests/gateway/configmap_http2_test.yaml
+++ b/helm/tests/gateway/configmap_http2_test.yaml
@@ -1,0 +1,47 @@
+suite: Test Gateway configmap - http2 flow-control windows
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Default configmap doesn't have any http2 config
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s http2:\s*
+
+  - it: Sets configmap http2 config globally
+    set:
+      gateway:
+        http:
+          http2:
+            connectionWindowSize: 20971520
+            streamWindowSize: 20971520
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s http2:\s*
+            \s   connectionWindowSize: 20971520
+            \s   streamWindowSize: 20971520
+          multiline: true
+
+  - it: Sets configmap http2 config in servers
+    set:
+      gateway:
+        servers:
+          - type: http
+            port: 8082
+            http2:
+              connectionWindowSize: 20971520
+              streamWindowSize: 20971520
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            servers:
+              - type: http
+                port: 8082
+                host: 0.0.0.0
+                http2:\s*
+                  connectionWindowSize: 20971520
+                  streamWindowSize: 20971520

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1001,6 +1001,12 @@ gateway:
 #      haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 #        proxyProtocol: false
 #        proxyProtocolTimeout: 10000
+#      # HTTP/2 flow-control windows, in bytes. Unset by default, which keeps the 65535 bytes protocol
+#      # default. Set both or neither, and keep connectionWindowSize >= streamWindowSize. See
+#      # gateway.http.http2 below for what raising them buys and what they cost.
+#      http2:
+#        connectionWindowSize: 20971520
+#        streamWindowSize: 20971520
 #          # in the case of having multiple servers configured, this can be used for mapping the ports
 #      service:
 #        type: ClusterIP
@@ -1048,6 +1054,8 @@ gateway:
     # bottleneck. Keep connectionWindowSize >= streamWindowSize.
     # Raising them costs gateway memory per connection and per concurrent request respectively,
     # and neither is capped, so size them against the concurrency you expect.
+    # Read only when gateway.servers is unset. With gateway.servers configured this block is
+    # ignored, and http2 goes on each gateway.servers[] entry, as websocket and haproxy do.
     # http2:
     #   connectionWindowSize: 20971520
     #   streamWindowSize: 20971520

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,8 +473,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.27.0.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.27.0.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.28.1.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.28.1.zip
 
 api:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1038,6 +1038,19 @@ gateway:
     maxInitialLineLength: 4096
     maxFormAttributeSize: 2048
     alpn: "true"
+    # HTTP/2 flow-control windows, in bytes. A client may only send this many bytes of request
+    # body before waiting for the gateway to acknowledge them, so upload throughput is bounded
+    # by window size / round-trip time. The 65535 bytes protocol default throttles large uploads
+    # as soon as there is real network latency, where HTTP/1.1 is unaffected.
+    # Unset by default, which keeps the protocol default. Set both or neither: the initial
+    # settings the gateway sends reach streams only, never the connection, so raising
+    # streamWindowSize alone leaves the connection window at 65535 bytes and it stays the
+    # bottleneck. Keep connectionWindowSize >= streamWindowSize.
+    # Raising them costs gateway memory per connection and per concurrent request respectively,
+    # and neither is capped, so size them against the concurrency you expect.
+    # http2:
+    #   connectionWindowSize: 20971520
+    #   streamWindowSize: 20971520
     requestTimeout: 30000
     requestTimeoutGraceDelay: 30
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.1.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.27.0</gravitee-node.version>
+        <gravitee-node.version>7.28.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.11.1</gravitee-plugin.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-15040

**Description**

Backport of #19653 to `4.9.x`, same four commits: the commented `http2` block in the reference `gravitee.yml`, the chart rendering `http2` for `gateway.http` and `gateway.servers[]` with its tests, the review follow-ups, and the `gravitee-node` bump to **7.28.1** — the release of that line carrying the two server options — with the Hazelcast cache and cluster plugins aligned.

**Additional context**

Applied with the `gravitee.yml` path of this line and the CHANGELOG entry under `### 4.9.34` (a new heading matching the chart version: the file had stopped at 4.9.25). Chart suite green locally, 562 tests. gravitee-io/gravitee-platform-docs#2333 documents these keys for 4.9 through 4.13, so each line needs this before that PR leaves draft.
