### PR TITLE
fix(GKO-3207): allow empty health-check cron when inherited or set on all endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainService.java
@@ -25,7 +25,6 @@ import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
-import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.service.Service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -49,66 +48,100 @@ public class ValidateHealthCheckScheduleDomainService {
             if (!(group instanceof EndpointGroup httpGroup)) {
                 continue;
             }
-            validateGroupHealthCheck(httpGroup.getName(), httpGroup.getServices(), errors);
-            if (httpGroup.getEndpoints() == null) {
+            validateHttpGroup(httpGroup, errors);
+        }
+    }
+
+    private void validateHttpGroup(EndpointGroup group, List<Validator.Error> errors) {
+        if (group.getEndpoints() == null) {
+            return;
+        }
+        Service groupHealthCheck = healthCheckOf(group.getServices());
+        boolean groupScheduleReported = false;
+        for (Endpoint endpoint : group.getEndpoints()) {
+            if (!probeMayRun(groupHealthCheck, endpoint)) {
                 continue;
             }
-            for (Endpoint endpoint : httpGroup.getEndpoints()) {
-                validateEndpointHealthCheck(httpGroup, endpoint, errors);
+            Service endpointHealthCheck = healthCheckOf(endpoint);
+            if (overridesGroupConfiguration(endpointHealthCheck)) {
+                validateSchedule(
+                    "endpointGroups[%s].endpoints[%s].services.healthCheck.configuration.schedule".formatted(
+                        group.getName(),
+                        endpoint.getName()
+                    ),
+                    endpointHealthCheck,
+                    errors
+                );
+            } else if (!groupScheduleReported) {
+                validateSchedule(
+                    "endpointGroups[%s].services.healthCheck.configuration.schedule".formatted(group.getName()),
+                    groupHealthCheck,
+                    errors
+                );
+                groupScheduleReported = true;
             }
         }
     }
 
-    private void validateEndpointHealthCheck(EndpointGroup group, Endpoint endpoint, List<Validator.Error> errors) {
-        EndpointServices endpointServices = endpoint.getServices();
-        if (endpointServices == null || endpointServices.getHealthCheck() == null) {
-            return;
+    /**
+     * Mirrors {@code HttpHealthCheckHelper.isServiceEnabled}: the probe runs when the endpoint enables it,
+     * or when the group enables it and the endpoint does not enable its own.
+     * This will check secondary endpoints CRON expression as well. This is done on purpose to cover the case when
+     * the endpoint is promoted to primary. As a result, the Gateway will then start a probe;
+     * hence a valid CRON expression is expected.
+     */
+    private static boolean probeMayRun(Service groupHealthCheck, Endpoint endpoint) {
+        Service endpointHealthCheck = healthCheckOf(endpoint);
+        if (isEnabledHttpHealthCheck(endpointHealthCheck)) {
+            return true;
         }
-        Service endpointHealthCheck = endpointServices.getHealthCheck();
-        if (!isEnabledHttpHealthCheck(endpointHealthCheck)) {
-            return;
-        }
-        if (!endpointHealthCheck.isOverrideConfiguration()) {
-            return;
-        }
-        validateSchedule(
-            "endpointGroups[%s].endpoints[%s].services.healthCheck.configuration.schedule".formatted(group.getName(), endpoint.getName()),
-            endpointHealthCheck.getConfiguration(),
-            errors
-        );
+        return isEnabledHttpHealthCheck(groupHealthCheck) && (endpointHealthCheck == null || !endpointHealthCheck.isEnabled());
     }
 
-    private void validateGroupHealthCheck(String groupName, EndpointGroupServices services, List<Validator.Error> errors) {
-        if (services == null || services.getHealthCheck() == null) {
+    private static boolean overridesGroupConfiguration(Service endpointHealthCheck) {
+        return endpointHealthCheck != null && endpointHealthCheck.isOverrideConfiguration();
+    }
+
+    private void validateSchedule(String fieldPath, Service healthCheck, List<Validator.Error> errors) {
+        ParsedSchedule schedule = parseSchedule(fieldPath, healthCheck, errors);
+        if (schedule.jsonInvalid()) {
             return;
         }
-        Service groupHealthCheck = services.getHealthCheck();
-        if (!isEnabledHttpHealthCheck(groupHealthCheck)) {
+        if (schedule.isPresent()) {
+            validateCron(fieldPath, schedule.value(), errors);
             return;
         }
-        validateSchedule(
-            "endpointGroups[%s].services.healthCheck.configuration.schedule".formatted(groupName),
-            groupHealthCheck.getConfiguration(),
-            errors
-        );
+        errors.add(Validator.Error.severe("property [%s] is required", fieldPath));
+    }
+
+    private static Service healthCheckOf(EndpointGroupServices services) {
+        return services == null ? null : services.getHealthCheck();
+    }
+
+    private static Service healthCheckOf(Endpoint endpoint) {
+        if (endpoint.getServices() == null) {
+            return null;
+        }
+        return endpoint.getServices().getHealthCheck();
     }
 
     private static boolean isEnabledHttpHealthCheck(Service healthCheck) {
-        return healthCheck.isEnabled() && HTTP_HEALTH_CHECK_TYPE.equals(healthCheck.getType());
+        return healthCheck != null && healthCheck.isEnabled() && HTTP_HEALTH_CHECK_TYPE.equals(healthCheck.getType());
     }
 
-    private void validateSchedule(String fieldPath, String configuration, List<Validator.Error> errors) {
-        String schedule;
+    private ParsedSchedule parseSchedule(String fieldPath, Service healthCheck, List<Validator.Error> errors) {
+        if (healthCheck == null) {
+            return ParsedSchedule.missing();
+        }
         try {
-            schedule = readSchedule(configuration);
+            return ParsedSchedule.of(readSchedule(healthCheck.getConfiguration()));
         } catch (JsonProcessingException e) {
             errors.add(Validator.Error.severe("property [%s] has invalid JSON configuration", fieldPath));
-            return;
+            return ParsedSchedule.jsonError();
         }
-        if (schedule == null || schedule.isBlank()) {
-            errors.add(Validator.Error.severe("property [%s] is required", fieldPath));
-            return;
-        }
+    }
+
+    private void validateCron(String fieldPath, String schedule, List<Validator.Error> errors) {
         try {
             new CronTrigger(schedule);
         } catch (IllegalArgumentException e) {
@@ -126,5 +159,27 @@ public class ValidateHealthCheckScheduleDomainService {
             return null;
         }
         return scheduleNode.asText();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private record ParsedSchedule(String value, boolean jsonInvalid) {
+        static ParsedSchedule missing() {
+            return new ParsedSchedule(null, false);
+        }
+
+        static ParsedSchedule jsonError() {
+            return new ParsedSchedule(null, true);
+        }
+
+        static ParsedSchedule of(String value) {
+            return new ParsedSchedule(value, false);
+        }
+
+        boolean isPresent() {
+            return hasText(value);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateHealthCheckScheduleDomainServiceTest.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.core.api.domain_service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fixtures.core.model.ApiCRDFixtures;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -30,10 +29,14 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ValidateHealthCheckScheduleDomainServiceTest {
+
+    private static final String VALID_CRON = "0 */30 * * * *";
+    private static final String INVALID_FIVE_FIELD_CRON = "*/30 * * * *";
 
     private ValidateHealthCheckScheduleDomainService cut;
 
@@ -42,79 +45,207 @@ class ValidateHealthCheckScheduleDomainServiceTest {
         cut = new ValidateHealthCheckScheduleDomainService(new ObjectMapper());
     }
 
-    @Test
-    void should_reject_five_field_cron_on_group_health_check() {
+    @Nested
+    class CronExpressionSyntax {
+
+        @Test
+        void should_reject_five_field_cron_on_group_health_check() {
+            var errors = validate(groupWithHealthCheck(INVALID_FIVE_FIELD_CRON, inheritingEndpoint("default-endpoint")));
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().isSevere()).isTrue();
+            assertThat(errors.getFirst().getMessage()).contains(INVALID_FIVE_FIELD_CRON);
+            assertThat(errors.getFirst().getMessage()).contains("6 fields");
+            assertThat(errors.getFirst().getMessage()).contains(
+                "endpointGroups[default-group].services.healthCheck.configuration.schedule"
+            );
+        }
+
+        @Test
+        void should_accept_valid_six_field_cron_on_group_health_check() {
+            var errors = validate(groupWithHealthCheck(VALID_CRON, inheritingEndpoint("default-endpoint")));
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_ignore_invalid_group_cron_when_no_endpoint_uses_it() {
+            var errors = validate(group(enabledHealthCheck(false, INVALID_FIVE_FIELD_CRON), overridingEndpoint("ep-1", VALID_CRON)));
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_ignore_invalid_cron_on_inheriting_endpoint_when_group_config_is_used() {
+            var errors = validate(group(enabledHealthCheck(false, VALID_CRON), inheritingEnabledEndpoint("ep-1", INVALID_FIVE_FIELD_CRON)));
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_reject_invalid_cron_on_disabled_overriding_endpoint_when_group_probe_runs() {
+            var errors = validate(
+                group(enabledHealthCheck(false, VALID_CRON), overridingDisabledEndpoint("ep-1", INVALID_FIVE_FIELD_CRON))
+            );
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("endpoints[ep-1]");
+            assertThat(errors.getFirst().getMessage()).contains("6 fields");
+        }
+
+        @Test
+        void should_reject_invalid_schedule_on_endpoint_override() {
+            var errors = validate(group(null, overridingEndpoint("default-endpoint", INVALID_FIVE_FIELD_CRON)));
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("endpoints[default-endpoint]");
+            assertThat(errors.getFirst().getMessage()).contains("6 fields");
+        }
+
+        @Test
+        void should_skip_disabled_health_check_with_invalid_schedule() {
+            var errors = validate(group(healthCheck(false, false, INVALID_FIVE_FIELD_CRON), inheritingEndpoint("default-endpoint")));
+
+            assertThat(errors).isEmpty();
+        }
+    }
+
+    @Nested
+    class EmptyScheduleOnGroup {
+
+        @Test
+        void should_allow_group_without_cron_when_all_endpoints_have_one() {
+            var errors = validate(
+                group(enabledHealthCheck(false, null), overridingEndpoint("ep-1", VALID_CRON), overridingEndpoint("ep-2", VALID_CRON))
+            );
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_reject_group_without_cron_when_an_endpoint_does_not_have_one() {
+            var errors = validate(
+                group(enabledHealthCheck(false, null), overridingEndpoint("ep-1", VALID_CRON), inheritingEndpoint("ep-2"))
+            );
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("is required");
+            assertThat(errors.getFirst().getMessage()).contains(
+                "endpointGroups[default-group].services.healthCheck.configuration.schedule"
+            );
+        }
+    }
+
+    @Nested
+    class EmptyScheduleOnInheritedEndpoint {
+
+        @Test
+        void should_allow_inheriting_endpoint_without_cron_when_group_has_one() {
+            var errors = validate(group(enabledHealthCheck(false, VALID_CRON), inheritingEnabledEndpoint("ep-1", null)));
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_allow_inheriting_disabled_endpoint_without_cron_when_group_has_one() {
+            var errors = validate(group(enabledHealthCheck(false, VALID_CRON), inheritingEndpoint("ep-1")));
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        void should_require_group_cron_when_inheriting_endpoint_is_enabled_and_group_has_none() {
+            var errors = validate(group(healthCheck(false, false, null), inheritingEnabledEndpoint("ep-1", null)));
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("is required");
+            assertThat(errors.getFirst().getMessage()).contains(
+                "endpointGroups[default-group].services.healthCheck.configuration.schedule"
+            );
+        }
+
+        @Test
+        void should_allow_inheriting_enabled_endpoint_when_disabled_group_has_a_cron() {
+            var errors = validate(group(healthCheck(false, false, VALID_CRON), inheritingEnabledEndpoint("canary", null)));
+
+            assertThat(errors).isEmpty();
+        }
+    }
+
+    @Nested
+    class EmptyScheduleOnOverridingEndpoint {
+
+        @Test
+        void should_require_cron_on_enabled_overriding_endpoint_even_when_group_has_one() {
+            var errors = validate(group(enabledHealthCheck(false, VALID_CRON), overridingEndpoint("ep-1", null)));
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("is required");
+            assertThat(errors.getFirst().getMessage()).contains("endpoints[ep-1]");
+        }
+
+        @Test
+        void should_require_cron_on_enabled_overriding_endpoint_when_group_has_none() {
+            var errors = validate(group(null, overridingEndpoint("ep-1", null)));
+
+            assertThat(errors).hasSize(1);
+            assertThat(errors.getFirst().getMessage()).contains("is required");
+            assertThat(errors.getFirst().getMessage()).contains("endpoints[ep-1]");
+        }
+    }
+
+    private List<Validator.Error> validate(EndpointGroup group) {
         var errors = new ArrayList<Validator.Error>();
-        var group = endpointGroupWithGroupHealthCheck("*/30 * * * *");
-
         cut.validate(List.of(group), errors);
-
-        assertThat(errors).hasSize(1);
-        assertThat(errors.getFirst().isSevere()).isTrue();
-        assertThat(errors.getFirst().getMessage()).contains("*/30 * * * *");
-        assertThat(errors.getFirst().getMessage()).contains("6 fields");
-        assertThat(errors.getFirst().getMessage()).contains("endpointGroups[default-group].services.healthCheck.configuration.schedule");
+        return errors;
     }
 
-    @Test
-    void should_accept_valid_six_field_cron_on_group_health_check() {
-        var errors = new ArrayList<Validator.Error>();
-        var group = endpointGroupWithGroupHealthCheck("0 */30 * * * *");
-
-        cut.validate(List.of(group), errors);
-
-        assertThat(errors).isEmpty();
+    private static EndpointGroup groupWithHealthCheck(String schedule, Endpoint... endpoints) {
+        return group(enabledHealthCheck(false, schedule), endpoints);
     }
 
-    @Test
-    void should_skip_disabled_health_check_with_invalid_schedule() {
-        var errors = new ArrayList<Validator.Error>();
-        var healthCheck = healthCheckService("*/30 * * * *", true);
-        healthCheck.setEnabled(false);
-        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
-        group.getServices().setHealthCheck(healthCheck);
-
-        cut.validate(List.of(group), errors);
-
-        assertThat(errors).isEmpty();
+    private static EndpointGroup group(Service groupHealthCheck, Endpoint... endpoints) {
+        return EndpointGroup.builder()
+            .name("default-group")
+            .type("http-proxy")
+            .services(EndpointGroupServices.builder().healthCheck(groupHealthCheck).build())
+            .endpoints(List.of(endpoints))
+            .build();
     }
 
-    @Test
-    void should_reject_invalid_schedule_on_endpoint_override() {
-        var errors = new ArrayList<Validator.Error>();
-        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
-        var endpoint = group.getEndpoints().getFirst();
-        endpoint.setServices(EndpointServices.builder().healthCheck(healthCheckService("*/30 * * * *", true)).build());
-
-        cut.validate(List.of(group), errors);
-
-        assertThat(errors).hasSize(1);
-        assertThat(errors.getFirst().getMessage()).contains("endpoints[default-endpoint]");
-        assertThat(errors.getFirst().getMessage()).contains("6 fields");
+    private static Endpoint inheritingEndpoint(String name) {
+        return Endpoint.builder().name(name).type("http-proxy").build();
     }
 
-    @Test
-    void should_reject_missing_schedule_on_enabled_health_check() {
-        var errors = new ArrayList<Validator.Error>();
-        var group = endpointGroupWithGroupHealthCheck(null);
-
-        cut.validate(List.of(group), errors);
-
-        assertThat(errors).hasSize(1);
-        assertThat(errors.getFirst().getMessage()).contains("is required");
+    private static Endpoint inheritingEnabledEndpoint(String name, String schedule) {
+        return endpoint(name, healthCheck(true, false, schedule));
     }
 
-    private static EndpointGroup endpointGroupWithGroupHealthCheck(String schedule) {
-        var group = (EndpointGroup) ApiCRDFixtures.newBaseSpec().build().getEndpointGroups().getFirst();
-        group.setServices(EndpointGroupServices.builder().healthCheck(healthCheckService(schedule, false)).build());
-        return group;
+    private static Endpoint overridingEndpoint(String name, String schedule) {
+        return endpoint(name, healthCheck(true, true, schedule));
     }
 
-    private static Service healthCheckService(String schedule, boolean overrideConfiguration) {
+    private static Endpoint overridingDisabledEndpoint(String name, String schedule) {
+        return endpoint(name, healthCheck(false, true, schedule));
+    }
+
+    private static Endpoint endpoint(String name, Service healthCheck) {
+        return Endpoint.builder()
+            .name(name)
+            .type("http-proxy")
+            .services(EndpointServices.builder().healthCheck(healthCheck).build())
+            .build();
+    }
+
+    private static Service enabledHealthCheck(boolean overrideConfiguration, String schedule) {
+        return healthCheck(true, overrideConfiguration, schedule);
+    }
+
+    private static Service healthCheck(boolean enabled, boolean overrideConfiguration, String schedule) {
         var configuration = schedule == null ? "{}" : "{\"schedule\":\"%s\"}".formatted(schedule);
         return Service.builder()
             .type(ValidateHealthCheckScheduleDomainService.HTTP_HEALTH_CHECK_TYPE)
-            .enabled(true)
+            .enabled(enabled)
             .overrideConfiguration(overrideConfiguration)
             .configuration(configuration)
             .build();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-3207

## Summary

- The first GKO-3207 change rejected any enabled HTTP health-check with a missing cron. That was too strict: group vs endpoint inheritance can make an empty schedule valid.
- Empty schedule is now allowed when the group has no cron but every endpoint overrides with its own, and when an endpoint inherits a group that already has a cron.
- Empty schedule is still required when an enabled endpoint overrides the group, or when the group health-check is off and the endpoint is on. Provided expressions are still syntax-checked.
