### PR TITLE
ci: post Validate workflow status when a pull request builds nothing

### DIFF
--- a/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
@@ -39,6 +39,7 @@ describe('Pull requests workflow tests', () => {
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-rest-api']}                                                  | ${'pull-requests-custom-branch-backend-rest-api-only.yml'}
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway/pom.xml']}                                           | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution/pom.xml']}                                      | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['.github/renovate.json5']}                                                  | ${'pull-requests-custom-branch-no-source-changes.yml'}
   `(
     'should generate pull-requests config for branch $branchName with changedFiles $changedFiles',
     ({ baseBranch, branch, changedFiles, expectedFileName }) => {

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-no-source-changes.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-no-source-changes.yml
@@ -1,0 +1,67 @@
+# This file is generated from the TypeScript sources in .circleci/ci.
+# Do not edit it by hand — run `npm run generate` instead.
+
+version: 2.1
+setup: false
+parameters:
+  gio_action:
+    type: string
+    default: pull_requests
+    description: ""
+  dry_run:
+    type: boolean
+    default: true
+    description: Run in dry run mode?
+  docker_tag_as_latest:
+    type: boolean
+    default: false
+    description: Is this version the latest version available?
+  graviteeio_version:
+    type: string
+    default: ""
+    description: Version of APIM to be used in docker images
+  apim_version_path:
+    type: string
+    default: /home/circleci/project/pom.xml
+    description: Path to pom.xml with APIM version
+commands:
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
+jobs:
+  job-danger-js:
+    docker:
+      - image: cimg/node:24.18.0
+    resource_class: small
+    steps:
+      - checkout
+      - cmd-install-yarn
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: DANGER_GITHUB_API_TOKEN
+      - run:
+          name: Run Danger JS
+          command: cd .circleci/danger && yarn install && yarn run danger
+  job-validate-workflow-status:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - run:
+          name: Check workflow jobs
+          command: echo "Congratulations! If you can read this, everything is OK"
+workflows:
+  pull_requests:
+    jobs:
+      - job-danger-js:
+          name: Run Danger JS
+          context:
+            - cicd-orchestrator
+      - job-validate-workflow-status:
+          name: Validate workflow status
+orbs:
+  keeper: gravitee-io/keeper@0.7.1

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -119,7 +119,9 @@ export class PullRequestsWorkflow {
     }
 
     // compute check-workflow job
-    if (addValidationJob && requires.length > 0) {
+    // This is the required status check on master and on the support branches. It only aggregates
+    // what ran, so with nothing to wait for it must still post, alone and green.
+    if (addValidationJob) {
       const checkWorkflowJob = new Job('job-validate-workflow-status', BaseExecutor.create('small'), [
         new commands.Run({
           name: 'Check workflow jobs',
@@ -127,7 +129,12 @@ export class PullRequestsWorkflow {
         }),
       ]);
       dynamicConfig.addJob(checkWorkflowJob);
-      jobs.push(new workflow.WorkflowJob(checkWorkflowJob, { name: 'Validate workflow status', requires }));
+      jobs.push(
+        new workflow.WorkflowJob(
+          checkWorkflowJob,
+          requires.length > 0 ? { name: 'Validate workflow status', requires } : { name: 'Validate workflow status' },
+        ),
+      );
     }
 
     return jobs;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-271

## Description

`ci/circleci: Validate workflow status` is the **only** required status check on `master`:

```console
$ gh api repos/gravitee-io/gravitee-api-management/branches/master/protection \
    --jq .required_status_checks.contexts
["ci/circleci: Validate workflow status"]
```

It was emitted only when at least one build job had been generated:

```ts
if (addValidationJob && requires.length > 0) {
```

`requires` is filled by the helm, backend and frontend job groups. A pull request whose changed
files wake none of the predicates in `changed-files.ts` therefore produces an empty `requires`, the
job is never created, the required check never posts, and the pull request cannot be merged at all —
every other check green.

`shouldBuildAll` matches `.circleci`, `.gitignore`, `.prettierrc`, the e2e distribution directory,
and the root `pom.xml` by exact name. So `.github/**`, `docker/**` and documentation outside `helm/`
all land in that hole.

The job is a pure aggregator — its body is `echo "Congratulations! If you can read this, everything
is OK"` — so it is now emitted unconditionally, with no `requires` when there is nothing to wait
for. "Everything that had to run, ran and passed" is true, vacuously, when nothing had to run.

## Additional context

**This has bitten before, on the same file.** BX-271 records it: PR #16873 added only
`.github/workflows/bump-from-module.yml` and was blocked until a `.gitignore` change was added to
force a full build. It is happening again right now on #19605, which touches only `.github`.

**The ticket's premise is stale, and this PR does not follow it.** BX-271 proposes fixing
`generate-config` in `.circleci/config.yml`, on the grounds that "the `generate-config` job produces
no continuation pipeline". That was written in May, before the pipeline rework. Today
`generate-config` always calls `continuation/continue`, and the continuation pipeline is produced and
runs — `ci/circleci: Run Danger JS` is green on #19605. Only the aggregator job was missing, so the
fix belongs in `workflow-pull-requests.ts`. The ticket is worth updating rather than closing as
described.

**Why not just drop it from branch protection.** The check is the one thing standing between a red
build and `master`. The bug is that it does not post, not that it exists.

**A note on the test fixtures.** All seventeen existing ones cover paths that *do* produce jobs
(`*-only` for backend, frontend, helm). The zero-job case had no fixture, which is why the hole
survived. This adds `pull-requests-custom-branch-no-source-changes.yml`.

### Verification

- `npm test` in `.circleci/ci`: **168 passing**, up from 167. The seventeen existing golden files are
  unchanged, which is the check that the non-empty branch still generates byte-identical config.
- `npm run lint`: clean (eslint, prettier, license headers).
- `circleci config validate` on the new fixture: valid. `npm run validate:test` validates all 33
  fixtures with no error.
- This PR touches `.circleci`, which `shouldBuildAll` matches — so it triggers a full build and gets
  its own `Validate workflow status`. It can be merged normally, and unblocks #19605 behind it.
