### PR TITLE
fix(analytics): declare ENTRYPOINT so its values can be listed

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -74,10 +74,11 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
             .satisfies(filters -> {
                 // The bare count keeps every catalog addition a deliberate decision. On its own it
                 // says nothing about what broke, so the names of the last additions come with it.
-                assertThat(filters).hasSize(60);
+                assertThat(filters).hasSize(61);
                 assertThat(filters)
                     .extracting(filter -> filter.getName().getValue())
                     .contains(
+                        "ENTRYPOINT",
                         "NATIVE_FAILURE_SIDE",
                         "NATIVE_CLIENT_ID",
                         "NATIVE_CLIENT_SOFTWARE_NAME",
@@ -206,6 +207,7 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                     "API",
                     "APPLICATION",
                     "PLAN",
+                    "ENTRYPOINT",
                     "API_PRODUCT",
                     "HTTP_METHOD",
                     "HTTP_STATUS",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1788,6 +1788,16 @@ spec:
               - EQ
               - IN
 
+        - name: ENTRYPOINT
+          label: Entrypoint
+          signals:
+              - LOGS
+              - ANALYTICS
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
         - name: TENANT
           label: Tenant
           signals:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-143

## Description

Listing the values of the `ENTRYPOINT` filter answers

```
400 Filter 'ENTRYPOINT' of type KEYWORD does not support value listing
```

The message blames the filter's type, and that is misleading. The type was never the problem —
`API` and `APPLICATION` are `KEYWORD` too and list fine. The filter was simply never declared in
`analytics-definition.yaml`, so `GetFilterValuesUseCase#findFilterSpec` threw `Filter not found`, and
Gamma turned that into a "not supported" 400 (`ObservabilityFilterDataPortAdapter`, whose comment says
as much: *"The platform analytics catalog doesn't list values for this filter yet"*).

Everything else was already in place:

- `FilterSpec.Name` carries `ENTRYPOINT`
- `FilterValuesQueryServiceImpl` maps it onto `entrypoint-id`, which the connection documents carry
- Gamma advertises it in `StaticFilters` as LOGS + ANALYTICS, KEYWORD, EQ/IN

So this adds the missing declaration, with the signals and operators Gamma already advertises, so the
two sides describe the same filter.

## Effect

Filtering by entrypoint already worked through the search endpoint — `ENTRYPOINT IN ["sse"]` returns
the right rows. Only *choosing* the value from the picker did not: the list could never populate, and
because the field is a server-fed combobox, a typed value was rejected too. On a Message API exposed
over `http-post` / `http-get` / `sse`, that is the one dimension worth slicing by.

Verified against a local stack carrying 314 connections over those three entrypoints: `API` and
`APPLICATION` listed their values, `ENTRYPOINT` answered 400.

The combobox side of it — a filter should stay usable when its listing fails, whatever the reason —
is fixed separately in gravitee-io/gamma-lib-observability#98.

## Tests

`GetFilterValuesUseCaseTest`: 56 tests, 0 failures.
