### PR TITLE
docs(openapi): declare the multi-value query parameters as comma-separated

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-analytics.yaml
@@ -256,8 +256,9 @@ paths:
                 - name: signal
                   in: query
                   required: false
-                  description: Observability signal(s) to narrow the catalog by. Repeat for multiple values.
+                  description: Observability signal(s) to narrow the catalog by. Comma-separate multiple values.
                   example: LOGS
+                  explode: false
                   schema:
                       type: array
                       items:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-api-products.yaml
@@ -802,6 +802,7 @@ paths:
           in: query
           description: Filter by plan status(es)
           required: false
+          explode: false
           schema:
             type: array
             items:
@@ -811,6 +812,7 @@ paths:
           in: query
           description: Filter by security type(s)
           required: true
+          explode: false
           schema:
             type: array
             items:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-apis.yaml
@@ -638,6 +638,7 @@ paths:
                   in: query
                   required: false
                   description: Exclude additional data from the API definition export
+                  explode: false
                   schema:
                       type: array
                       items:
@@ -2155,6 +2156,7 @@ paths:
                 - name: expands
                   in: query
                   description: Expansion of data to return in subscriptions.
+                  explode: false
                   schema:
                       type: array
                       items:
@@ -9507,6 +9509,7 @@ components:
             name: expands
             in: query
             description: Expansion of data to return in APIs.
+            explode: false
             schema:
                 type: array
                 items:
@@ -9517,6 +9520,7 @@ components:
             name: expands
             in: query
             description: Expansion of data to return in APIs.
+            explode: false
             schema:
                 type: array
                 items:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-model/src/main/resources/openapi/openapi-environments.yaml
@@ -3404,7 +3404,8 @@ components:
       in: query
       required: false
       description: |-
-        Filter clusters by lifecycle state. Repeat the parameter to match several states.
+        Filter clusters by lifecycle state. Comma-separate several states (`?lifecycleState=DEPLOYED,PENDING`).
+      explode: false
       schema:
         type: array
         items:
@@ -3435,6 +3436,7 @@ components:
       description: >
         Comma-separated list of fields to expand. Possible value: 'content'
       required: false
