### PR TITLE
build(distribution): move the AIM module to 4.3.0-beta.4

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -273,7 +273,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>4.3.0-beta.1</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.4</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## What

Bumps `gravitee-gamma-module-aim.version` in the distribution from 4.3.0-beta.1 to **4.3.0-beta.4**, the AIM module release (GitHub pre-release of 2026-09-08) carrying gravitee-io/gravitee-gamma-module-aim#775: the Targets tab on the LLM, MCP and A2A proxy detail pages and the Targets column on their lists, built on `@gravitee/gamma-lib-observability` 3.3.0-beta.2, the same library version this branch pins for the APIM module since #19719.

One property, no other change. Compatibility-sensitive by category (distribution deployment file), no behaviour change outside the bundled AIM module plugin.

Relates to AIAM-514