### PR TITLE
build(gamma): move the observability library to 3.3.0-beta.2

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "3.3.0-beta.1",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.2",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "3.3.0-beta.1",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.2",
         "@gravitee/graphene-charts": "3.14.0",
         "@gravitee/graphene-core": "3.14.0",
         "@gravitee/graphene-policy-studio": "3.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,9 +4627,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:3.3.0-beta.1":
-  version: 3.3.0-beta.1
-  resolution: "@gravitee/gamma-lib-observability@npm:3.3.0-beta.1"
+"@gravitee/gamma-lib-observability@npm:3.3.0-beta.2":
+  version: 3.3.0-beta.2
+  resolution: "@gravitee/gamma-lib-observability@npm:3.3.0-beta.2"
   peerDependencies:
     "@gravitee/graphene-charts": ^3.13.0
     "@gravitee/graphene-core": ^3.13.0
@@ -4651,7 +4651,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/4b5589f19296a9dbf9e656eecb572cd4736382dbc87152df31e46846fcf1f28a156423be07d811ba78b2b616b876d5830995c5e440abc45fbb1fff19071e0261
+  checksum: 10c0/1735f56594ac963d7167e013833a71ab05e6e6dfa7110a0b97484399d1666f5fcfe9779301ac4aa7d16c547de539223c432754fc153f5209251bd0bd553c2a65
   languageName: node
   linkType: hard
 
@@ -21901,7 +21901,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:3.3.0-beta.1"
+    "@gravitee/gamma-lib-observability": "npm:3.3.0-beta.2"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.14.0"
     "@gravitee/graphene-core": "npm:3.14.0"


### PR DESCRIPTION
## What

Moves the workspace and the APIM module from `@gravitee/gamma-lib-observability` 3.3.0-beta.1 to **3.3.0-beta.2**, the `beta` channel release carrying the time-axis history of the Targets tab (gravitee-io/gamma-lib-observability#95): evaluations sit where they happened, a quiet stretch under scheduler back-off shows as a quiet stretch, and the 2 h / 6 h / 24 h ranges mean what they say.

Same version the AIM module moves to in gravitee-io/gravitee-gamma-module-aim#775, so both modules render the Targets tab from one library build.

## Notes

- Lockfile diff is the single library entry; no other dependency moves.
- The AIM module itself needs no change here: the distribution pins `gravitee-gamma-module-aim` at `4.3.0-amp-demo-SNAPSHOT`, which the AIM CI republishes from its `amp-demo` branch, so the next distribution build picks up #775 once it is merged.
- Typecheck of the module against beta.2 is clean; the module tests ran green against the same Targets exports in #19698.

Relates to AIAM-514