### PR TITLE
fix(reporter): declare path-info in the v4-metrics index templates

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -72,8 +72,13 @@
             "uri": {
                 "type": "keyword"
             },
-            "path": {
-                "type": "keyword"
+            "path-info": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword"
+                    }
+                }
             },
             "mapped-path": {
                 "type": "keyword"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -73,8 +73,13 @@
                 "uri": {
                     "type": "keyword"
                 },
-                "path": {
-                    "type": "keyword"
+                "path-info": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    }
                 },
                 "mapped-path": {
                     "type": "keyword"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
@@ -73,8 +73,13 @@
                 "uri": {
                     "type": "keyword"
                 },
-                "path": {
-                    "type": "keyword"
+                "path-info": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    }
                 },
                 "mapped-path": {
                     "type": "keyword"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
@@ -73,8 +73,13 @@
                 "uri": {
                     "type": "keyword"
                 },
-                "path": {
-                    "type": "keyword"
+                "path-info": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    }
                 },
                 "mapped-path": {
                     "type": "keyword"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/V4MetricsPathIndexingIntegrationTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/V4MetricsPathIndexingIntegrationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.reporter.elasticsearch.IntegrationTestConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.client.Client;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Drives the v4-metrics template against a real Elasticsearch container to prove what an operator actually
+ * gets from the HTTP path dimension: a long request path stays filterable and stays in the facet buckets.
+ *
+ * <p>That is the behaviour the declaration exists for. Left to dynamic mapping, {@code path-info} is a
+ * {@code text} field whose {@code keyword} sub-field carries the Elasticsearch default {@code
+ * ignore_above: 256}, so a longer path is not indexed into it: the {@code HTTP_PATH} filter stops matching
+ * and the {@code HTTP_PATH} facet loses the bucket, silently. Both queries below are the shapes
+ * {@code HTTPFieldResolver} produces, over {@code path-info.keyword}.
+ *
+ * <p>Scope: what the templates render is asserted by {@link V4MetricsPathMappingTest}, which needs no
+ * container.
+ */
+@SpringJUnitConfig(IntegrationTestConfiguration.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class V4MetricsPathIndexingIntegrationTest {
+
+    /** Comfortably past the 256 the default dynamic mapping would have capped the sub-field at. */
+    private static final String LONG_PATH = "/orders/" + "a".repeat(300);
+
+    private static final String PATH_KEYWORD = "path-info.keyword";
+
+    @Autowired
+    private Client client;
+
+    @Autowired
+    private ReporterConfiguration configuration;
+
+    @Autowired
+    private FreeMarkerComponent freeMarkerComponent;
+
+    @Autowired
+    private PipelineConfiguration pipelineConfiguration;
+
+    @Test
+    void should_match_a_long_path_on_the_http_path_filter() {
+        String index = prepareAndIndexOneMetric("gravitee-long-path-filter");
+
+        assertThat(termHits(index, LONG_PATH)).isOne();
+    }
+
+    @Test
+    void should_bucket_a_long_path_in_the_http_path_facet() {
+        String index = prepareAndIndexOneMetric("gravitee-long-path-facet");
+
+        assertThat(facetKeys(index)).containsExactly(LONG_PATH);
+    }
+
+    /**
+     * Puts every index template through the reporter's own preparer, then indexes a single v4 metric into an
+     * index the {@code -v4-metrics} template pattern covers. The bulk is refreshed so the searches that
+     * follow see it without the test having to wait on {@code refresh_interval}.
+     */
+    private String prepareAndIndexOneMetric(String indexName) {
+        configuration.setIndexName(indexName);
+
+        new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client)
+            .prepare()
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete();
+
+        String index = indexName + "-v4-metrics-test";
+        var document = JsonObject.of(
+            "@timestamp",
+            "2026-09-08T10:00:00.000Z",
+            "api-id",
+            "an-api",
+            "request-id",
+            "a-request",
+            "uri",
+            LONG_PATH + "?page=2",
+            "path-info",
+            LONG_PATH
+        );
+        var bulk = Buffer.buffer(JsonObject.of("index", JsonObject.of("_index", index)).encode() + "\n" + document.encode() + "\n");
+
+        var response = client.bulk(bulk, true).blockingGet();
+        assertThat(response.getErrors()).as("bulk indexing into %s reported errors: %s", index, response.getItems()).isFalse();
+
+        return index;
+    }
+
+    /** The shape the analytics engine builds for an {@code EQ} filter on {@code HTTP_PATH}. */
+    private long termHits(String index, String path) {
+        var query = JsonObject.of("query", JsonObject.of("term", JsonObject.of(PATH_KEYWORD, path)));
+
+        return client.search(index, null, query.encode()).blockingGet().getSearchHits().getTotal().getValue();
+    }
+
+    /** The shape the analytics engine builds for the {@code HTTP_PATH} facet. */
+    private List<String> facetKeys(String index) {
+        var query = JsonObject.of(
+            "size",
+            0,
+            "aggs",
+            JsonObject.of("paths", JsonObject.of("terms", JsonObject.of("field", PATH_KEYWORD, "size", 10)))
+        );
+
+        return client
+            .search(index, null, query.encode())
+            .blockingGet()
+            .getAggregations()
+            .get("paths")
+            .getBuckets()
+            .stream()
+            .map(bucket -> bucket.get("key").asText())
+            .toList();
+    }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/V4MetricsPathMappingTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/V4MetricsPathMappingTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.opensearch.OpenSearchIndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.utils.Type;
+import io.vertx.core.json.JsonObject;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Pins how the v4-metrics templates map the request path, across every template tree.
+ *
+ * <p>The analytics engine reads the HTTP path dimension — filter and facet alike — from
+ * {@code path-info.keyword} (APIM-15072). No template ever declared {@code path-info}, so the field existed
+ * only through Elasticsearch dynamic mapping, whose default for a string caps the keyword sub-field at
+ * {@code ignore_above: 256}. A longer path was therefore absent from every filter match and every facet
+ * bucket, silently — the same failure mode APIM-15072 had just fixed, one level down.
+ *
+ * <p>The sub-field is part of the contract: the resolver queries {@code path-info.keyword}, and a search
+ * spans indices created on both sides of a template change, so the queryable path has to stay identical.
+ * The always-empty {@code path} that used to sit next to it is gone; this pins that it stays gone.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class V4MetricsPathMappingTest {
+
+    @ParameterizedTest(name = "{0} declares path-info with the keyword sub-field the engine queries")
+    @ValueSource(strings = { "es7x", "es8x", "es9x", "opensearch" })
+    void should_declare_path_info_with_a_keyword_sub_field(String tree) {
+        assertThat(pathInfoKeywordOf(tree)).containsEntry("type", "keyword");
+    }
+
+    @ParameterizedTest(name = "{0} indexes a path of any length into path-info.keyword")
+    @ValueSource(strings = { "es7x", "es8x", "es9x", "opensearch" })
+    void should_not_cap_the_indexed_path_length(String tree) {
+        // ignore_above drops the value from the sub-field altogether, so a long path stops matching the
+        // HTTP_PATH filter and disappears from its facet buckets, with nothing reported.
+        //
+        // The opposite call from IndexTemplateTest#should_bound_additional_keyword_metrics_..., which bounds
+        // additional-metrics.keyword_* precisely so one oversized value cannot break indexing. Both hold:
+        // that one guards a client-controlled value with no other bound, whereas a path arrives on the
+        // request line, capped by maxInitialLineLength (4096 by default). Past Lucene's 32766-byte term
+        // limit Elasticsearch rejects the whole document, but `uri` on that same document is an uncapped
+        // keyword and always at least as long, so the record was already lost — a cap here would buy
+        // nothing and would only hide long paths from the filter and the facet.
+        assertThat(pathInfoKeywordOf(tree)).doesNotContainKey("ignore_above");
+    }
+
+    @ParameterizedTest(name = "{0} does not declare the path field v4 never writes")
+    @ValueSource(strings = { "es7x", "es8x", "es9x", "opensearch" })
+    void should_not_declare_the_unwritten_path_field(String tree) {
+        // v4 reports the path after the context path as path-info; `path` belongs to the v2 request index.
+        // Declared here but empty on every document, it read as a usable dimension and cost APIM-15072 to
+        // disprove.
+        //
+        // Removing it is not entirely free, and the case that occurs daily is the gravitee-v4-metrics-*
+        // wildcard itself, spanning indices created before and after this change for the whole retention
+        // window. Measured on Elasticsearch 8.17.2 across one such pair: a term filter and a terms
+        // aggregation are unchanged (both already returned nothing), while a sort degrades to a 200 with
+        // fewer hits — the shard whose mapping lacks the field fails, and the search reports it as a
+        // partial result. Nothing in APIM sorts on this field, so the exposure was weighed and accepted;
+        // a direct consumer of the indices that does sort on it wants unmapped_type.
+        assertThat(propertiesOf(tree).getMap()).doesNotContainKey("path");
+    }
+
+    private static Map<String, Object> pathInfoKeywordOf(String tree) {
+        var pathInfo = propertiesOf(tree).getJsonObject("path-info");
+        assertThat(pathInfo).as("%s declares path-info", tree).isNotNull();
+        var fields = pathInfo.getJsonObject("fields");
+        assertThat(fields).as("%s gives path-info a sub-field", tree).isNotNull();
+        var keyword = fields.getJsonObject("keyword");
+        assertThat(keyword).as("%s names that sub-field keyword", tree).isNotNull();
+        return keyword.getMap();
+    }
+
+    /**
+     * Reads the v4-metrics field mappings out of a rendered template. es7x puts {@code mappings} at the root
+     * while the composable-template trees nest it under {@code template}, so both shapes are accepted.
+     */
+    private static JsonObject propertiesOf(String tree) {
+        var root = new JsonObject(render(tree));
+        var mappings = root.containsKey("mappings")
+            ? root.getJsonObject("mappings")
+            : root.getJsonObject("template").getJsonObject("mappings");
+
+        return mappings.getJsonObject("properties");
+    }
+
+    private static String render(String tree) {
+        var freeMarkerComponent = FreeMarkerComponent.builder()
+            .classLoader(V4MetricsPathMappingTest.class.getClassLoader())
+            .classLoaderTemplateBase("freemarker")
+            .build();
+        var pipelineConfiguration = new PipelineConfiguration(freeMarkerComponent);
+        var configuration = new ReporterConfiguration();
+
+        // No client: generateIndexTemplate only renders, it never talks to the cluster.
+        AbstractIndexPreparer preparer = switch (tree) {
+            case "es7x" -> new ES7IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es8x" -> new ES8IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es9x" -> new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "opensearch" -> new OpenSearchIndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            default -> throw new IllegalArgumentException("Unknown template tree: " + tree);
+        };
+
+        return preparer.generateIndexTemplate(Type.V4_METRICS);
+    }
+}


### PR DESCRIPTION
## Summary

Since APIM-15072 ([#19668](https://github.com/gravitee-io/gravitee-api-management/pull/19668), merged as `bd6b52c`), the analytics engine reads the HTTP path dimension — filter *and* facet — from `path-info.keyword`. That fix repointed the resolver but left the field undeclared: no index template ever mentioned `path-info`, so it existed only through Elasticsearch dynamic mapping, whose default for a string caps the keyword sub-field at `ignore_above: 256`. A path longer than that was absent from every filter match and every facet bucket, with no error.

Measured on a live index (Elasticsearch 8.17.2, `gravitee-v4-metrics-*`, 832 documents):

| Field | Declared before? | Mapping before | `exists` before | After this PR |
| --- | --- | --- | --- | --- |
| `uri` | yes, `keyword` | `keyword` | 832 / 832 | unchanged |
| `path` | yes, `keyword` | `keyword` | **0 / 832** | **declaration removed** |
| `mapped-path` | yes, `keyword` | `keyword` | — | unchanged |
| `path-info` | **no** | `text` + `keyword` sub-field, **`ignore_above: 256`** | 832 / 832 | declared `text` + `keyword` sub-field, **no cap** |

Closes OBS-100. Follow-up to APIM-15072.

## Changes

- Declare `path-info` in the four template trees (`es7x`, `es8x`, `es9x`, `opensearch`) as `text` with a `keyword` sub-field and **no** `ignore_above`.
- Remove the `path` declaration from the same four templates.
- `V4MetricsPathIndexingIntegrationTest` — drives the templates onto a real cluster, indexes one document whose `path-info` is 308 characters, and asserts the two shapes `HTTPFieldResolver` produces: a `term` on `path-info.keyword` and a `terms` aggregation over it. This is the behaviour the fix exists for.
- `V4MetricsPathMappingTest` — pins the rendered template across the four trees: the declaration, the absence of a length cap, and the removal of `path`.

### Why `text` + sub-field rather than a plain `keyword`

The resolver queries `path-info.keyword` — the sub-field. Indices are rolling (`gravitee-v4-metrics-YYYY.MM.DD`) and the engine searches the wildcard, so one query spans indices created on both sides of this change: the queryable field path has to stay identical. Declaring a plain `keyword` would drop the sub-field on new indices and break the filter and the facet while appearing to fix them. Moving to a plain `keyword` needs a resolver change plus a reindex of the history — a separate decision, tracked on OBS-23.

### Why no `ignore_above`, when the sibling test bounds `additional-metrics.keyword_*`

`IndexTemplateTest.should_bound_additional_keyword_metrics_so_one_oversized_value_cannot_break_indexing` asserts the opposite policy, so the two are worth reading together. Both hold, for different reasons: `additional-metrics.keyword_*` guards a client-controlled value with no other bound, whereas a path arrives on the request line, capped by `maxInitialLineLength` (4096 by default). Past Lucene's 32766-byte term limit Elasticsearch rejects the whole document, but `uri` on that same document is an uncapped keyword and always at least as long, so the record was already lost — a cap here would buy nothing and would only hide long paths from the filter and the facet. Recorded next to the assertion.

### Removing `path`: the risk, measured and accepted

The v4 reporter never writes `path` — the v4 `Metrics` model in `gravitee-reporter-api` has no `getPath()`, only `getPathInfo()` and `getMappedPath()`, and `"path"` appears nowhere in the history of the v4-metrics document template. The field belongs to the v2 `request` index, and declared-but-always-empty here is exactly what made the bug APIM-15072 fixed look plausible for months.

Removing a declaration is not entirely free, so it was measured. The case that occurs daily is the `gravitee-v4-metrics-*` wildcard itself, spanning indices created before and after this change for the whole retention window. On Elasticsearch 8.17.2, across one such pair:

| Query on `path` | Result |
| --- | --- |
| `term` filter | 2 shards successful, 0 hits — **unchanged** |
| `terms` aggregation | 2 shards successful, 0 buckets — **unchanged** |
| `sort` | 1 successful, **1 failed** — 1 hit instead of 2 |

Only `sort` degrades, to a silent partial result (`No mapping found for [path] in order to sort on`). **Nothing in APIM sorts on `path`**: the field has no reference anywhere in `gravitee-apim-repository-elasticsearch` outside the resolver, which stopped using it in APIM-15072. The residual exposure is a consumer reading the `gravitee-*` indices directly and sorting on a field that has always been empty on v4 — weighed and judged negligible; such a caller wants `unmapped_type` in any case. Recorded so the decision is visible rather than implicit.

## Test plan

- [ ] `mvn -pl gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch clean test` — full module suite green: **189 tests**, including the container-backed `IndexPreparerIntegrationTest`, `LogBodyIndexingIntegrationTest` and the new `V4MetricsPathIndexingIntegrationTest`, which push the rendered templates to a real cluster and so prove Elasticsearch and OpenSearch accept the mapping.
- [ ] `V4MetricsPathIndexingIntegrationTest` — RED -> GREEN checked rather than assumed: with the `es9x` template restored to `master`, both tests fail (expected 1, actual 0 — no hit, no bucket); with the declaration, both pass.
- [ ] `V4MetricsPathMappingTest` fails on `master` and passes here.
- [ ] `AnalyticsElasticsearchRepositoryTest.HTTPPathFilters` (added by APIM-15072) stays green.

## Reviewer notes

**Not a breaking change, and no impact on v2 APIs.** An index template applies at index *creation*: existing indices keep their mapping, nothing is rewritten or reindexed. No field is renamed, and the declared shape for `path-info` is exactly what dynamic mapping already produced, so `path-info.keyword` resolves identically on indices from both sides of this change.

The reporter routes by reportable class (`AbstractPerTypeIndexNameGenerator`): v1/v2 metrics go to the `request` index, v4 to `v4-metrics`, so no v2 traffic lands in the index this PR touches. `index-template-request.ftl` is an independent file with its own `index_patterns` and keeps its own `path` mapping, untouched.

Worth noting for APIM-15072 itself: because `path` was never written on v4, repointing away from it cannot orphan indexed documents — 0/832 matched before, all of them match `path-info` now. The visible change is the value vocabulary: `path-info` is the path *after the context path* (`/orders`), not the full URI (`/myapi/orders?page=2`), so a saved `HTTP_PATH` filter holding a full path keeps returning nothing until it is retyped — and the previously empty "Top HTTP Path" widgets now populate.

**This only affects newly created indices.** Existing ones keep the dynamic mapping and its truncation; there is no backfill, so the change becomes fully effective once the retention window rolls over.

The four template trees must stay in sync — they are re-emitted into the distribution's `es-index-mappings` artifact, so a tree left behind ships a divergent mapping. The mapping test covers all four; the integration test drives es9x, the tree the container runs.

Two things deliberately **not** done, both raised in review and left as follow-ups: `"index": false` on the parent `text` field, which is never queried and so pays for analysis nobody uses — it changes `exists` semantics on the parent and diverges from existing indices a second way; and collapsing the four copies of the preparer switch across this package's test classes, which would touch three test files this fix has no reason to open.