### PR TITLE
fix(rest-api): reset performance target back-off on manual runs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -171,6 +171,7 @@ import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudSer
 import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificationDomainService;
 import io.gravitee.apim.core.open_api.OpenApiValidator;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
 import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
@@ -1599,6 +1600,11 @@ public class ResourceContextConfiguration {
         AnalyticsDefinitionQueryService analyticsDefinitionQueryService
     ) {
         return new ValidatePerformanceTargetDomainService(apiCrudServiceInMemory, analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public PerformanceTargetScheduleStateDomainService performanceTargetScheduleStateDomainService() {
+        return new PerformanceTargetScheduleStateDomainService();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * What the scheduler knows about each target on this node: when it was last evaluated and how many times in a row it
+ * was not evaluable, which is what its backoff is judged on (see {@code PerformanceTargetSchedule}).
+ *
+ * <p>Kept here rather than inside the scheduled use case so that every path that produces or invalidates an
+ * evaluation can update it: an on-demand evaluation that finds traffic ends a backoff on the spot instead of at the
+ * next backed-off slot, and an updated target starts a fresh schedule instead of inheriting the backoff of the
+ * definition it replaced.
+ */
+@DomainService
+public class PerformanceTargetScheduleStateDomainService {
+
+    private final Map<String, State> states = new ConcurrentHashMap<>();
+
+    /** The state of a target, seeding it when this node has not seen the target yet. */
+    public State stateOf(String targetId, Supplier<State> seed) {
+        return states.computeIfAbsent(targetId, id -> seed.get());
+    }
+
+    public Optional<State> current(String targetId) {
+        return Optional.ofNullable(states.get(targetId));
+    }
+
+    /** An evaluation was stored for the target, by the scheduler or on demand. */
+    public void record(String targetId, PerformanceTargetEvaluation evaluation) {
+        states.compute(targetId, (id, state) -> (state == null ? State.FRESH : state).after(evaluation));
+    }
+
+    /** The scheduler tried but the evaluator left the target out: it is retried at its next slot, not at every tick. */
+    public void attempted(String targetId, Instant now) {
+        states.computeIfPresent(targetId, (id, state) -> new State(now, state.consecutiveNotEvaluable()));
+    }
+
+    /** The target was redefined: its next slot is due at once and its backoff is forgotten. */
+    public void reset(String targetId) {
+        states.put(targetId, State.FRESH);
+    }
+
+    /** Forgets every target not in the set, so a deleted target does not linger. */
+    public void retain(Set<String> targetIds) {
+        states.keySet().retainAll(targetIds);
+    }
+
+    /**
+     * @param lastEvaluatedAt {@code null} when the target was never evaluated
+     */
+    public record State(Instant lastEvaluatedAt, int consecutiveNotEvaluable) {
+        public static final State FRESH = new State(null, 0);
+
+        public State after(PerformanceTargetEvaluation evaluation) {
+            var notEvaluable = evaluation.status() == PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
+            return new State(evaluation.evaluatedAt(), notEvaluable ? consecutiveNotEvaluable + 1 : 0);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
@@ -21,6 +21,8 @@ import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService.State;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
@@ -33,8 +35,6 @@ import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -42,9 +42,10 @@ import lombok.RequiredArgsConstructor;
  * {@link PerformanceTargetSchedule}), stores each result as the target's latest evaluation and prunes its history.
  *
  * <p>The schedule state of a target, when it was last evaluated and how many times in a row it was not evaluable,
- * is kept in memory and seeded from its stored evaluations the first time the target is seen, so a restart resumes
- * where the previous node left off instead of evaluating everything at once. A target the evaluator leaves out is
- * still counted as attempted: it is retried at its next slot, not at every tick.
+ * lives in {@link PerformanceTargetScheduleStateDomainService} and is seeded from its stored evaluations the first
+ * time the target is seen, so a restart resumes where the previous node left off instead of evaluating everything at
+ * once. A target the evaluator leaves out is still counted as attempted: it is retried at its next slot, not at every
+ * tick.
  */
 @RequiredArgsConstructor
 @UseCase
@@ -54,19 +55,18 @@ public class EvaluateDuePerformanceTargetsUseCase {
     private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
     private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
     private final PerformanceTargetEvaluator performanceTargetEvaluator;
-
-    private final Map<String, State> states = new ConcurrentHashMap<>();
+    private final PerformanceTargetScheduleStateDomainService scheduleState;
 
     public Output execute(Input input) {
         var schedule = input.schedule();
         var now = TimeProvider.instantNow();
         var targets = performanceTargetQueryService.findAll();
-        states.keySet().retainAll(targets.stream().map(PerformanceTarget::id).collect(toSet()));
+        scheduleState.retain(targets.stream().map(PerformanceTarget::id).collect(toSet()));
 
         var due = targets
             .stream()
             .filter(target -> {
-                var state = states.computeIfAbsent(target.id(), id -> seed(target, schedule));
+                var state = scheduleState.stateOf(target.id(), () -> seed(target, schedule));
                 return schedule.isDue(target, state.lastEvaluatedAt(), state.consecutiveNotEvaluable(), now);
             })
             .toList();
@@ -80,10 +80,10 @@ public class EvaluateDuePerformanceTargetsUseCase {
             .collect(toMap(PerformanceTargetEvaluation::targetId, identity()));
         var stored = new ArrayList<PerformanceTargetEvaluation>();
         for (var target : due) {
-            var previous = states.get(target.id());
+            var previous = scheduleState.current(target.id()).orElse(State.FRESH);
             var evaluation = evaluationsByTarget.get(target.id());
             if (evaluation == null) {
-                states.put(target.id(), new State(now, previous.consecutiveNotEvaluable()));
+                scheduleState.attempted(target.id(), now);
                 continue;
             }
             var slotStart = schedule.slotStart(target, previous.consecutiveNotEvaluable(), now);
@@ -94,7 +94,7 @@ public class EvaluateDuePerformanceTargetsUseCase {
                     performanceTargetEvaluationCrudService.pruneHistory(target.id(), schedule.retention());
                     stored.add(created);
                 });
-            states.put(target.id(), previous.after(latest));
+            scheduleState.record(target.id(), latest);
         }
         return new Output(targets.size(), stored);
     }
@@ -111,21 +111,11 @@ public class EvaluateDuePerformanceTargetsUseCase {
         var history = performanceTargetEvaluationQueryService
             .findByTargetId(target.id(), new PageableImpl(1, schedule.historyDepth(target)))
             .getContent();
-        var state = new State(null, 0);
+        var state = State.FRESH;
         for (var evaluation : history.reversed()) {
             state = state.after(evaluation);
         }
         return state;
-    }
-
-    /**
-     * @param lastEvaluatedAt {@code null} when the target was never evaluated
-     */
-    private record State(Instant lastEvaluatedAt, int consecutiveNotEvaluable) {
-        State after(PerformanceTargetEvaluation evaluation) {
-            var notEvaluable = evaluation.status() == PerformanceTargetEvaluation.Status.NOT_EVALUABLE;
-            return new State(evaluation.evaluatedAt(), notEvaluable ? consecutiveNotEvaluable + 1 : 0);
-        }
     }
 
     public record Input(PerformanceTargetSchedule schedule) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.performance_target.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetEvaluationCrudService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.core.performance_target.query_service.PerformanceTargetEvaluationQueryService;
@@ -44,6 +45,7 @@ public class EvaluatePerformanceTargetUseCase {
     private final PerformanceTargetEvaluationQueryService performanceTargetEvaluationQueryService;
     private final PerformanceTargetEvaluationCrudService performanceTargetEvaluationCrudService;
     private final PerformanceTargetEvaluator performanceTargetEvaluator;
+    private final PerformanceTargetScheduleStateDomainService scheduleState;
 
     public Output execute(Input input) {
         var target = performanceTargetCrudService.get(input.environmentId(), input.targetId());
@@ -63,6 +65,8 @@ public class EvaluatePerformanceTargetUseCase {
         var evaluation = performanceTargetEvaluator.evaluate(target, now).toBuilder().id(UuidString.generateRandom()).latest(true).build();
         var stored = performanceTargetEvaluationCrudService.create(evaluation);
         performanceTargetEvaluationCrudService.pruneHistory(target.id(), PerformanceTargetEvaluation.HISTORY_RETENTION);
+        // The scheduler judges a backoff on the latest evaluations it knows of; this one counts as much as its own.
+        scheduleState.record(target.id(), stored);
         return new Output(stored);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCase.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.performance_target.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.performance_target.crud_service.PerformanceTargetCrudService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
 import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.common.utils.TimeProvider;
@@ -28,6 +29,7 @@ public class UpdatePerformanceTargetUseCase {
 
     private final PerformanceTargetCrudService performanceTargetCrudService;
     private final ValidatePerformanceTargetDomainService validatePerformanceTargetDomainService;
+    private final PerformanceTargetScheduleStateDomainService scheduleState;
 
     public Output execute(Input input) {
         var updated = performanceTargetCrudService
@@ -41,7 +43,10 @@ public class UpdatePerformanceTargetUseCase {
             .updatedAt(TimeProvider.now())
             .build();
         validatePerformanceTargetDomainService.validate(updated);
-        return new Output(performanceTargetCrudService.update(updated));
+        var stored = performanceTargetCrudService.update(updated);
+        // A redefined target is a new declaration: it is due at the next tick, whatever backoff the old one had earned.
+        scheduleState.reset(stored.id());
+        return new Output(stored);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PerformanceTargetFixtures;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService.State;
+import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
+import java.time.Instant;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PerformanceTargetScheduleStateDomainServiceTest {
+
+    private static final Instant T0 = Instant.parse("2021-06-01T10:00:00Z");
+
+    private final PerformanceTargetScheduleStateDomainService service = new PerformanceTargetScheduleStateDomainService();
+
+    @Test
+    void should_seed_a_target_once_and_keep_the_seeded_state() {
+        var seeded = new State(T0, 2);
+
+        var first = service.stateOf("t", () -> seeded);
+        var second = service.stateOf("t", () -> State.FRESH);
+
+        assertThat(first).isEqualTo(seeded);
+        assertThat(second).isEqualTo(seeded);
+    }
+
+    @Test
+    void should_count_consecutive_not_evaluable_evaluations_and_reset_the_count_on_an_evaluable_one() {
+        service.record("t", evaluation(PerformanceTargetEvaluation.Status.NOT_EVALUABLE, T0));
+        service.record("t", evaluation(PerformanceTargetEvaluation.Status.NOT_EVALUABLE, T0.plusSeconds(60)));
+        assertThat(service.current("t")).contains(new State(T0.plusSeconds(60), 2));
+
+        service.record("t", evaluation(PerformanceTargetEvaluation.Status.PASS, T0.plusSeconds(120)));
+
+        assertThat(service.current("t")).contains(new State(T0.plusSeconds(120), 0));
+    }
+
+    @Test
+    void should_record_an_evaluation_of_a_target_it_has_not_seen_yet() {
+        service.record("t", evaluation(PerformanceTargetEvaluation.Status.BREACH, T0));
+
+        assertThat(service.current("t")).contains(new State(T0, 0));
+    }
+
+    @Test
+    void should_only_move_the_last_attempt_of_a_target_it_knows() {
+        service.attempted("unknown", T0);
+        service.stateOf("t", () -> new State(T0, 3));
+
+        service.attempted("t", T0.plusSeconds(60));
+
+        assertThat(service.current("unknown")).isEmpty();
+        assertThat(service.current("t")).contains(new State(T0.plusSeconds(60), 3));
+    }
+
+    @Test
+    void should_start_a_fresh_schedule_on_reset() {
+        service.stateOf("t", () -> new State(T0, 5));
+
+        service.reset("t");
+
+        assertThat(service.current("t")).contains(State.FRESH);
+    }
+
+    @Test
+    void should_forget_the_targets_it_is_not_told_to_retain() {
+        service.stateOf("kept", () -> State.FRESH);
+        service.stateOf("gone", () -> State.FRESH);
+
+        service.retain(Set.of("kept"));
+
+        assertThat(service.current("kept")).isPresent();
+        assertThat(service.current("gone")).isEmpty();
+    }
+
+    private static PerformanceTargetEvaluation evaluation(PerformanceTargetEvaluation.Status status, Instant evaluatedAt) {
+        return PerformanceTargetFixtures.anEvaluation("e-" + evaluatedAt.getEpochSecond(), "t", status, evaluatedAt);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
@@ -24,6 +24,7 @@ import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
 import inmemory.PerformanceTargetEvaluationQueryServiceInMemory;
 import inmemory.PerformanceTargetEvaluatorInMemory;
 import inmemory.PerformanceTargetQueryServiceInMemory;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
 import io.gravitee.apim.core.performance_target.model.PerformanceTarget;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetSchedule;
@@ -54,8 +55,9 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         evaluationCrudService
     );
     PerformanceTargetEvaluatorInMemory evaluator = new PerformanceTargetEvaluatorInMemory();
+    PerformanceTargetScheduleStateDomainService scheduleState = new PerformanceTargetScheduleStateDomainService();
 
-    EvaluateDuePerformanceTargetsUseCase useCase = newUseCase(evaluator);
+    EvaluateDuePerformanceTargetsUseCase useCase = newUseCase(evaluator, scheduleState);
 
     @AfterEach
     void tearDown() {
@@ -305,8 +307,75 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         assertThat(evaluationCrudService.storage()).isEmpty();
     }
 
+    @Test
+    void should_end_the_backoff_of_an_idle_target_as_soon_as_an_on_demand_evaluation_finds_traffic() {
+        var target = aTarget("idle");
+        targetCrudService.initWith(List.of(target));
+        evaluator.status(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+        var now = T0;
+        while (now.isBefore(T0.plus(Duration.ofHours(5)))) {
+            tick(now);
+            now = now.plus(TICK);
+        }
+        var lastScheduled = evaluationCrudService
+            .storage()
+            .stream()
+            .map(PerformanceTargetEvaluation::evaluatedAt)
+            .max(Instant::compareTo)
+            .get();
+        // the target is backed off to the cap: nothing is due for the better part of an hour
+        assertThat(tick(lastScheduled.plus(INTERVAL.multipliedBy(2))).evaluations()).isEmpty();
+
+        evaluator.status(PerformanceTargetEvaluation.Status.PASS);
+        var onDemand = new EvaluatePerformanceTargetUseCase(
+            targetCrudService,
+            evaluationQueryService,
+            evaluationCrudService,
+            evaluator,
+            scheduleState
+        );
+        var clicked = lastScheduled.plus(INTERVAL.multipliedBy(2)).plusSeconds(30);
+        input(clicked);
+        onDemand.execute(new EvaluatePerformanceTargetUseCase.Input(target.environmentId(), target.id()));
+
+        var nextSlot = tick(clicked.plus(INTERVAL).plus(TICK));
+
+        assertThat(nextSlot.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
+    }
+
+    @Test
+    void should_evaluate_an_updated_target_at_the_next_tick_whatever_its_backoff_was() {
+        var target = aTarget("idle");
+        targetCrudService.initWith(List.of(target));
+        evaluator.status(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+        var now = T0;
+        while (now.isBefore(T0.plus(Duration.ofHours(5)))) {
+            tick(now);
+            now = now.plus(TICK);
+        }
+        assertThat(tick(now).evaluations()).isEmpty();
+
+        scheduleState.reset(target.id());
+
+        assertThat(tick(now.plus(TICK)).evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
+    }
+
+    /** Another node: its own schedule state, the same stores. */
     private EvaluateDuePerformanceTargetsUseCase newUseCase(PerformanceTargetEvaluatorInMemory evaluator) {
-        return new EvaluateDuePerformanceTargetsUseCase(targetQueryService, evaluationQueryService, evaluationCrudService, evaluator);
+        return newUseCase(evaluator, new PerformanceTargetScheduleStateDomainService());
+    }
+
+    private EvaluateDuePerformanceTargetsUseCase newUseCase(
+        PerformanceTargetEvaluatorInMemory evaluator,
+        PerformanceTargetScheduleStateDomainService scheduleState
+    ) {
+        return new EvaluateDuePerformanceTargetsUseCase(
+            targetQueryService,
+            evaluationQueryService,
+            evaluationCrudService,
+            evaluator,
+            scheduleState
+        );
     }
 
     private EvaluateDuePerformanceTargetsUseCase.Output tick(Instant now) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluatePerformanceTargetUseCaseTest.java
@@ -24,6 +24,7 @@ import inmemory.PerformanceTargetCrudServiceInMemory;
 import inmemory.PerformanceTargetEvaluationCrudServiceInMemory;
 import inmemory.PerformanceTargetEvaluationQueryServiceInMemory;
 import inmemory.PerformanceTargetEvaluatorInMemory;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetEvaluatedTooRecentlyException;
 import io.gravitee.apim.core.performance_target.exception.PerformanceTargetNotFoundException;
 import io.gravitee.apim.core.performance_target.model.PerformanceTargetEvaluation;
@@ -52,11 +53,14 @@ class EvaluatePerformanceTargetUseCaseTest {
         evaluationCrudService
     );
 
+    PerformanceTargetScheduleStateDomainService scheduleState = new PerformanceTargetScheduleStateDomainService();
+
     EvaluatePerformanceTargetUseCase useCase = new EvaluatePerformanceTargetUseCase(
         targetCrudService,
         evaluationQueryService,
         evaluationCrudService,
-        new PerformanceTargetEvaluatorInMemory()
+        new PerformanceTargetEvaluatorInMemory(),
+        scheduleState
     );
 
     @BeforeEach
@@ -81,6 +85,15 @@ class EvaluatePerformanceTargetUseCaseTest {
         assertThat(output.evaluation().latest()).isTrue();
         assertThat(output.evaluation().evaluatedAt()).isEqualTo(NOW);
         assertThat(evaluationCrudService.storage()).containsExactly(output.evaluation());
+    }
+
+    @Test
+    void should_tell_the_scheduler_about_the_evaluation_so_a_backoff_ends_with_it() {
+        scheduleState.stateOf(TARGET_ID, () -> new PerformanceTargetScheduleStateDomainService.State(NOW.minusSeconds(3600), 6));
+
+        useCase.execute(new EvaluatePerformanceTargetUseCase.Input(ENVIRONMENT_ID, TARGET_ID));
+
+        assertThat(scheduleState.current(TARGET_ID)).contains(new PerformanceTargetScheduleStateDomainService.State(NOW, 0));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/UpdatePerformanceTargetUseCaseTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.performance_target.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PerformanceTargetFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PerformanceTargetCrudServiceInMemory;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService;
+import io.gravitee.apim.core.performance_target.domain_service.PerformanceTargetScheduleStateDomainService.State;
+import io.gravitee.apim.core.performance_target.domain_service.ValidatePerformanceTargetDomainService;
+import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UpdatePerformanceTargetUseCaseTest {
+
+    private static final String TARGET_ID = "target-id";
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    PerformanceTargetCrudServiceInMemory targetCrudService = new PerformanceTargetCrudServiceInMemory();
+    PerformanceTargetScheduleStateDomainService scheduleState = new PerformanceTargetScheduleStateDomainService();
+
+    UpdatePerformanceTargetUseCase useCase = new UpdatePerformanceTargetUseCase(
+        targetCrudService,
+        new ValidatePerformanceTargetDomainService(apiCrudService, new AnalyticsDefinitionYAMLQueryService()),
+        scheduleState
+    );
+
+    @BeforeEach
+    void setUp() {
+        apiCrudService.initWith(List.of(ApiFixtures.anA2AProxyApiV4().toBuilder().id(PerformanceTargetFixtures.A2A_API_ID).build()));
+        targetCrudService.initWith(List.of(PerformanceTargetFixtures.aTarget(TARGET_ID)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(apiCrudService, targetCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_replace_the_schedule_and_rules_and_start_a_fresh_scheduler_state() {
+        scheduleState.stateOf(TARGET_ID, () -> new State(Instant.parse("2021-06-01T10:00:00Z"), 6));
+        var redefined = PerformanceTargetFixtures.aTarget(TARGET_ID).toBuilder().interval(Duration.ofMinutes(1)).build();
+
+        var output = useCase.execute(
+            new UpdatePerformanceTargetUseCase.Input(PerformanceTargetFixtures.ENVIRONMENT_ID, TARGET_ID, redefined)
+        );
+
+        assertThat(output.target().interval()).isEqualTo(Duration.ofMinutes(1));
+        assertThat(targetCrudService.storage())
+            .singleElement()
+            .extracting(t -> t.interval())
+            .isEqualTo(Duration.ofMinutes(1));
+        assertThat(scheduleState.current(TARGET_ID)).contains(State.FRESH);
+    }
+}


### PR DESCRIPTION
## What

The scheduler (AIAM-511) backs an idle target off after 3 consecutive NOT_EVALUABLE windows, doubling its interval up to the cap. That state lived in a private map of `EvaluateDuePerformanceTargetsUseCase`, so an **Evaluate now** or a **PUT** on the target never touched it: a target that had backed off while idle stayed backed off even though manual evaluations showed fresh results, which read in the Gamma UI as the scheduler having stopped ("Evaluated 9 min ago" on a 1-minute target).

- New `PerformanceTargetScheduleStateDomainService` (core domain service, per node, in memory) owns the per-target state: `stateOf` (seeded from history), `current`, `record`, `attempted`, `reset`, `retain`.
- `EvaluateDuePerformanceTargetsUseCase` uses it instead of its own map.
- `EvaluatePerformanceTargetUseCase` records the manual evaluation, so the next slot is computed from it.
- `UpdatePerformanceTargetUseCase` resets the target to a fresh schedule.

## Tests

TDD: new `PerformanceTargetScheduleStateDomainServiceTest`, `UpdatePerformanceTargetUseCaseTest`, two tests on the due-targets use case (manual evaluation moves the slot, update resets the back-off) and one on evaluate-now; existing tests keep one state instance per simulated node. `CoreRulesTest` and the v2 `EnvironmentPerformanceTarget*ResourceTest` pass; `prettier:check` clean.

Verified on a running stack: after the fix a backed-off target returns to its 1-minute cadence as soon as traffic returns.

Not security-sensitive.

Relates to AIAM-511