### PR TITLE
fix(gamma): truncate notification long list

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.spec.tsx
@@ -106,6 +106,7 @@ describe('EnvironmentNotificationsTable', () => {
         expect(target.className).toContain('min-w-0');
         expect(target.className).toContain('max-w-full');
         expect(target.getAttribute('title')).toBe(longTarget);
+        expect(document.querySelector('table')?.style.tableLayout).toBe('fixed');
     });
 
     it('puts row actions behind a three-dot menu, not inline edit/delete icons', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/environment-notifications/components/EnvironmentNotificationsTable.tsx
@@ -197,7 +197,7 @@ function buildColumns({
         });
     }
 
-    return columns;
+    return columns.map(column => ({ ...column, enableResizing: false }));
 }
 
 export function EnvironmentNotificationsTable({
@@ -246,7 +246,7 @@ export function EnvironmentNotificationsTable({
                         ))}
                     </div>
                 ) : (
-                    <DataTable columns={columns} data={rows} emptyMessage="No notifications configured." />
+                    <DataTable enableColumnResizing columns={columns} data={rows} emptyMessage="No notifications configured." />
                 )}
             </CardContent>
         </Card>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-60

## Description

Fix the gamma env notification long list column data

## Additional context

Befor :

<img width="1728" height="948" alt="image" src="https://github.com/user-attachments/assets/d15a030c-715f-43c6-b6df-d663f28ba2b3" />


After :

<img width="1728" height="951" alt="image" src="https://github.com/user-attachments/assets/b47ced70-fc1c-4fe9-b778-34606a2ff48c" />


