### PR TITLE
chore(deps): bump gravitee-policy-data-logging-masking from to 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
         <gravitee-policy-data-cache.version>1.1.0</gravitee-policy-data-cache.version>
-        <gravitee-policy-data-logging-masking.version>3.1.3</gravitee-policy-data-logging-masking.version>
+        <gravitee-policy-data-logging-masking.version>3.1.4</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>2.1.0</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15041


## Description

Bumps `gravitee-policy-data-logging-masking` from `3.1.3` to `3.1.4` 

Version `3.1.4` fixes response header masking in APIM v4 runtime logs while keeping the actual Gateway response unchanged. It also preserves all values of multi-valued response headers.

## Additional context

Policy implementation:
https://github.com/gravitee-io/gravitee-policy-data-logging-masking/pull/93



