### PR TITLE
feat(gamma): mount the Targets tab in the APIM module

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "3.2.0-amp-demo.da2facd",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.1",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "1.39.2",
+        "@gravitee/gamma-lib-observability": "3.2.0-amp-demo.da2facd",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -68,6 +68,7 @@ import { ApiDynamicPropertiesPage } from '../features/apis/pages/detail/properti
 import { ApiReporterSettingsPage } from '../features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage';
 import { ApiResourcesPage } from '../features/apis/pages/detail/resources/ApiResourcesPage';
 import { ApiResourceWizardPage } from '../features/apis/pages/detail/resources/ApiResourceWizardPage';
+import { ApiTargetsPage } from '../features/apis/pages/detail/targets/ApiTargetsPage';
 import { UserPermissionsPage } from '../features/apis/pages/detail/user-permissions/UserPermissionsPage';
 import { ImportApiPage } from '../features/apis/pages/ImportApiPage';
 import { PolicyStudioPage } from '../features/apis/pages/policy-studio/PolicyStudioPage';
@@ -256,6 +257,7 @@ export function AppRoutes() {
                                     <Route path=":alertId" element={<AlertFormPage />} />
                                 </Route>
                                 <Route path="audit-logs" element={<AuditLogsPage />} />
+                                <Route path="targets" element={<ApiTargetsPage />} />
                                 <Route path="deployment">
                                     <Route index element={<Navigate to="configuration" replace />} />
                                     <Route path="configuration" element={<DeploymentConfigurationPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
@@ -56,6 +56,14 @@ describe('API_PROXY_NAV_GROUPS', () => {
         expect(deployment.children).toHaveLength(2);
         expect(deployment.children!.map(c => c.path)).toEqual(['configuration', 'history']);
     });
+
+    it('lists Targets under Monitoring, next to Alerts', () => {
+        const monitoring = GROUPS.find(g => g.label === 'Monitoring')!;
+        expect(monitoring.items.map(i => i.path)).toEqual(['alerts', 'targets', 'audit-logs']);
+        const targets = monitoring.items.find(i => i.path === 'targets');
+        expect(targets?.label).toBe('Targets');
+        expect(targets?.comingSoon).toBeUndefined();
+    });
 });
 
 // ─── Flat nav links ───────────────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -19,6 +19,7 @@ import {
     BellIcon,
     ChevronDownIcon,
     ChevronRightIcon,
+    CircleDotIcon,
     GlobeIcon,
     LayoutDashboardIcon,
     ListIcon,
