### PR TITLE
Hackathon/ai marketplace hide application step

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
@@ -126,7 +126,7 @@
     <div>
       @if (currentStep() !== SubscribeStep.REVIEW) {
         <div class="subscribe-to-api__actions__next">
-          @if (currentApplication()) {
+          @if (currentApplication() && !autoSelectedApplication()) {
             <div class="m3-body-medium subscribe-to-api__actions__selected-application">
               <div><span i18n="@@subscribeToApiAppSelected">Selected Application</span>:</div>
               <mat-chip (removed)="currentApplication.set(undefined)"

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
@@ -1328,6 +1328,80 @@ describe('SubscribeToApiComponent', () => {
         expect(getTitle()).toEqual('Review');
       });
 
+      it('should not show the selected application chip when there is a single eligible application', async () => {
+        await init(false, AGENT_API);
+        const step1 = await harnessLoader.getHarness(SubscribeToApiChoosePlanHarness);
+        await step1.selectPlanByPlanId(API_KEY_PLAN_ID);
+        fixture.detectChanges();
+        expectGetSubscriptionsForApi(API_ID);
+        expectGetApplications(
+          1,
+          fakeApplicationsResponse({
+            data: [fakeApplication({ id: APP_ID, name: 'App 1' })],
+            metadata: {
+              pagination: {
+                current_page: 1,
+                first: 1,
+                last: 1,
+                size: 1,
+                total: 1,
+                total_pages: 1,
+              },
+            },
+          }),
+        );
+        fixture.detectChanges();
+        expect(await getSelectedApplicationName()).toBeNull();
+      });
+
+      it('should not show the selected application chip after switching to a keyless plan', async () => {
+        await init(false, AGENT_API);
+        const step1 = await harnessLoader.getHarness(SubscribeToApiChoosePlanHarness);
+        await step1.selectPlanByPlanId(API_KEY_PLAN_ID);
+        fixture.detectChanges();
+        expectGetSubscriptionsForApi(API_ID);
+        expectGetApplications(
+          1,
+          fakeApplicationsResponse({
+            data: [fakeApplication({ id: APP_ID, name: 'App 1' })],
+            metadata: {
+              pagination: {
+                current_page: 1,
+                first: 1,
+                last: 1,
+                size: 1,
+                total: 1,
+                total_pages: 1,
+              },
+            },
+          }),
+        );
+        fixture.detectChanges();
+        expect(await getSelectedApplicationName()).toBeNull();
+
+        await step1.selectPlanByPlanId(KEYLESS_PLAN_ID);
+        fixture.detectChanges();
+        expectGetSubscriptionsForApi(API_ID);
+        expectGetApplications(
+          1,
+          fakeApplicationsResponse({
+            data: [fakeApplication({ id: APP_ID, name: 'App 1' })],
+            metadata: {
+              pagination: {
+                current_page: 1,
+                first: 1,
+                last: 1,
+                size: 1,
+                total: 1,
+                total_pages: 1,
+              },
+            },
+          }),
+        );
+        fixture.detectChanges();
+        expect(await getSelectedApplicationName()).toBeNull();
+      });
+
       it('should keep the application step when more than one application exists', async () => {
         await init(false, AGENT_API);
         const step1 = await harnessLoader.getHarness(SubscribeToApiChoosePlanHarness);
@@ -1434,7 +1508,7 @@ describe('SubscribeToApiComponent', () => {
 
   async function getSelectedApplicationName(): Promise<string | null> {
     return await harnessLoader
-      .getHarness(MatChipHarness)
+      .getHarness(MatChipHarness.with({ ancestor: '.subscribe-to-api__actions__selected-application' }))
       .then(chip => chip.getText())
       .catch(_ => null);
   }

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -363,7 +363,7 @@ export class SubscribeToApiComponent implements OnInit {
 
   private maybeAutoSelectApplication(data: ApplicationsData): void {
     if (this.api().type !== 'A2A_PROXY' || !this.currentPlan() || this.currentPlan()?.security === 'KEY_LESS') {
-      this.autoSelectedApplication.set(false);
+      this.clearAutoSelectedApplication();
       return;
     }
 
@@ -379,6 +379,13 @@ export class SubscribeToApiComponent implements OnInit {
       return;
     }
 
+    this.clearAutoSelectedApplication();
+  }
+
+  private clearAutoSelectedApplication(): void {
+    if (this.autoSelectedApplication()) {
+      this.currentApplication.set(undefined);
+    }
     this.autoSelectedApplication.set(false);
   }
 

--- a/gravitee-apim-portal-webui-next/src/marketplace/custom-theme.css
+++ b/gravitee-apim-portal-webui-next/src/marketplace/custom-theme.css
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+app-navigation-page-full-width gmd-viewer {
+  padding: 0 !important;
+  max-width: initial !important;
+}

--- a/gravitee-apim-portal-webui-next/src/marketplace/draft/homepage-draft.html
+++ b/gravitee-apim-portal-webui-next/src/marketplace/draft/homepage-draft.html
@@ -1,0 +1,880 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<style>
+  /* ── Reset & Base ── */
+  .amp * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  .amp {
+    font-family:
+      'Inter',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      sans-serif;
+    color: #1a1a2e;
+    line-height: 1.6;
+    background: #f8f9fc;
+  }
+
+  /* ── Hero ── */
+  .amp-hero {
+    background: linear-gradient(135deg, #0f0c29 0%, #1a1a4e 40%, #302b63 70%, #24243e 100%);
+    padding: 64px 32px 56px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+  }
+  .amp-hero::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background:
+      radial-gradient(ellipse at 30% 50%, rgba(99, 102, 241, 0.15) 0%, transparent 60%),
+      radial-gradient(ellipse at 70% 50%, rgba(16, 185, 129, 0.1) 0%, transparent 60%);
+    animation: amp-glow 8s ease-in-out infinite alternate;
+  }
+  @keyframes amp-glow {
+    0% {
+      transform: translate(0, 0) scale(1);
+    }
+    100% {
+      transform: translate(2%, -2%) scale(1.05);
+    }
+  }
+  .amp-hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  .amp-hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(99, 102, 241, 0.2);
+    border: 1px solid rgba(99, 102, 241, 0.35);
+    color: #a5b4fc;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    padding: 6px 16px;
+    border-radius: 100px;
+    margin-bottom: 20px;
+  }
+  .amp-hero-badge::before {
+    content: '✦';
+    font-size: 10px;
+  }
+  .amp-hero h1 {
+    font-size: 44px;
+    font-weight: 800;
+    color: #ffffff;
+    letter-spacing: -0.5px;
+    line-height: 1.15;
+    margin-bottom: 16px;
+  }
+  .amp-hero h1 span {
+    background: linear-gradient(90deg, #818cf8, #34d399);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .amp-hero p {
+    font-size: 17px;
+    color: #94a3b8;
+    max-width: 620px;
+    margin: 0 auto 32px;
+    line-height: 1.7;
+  }
+
+  /* ── Search Bar ── */
+  .amp-search {
+    max-width: 560px;
+    margin: 0 auto;
+    position: relative;
+  }
+  .amp-search input {
+    width: 100%;
+    padding: 16px 20px 16px 48px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 14px;
+    color: #ffffff;
+    font-size: 15px;
+    outline: none;
+    transition: all 0.3s;
+  }
+  .amp-search input::placeholder {
+    color: #64748b;
+  }
+  .amp-search input:focus {
+    border-color: rgba(99, 102, 241, 0.5);
+    background: rgba(255, 255, 255, 0.12);
+  }
+  .amp-search-icon {
+    position: absolute;
+    left: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #64748b;
+    font-size: 18px;
+  }
+
+  /* ── Stats Bar ── */
+  .amp-stats {
+    display: flex;
+    justify-content: center;
+    gap: 48px;
+    padding: 28px 32px;
+    max-width: 700px;
+    margin: -28px auto 0;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+    position: relative;
+    z-index: 1;
+    backdrop-filter: blur(8px);
+  }
+  .amp-stat {
+    text-align: center;
+  }
+  .amp-stat-number {
+    font-size: 28px;
+    font-weight: 800;
+    color: #ffffff;
+  }
+  .amp-stat-label {
+    font-size: 12px;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-top: 2px;
+  }
+
+  /* ── Section Shared ── */
+  .amp-section {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 48px 32px 0;
+  }
+  .amp-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+  }
+  .amp-section-header h2 {
+    font-size: 24px;
+    font-weight: 700;
+    color: #1a1a2e;
+  }
+  .amp-section-link {
+    font-size: 14px;
+    font-weight: 600;
+    color: #6366f1;
+    text-decoration: none;
+  }
+  .amp-section-link:hover {
+    text-decoration: underline;
+  }
+
+  /* ── Categories ── */
+  .amp-categories {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(155px, 1fr));
+    gap: 14px;
+  }
+  .amp-cat {
+    background: #ffffff;
+    border: 1px solid #e8eaf0;
+    border-radius: 14px;
+    padding: 20px 16px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.25s;
+    text-decoration: none;
+    color: inherit;
+  }
+  .amp-cat:hover {
+    border-color: #6366f1;
+    transform: translateY(-3px);
+    box-shadow: 0 8px 24px rgba(99, 102, 241, 0.1);
+  }
+  .amp-cat-icon {
+    font-size: 30px;
+    margin-bottom: 8px;
+    display: block;
+  }
+  .amp-cat-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: #334155;
+  }
+  .amp-cat-count {
+    font-size: 11px;
+    color: #94a3b8;
+    margin-top: 2px;
+  }
+
+  /* ── Agent Cards ── */
+  .amp-agents {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 20px;
+  }
+
+  .amp-card {
+    background: #ffffff;
+    border: 1px solid #e8eaf0;
+    border-radius: 16px;
+    padding: 24px;
+    transition: all 0.25s;
+    cursor: pointer;
+    position: relative;
+  }
+  .amp-card:hover {
+    border-color: #c7d2fe;
+    transform: translateY(-3px);
+    box-shadow: 0 12px 32px rgba(99, 102, 241, 0.08);
+  }
+
+  .amp-card-top {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    margin-bottom: 14px;
+  }
+  .amp-card-logo {
+    width: 52px;
+    height: 52px;
+    border-radius: 12px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+  }
+  .amp-card-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .amp-card-name {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin-bottom: 2px;
+  }
+  .amp-card-publisher {
+    font-size: 12px;
+    color: #64748b;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .amp-verified {
+    color: #6366f1;
+    font-size: 13px;
+  }
+  .amp-card-desc {
+    font-size: 13.5px;
+    color: #475569;
+    line-height: 1.6;
+    margin-bottom: 14px;
+  }
+
+  /* ── Tags ── */
+  .amp-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+  }
+  .amp-tag {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: #f1f5f9;
+    color: #475569;
+  }
+  .amp-tag-protocol {
+    background: #eef2ff;
+    color: #4f46e5;
+  }
+  .amp-tag-new {
+    background: #ecfdf5;
+    color: #059669;
+  }
+
+  /* ── Card Footer ── */
+  .amp-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid #f1f5f9;
+    padding-top: 14px;
+  }
+  .amp-price {
+    font-size: 14px;
+    font-weight: 700;
+    color: #1a1a2e;
+  }
+  .amp-price-unit {
+    font-size: 11px;
+    font-weight: 400;
+    color: #94a3b8;
+  }
+  .amp-card-btn {
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 18px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    background: #6366f1;
+    color: #ffffff;
+  }
+  .amp-card-btn:hover {
+    background: #4f46e5;
+  }
+  .amp-card-btn-outline {
+    background: transparent;
+    color: #6366f1;
+    border: 1.5px solid #c7d2fe;
+  }
+  .amp-card-btn-outline:hover {
+    background: #eef2ff;
+  }
+
+  /* ── Featured Banner ── */
+  .amp-featured {
+    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+    border-radius: 20px;
+    padding: 40px;
+    display: flex;
+    align-items: center;
+    gap: 40px;
+    margin-bottom: 12px;
+    color: #ffffff;
+    position: relative;
+    overflow: hidden;
+  }
+  .amp-featured::after {
+    content: '';
+    position: absolute;
+    right: -40px;
+    top: -40px;
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(99, 102, 241, 0.3), transparent 70%);
+  }
+  .amp-featured-content {
+    flex: 1;
+    position: relative;
+    z-index: 1;
+  }
+  .amp-featured-label {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: #a5b4fc;
+    margin-bottom: 12px;
+  }
+  .amp-featured h3 {
+    font-size: 26px;
+    font-weight: 800;
+    margin-bottom: 8px;
+  }
+  .amp-featured p {
+    font-size: 14px;
+    color: #c7d2fe;
+    max-width: 480px;
+    line-height: 1.7;
+  }
+  .amp-featured-btn {
+    display: inline-block;
+    margin-top: 20px;
+    padding: 12px 28px;
+    background: #6366f1;
+    color: #ffffff;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .amp-featured-btn:hover {
+    background: #818cf8;
+  }
+  .amp-featured-visual {
+    width: 180px;
+    height: 180px;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 72px;
+    position: relative;
+    z-index: 1;
+  }
+
+  /* ── How It Works ── */
+  .amp-how {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    margin-top: 8px;
+  }
+  .amp-how-step {
+    text-align: center;
+    padding: 32px 20px;
+    background: #ffffff;
+    border: 1px solid #e8eaf0;
+    border-radius: 16px;
+  }
+  .amp-how-num {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 800;
+    background: #eef2ff;
+    color: #6366f1;
+    margin-bottom: 14px;
+  }
+  .amp-how-title {
+    font-size: 15px;
+    font-weight: 700;
+    margin-bottom: 6px;
+    color: #1a1a2e;
+  }
+  .amp-how-desc {
+    font-size: 13px;
+    color: #64748b;
+    line-height: 1.6;
+  }
+
+  /* ── Trust Banner ── */
+  .amp-trust {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 36px;
+    padding: 36px 32px;
+    margin-top: 48px;
+    background: #ffffff;
+    border-top: 1px solid #e8eaf0;
+    border-bottom: 1px solid #e8eaf0;
+  }
+  .amp-trust-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .amp-trust-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+  }
+  .amp-trust-text {
+    font-size: 13px;
+    font-weight: 600;
+    color: #334155;
+  }
+  .amp-trust-sub {
+    font-size: 11px;
+    color: #94a3b8;
+    font-weight: 400;
+  }
+
+  /* ── Footer ── */
+  .amp-footer {
+    text-align: center;
+    padding: 40px 32px;
+    font-size: 13px;
+    color: #94a3b8;
+  }
+  .amp-footer a {
+    color: #6366f1;
+    text-decoration: none;
+    font-weight: 600;
+  }
+  .amp-footer a:hover {
+    text-decoration: underline;
+  }
+</style>
+
+<div class="amp">
+  <!-- ══ HERO ══ -->
+  <div class="amp-hero">
+    <div class="amp-hero-content">
+      <div class="amp-hero-badge">AI Agent Marketplace</div>
+      <h1>Discover, acquire &amp; govern <span>AI Agents</span></h1>
+      <p>
+        A curated marketplace of production-ready AI agents — discoverable, subscribable, and governed through the Gravitee Gateway with
+        full traffic observability.
+      </p>
+      <div class="amp-search">
+        <span class="amp-search-icon">🔍</span>
+        <input type="text" placeholder="Search agents by name, skill, protocol, or publisher..." />
+      </div>
+    </div>
+    <div class="amp-stats">
+      <div class="amp-stat">
+        <div class="amp-stat-number">127</div>
+        <div class="amp-stat-label">Agents</div>
+      </div>
+      <div class="amp-stat">
+        <div class="amp-stat-number">34</div>
+        <div class="amp-stat-label">Publishers</div>
+      </div>
+      <div class="amp-stat">
+        <div class="amp-stat-number">8</div>
+        <div class="amp-stat-label">Categories</div>
+      </div>
+      <div class="amp-stat">
+        <div class="amp-stat-number">2.4M</div>
+        <div class="amp-stat-label">Calls / month</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ CATEGORIES ══ -->
+  <div class="amp-section">
+    <div class="amp-section-header">
+      <h2>Browse by Category</h2>
+      <a href="#" class="amp-section-link">View all →</a>
+    </div>
+    <div class="amp-categories">
+      <div class="amp-cat">
+        <span class="amp-cat-icon">🤖</span>
+        <div class="amp-cat-name">Customer Service</div>
+        <div class="amp-cat-count">24 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">📊</span>
+        <div class="amp-cat-name">Data &amp; Analytics</div>
+        <div class="amp-cat-count">19 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">💼</span>
+        <div class="amp-cat-name">Sales &amp; CRM</div>
+        <div class="amp-cat-count">17 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">🔐</span>
+        <div class="amp-cat-name">Security &amp; Compliance</div>
+        <div class="amp-cat-count">15 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">🛠️</span>
+        <div class="amp-cat-name">IT Operations</div>
+        <div class="amp-cat-count">21 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">📝</span>
+        <div class="amp-cat-name">HR &amp; Recruiting</div>
+        <div class="amp-cat-count">12 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">💰</span>
+        <div class="amp-cat-name">Finance &amp; Billing</div>
+        <div class="amp-cat-count">11 agents</div>
+      </div>
+      <div class="amp-cat">
+        <span class="amp-cat-icon">⚡</span>
+        <div class="amp-cat-name">DevOps &amp; CI/CD</div>
+        <div class="amp-cat-count">8 agents</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ FEATURED ══ -->
+  <div class="amp-section">
+    <div class="amp-featured">
+      <div class="amp-featured-content">
+        <div class="amp-featured-label">⭐ Featured Agent</div>
+        <h3>Enterprise Knowledge Navigator</h3>
+        <p>
+          AI-powered agent that connects to your internal knowledge bases, Confluence, SharePoint, and Notion — delivering instant, cited
+          answers to employee questions with full access control through the gateway.
+        </p>
+        <button class="amp-featured-btn">View Agent →</button>
+      </div>
+      <div class="amp-featured-visual">🧠</div>
+    </div>
+  </div>
+
+  <!-- ══ POPULAR AGENTS ══ -->
+  <div class="amp-section">
+    <div class="amp-section-header">
+      <h2>Popular Agents</h2>
+      <a href="#" class="amp-section-link">View all →</a>
+    </div>
+    <div class="amp-agents">
+      <!-- Agent 1 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #dbeafe, #bfdbfe)">🎧</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">Resolve AI — Support Agent</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> Resolve Inc.</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Autonomous L1/L2 customer support agent. Handles ticket triage, sentiment analysis, knowledge-base lookups, and escalation —
+          reducing mean time to resolution by 68%.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">A2A</span>
+          <span class="amp-tag amp-tag-protocol">MCP</span>
+          <span class="amp-tag">Zendesk</span>
+          <span class="amp-tag">Intercom</span>
+          <span class="amp-tag">Salesforce</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$0.003 <span class="amp-price-unit">/ call</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+
+      <!-- Agent 2 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #fce7f3, #fbcfe8)">📈</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">InsightForge — Analytics Agent</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> DataCraft Labs</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Natural-language data analyst. Connects to SQL databases, warehouses, and BI tools — generates queries, charts, and executive
+          summaries from plain-English questions.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">A2A</span>
+          <span class="amp-tag">BigQuery</span>
+          <span class="amp-tag">Snowflake</span>
+          <span class="amp-tag">Looker</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$49 <span class="amp-price-unit">/ month</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+
+      <!-- Agent 3 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #d1fae5, #a7f3d0)">🔍</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">ComplianceGuard Agent</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> TrustLayer AI</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Continuous compliance monitoring agent. Scans policies, contracts, and operations against SOC2, GDPR, HIPAA, and ISO 27001 — flags
+          violations in real time.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">MCP</span>
+          <span class="amp-tag">SOC2</span>
+          <span class="amp-tag">GDPR</span>
+          <span class="amp-tag">HIPAA</span>
+          <span class="amp-tag amp-tag-new">New</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$99 <span class="amp-price-unit">/ month</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+
+      <!-- Agent 4 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #fef3c7, #fde68a)">⚡</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">PipelineBot — CI/CD Agent</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> DevStream</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Intelligent CI/CD orchestrator. Analyzes build failures, auto-generates fixes, manages deployments, and provides real-time
+          pipeline health diagnostics.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">A2A</span>
+          <span class="amp-tag amp-tag-protocol">MCP</span>
+          <span class="amp-tag">GitHub</span>
+          <span class="amp-tag">Jenkins</span>
+          <span class="amp-tag amp-tag-new">New</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$0.005 <span class="amp-price-unit">/ call</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+
+      <!-- Agent 5 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #ede9fe, #ddd6fe)">💼</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">DealSense — Sales Intel Agent</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> RevOps AI</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Sales intelligence agent that enriches leads, scores opportunities, drafts personalized outreach, and predicts deal outcomes using
+          CRM and market signals.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">A2A</span>
+          <span class="amp-tag">HubSpot</span>
+          <span class="amp-tag">Salesforce</span>
+          <span class="amp-tag">LinkedIn</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$79 <span class="amp-price-unit">/ month</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+
+      <!-- Agent 6 -->
+      <div class="amp-card">
+        <div class="amp-card-top">
+          <div class="amp-card-logo" style="background: linear-gradient(135deg, #fee2e2, #fecaca)">🏥</div>
+          <div class="amp-card-info">
+            <div class="amp-card-name">DocuMind — Document Processor</div>
+            <div class="amp-card-publisher"><span class="amp-verified">✓</span> Neuralign</div>
+          </div>
+        </div>
+        <div class="amp-card-desc">
+          Extracts, classifies, and summarizes information from contracts, invoices, reports, and forms. Supports 40+ document types with
+          configurable extraction schemas.
+        </div>
+        <div class="amp-tags">
+          <span class="amp-tag amp-tag-protocol">MCP</span>
+          <span class="amp-tag">PDF</span>
+          <span class="amp-tag">OCR</span>
+          <span class="amp-tag">S3</span>
+        </div>
+        <div class="amp-card-footer">
+          <div class="amp-price">$0.01 <span class="amp-price-unit">/ document</span></div>
+          <button class="amp-card-btn">Subscribe</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ HOW IT WORKS ══ -->
+  <div class="amp-section" style="padding-bottom: 8px">
+    <div class="amp-section-header">
+      <h2>How It Works</h2>
+    </div>
+    <div class="amp-how">
+      <div class="amp-how-step">
+        <div class="amp-how-num">1</div>
+        <div class="amp-how-title">Discover</div>
+        <div class="amp-how-desc">
+          Browse curated agents by category, protocol (A2A, MCP), or publisher. Every listing shows skills, systems, and pricing.
+        </div>
+      </div>
+      <div class="amp-how-step">
+        <div class="amp-how-num">2</div>
+        <div class="amp-how-title">Subscribe</div>
+        <div class="amp-how-desc">
+          Choose a plan, accept terms, and get approved. Credentials are issued automatically — API key or OAuth client.
+        </div>
+      </div>
+      <div class="amp-how-step">
+        <div class="amp-how-num">3</div>
+        <div class="amp-how-title">Consume</div>
+        <div class="amp-how-desc">
+          Call agents through the Gravitee Gateway. Traffic is authenticated, rate-limited, and observable on every request.
+        </div>
+      </div>
+      <div class="amp-how-step">
+        <div class="amp-how-num">4</div>
+        <div class="amp-how-title">Govern &amp; Pay</div>
+        <div class="amp-how-desc">
+          Usage is metered per subscription. Policies enforce guardrails. Invoices are generated automatically via billing integration.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ TRUST BAR ══ -->
+  <div class="amp-trust">
+    <div class="amp-trust-item">
+      <div class="amp-trust-icon" style="background: #eef2ff; color: #6366f1">🛡️</div>
+      <div>
+        <div class="amp-trust-text">Gateway-Enforced Governance</div>
+        <div class="amp-trust-sub">Every call governed by policy</div>
+      </div>
+    </div>
+    <div class="amp-trust-item">
+      <div class="amp-trust-icon" style="background: #ecfdf5; color: #059669">✓</div>
+      <div>
+        <div class="amp-trust-text">Verified Publishers</div>
+        <div class="amp-trust-sub">Identity &amp; card validated</div>
+      </div>
+    </div>
+    <div class="amp-trust-item">
+      <div class="amp-trust-icon" style="background: #fef3c7; color: #d97706">📊</div>
+      <div>
+        <div class="amp-trust-text">Full Observability</div>
+        <div class="amp-trust-sub">Traffic analytics on every request</div>
+      </div>
+    </div>
+    <div class="amp-trust-item">
+      <div class="amp-trust-icon" style="background: #fce7f3; color: #db2777">🔑</div>
+      <div>
+        <div class="amp-trust-text">Instant Provisioning</div>
+        <div class="amp-trust-sub">Credentials on approval</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══ FOOTER ══ -->
+  <div class="amp-footer">
+    <p>Powered by <a href="#">Gravitee.io</a> — Runtime-neutral agent governance through the API Gateway.</p>
+  </div>
+</div>

--- a/gravitee-apim-portal-webui-next/src/marketplace/homepage.html
+++ b/gravitee-apim-portal-webui-next/src/marketplace/homepage.html
@@ -1,0 +1,1623 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Agent Marketplace — Gravitee</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  HERO                                                             -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <section class="hero">
+      <div class="hero-content">
+        <!-- <div class="hero-badge">
+      <span class="hero-badge-dot"></span>
+      AI Agent Marketplace
+    </div> -->
+        <h1>Find the right AI agent.<br /><em>Subscribe in seconds.</em></h1>
+        <p class="hero-sub">
+          Browse production-ready agents from verified publishers &mdash; governed, metered, and observable through the Gravitee Gateway.
+        </p>
+        <div class="hero-actions">
+          <button class="btn-primary">
+            <a href="/catalog" style="display: flex">
+              Explore the Catalog
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </a>
+          </button>
+          <a href="#how-it-works" class="btn-secondary">
+            How it works
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M7 3v8M4 8l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  STATS STRIP                                                      -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="stats-strip">
+      <div class="stats-card">
+        <div class="stat">
+          <div class="stat-number">127</div>
+          <div class="stat-label">Agents</div>
+        </div>
+        <div class="stat">
+          <div class="stat-number">34</div>
+          <div class="stat-label">Publishers</div>
+        </div>
+        <div class="stat">
+          <div class="stat-number">8</div>
+          <div class="stat-label">Categories</div>
+        </div>
+        <div class="stat">
+          <div class="stat-number">2.4<span>M</span></div>
+          <div class="stat-label">Calls / month</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  SPOTLIGHT                                                        -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="section">
+      <div class="container">
+        <div class="spotlight">
+          <div class="spotlight-content">
+            <div class="spotlight-eyebrow">Agent of the Week</div>
+            <h3>Enterprise Knowledge Navigator</h3>
+            <div class="spotlight-publisher">
+              <span class="verified">&#10003;</span>
+              Nexus AI &middot; Verified Publisher
+            </div>
+            <p>
+              Connects to your internal knowledge bases &mdash; Confluence, SharePoint, Notion &mdash; and delivers instant, cited answers
+              with full access control through the gateway.
+            </p>
+            <div class="spotlight-tags">
+              <span class="spotlight-tag spotlight-tag-protocol">A2A</span>
+              <span class="spotlight-tag spotlight-tag-protocol">MCP</span>
+              <span class="spotlight-tag">Knowledge Base</span>
+              <span class="spotlight-tag">RAG</span>
+              <span class="spotlight-tag">Enterprise</span>
+            </div>
+            <button class="spotlight-btn">
+              View Agent
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path
+                  d="M2.5 7h9M8 3.5L11.5 7 8 10.5"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+          <div class="spotlight-visual">
+            <div class="spotlight-visual-icon">
+              <svg viewBox="0 0 40 40" fill="none">
+                <path
+                  d="M20 6C12.268 6 6 12.268 6 20s6.268 14 14 14 14-6.268 14-14S27.732 6 20 6z"
+                  stroke="#fff"
+                  stroke-width="1.5"
+                  opacity="0.3"
+                />
+                <path d="M14 18l4 4 8-8" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                <circle cx="20" cy="20" r="3" fill="#fff" opacity="0.5" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  BROWSE BY USE CASE                                               -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="section" style="padding-top: 0">
+      <div class="container">
+        <div class="section-header">
+          <div>
+            <div class="section-label">Browse by Use Case</div>
+            <div class="section-title">What do your teams need?</div>
+          </div>
+          <a href="#" class="section-link">View all categories &rarr;</a>
+        </div>
+        <div class="categories">
+          <div class="cat">
+            <div class="cat-icon" style="background: #dbeafe">
+              <svg viewBox="0 0 24 24" fill="none">
+                <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" stroke="#3b82f6" stroke-width="1.5" />
+                <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="9" cy="10" r="1" fill="#3b82f6" />
+                <circle cx="15" cy="10" r="1" fill="#3b82f6" />
+              </svg>
+            </div>
+            <div class="cat-name">Customer Service</div>
+            <div class="cat-count">24 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #fce7f3">
+              <svg viewBox="0 0 24 24" fill="none">
+                <rect x="3" y="3" width="7" height="7" rx="1.5" stroke="#ec4899" stroke-width="1.5" />
+                <rect x="14" y="3" width="7" height="7" rx="1.5" stroke="#ec4899" stroke-width="1.5" />
+                <rect x="3" y="14" width="7" height="7" rx="1.5" stroke="#ec4899" stroke-width="1.5" />
+                <rect x="14" y="14" width="7" height="7" rx="1.5" stroke="#ec4899" stroke-width="1.5" />
+              </svg>
+            </div>
+            <div class="cat-name">Data &amp; Analytics</div>
+            <div class="cat-count">19 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #ede9fe">
+              <svg viewBox="0 0 24 24" fill="none">
+                <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="9" cy="7" r="4" stroke="#7c3aed" stroke-width="1.5" />
+                <path d="M22 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </div>
+            <div class="cat-name">Sales &amp; CRM</div>
+            <div class="cat-count">17 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #d1fae5">
+              <svg viewBox="0 0 24 24" fill="none">
+                <rect x="3" y="11" width="18" height="11" rx="2" stroke="#059669" stroke-width="1.5" />
+                <path d="M7 11V7a5 5 0 0110 0v4" stroke="#059669" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="12" cy="16" r="1.5" fill="#059669" />
+              </svg>
+            </div>
+            <div class="cat-name">Security &amp; Compliance</div>
+            <div class="cat-count">15 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #fef3c7">
+              <svg viewBox="0 0 24 24" fill="none">
+                <rect x="2" y="3" width="20" height="14" rx="2" stroke="#d97706" stroke-width="1.5" />
+                <path d="M8 21h8M12 17v4" stroke="#d97706" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M6 10h4M6 13h3" stroke="#d97706" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </div>
+            <div class="cat-name">IT Operations</div>
+            <div class="cat-count">21 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #fce7f3">
+              <svg viewBox="0 0 24 24" fill="none">
+                <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" stroke="#db2777" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="9" cy="7" r="4" stroke="#db2777" stroke-width="1.5" />
+                <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" stroke="#db2777" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </div>
+            <div class="cat-name">HR &amp; Recruiting</div>
+            <div class="cat-count">12 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #ecfdf5">
+              <svg viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M12 2v20M17 5H9.5a3.5 3.5 0 100 7h5a3.5 3.5 0 110 7H6"
+                  stroke="#059669"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            <div class="cat-name">Finance &amp; Billing</div>
+            <div class="cat-count">11 agents</div>
+          </div>
+          <div class="cat">
+            <div class="cat-icon" style="background: #fee2e2">
+              <svg viewBox="0 0 24 24" fill="none">
+                <polyline points="16 18 22 12 16 6" stroke="#dc2626" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <polyline points="8 6 2 12 8 18" stroke="#dc2626" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <line x1="14" y1="4" x2="10" y2="20" stroke="#dc2626" stroke-width="1.5" />
+              </svg>
+            </div>
+            <div class="cat-name">DevOps &amp; CI/CD</div>
+            <div class="cat-count">8 agents</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  TRENDING AGENTS                                                  -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="section" style="padding-top: 0">
+      <div class="container">
+        <div class="section-header">
+          <div>
+            <div class="section-label">Trending</div>
+            <div class="section-title">Most subscribed this month</div>
+          </div>
+          <a href="#" class="section-link">View all agents &rarr;</a>
+        </div>
+        <div class="agents-grid">
+          <!-- Agent 1 -->
+          <div class="agent-card">
+            <div class="agent-card-top">
+              <div class="agent-logo" style="background: linear-gradient(135deg, #dbeafe, #bfdbfe)">
+                <svg viewBox="0 0 26 26" fill="none">
+                  <circle cx="13" cy="13" r="11" stroke="#3b82f6" stroke-width="1.5" />
+                  <path d="M9 13l3 3 5-5" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <div class="agent-info">
+                <div class="agent-name">Resolve AI &mdash; Support Agent</div>
+                <div class="agent-publisher"><span class="verified">&#10003;</span> Resolve Inc.</div>
+              </div>
+            </div>
+            <div class="agent-desc">
+              Autonomous L1/L2 customer support. Handles ticket triage, sentiment analysis, knowledge-base lookups, and escalation &mdash;
+              reducing MTTR by 68%.
+            </div>
+            <div class="agent-tags">
+              <span class="tag tag-protocol">A2A</span>
+              <span class="tag tag-protocol">MCP</span>
+              <span class="tag">Zendesk</span>
+              <span class="tag">Intercom</span>
+            </div>
+            <div class="agent-footer">
+              <div class="agent-price">$0.003 <span class="agent-price-unit">/ call</span></div>
+              <button class="btn-subscribe">Subscribe</button>
+            </div>
+          </div>
+          <!-- Agent 2 -->
+          <div class="agent-card">
+            <div class="agent-card-top">
+              <div class="agent-logo" style="background: linear-gradient(135deg, #fce7f3, #fbcfe8)">
+                <svg viewBox="0 0 26 26" fill="none">
+                  <rect x="4" y="4" width="18" height="18" rx="3" stroke="#ec4899" stroke-width="1.5" />
+                  <path d="M9 13h8M13 9v8" stroke="#ec4899" stroke-width="1.5" stroke-linecap="round" />
+                </svg>
+              </div>
+              <div class="agent-info">
+                <div class="agent-name">InsightForge &mdash; Analytics</div>
+                <div class="agent-publisher"><span class="verified">&#10003;</span> DataCraft Labs</div>
+              </div>
+            </div>
+            <div class="agent-desc">
+              Natural-language data analyst. Connects to SQL databases, warehouses, and BI tools &mdash; generates queries, charts, and
+              summaries from plain English.
+            </div>
+            <div class="agent-tags">
+              <span class="tag tag-protocol">A2A</span>
+              <span class="tag">BigQuery</span>
+              <span class="tag">Snowflake</span>
+            </div>
+            <div class="agent-footer">
+              <div class="agent-price">$49 <span class="agent-price-unit">/ month</span></div>
+              <button class="btn-subscribe">Subscribe</button>
+            </div>
+          </div>
+          <!-- Agent 3 -->
+          <div class="agent-card">
+            <div class="agent-card-top">
+              <div class="agent-logo" style="background: linear-gradient(135deg, #d1fae5, #a7f3d0)">
+                <svg viewBox="0 0 26 26" fill="none">
+                  <path d="M13 3L4 8v10l9 5 9-5V8L13 3z" stroke="#059669" stroke-width="1.5" stroke-linejoin="round" />
+                  <path d="M4 8l9 5 9-5M13 13v10" stroke="#059669" stroke-width="1.5" stroke-linejoin="round" />
+                </svg>
+              </div>
+              <div class="agent-info">
+                <div class="agent-name">ComplianceGuard</div>
+                <div class="agent-publisher"><span class="verified">&#10003;</span> TrustLayer AI</div>
+              </div>
+            </div>
+            <div class="agent-desc">
+              Continuous compliance monitoring. Scans policies, contracts, and operations against SOC2, GDPR, HIPAA, and ISO 27001 &mdash;
+              flags violations in real time.
+            </div>
+            <div class="agent-tags">
+              <span class="tag tag-protocol">MCP</span>
+              <span class="tag">SOC2</span>
+              <span class="tag">GDPR</span>
+              <span class="tag tag-new">New</span>
+            </div>
+            <div class="agent-footer">
+              <div class="agent-price">$99 <span class="agent-price-unit">/ month</span></div>
+              <button class="btn-subscribe">Subscribe</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  HOW IT WORKS                                                     -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <section id="how-it-works" class="how-section">
+      <div class="container">
+        <div style="text-align: center; padding: 48px 0 8px">
+          <div class="section-label" style="text-align: center">How It Works</div>
+          <div class="section-title" style="text-align: center">From discovery to production in four steps</div>
+        </div>
+        <div class="how-grid">
+          <div class="how-step">
+            <div class="how-num">1</div>
+            <div class="how-title">Discover</div>
+            <div class="how-desc">
+              Browse agents by category, protocol, or publisher. Every listing shows capabilities, pricing, and integrations.
+            </div>
+          </div>
+          <div class="how-step">
+            <div class="how-num">2</div>
+            <div class="how-title">Subscribe</div>
+            <div class="how-desc">
+              Choose a plan, accept terms, and get approved. Credentials are issued automatically &mdash; API key or OAuth.
+            </div>
+          </div>
+          <div class="how-step">
+            <div class="how-num">3</div>
+            <div class="how-title">Connect</div>
+            <div class="how-desc">Call agents through the gateway &mdash; via chat for end users, or A2A protocol for your own agents.</div>
+          </div>
+          <div class="how-step">
+            <div class="how-num">4</div>
+            <div class="how-title">Monitor &amp; Pay</div>
+            <div class="how-desc">Usage metered per subscription. Policies enforce guardrails. Invoices generated automatically.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  DASHBOARD PREVIEW                                                -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="section">
+      <div class="container">
+        <div style="text-align: center; margin-bottom: 40px">
+          <div class="section-label" style="text-align: center">Your Agents at a Glance</div>
+          <div class="section-title" style="text-align: center">Monitor every subscription from one dashboard</div>
+          <div class="section-sub" style="text-align: center; margin: 8px auto 0">
+            Track usage, health, and spend across all your active agents.
+          </div>
+        </div>
+        <div class="dash-card" style="max-width: 760px; margin: 0 auto">
+          <div class="dash-header">
+            <h4>Active Subscriptions</h4>
+            <a href="#" class="dash-link">Go to Dashboard &rarr;</a>
+          </div>
+          <div class="dash-body">
+            <div class="dash-subs">
+              <div class="dash-sub">
+                <div class="dash-sub-icon" style="background: linear-gradient(135deg, #dbeafe, #bfdbfe)">
+                  <svg viewBox="0 0 20 20" fill="none">
+                    <circle cx="10" cy="10" r="8" stroke="#3b82f6" stroke-width="1.5" />
+                    <path d="M7 10l2 2 4-4" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </div>
+                <div class="dash-sub-info">
+                  <div class="dash-sub-name">Resolve AI &mdash; Support Agent</div>
+                  <div class="dash-sub-meta">12,847 calls this month &middot; $38.54</div>
+                </div>
+                <div class="dash-sub-status" style="color: #16a34a">
+                  <span class="status-dot status-dot-green"></span>
+                  Healthy
+                </div>
+              </div>
+              <div class="dash-sub">
+                <div class="dash-sub-icon" style="background: linear-gradient(135deg, #fce7f3, #fbcfe8)">
+                  <svg viewBox="0 0 20 20" fill="none">
+                    <rect x="3" y="3" width="14" height="14" rx="2.5" stroke="#ec4899" stroke-width="1.5" />
+                    <path d="M7 10h6M10 7v6" stroke="#ec4899" stroke-width="1.5" stroke-linecap="round" />
+                  </svg>
+                </div>
+                <div class="dash-sub-info">
+                  <div class="dash-sub-name">InsightForge &mdash; Analytics</div>
+                  <div class="dash-sub-meta">Plan: Pro &middot; Renews Sep 18</div>
+                </div>
+                <div class="dash-sub-status" style="color: #16a34a">
+                  <span class="status-dot status-dot-green"></span>
+                  Healthy
+                </div>
+              </div>
+              <div class="dash-sub">
+                <div class="dash-sub-icon" style="background: linear-gradient(135deg, #d1fae5, #a7f3d0)">
+                  <svg viewBox="0 0 20 20" fill="none">
+                    <path d="M10 2L3 6v8l7 4 7-4V6L10 2z" stroke="#059669" stroke-width="1.5" stroke-linejoin="round" />
+                  </svg>
+                </div>
+                <div class="dash-sub-info">
+                  <div class="dash-sub-name">ComplianceGuard</div>
+                  <div class="dash-sub-meta">Quota: 82% used &middot; 1,640 / 2,000</div>
+                </div>
+                <div class="dash-sub-status" style="color: #d97706">
+                  <span class="status-dot status-dot-amber"></span>
+                  Near limit
+                </div>
+              </div>
+            </div>
+            <div class="dash-chart-label">Calls this week</div>
+            <div class="dash-chart">
+              <div class="dash-bar" style="height: 45%"></div>
+              <div class="dash-bar" style="height: 62%"></div>
+              <div class="dash-bar" style="height: 58%"></div>
+              <div class="dash-bar" style="height: 80%"></div>
+              <div class="dash-bar" style="height: 72%"></div>
+              <div class="dash-bar" style="height: 95%"></div>
+              <div class="dash-bar" style="height: 40%; opacity: 0.4"></div>
+            </div>
+            <div class="dash-chart-days">
+              <span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span><span>Sun</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  TRUST BAR                                                        -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <div class="trust">
+      <div class="trust-item">
+        <div class="trust-icon" style="background: #eef2ff">
+          <svg viewBox="0 0 22 22" fill="none">
+            <path
+              d="M11 2L3 6v5c0 5.25 3.4 10.15 8 11.25 4.6-1.1 8-6 8-11.25V6L11 2z"
+              stroke="#6366f1"
+              stroke-width="1.5"
+              stroke-linejoin="round"
+            />
+            <path d="M8 11l2.5 2.5L15 9" stroke="#6366f1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </div>
+        <div>
+          <div class="trust-text">Gateway-Enforced Governance</div>
+          <div class="trust-sub">Every call governed by policy</div>
+        </div>
+      </div>
+      <div class="trust-item">
+        <div class="trust-icon" style="background: #ecfdf5">
+          <svg viewBox="0 0 22 22" fill="none">
+            <circle cx="11" cy="11" r="9" stroke="#059669" stroke-width="1.5" />
+            <path d="M8 11l2 2 4-4" stroke="#059669" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </div>
+        <div>
+          <div class="trust-text">Verified Publishers</div>
+          <div class="trust-sub">Identity &amp; credentials validated</div>
+        </div>
+      </div>
+      <div class="trust-item">
+        <div class="trust-icon" style="background: #fef3c7">
+          <svg viewBox="0 0 22 22" fill="none">
+            <rect x="3" y="3" width="16" height="16" rx="2" stroke="#d97706" stroke-width="1.5" />
+            <path d="M7 14l3-4 3 2 3-5" stroke="#d97706" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </div>
+        <div>
+          <div class="trust-text">Full Observability</div>
+          <div class="trust-sub">Traffic analytics on every request</div>
+        </div>
+      </div>
+      <div class="trust-item">
+        <div class="trust-icon" style="background: #fce7f3">
+          <svg viewBox="0 0 22 22" fill="none">
+            <path
+              d="M11 2v4M11 16v4M4.93 4.93l2.83 2.83M14.24 14.24l2.83 2.83M2 11h4M16 11h4M4.93 17.07l2.83-2.83M14.24 7.76l2.83-2.83"
+              stroke="#db2777"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </div>
+        <div>
+          <div class="trust-text">Instant Provisioning</div>
+          <div class="trust-sub">Credentials issued on approval</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  FOOTER CTA                                                       -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <section class="footer-cta">
+      <h2>Ready to put agents to work?</h2>
+      <p>Browse the marketplace, subscribe to a plan, and start calling agents &mdash; governed and metered from day one.</p>
+      <button class="btn-primary">
+        Browse the Marketplace
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+    </section>
+
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <!--  FOOTER                                                           -->
+    <!-- ══════════════════════════════════════════════════════════════════ -->
+    <footer class="footer">
+      <p>Powered by <a href="#">Gravitee.io</a> &mdash; Runtime-neutral agent governance through the API Gateway.</p>
+    </footer>
+  </body>
+</html>
+
+<style>
+  /* ------------------------------------------------------------------ */
+  /*  RESET & BASE                                                       */
+  /* ------------------------------------------------------------------ */
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  html {
+    scroll-behavior: smooth;
+  }
+  body {
+    font-family:
+      'Inter',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      sans-serif;
+    color: #1a1a2e;
+    line-height: 1.6;
+    background: #f8f9fc;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  img {
+    display: block;
+    max-width: 100%;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  UTILITIES                                                          */
+  /* ------------------------------------------------------------------ */
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 32px;
+  }
+  .mono {
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .serif {
+    font-family: 'Instrument Serif', Georgia, serif;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  NAV BAR                                                            */
+  /* ------------------------------------------------------------------ */
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: rgba(15, 12, 41, 0.92);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+  .nav-inner {
+    display: flex;
+    align-items: center;
+    height: 60px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 32px;
+    gap: 28px;
+  }
+  .nav-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-size: 15px;
+    color: #fff;
+    letter-spacing: -0.01em;
+  }
+  .nav-brand-mark {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: linear-gradient(135deg, #818cf8, #34d399);
+  }
+  .nav-links {
+    display: flex;
+    gap: 24px;
+  }
+  .nav-links a {
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 500;
+    transition: color 0.2s;
+  }
+  .nav-links a:hover,
+  .nav-links a.active {
+    color: #fff;
+  }
+  .nav-right {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .nav-search-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 34px;
+    padding: 0 14px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color 0.2s;
+  }
+  .nav-search-btn:hover {
+    border-color: rgba(255, 255, 255, 0.25);
+  }
+  .nav-search-btn kbd {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.35);
+  }
+  .nav-cta {
+    height: 34px;
+    padding: 0 18px;
+    border: 0;
+    border-radius: 9px;
+    background: #6366f1;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .nav-cta:hover {
+    background: #818cf8;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  HERO                                                               */
+  /* ------------------------------------------------------------------ */
+  .hero {
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(160deg, #0f0c29 0%, #1a1a4e 35%, #302b63 65%, #24243e 100%);
+    padding: 100px 32px 120px;
+    text-align: center;
+  }
+  .hero::before {
+    content: '';
+    position: absolute;
+    top: -40%;
+    left: -30%;
+    width: 160%;
+    height: 180%;
+    background:
+      radial-gradient(ellipse 600px 500px at 25% 40%, rgba(99, 102, 241, 0.18) 0%, transparent 70%),
+      radial-gradient(ellipse 500px 400px at 75% 60%, rgba(52, 211, 153, 0.1) 0%, transparent 70%),
+      radial-gradient(ellipse 300px 300px at 50% 20%, rgba(139, 92, 246, 0.12) 0%, transparent 60%);
+    animation: heroGlow 10s ease-in-out infinite alternate;
+    pointer-events: none;
+  }
+  @keyframes heroGlow {
+    0% {
+      transform: translate(0, 0) scale(1);
+      opacity: 1;
+    }
+    100% {
+      transform: translate(2%, -3%) scale(1.06);
+      opacity: 0.85;
+    }
+  }
+  .hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 780px;
+    margin: 0 auto;
+  }
+  .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+    color: #a5b4fc;
+    background: rgba(99, 102, 241, 0.15);
+    border: 1px solid rgba(99, 102, 241, 0.28);
+    padding: 7px 18px;
+    border-radius: 100px;
+    margin-bottom: 28px;
+  }
+  .hero-badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #34d399;
+    box-shadow: 0 0 6px rgba(52, 211, 153, 0.6);
+    animation: pulse 2s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.5;
+      transform: scale(0.8);
+    }
+  }
+  .hero h1 {
+    font-family: 'Instrument Serif', Georgia, serif;
+    font-weight: 400;
+    font-size: 58px;
+    line-height: 1.1;
+    color: #fff;
+    letter-spacing: -0.5px;
+    margin-bottom: 20px;
+  }
+  .hero h1 em {
+    font-style: italic;
+    background: linear-gradient(90deg, #818cf8, #34d399);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero-sub {
+    font-size: 17px;
+    line-height: 1.7;
+    color: #94a3b8;
+    max-width: 600px;
+    margin: 0 auto 36px;
+  }
+  .hero-actions {
+    display: flex;
+    justify-content: center;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 48px;
+    padding: 0 28px;
+    border: 0;
+    border-radius: 12px;
+    background: #6366f1;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+      background 0.2s,
+      transform 0.15s;
+  }
+  .btn-primary:hover {
+    background: #818cf8;
+    transform: translateY(-1px);
+  }
+  .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 48px;
+    padding: 0 28px;
+    border: 1.5px solid rgba(255, 255, 255, 0.15);
+    border-radius: 12px;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 15px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 0.2s,
+      color 0.2s;
+  }
+  .btn-secondary:hover {
+    border-color: rgba(255, 255, 255, 0.35);
+    color: #fff;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  STATS STRIP                                                        */
+  /* ------------------------------------------------------------------ */
+  .stats-strip {
+    position: relative;
+    z-index: 2;
+    margin-top: -52px;
+  }
+  .stats-card {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    max-width: 820px;
+    margin: 0 auto;
+    background: rgba(255, 255, 255, 0.07);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 18px;
+    padding: 28px 0;
+  }
+  .stat {
+    text-align: center;
+  }
+  .stat + .stat {
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .stat-number {
+    font-size: 32px;
+    font-weight: 800;
+    color: #fff;
+    letter-spacing: -0.5px;
+  }
+  .stat-number span {
+    font-size: 20px;
+    font-weight: 600;
+  }
+  .stat-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.4);
+    margin-top: 4px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  SECTION SHARED                                                     */
+  /* ------------------------------------------------------------------ */
+  .section {
+    padding: 72px 0;
+  }
+  .section-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+    color: #6366f1;
+    margin-bottom: 12px;
+  }
+  .section-title {
+    font-size: 28px;
+    font-weight: 800;
+    color: #1a1a2e;
+    letter-spacing: -0.3px;
+    margin-bottom: 8px;
+  }
+  .section-sub {
+    font-size: 15px;
+    color: #64748b;
+    max-width: 560px;
+    margin-bottom: 40px;
+  }
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 32px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .section-link {
+    font-size: 14px;
+    font-weight: 600;
+    color: #6366f1;
+    transition: color 0.2s;
+  }
+  .section-link:hover {
+    color: #4f46e5;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  SPOTLIGHT                                                          */
+  /* ------------------------------------------------------------------ */
+  .spotlight {
+    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #1e1b4b 100%);
+    border-radius: 20px;
+    padding: 48px;
+    display: flex;
+    align-items: center;
+    gap: 48px;
+    position: relative;
+    overflow: hidden;
+  }
+  .spotlight::after {
+    content: '';
+    position: absolute;
+    right: -60px;
+    top: -60px;
+    width: 280px;
+    height: 280px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(99, 102, 241, 0.25), transparent 70%);
+    pointer-events: none;
+  }
+  .spotlight-content {
+    flex: 1;
+    position: relative;
+    z-index: 1;
+  }
+  .spotlight-eyebrow {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #a5b4fc;
+    margin-bottom: 14px;
+  }
+  .spotlight h3 {
+    font-size: 28px;
+    font-weight: 800;
+    color: #fff;
+    letter-spacing: -0.3px;
+    margin-bottom: 10px;
+  }
+  .spotlight-publisher {
+    font-size: 13px;
+    color: #c7d2fe;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .spotlight-publisher .verified {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: #6366f1;
+    color: #fff;
+    font-size: 9px;
+    font-weight: 700;
+  }
+  .spotlight p {
+    font-size: 15px;
+    color: #c7d2fe;
+    line-height: 1.7;
+    max-width: 520px;
+  }
+  .spotlight-tags {
+    display: flex;
+    gap: 8px;
+    margin: 18px 0 24px;
+    flex-wrap: wrap;
+  }
+  .spotlight-tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    padding: 5px 12px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+  .spotlight-tag-protocol {
+    background: rgba(99, 102, 241, 0.2);
+    color: #a5b4fc;
+    border-color: rgba(99, 102, 241, 0.3);
+  }
+  .spotlight-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 44px;
+    padding: 0 24px;
+    border: 0;
+    border-radius: 11px;
+    background: #6366f1;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .spotlight-btn:hover {
+    background: #818cf8;
+  }
+  .spotlight-visual {
+    width: 200px;
+    height: 200px;
+    flex-shrink: 0;
+    border-radius: 24px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(52, 211, 153, 0.1));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    z-index: 1;
+  }
+  .spotlight-visual-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 20px;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 32px rgba(99, 102, 241, 0.3);
+  }
+  .spotlight-visual-icon svg {
+    width: 40px;
+    height: 40px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  CATEGORIES                                                         */
+  /* ------------------------------------------------------------------ */
+  .categories {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
+    gap: 14px;
+  }
+  .cat {
+    background: #fff;
+    border: 1px solid #e8eaf0;
+    border-radius: 14px;
+    padding: 22px 16px;
+    text-align: center;
+    transition: all 0.25s;
+    cursor: pointer;
+  }
+  .cat:hover {
+    border-color: #c7d2fe;
+    transform: translateY(-3px);
+    box-shadow: 0 8px 28px rgba(99, 102, 241, 0.1);
+  }
+  .cat-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    margin: 0 auto 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .cat-icon svg {
+    width: 24px;
+    height: 24px;
+  }
+  .cat-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: #334155;
+  }
+  .cat-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: #94a3b8;
+    margin-top: 3px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  TRENDING AGENTS                                                    */
+  /* ------------------------------------------------------------------ */
+  .agents-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 18px;
+  }
+
+  .agent-card {
+    background: #fff;
+    border: 1px solid #e8eaf0;
+    border-radius: 16px;
+    padding: 24px;
+    transition: all 0.25s;
+    cursor: pointer;
+    position: relative;
+  }
+  .agent-card:hover {
+    border-color: #c7d2fe;
+    transform: translateY(-3px);
+    box-shadow: 0 12px 36px rgba(99, 102, 241, 0.08);
+  }
+  .agent-card-top {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    margin-bottom: 14px;
+  }
+  .agent-logo {
+    width: 52px;
+    height: 52px;
+    border-radius: 13px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .agent-logo svg {
+    width: 26px;
+    height: 26px;
+  }
+  .agent-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .agent-name {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin-bottom: 2px;
+  }
+  .agent-publisher {
+    font-size: 12px;
+    color: #64748b;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .agent-publisher .verified {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #6366f1;
+    color: #fff;
+    font-size: 8px;
+    font-weight: 700;
+  }
+  .agent-desc {
+    font-size: 13.5px;
+    color: #475569;
+    line-height: 1.6;
+    margin-bottom: 14px;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .agent-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+  }
+  .tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: #f1f5f9;
+    color: #475569;
+  }
+  .tag-protocol {
+    background: #eef2ff;
+    color: #4f46e5;
+  }
+  .tag-new {
+    background: #ecfdf5;
+    color: #059669;
+  }
+  .agent-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid #f1f5f9;
+    padding-top: 14px;
+  }
+  .agent-price {
+    font-size: 14px;
+    font-weight: 700;
+    color: #1a1a2e;
+  }
+  .agent-price-unit {
+    font-size: 11px;
+    font-weight: 400;
+    color: #94a3b8;
+  }
+  .btn-subscribe {
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 20px;
+    border-radius: 9px;
+    border: 0;
+    background: #6366f1;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .btn-subscribe:hover {
+    background: #4f46e5;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  HOW IT WORKS                                                       */
+  /* ------------------------------------------------------------------ */
+  .how-section {
+    background: #fff;
+    border-top: 1px solid #e8eaf0;
+    border-bottom: 1px solid #e8eaf0;
+  }
+  .how-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+  }
+  .how-step {
+    text-align: center;
+    padding: 40px 24px;
+    position: relative;
+  }
+  .how-step + .how-step::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+    height: 60px;
+    background: #e8eaf0;
+  }
+  .how-num {
+    display: inline-flex;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    align-items: center;
+    justify-content: center;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    font-weight: 700;
+    background: #eef2ff;
+    color: #6366f1;
+    margin-bottom: 16px;
+  }
+  .how-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin-bottom: 8px;
+  }
+  .how-desc {
+    font-size: 13px;
+    color: #64748b;
+    line-height: 1.65;
+    max-width: 220px;
+    margin: 0 auto;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  DASHBOARD PREVIEW                                                  */
+  /* ------------------------------------------------------------------ */
+  .dash-card {
+    background: #fff;
+    border: 1px solid #e8eaf0;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.04);
+  }
+  .dash-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 28px;
+    border-bottom: 1px solid #f1f5f9;
+  }
+  .dash-header h4 {
+    font-size: 15px;
+    font-weight: 700;
+    color: #1a1a2e;
+  }
+  .dash-link {
+    font-size: 13px;
+    font-weight: 600;
+    color: #6366f1;
+    transition: color 0.2s;
+  }
+  .dash-link:hover {
+    color: #4f46e5;
+  }
+  .dash-body {
+    padding: 24px 28px;
+  }
+  .dash-subs {
+    display: grid;
+    gap: 14px;
+    margin-bottom: 28px;
+  }
+  .dash-sub {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 18px;
+    border-radius: 12px;
+    background: #f8f9fc;
+    border: 1px solid #f1f5f9;
+  }
+  .dash-sub-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .dash-sub-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+  .dash-sub-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .dash-sub-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a2e;
+  }
+  .dash-sub-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: #94a3b8;
+    margin-top: 2px;
+  }
+  .dash-sub-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+  .status-dot-green {
+    background: #22c55e;
+    box-shadow: 0 0 6px rgba(34, 197, 94, 0.4);
+  }
+  .status-dot-amber {
+    background: #f59e0b;
+    box-shadow: 0 0 6px rgba(245, 158, 11, 0.4);
+  }
+
+  .dash-chart-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: #94a3b8;
+    margin-bottom: 14px;
+  }
+  .dash-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    height: 80px;
+  }
+  .dash-bar {
+    flex: 1;
+    border-radius: 4px 4px 0 0;
+    background: linear-gradient(180deg, #6366f1, #818cf8);
+    transition: height 0.3s;
+  }
+  .dash-chart-days {
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: #94a3b8;
+    margin-top: 8px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  TRUST BAR                                                          */
+  /* ------------------------------------------------------------------ */
+  .trust {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+    background: #fff;
+    border-top: 1px solid #e8eaf0;
+    border-bottom: 1px solid #e8eaf0;
+  }
+  .trust-item {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 32px 24px;
+    position: relative;
+  }
+  .trust-item + .trust-item::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+    height: 48px;
+    background: #e8eaf0;
+  }
+  .trust-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .trust-icon svg {
+    width: 22px;
+    height: 22px;
+  }
+  .trust-text {
+    font-size: 13px;
+    font-weight: 600;
+    color: #334155;
+  }
+  .trust-sub {
+    font-size: 11px;
+    color: #94a3b8;
+    font-weight: 400;
+    margin-top: 2px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  FOOTER CTA                                                         */
+  /* ------------------------------------------------------------------ */
+  .footer-cta {
+    text-align: center;
+    padding: 80px 32px;
+    background: linear-gradient(180deg, #f8f9fc 0%, #eef2ff 100%);
+  }
+  .footer-cta h2 {
+    font-family: 'Instrument Serif', Georgia, serif;
+    font-weight: 400;
+    font-size: 40px;
+    color: #1a1a2e;
+    letter-spacing: -0.3px;
+    margin-bottom: 16px;
+  }
+  .footer-cta p {
+    font-size: 16px;
+    color: #64748b;
+    max-width: 480px;
+    margin: 0 auto 32px;
+  }
+  .footer-cta .btn-primary {
+    background: #1a1a2e;
+  }
+  .footer-cta .btn-primary:hover {
+    background: #302b63;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  FOOTER                                                             */
+  /* ------------------------------------------------------------------ */
+  .footer {
+    text-align: center;
+    padding: 32px;
+    font-size: 13px;
+    color: #94a3b8;
+    border-top: 1px solid #e8eaf0;
+  }
+  .footer a {
+    color: #6366f1;
+    font-weight: 600;
+  }
+  .footer a:hover {
+    text-decoration: underline;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  RESPONSIVE                                                         */
+  /* ------------------------------------------------------------------ */
+  @media (max-width: 900px) {
+    .hero h1 {
+      font-size: 40px;
+    }
+    .stats-card {
+      grid-template-columns: repeat(2, 1fr);
+      gap: 20px;
+      padding: 24px 16px;
+    }
+    .stat + .stat {
+      border-left: none;
+    }
+    .spotlight {
+      flex-direction: column;
+      padding: 32px;
+    }
+    .spotlight-visual {
+      width: 140px;
+      height: 140px;
+      order: -1;
+    }
+    .how-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .how-step + .how-step::before {
+      display: none;
+    }
+    .agents-grid {
+      grid-template-columns: 1fr;
+    }
+    .trust {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .trust-item + .trust-item::before {
+      display: none;
+    }
+    .categories {
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    }
+  }
+  @media (max-width: 600px) {
+    .hero {
+      padding: 60px 20px 90px;
+    }
+    .hero h1 {
+      font-size: 32px;
+    }
+    .hero-sub {
+      font-size: 15px;
+    }
+    .container {
+      padding: 0 20px;
+    }
+    .stats-card {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .how-grid {
+      grid-template-columns: 1fr;
+    }
+    .trust {
+      grid-template-columns: 1fr;
+    }
+    .hero-actions {
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+</style>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-568
https://gravitee.atlassian.net/browse/AIAM-569

### Description

On the portal subscribe flow for A2A proxy APIs, a single eligible application is already auto-selected and the application step is skipped. The selected-application chip still appeared in the footer, which made the shortcut feel like a leftover choice rather than an automatic one. This change hides that chip when the application was auto-selected, and clears that selection if the user switches to a keyless plan so the chip does not come back later.

It also adds an example AI Agent Marketplace homepage and a small theme override so the page can be dropped into a portal as full-width markdown content.

### Changes

#### Subscribe flow: hide auto-selected application chip

The selected-application chip in the subscribe footer is shown only when the application was chosen by the user. When a single eligible application is auto-selected for an A2A proxy API, the chip is omitted. Switching away from that condition (for example to a keyless plan) clears the auto-selected application so the chip stays hidden.

#### Example marketplace homepage

Adds an example homepage for an AI Agent Marketplace (hero, stats, spotlight, catalog-oriented sections) plus a draft variant. A custom theme override removes padding and max-width on the full-width markdown viewer so the page can span the content area.