+      explode: false
       schema:
         type: array
         items:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -94,7 +94,7 @@ class ClustersResourceTest extends AbstractResourceTest {
     public void tearDown() {
         super.tearDown();
         GraviteeContext.cleanContext();
-        reset(createClusterUseCase, getDeployedClustersUseCase);
+        reset(createClusterUseCase, getDeployedClustersUseCase, searchClusterUseCase, countClustersByLifecycleStateUseCase);
     }
 
     @Nested
@@ -337,13 +337,6 @@ class ClustersResourceTest extends AbstractResourceTest {
      */
     @Nested
     class MultiValueQueryParameters {
-
-        // The shared use-case mock is not reset by the class tearDown, so each of these tests starts
-        // from a clean invocation count rather than counting a neighbour's call.
-        @BeforeEach
-        public void resetUseCase() {
-            reset(searchClusterUseCase);
-        }
 
         @Test
         public void should_bind_every_value_of_a_comma_separated_parameter() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -326,4 +326,53 @@ class ClustersResourceTest extends AbstractResourceTest {
             );
         }
     }
+
+    /**
+     * Multi-value query parameters in Management v2 are comma-separated, not repeated:
+     * {@link io.gravitee.rest.api.management.v2.rest.provider.CommaSeparatedQueryParamConverterProvider}
+     * is registered application-wide and binds a whole {@code List}/{@code Set} from ONE value, so a
+     * repeated parameter contributes only its first occurrence.
+     *
+     * These two tests pin that contract, which the OpenAPI declares with `explode: false`.
+     */
+    @Nested
+    class MultiValueQueryParameters {
+
+        // The shared use-case mock is not reset by the class tearDown, so each of these tests starts
+        // from a clean invocation count rather than counting a neighbour's call.
+        @BeforeEach
+        public void resetUseCase() {
+            reset(searchClusterUseCase);
+        }
+
+        @Test
+        public void should_bind_every_value_of_a_comma_separated_parameter() {
+            when(searchClusterUseCase.execute(any())).thenReturn(new SearchClusterUseCase.Output(new Page<>(List.of(), 1, 10, 0)));
+
+            final Response response = rootTarget().queryParam("lifecycleState", "DEPLOYED,UNDEPLOYED").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var captor = ArgumentCaptor.forClass(SearchClusterUseCase.Input.class);
+            verify(searchClusterUseCase).execute(captor.capture());
+            assertThat(captor.getValue().lifecycleStates()).containsExactly("DEPLOYED", "UNDEPLOYED");
+        }
+
+        @Test
+        public void should_keep_only_the_first_occurrence_of_a_repeated_parameter() {
+            when(searchClusterUseCase.execute(any())).thenReturn(new SearchClusterUseCase.Output(new Page<>(List.of(), 1, 10, 0)));
+
+            final Response response = rootTarget()
+                .queryParam("lifecycleState", "DEPLOYED")
+                .queryParam("lifecycleState", "UNDEPLOYED")
+                .request()
+                .get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var captor = ArgumentCaptor.forClass(SearchClusterUseCase.Input.class);
+            verify(searchClusterUseCase).execute(captor.capture());
+            // Not [DEPLOYED, UNDEPLOYED]: the second occurrence is dropped. Documenting the parameter
+            // as repeatable would make a generated client filter on one state without saying so.
+            assertThat(captor.getValue().lifecycleStates()).containsExactly("DEPLOYED");
+        }
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ESM-205

## Description

Management v2 registers `CommaSeparatedQueryParamConverterProvider` application-wide (`GraviteeManagementV2Application:121`). It binds a whole `List`/`Set` query parameter from **one comma-separated value**, so a *repeated* parameter contributes only its first occurrence.

Most array query parameters already declare `explode: false`. Four never did, and two of those actively documented the opposite:

| Parameter | Description on `master` |
|---|---|
| `signal` | "Observability signal(s) to narrow the catalog by. **Repeat for multiple values**." |
| `lifecycleState` | "Filter clusters by lifecycle state. **Repeat the parameter** to match several states." |

A client generated from those declarations sends `?lifecycleState=DEPLOYED&lifecycleState=PENDING` and silently filters on `DEPLOYED` alone — no error, no warning, just a narrower result than it asked for.

This PR declares `explode: false` on the four remaining collection-bound parameters and rewrites the two misleading descriptions. **Spec only, no runtime change.**

## Verified, not assumed

The claim is pinned by two tests on the clusters search rather than left to be re-derived from the provider:

- `?lifecycleState=DEPLOYED,UNDEPLOYED` → the resource receives `[DEPLOYED, UNDEPLOYED]`
- `?lifecycleState=DEPLOYED&lifecycleState=UNDEPLOYED` → the resource receives `[DEPLOYED]`

I found this while adding a filter to another endpoint: my first attempt used a repeated parameter and only the first value ever arrived.

## Scope

`apiMetadataSourceParam` is deliberately **left alone**. It declares `type: array` but `ApiMetadataResource:51` binds it as a plain `String` — a different inconsistency, and fixing it here would be guessing which side is wrong.

**One of the four is documented rather than verified.** `expandComponents` (`GET /portal-pages`) is declared in the v2 spec but served by nothing in Management v2 — no `@Path`, no `@QueryParam("expands")`. The only `getPortalPages` in the repo is the v1 one (`management-rest/.../PortalPagesResource:153`), a different application, declaring no `expands` at all. So `explode: false` there rests on the parameter's own prose ("Comma-separated list of fields to expand") rather than on an observable binding, unlike the other three. Kept, because it makes the declaration agree with the sentence above it and hands the convention to whoever implements the endpoint — but flagged so it is not mistaken for a verified one.

## Tests

- `ClustersResourceTest` — 2 new tests (above), 15/15
- `ApiSubscriptionsResourceTest`, `ApiPlansResourceTest`, `ApisResourceTest`, `ApiResourceTest`, `ApiProductPlansResourceTest`, `ApiMetadataResourceTest` — 128/128
- All four specs re-parsed to confirm they stay valid YAML

`ObservabilityFiltersDefinitionResourceTest` has 2 failures, **pre-existing on `master`** — verified by stashing this branch and re-running them unchanged. Untouched here.

## Additional context

Follow-up to #19706, which uses this convention for its new `apiTypes` parameter.

Worth considering separately: a rule in `.agent-rules/` or `gravitee-apim-rest-api/AGENTS.md` stating that multi-value query parameters in Management v2 are comma-separated and must declare `explode: false` — this is exactly the kind of mistake that repo's own guidance says deserves a written rule.