@@ -122,6 +123,7 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
         label: 'Monitoring',
         items: [
             { path: 'alerts', label: 'Alerts', icon: ActivityIcon },
+            { path: 'targets', label: 'Targets', icon: CircleDotIcon },
             { path: 'audit-logs', label: 'Audit Logs', icon: ScrollTextIcon },
         ],
     },

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useLatestTargetEvaluations } from '@gravitee/gamma-lib-observability';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
@@ -28,9 +29,16 @@ jest.mock('react-router-dom', () => ({
 jest.mock('@gravitee/gamma-lib-observability', () => ({
     DEFAULT_TIME_RANGE: { type: 'relative', period: '5m' },
     encodeObservabilityState: () => ({ q: 'ENCODED_Q', v: '1' }),
+    TargetStatusBadge: ({ evaluation }: { evaluation: { status: string } | null | undefined }) => (
+        <span data-testid="target-status">
+            {evaluation === undefined ? 'loading' : evaluation === null ? 'No target' : evaluation.status}
+        </span>
+    ),
+    useLatestTargetEvaluations: jest.fn(() => ({ data: undefined })),
 }));
 
 const mockNavigate = jest.fn();
+const mockUseLatestTargetEvaluations = useLatestTargetEvaluations as jest.Mock;
 
 function makeApi(overrides: Partial<ApiListItem> = {}): ApiListItem {
     return { id: 'api-1', name: 'Test API', apiVersion: '1.0', type: 'PROXY', definitionVersion: 'V4', ...overrides };
@@ -149,5 +157,31 @@ describe('ApiListTable', () => {
         const api = makeApi({ primaryOwner: { displayName: 'Jane Doe' } });
         renderTable({ apis: [api] });
         expect(screen.queryByText('Jane Doe')).not.toBeNull();
+    });
+
+    describe('Targets column', () => {
+        it('asks for the latest evaluation of the whole page in one call and hands each row its own answer', () => {
+            mockUseLatestTargetEvaluations.mockReturnValue({
+                data: { 'api-1': { status: 'BREACH' }, 'api-2': null },
+            });
+            renderTable({ apis: [makeApi({ id: 'api-1', name: 'Orders' }), makeApi({ id: 'api-2', name: 'Users' })] });
+
+            expect(mockUseLatestTargetEvaluations).toHaveBeenCalledTimes(1);
+            expect(mockUseLatestTargetEvaluations).toHaveBeenCalledWith(['api-1', 'api-2']);
+            expect(screen.getAllByTestId('target-status').map(cell => cell.textContent)).toEqual(['BREACH', 'No target']);
+        });
+
+        it('shows the badges as loading until the batch answers', () => {
+            mockUseLatestTargetEvaluations.mockReturnValue({ data: undefined });
+            renderTable({ apis: [makeApi()] });
+
+            expect(screen.getByTestId('target-status')).toHaveTextContent('loading');
+        });
+
+        it('names the column so it can be hidden like the others', () => {
+            renderTable({ apis: [makeApi()] });
+
+            expect(screen.getByRole('columnheader', { name: /Targets/ })).toBeInTheDocument();
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { TargetStatusBadge, useLatestTargetEvaluations, type LatestTargetEvaluations } from '@gravitee/gamma-lib-observability';
 import {
     Badge,
     Button,
@@ -123,7 +124,10 @@ function ApiActionsMenu({ apiId, onNavigate }: { apiId: string; onNavigate: (pat
 
 // ─── Column definitions ───────────────────────────────────────────────────────
 
-function buildColumns(navigate: ReturnType<typeof useNavigate>): DataTableProps<ApiListItem>['columns'] {
+function buildColumns(
+    navigate: ReturnType<typeof useNavigate>,
+    latestTargets: LatestTargetEvaluations | undefined,
+): DataTableProps<ApiListItem>['columns'] {
     return [
         {
             id: 'API Name',
@@ -160,6 +164,13 @@ function buildColumns(navigate: ReturnType<typeof useNavigate>): DataTableProps<
             header: 'Sync Status',
             enableSorting: false,
             cell: ({ row }: ColCell<ApiListItem>) => <SyncStatusBadge deploymentState={row.original.deploymentState} />,
+        },
+        {
+            id: 'Targets',
+            header: 'Targets',
+            enableSorting: false,
+            // One batch request answers the whole page; a row only reads its own entry.
+            cell: ({ row }: ColCell<ApiListItem>) => <TargetStatusBadge evaluation={latestTargets?.[row.original.id]} />,
         },
         {
             id: 'access',
@@ -235,7 +246,8 @@ export function ApiListTable({
     toolbar,
 }: ApiListTableProps) {
     const navigate = useNavigate();
-    const columns = buildColumns(navigate);
+    const latestTargets = useLatestTargetEvaluations(apis.map(api => api.id));
+    const columns = buildColumns(navigate, latestTargets.data);
 
     return (
         <DataTable

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.spec.tsx
@@ -22,6 +22,8 @@ import { useApiStats } from '../../hooks/useApiStats';
 jest.mock('@gravitee/gamma-lib-observability', () => ({
     DEFAULT_TIME_RANGE: { type: 'relative', period: '5m' },
     encodeObservabilityState: () => ({ q: 'ENCODED_Q', v: '1' }),
+    TargetStatusBadge: () => null,
+    useLatestTargetEvaluations: () => ({ data: undefined }),
 }));
 
 jest.mock('../../hooks/useApiStats');

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/targets/ApiTargetsProvider.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/targets/ApiTargetsProvider.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TargetsProvider } from '@gravitee/gamma-lib-observability';
+import type { ReactNode } from 'react';
+
+import { useTargetsBaseUrl } from '../../../../lib/hooks/useTargetsBaseUrl';
+import { gammaConsoleHttpOptions } from '../../../../shared/api/apimClient';
+
+/**
+ * The targets library wired to this console: the management v2 environment root
+ * and the authenticated transport every other module call uses. Renders its
+ * children before the base URL is known, so a list can show while its badges wait.
+ */
+export function ApiTargetsProvider({ children }: { readonly children: ReactNode }) {
+    const baseUrl = useTargetsBaseUrl();
+    return (
+        <TargetsProvider baseUrl={baseUrl} http={gammaConsoleHttpOptions}>
+            {children}
+        </TargetsProvider>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/ApisPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/ApisPage.spec.tsx
@@ -23,6 +23,12 @@ import { useApiStats } from '../hooks/useApiStats';
 jest.mock('@gravitee/gamma-lib-observability', () => ({
     DEFAULT_TIME_RANGE: { type: 'relative', period: '5m' },
     encodeObservabilityState: () => ({ q: 'ENCODED_Q', v: '1' }),
+    TargetStatusBadge: () => null,
+    useLatestTargetEvaluations: () => ({ data: undefined }),
+}));
+
+jest.mock('../components/targets/ApiTargetsProvider', () => ({
+    ApiTargetsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 jest.mock('../hooks/useApiList');

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/ApisPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/ApisPage.tsx
@@ -22,6 +22,7 @@ import { ApisEmptyLanding } from '../components';
 import { ApisPageSkeleton } from '../components/ApisPageSkeleton';
 import { ApisListView } from '../components/list';
 import { toApiListSortBy } from '../components/list/ApiListTable';
+import { ApiTargetsProvider } from '../components/targets/ApiTargetsProvider';
 import { useApiList } from '../hooks/useApiList';
 
 type SortingState = NonNullable<DataTableProps<unknown>['sorting']>;
@@ -77,21 +78,23 @@ export function ApisPage() {
     }
 
     return (
-        <ApisListView
-            apis={apis}
-            totalCount={totalCount}
-            isLoading={isLoading}
-            search={search}
-            debouncedSearch={debouncedSearch}
-            page={page}
-            perPage={perPage}
-            sorting={sorting}
-            onSortingChange={handleSortingChange}
-            onSearchChange={handleSearchChange}
-            onPageChange={setPage}
-            onPerPageChange={handlePerPageChange}
-            onCreateProxy={handleCreateProxy}
-            canCreate={canCreate}
-        />
+        <ApiTargetsProvider>
+            <ApisListView
+                apis={apis}
+                totalCount={totalCount}
+                isLoading={isLoading}
+                search={search}
+                debouncedSearch={debouncedSearch}
+                page={page}
+                perPage={perPage}
+                sorting={sorting}
+                onSortingChange={handleSortingChange}
+                onSearchChange={handleSearchChange}
+                onPageChange={setPage}
+                onPerPageChange={handlePerPageChange}
+                onCreateProxy={handleCreateProxy}
+                canCreate={canCreate}
+            />
+        </ApiTargetsProvider>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.spec.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TargetsPanel } from '@gravitee/gamma-lib-observability';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { ApiTargetsPage } from './ApiTargetsPage';
+import { ApiDetailContext } from '../../../context/ApiDetailContext';
+import type { ApiDetailDto } from '../../../types';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    ...jest.requireActual<object>('@gravitee/gamma-modules-sdk'),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('@gravitee/gamma-lib-observability', () => ({
+    TargetsPanel: jest.fn(() => <div data-testid="targets-panel" />),
+}));
+
+jest.mock('../../../components/targets/ApiTargetsProvider', () => ({
+    ApiTargetsProvider: ({ children }: { children: ReactNode }) => <div data-testid="targets-provider">{children}</div>,
+}));
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockTargetsPanel = TargetsPanel as unknown as jest.Mock;
+
+const API = { id: 'api-1', name: 'Orders API', type: 'PROXY', definitionVersion: 'V4' } as unknown as ApiDetailDto;
+
+function renderPage(api: ApiDetailDto | null, isLoading = false) {
+    return render(
+        <ApiDetailContext.Provider value={{ api, isLoading, permissionsReady: true }}>
+            <ApiTargetsPage />
+        </ApiDetailContext.Provider>,
+    );
+}
+
+describe('ApiTargetsPage', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('mounts the shared panel on the API as its own subject, under the targets provider', () => {
+        renderPage(API);
+
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Targets');
+        expect(screen.getByTestId('targets-provider')).toContainElement(screen.getByTestId('targets-panel'));
+        expect(mockTargetsPanel.mock.calls[0][0]).toEqual({
+            reference: 'api-1',
+            apiIds: ['api-1'],
+            apiTypes: ['PROXY'],
+            readOnly: false,
+        });
+    });
+
+    it('hands the panel a read-only flag to a user who may neither create nor update environment APIs', () => {
+        mockUseHasPermission.mockReturnValue(false);
+
+        renderPage(API);
+
+        expect(mockUseHasPermission).toHaveBeenCalledWith({ anyOf: ['environment-api-c', 'environment-api-u'] });
+        expect(mockTargetsPanel.mock.calls[0][0]).toMatchObject({ readOnly: true });
+    });
+
+    it('waits for the API before mounting the panel', () => {
+        renderPage(null, true);
+
+        expect(screen.queryByTestId('targets-panel')).not.toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TargetsPanel } from '@gravitee/gamma-lib-observability';
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Skeleton } from '@gravitee/graphene-core';
+
+import { ApiTargetsProvider } from '../../../components/targets/ApiTargetsProvider';
+import { useApiDetailContext } from '../../../context/ApiDetailContext';
+
+/**
+ * The "Targets" tab: the shared panel mounted on this API as its own subject.
+ * Targets are environment resources on the REST side, so the writes follow the
+ * environment API permissions rather than the API-scoped ones.
+ */
+export function ApiTargetsPage() {
+    const { api } = useApiDetailContext();
+    const canManage = useHasPermission({ anyOf: ['environment-api-c', 'environment-api-u'] });
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Targets</h1>
+                <p className="text-sm text-muted-foreground">
+                    What good looks like for this API: rules over its gateway telemetry, evaluated continuously against the thresholds you
+                    declare.
+                </p>
+            </div>
+            {api ? (
+                <ApiTargetsProvider>
+                    {/* The module only manages V4 HTTP proxies (`PROXY`), which the list search enforces server-side. */}
+                    <TargetsPanel reference={api.id} apiIds={[api.id]} apiTypes={[api.type ?? 'PROXY']} readOnly={!canManage} />
+                </ApiTargetsProvider>
+            ) : (
+                <Skeleton className="h-40 w-full" />
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/lib/hooks/useTargetsBaseUrl.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/lib/hooks/useTargetsBaseUrl.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+
+import { useEnvironmentId } from './useEnvironmentId';
+import { loadApimBootstrap } from '../../shared/api/apimClient';
+
+/**
+ * The Management API v2 environment root the targets library talks to
+ * (`{managementBaseURL}/v2/environments/{envId}`): performance targets and the
+ * analytics definition are management resources, not Gamma-scoped ones, so this
+ * is not the observability base URL.
+ */
+export function useTargetsBaseUrl(): string | undefined {
+    const environmentId = useEnvironmentId();
+
+    const { data } = useQuery({
+        queryKey: ['targets-base-url', environmentId] as const,
+        queryFn: async () => {
+            const { managementBaseURL } = await loadApimBootstrap();
+            return `${managementBaseURL}/v2/environments/${encodeURIComponent(environmentId)}`;
+        },
+        staleTime: Infinity,
+    });
+
+    return data;
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "3.2.0-amp-demo.da2facd",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.1",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",
         "@gravitee/graphene-policy-studio": "3.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "1.39.2",
+        "@gravitee/gamma-lib-observability": "3.2.0-amp-demo.da2facd",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",
         "@gravitee/graphene-policy-studio": "3.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,25 +4627,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:1.39.2":
-  version: 1.39.2
-  resolution: "@gravitee/gamma-lib-observability@npm:1.39.2"
+"@gravitee/gamma-lib-observability@npm:3.2.0-amp-demo.da2facd":
+  version: 3.2.0-amp-demo.da2facd
+  resolution: "@gravitee/gamma-lib-observability@npm:3.2.0-amp-demo.da2facd"
   peerDependencies:
-    "@gravitee/graphene-charts": ^3.7.0
-    "@gravitee/graphene-core": ^3.7.0
+    "@gravitee/graphene-charts": ^3.13.0
+    "@gravitee/graphene-core": ^3.13.0
+    "@monaco-editor/react": ^4.7.0
     "@tanstack/react-query": ^5.0.0
     "@xyflow/react": ^12.0.0
+    monaco-editor: ">=0.50.0 <1"
     react: ^19.0.0
     react-dom: ^19.0.0
     react-grid-layout: ^2.0.0
     react-router-dom: ^7.0.0
     tailwindcss: ^4.0.0
   peerDependenciesMeta:
+    "@monaco-editor/react":
+      optional: true
     "@xyflow/react":
+      optional: true
+    monaco-editor:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/7211182f355a57d35772e30f36d06b689153ec9efe85b19148c144965c347d2c444fd6dcfd83dbc77e3a75fbb15a7a021a2544eabbbd928e967938927e6a8732
+  checksum: 10c0/68a4e13b4c160df3746e1d6975c4270f5b860212af673c150ff87d4eed5e77ccf1d87c6392694d2fae06f3c5bb3b43efeb944f71b59f2e43d55329b175aaa63b
   languageName: node
   linkType: hard
 
@@ -21895,7 +21901,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:1.39.2"
+    "@gravitee/gamma-lib-observability": "npm:3.2.0-amp-demo.da2facd"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.14.0"
     "@gravitee/graphene-core": "npm:3.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,9 +4627,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:3.2.0-amp-demo.da2facd":
-  version: 3.2.0-amp-demo.da2facd
-  resolution: "@gravitee/gamma-lib-observability@npm:3.2.0-amp-demo.da2facd"
+"@gravitee/gamma-lib-observability@npm:3.3.0-beta.1":
+  version: 3.3.0-beta.1
+  resolution: "@gravitee/gamma-lib-observability@npm:3.3.0-beta.1"
   peerDependencies:
     "@gravitee/graphene-charts": ^3.13.0
     "@gravitee/graphene-core": ^3.13.0
@@ -4651,7 +4651,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/68a4e13b4c160df3746e1d6975c4270f5b860212af673c150ff87d4eed5e77ccf1d87c6392694d2fae06f3c5bb3b43efeb944f71b59f2e43d55329b175aaa63b
+  checksum: 10c0/4b5589f19296a9dbf9e656eecb572cd4736382dbc87152df31e46846fcf1f28a156423be07d811ba78b2b616b876d5830995c5e440abc45fbb1fff19071e0261
   languageName: node
   linkType: hard
 
@@ -21901,7 +21901,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:3.2.0-amp-demo.da2facd"
+    "@gravitee/gamma-lib-observability": "npm:3.3.0-beta.1"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.14.0"
     "@gravitee/graphene-core": "npm:3.14.0"


### PR DESCRIPTION
## What

Implements AIAM-513 on top of the shared component from gravitee-io/gamma-lib-observability#90 (AIAM-512).

- **Targets** entry on the API detail sidebar (Monitoring group, between Alerts and Audit Logs) and a `targets` route rendering `TargetsPanel` with `reference = apiId`, `apiIds = [apiId]`, `apiTypes = [api.type]`.
- **Targets** column on the APIs list, one `TargetStatusBadge` per row fed by the batch latest-evaluations endpoint (`useLatestTargetEvaluations`).
- `ApiTargetsProvider` points the library at the Management API v2 environment root (`useTargetsBaseUrl`), not the Gamma REST root the rest of the observability lib uses.
- Read-only unless the user holds `environment-api-c` or `environment-api-u`, aligned with the REST story's permissions.
- No Gamma shell change.

## Tests

Specs for the page, the sidebar entry, the route, the list column and the provider passthrough; module lint, typecheck and jest (86 suites / 661 tests) green; `nx format:check` clean.

## Depends on

- The module pins `@gravitee/gamma-lib-observability@3.3.0-beta.2`, the `beta` channel release carrying the Targets exports and the time-axis history. The pin moves to the stable 3.3.0 once `beta` is merged into `main`.

## Security-sensitive

Touches permission checks: the tab is read-only without `environment-api-c` / `environment-api-u` (no new endpoints, no server-side change).

Closes AIAM-513