### PR TITLE
feat(rest-api): encrypted dictionaries backward compatibilty

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/el/ELIntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/el/ELIntegrationTest.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
 import io.gravitee.gateway.dictionary.model.Dictionary;
+import io.gravitee.gateway.dictionary.model.DictionaryProperty;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -64,7 +65,7 @@ class ELIntegrationTest extends AbstractGatewayTest {
         dictionary.setId("test");
         dictionary.setKey("test");
         dictionary.setEnvironmentId("DEFAULT");
-        dictionary.setProperties(Map.of("test", DICTIONARY_VALUE));
+        dictionary.setProperties(Map.of("test", new DictionaryProperty(DICTIONARY_VALUE, false)));
         dictionaries.add(dictionary);
     }
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsRenewalV4IntegrationTest.java
@@ -37,6 +37,7 @@ import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.secrets.SecretProviderBuilder;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.dictionary.model.Dictionary;
+import io.gravitee.gateway.dictionary.model.DictionaryProperty;
 import io.gravitee.node.secrets.plugins.SecretProviderPlugin;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
@@ -99,7 +100,7 @@ public class SecretsRenewalV4IntegrationTest extends AbstractGatewayTest {
         testDictionary.setId("test");
         testDictionary.setKey("test");
         testDictionary.setEnvironmentId("DEFAULT");
-        testDictionary.setProperties(Map.of("value4", "/vault/secret/test:value4?renewable=true"));
+        testDictionary.setProperties(Map.of("value4", new DictionaryProperty("/vault/secret/test:value4?renewable=true", false)));
         dictionaries.add(testDictionary);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManager.java
@@ -60,7 +60,13 @@ public class MultiEnvironmentDictionaryManager implements DictionaryManager {
 
             log.info("Dictionary {} has been deployed with {} properties", dictionary, dictionary.getProperties().size());
             dictionaries.get(environmentId).put(key, dictionary);
-            values.get(environmentId).put(key, dictionary.getProperties());
+            // EL only ever sees plaintext key/value pairs. Today every value's .value() already
+            // is plaintext (no encrypted dictionary property can exist until a later story adds
+            // encryption); that later story's gateway-side decrypt hook belongs exactly here, in
+            // place of the plain .value() extraction below.
+            Map<String, String> flattenedProperties = new HashMap<>();
+            dictionary.getProperties().forEach((propKey, property) -> flattenedProperties.put(propKey, property.value()));
+            values.get(environmentId).put(key, flattenedProperties);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/model/Dictionary.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/model/Dictionary.java
@@ -48,5 +48,5 @@ public class Dictionary {
 
     private Date deployedAt;
 
-    private Map<String, String> properties;
+    private Map<String, DictionaryProperty> properties;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/model/DictionaryProperty.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/main/java/io/gravitee/gateway/dictionary/model/DictionaryProperty.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.dictionary.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+
+/**
+ * A single dictionary property value, as deployed to the gateway. Dual-reads a legacy
+ * bare-string value (produced by a not-yet-upgraded Management API) as {@code encrypted=false}.
+ *
+ * @author GraviteeSource Team
+ */
+@JsonDeserialize(using = DictionaryProperty.Deserializer.class)
+public record DictionaryProperty(String value, boolean encrypted) {
+    static class Deserializer extends JsonDeserializer<DictionaryProperty> {
+
+        @Override
+        public DictionaryProperty deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            JsonNode node = p.getCodec().readTree(p);
+            if (node.isTextual()) {
+                return new DictionaryProperty(node.asText(), false);
+            }
+            String value = node.hasNonNull("value") ? node.get("value").asText() : null;
+            boolean encrypted = node.hasNonNull("encrypted") && node.get("encrypted").asBoolean();
+            return new DictionaryProperty(value, encrypted);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/MultiEnvironmentDictionaryManagerTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.dictionary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.gateway.dictionary.model.Dictionary;
+import io.gravitee.gateway.dictionary.model.DictionaryProperty;
 import java.util.Date;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -152,7 +153,7 @@ class MultiEnvironmentDictionaryManagerTest {
         dictionary.setEnvironmentId(environmentId);
         dictionary.setName(id);
         dictionary.setDeployedAt(new Date(deployedAt));
-        dictionary.setProperties(Map.of("MY_PROP", propertyValue));
+        dictionary.setProperties(Map.of("MY_PROP", new DictionaryProperty(propertyValue, false)));
         return dictionary;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/model/DictionaryPropertyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/src/test/java/io/gravitee/gateway/dictionary/model/DictionaryPropertyTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.dictionary.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class DictionaryPropertyTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void should_deserialize_legacy_bare_string_as_unencrypted() throws Exception {
+        DictionaryProperty property = mapper.readValue("\"localhost\"", DictionaryProperty.class);
+
+        assertThat(property.value()).isEqualTo("localhost");
+        assertThat(property.encrypted()).isFalse();
+    }
+
+    @Test
+    void should_deserialize_typed_object() throws Exception {
+        DictionaryProperty property = mapper.readValue("{\"value\":\"cipher\",\"encrypted\":true}", DictionaryProperty.class);
+
+        assertThat(property.value()).isEqualTo("cipher");
+        assertThat(property.encrypted()).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/DictionaryMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/DictionaryMapperTest.java
@@ -64,4 +64,36 @@ class DictionaryMapperTest {
         event.setPayload(objectMapper.writeValueAsString("wrong"));
         cut.to(event).test().assertNoValues().assertComplete();
     }
+
+    @Test
+    void should_map_dictionary_with_legacy_bare_string_properties() throws JsonProcessingException {
+        Event event = new Event();
+        event.setPayload("{\"properties\":{\"legacy-key\":\"legacy-value\"}}");
+
+        cut
+            .to(event)
+            .test()
+            .assertValue(dictionary -> {
+                assertThat(dictionary.getProperties().get("legacy-key").value()).isEqualTo("legacy-value");
+                assertThat(dictionary.getProperties().get("legacy-key").encrypted()).isFalse();
+                return true;
+            })
+            .assertComplete();
+    }
+
+    @Test
+    void should_map_dictionary_with_typed_properties() throws JsonProcessingException {
+        Event event = new Event();
+        event.setPayload("{\"properties\":{\"typed-key\":{\"value\":\"cipher\",\"encrypted\":true}}}");
+
+        cut
+            .to(event)
+            .test()
+            .assertValue(dictionary -> {
+                assertThat(dictionary.getProperties().get("typed-key").value()).isEqualTo("cipher");
+                assertThat(dictionary.getProperties().get("typed-key").encrypted()).isTrue();
+                return true;
+            })
+            .assertComplete();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Dictionary.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Dictionary.java
@@ -85,7 +85,7 @@ public class Dictionary {
     /**
      * For {@code DictionaryType.MANUAL} dictionary;
      */
-    private Map<String, String> properties;
+    private Map<String, DictionaryProperty> properties;
 
     /**
      * For {@code DictionaryType.DYNAMIC} dictionary;
@@ -177,11 +177,11 @@ public class Dictionary {
         this.trigger = trigger;
     }
 
-    public Map<String, String> getProperties() {
+    public Map<String, DictionaryProperty> getProperties() {
         return properties;
     }
 
-    public void setProperties(Map<String, String> properties) {
+    public void setProperties(Map<String, DictionaryProperty> properties) {
         this.properties = properties;
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/DictionaryProperty.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/DictionaryProperty.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+
+/**
+ * A single dictionary property value, carrying whether it is currently stored encrypted.
+ * Dual-reads a legacy bare-string value (pre-encryption-support dictionaries) as
+ * {@code encrypted=false}.
+ *
+ * @author GraviteeSource Team
+ */
+@JsonDeserialize(using = DictionaryProperty.Deserializer.class)
+public record DictionaryProperty(String value, boolean encrypted) {
+    static class Deserializer extends JsonDeserializer<DictionaryProperty> {
+
+        @Override
+        public DictionaryProperty deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            JsonNode node = p.getCodec().readTree(p);
+            if (node.isTextual()) {
+                return new DictionaryProperty(node.asText(), false);
+            }
+            String value = node.hasNonNull("value") ? node.get("value").asText() : null;
+            boolean encrypted = node.hasNonNull("encrypted") && node.get("encrypted").asBoolean();
+            return new DictionaryProperty(value, encrypted);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/model/DictionaryPropertyTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/model/DictionaryPropertyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class DictionaryPropertyTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void should_construct_with_value_and_encrypted() {
+        DictionaryProperty property = new DictionaryProperty("secret", true);
+
+        assertThat(property.value()).isEqualTo("secret");
+        assertThat(property.encrypted()).isTrue();
+    }
+
+    @Test
+    void should_deserialize_legacy_bare_string_as_unencrypted() throws Exception {
+        DictionaryProperty property = mapper.readValue("\"localhost\"", DictionaryProperty.class);
+
+        assertThat(property.value()).isEqualTo("localhost");
+        assertThat(property.encrypted()).isFalse();
+    }
+
+    @Test
+    void should_deserialize_typed_object() throws Exception {
+        DictionaryProperty property = mapper.readValue("{\"value\":\"cipher\",\"encrypted\":true}", DictionaryProperty.class);
+
+        assertThat(property.value()).isEqualTo("cipher");
+        assertThat(property.encrypted()).isTrue();
+    }
+
+    @Test
+    void should_serialize_as_typed_object() throws Exception {
+        String json = mapper.writeValueAsString(new DictionaryProperty("x", false));
+
+        assertThat(json).isEqualTo("{\"value\":\"x\",\"encrypted\":false}");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcDictionaryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcDictionaryRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.jdbc.orm.JdbcColumn;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.DictionaryProperty;
 import io.gravitee.repository.management.model.DictionaryProvider;
 import io.gravitee.repository.management.model.DictionaryTrigger;
 import io.gravitee.repository.management.model.DictionaryType;
@@ -82,13 +83,13 @@ public class JdbcDictionaryRepository extends JdbcAbstractCrudRepository<Diction
     }
 
     private static final JdbcHelper.ChildAdder<Dictionary> CHILD_ADDER = (Dictionary parent, ResultSet rs) -> {
-        Map<String, String> properties = parent.getProperties();
+        Map<String, DictionaryProperty> properties = parent.getProperties();
         if (properties == null) {
             properties = new HashMap<>();
             parent.setProperties(properties);
         }
         if (rs.getString("k") != null) {
-            properties.put(rs.getString("k"), rs.getString("v"));
+            properties.put(rs.getString("k"), new DictionaryProperty(rs.getString("v"), rs.getBoolean("encrypted")));
         }
     };
 
@@ -236,15 +237,16 @@ public class JdbcDictionaryRepository extends JdbcAbstractCrudRepository<Diction
             jdbcTemplate.update("delete from " + DICTIONARY_PROPERTY + " where dictionary_id = ?", dictionary.getId());
         }
         if (dictionary.getProperties() != null && !dictionary.getProperties().isEmpty()) {
-            List<Map.Entry<String, String>> entries = new ArrayList<>(dictionary.getProperties().entrySet());
+            List<Map.Entry<String, DictionaryProperty>> entries = new ArrayList<>(dictionary.getProperties().entrySet());
             jdbcTemplate.batchUpdate(
-                "insert into " + DICTIONARY_PROPERTY + " ( dictionary_id, k, v ) values ( ?, ?, ? )",
+                "insert into " + DICTIONARY_PROPERTY + " ( dictionary_id, k, v, encrypted ) values ( ?, ?, ?, ? )",
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
                         ps.setString(1, dictionary.getId());
                         ps.setString(2, entries.get(i).getKey());
-                        ps.setString(3, entries.get(i).getValue());
+                        ps.setString(3, entries.get(i).getValue().value());
+                        ps.setBoolean(4, entries.get(i).getValue().encrypted());
                     }
 
                     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/18_add_encrypted_to_dictionary_property.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/18_add_encrypted_to_dictionary_property.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0_18_add_encrypted_to_dictionary_property
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}dictionary_property
+            columns:
+              - column: {name: encrypted, type: boolean, defaultValueBoolean: false, constraints: { nullable: false } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -421,3 +421,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_13_0/16_add_active_theme_id_to_portals.yml
     - include:
         - file: liquibase/changelogs/v4_13_0/17_add_automation_metadata_to_themes.yml
+    - include:
+        - file: liquibase/changelogs/v4_13_0/18_add_encrypted_to_dictionary_property.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.mongodb.common.AbstractRepositoryConfiguration;
 import io.gravitee.repository.mongodb.common.MongoFactory;
 import io.gravitee.repository.mongodb.encryption.EncryptionConfiguration;
 import io.gravitee.repository.mongodb.management.converters.BsonUndefinedToNullReadingConverter;
+import io.gravitee.repository.mongodb.management.converters.LegacyDictionaryPropertyReadingConverter;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -65,6 +66,11 @@ public class ManagementRepositoryConfiguration extends AbstractRepositoryConfigu
     @Bean
     public BsonUndefinedToNullReadingConverter bsonUndefinedToNullReadingConverter() {
         return new BsonUndefinedToNullReadingConverter();
+    }
+
+    @Bean
+    public LegacyDictionaryPropertyReadingConverter legacyDictionaryPropertyReadingConverter() {
+        return new LegacyDictionaryPropertyReadingConverter();
     }
 
     @Bean(name = "managementMongo")

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDictionaryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDictionaryRepository.java
@@ -18,10 +18,12 @@ package io.gravitee.repository.mongodb.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.DictionaryProperty;
 import io.gravitee.repository.management.model.DictionaryProvider;
 import io.gravitee.repository.management.model.DictionaryTrigger;
 import io.gravitee.repository.mongodb.management.internal.dictionary.DictionaryMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.DictionaryMongo;
+import io.gravitee.repository.mongodb.management.internal.model.DictionaryPropertyMongo;
 import io.gravitee.repository.mongodb.management.internal.model.DictionaryProviderMongo;
 import io.gravitee.repository.mongodb.management.internal.model.DictionaryTriggerMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
@@ -63,7 +65,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         Dictionary res = mapper.map(page);
 
         if (res != null && res.getProperties() != null) {
-            final Map<String, String> properties = new HashMap<>(res.getProperties().size());
+            final Map<String, DictionaryProperty> properties = new HashMap<>(res.getProperties().size());
             res.getProperties().forEach((key, value) -> properties.put(computeOriginalKey(key), value));
             res.setProperties(properties);
         }
@@ -79,7 +81,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         DictionaryMongo dictionaryMongo = mapper.map(dictionary);
 
         if (dictionaryMongo.getProperties() != null) {
-            final Map<String, String> properties = new HashMap<>(dictionaryMongo.getProperties().size());
+            final Map<String, DictionaryPropertyMongo> properties = new HashMap<>(dictionaryMongo.getProperties().size());
             dictionaryMongo.getProperties().forEach((key, value) -> properties.put(computeMongoDBCompliantKey(key), value));
             dictionaryMongo.setProperties(properties);
         }
@@ -89,7 +91,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         Dictionary res = mapper.map(createdDictionaryMongo);
 
         if (res != null && res.getProperties() != null) {
-            final Map<String, String> properties = new HashMap<>(res.getProperties().size());
+            final Map<String, DictionaryProperty> properties = new HashMap<>(res.getProperties().size());
             res.getProperties().forEach((key, value) -> properties.put(computeOriginalKey(key), value));
             res.setProperties(properties);
         }
@@ -118,8 +120,12 @@ public class MongoDictionaryRepository implements DictionaryRepository {
             dictionaryMongo.setDeployedAt(dictionary.getDeployedAt());
 
             if (dictionary.getProperties() != null) {
-                final Map<String, String> properties = new HashMap<>(dictionary.getProperties().size());
-                dictionary.getProperties().forEach((key, value) -> properties.put(computeMongoDBCompliantKey(key), value));
+                final Map<String, DictionaryPropertyMongo> properties = new HashMap<>(dictionary.getProperties().size());
+                dictionary
+                    .getProperties()
+                    .forEach((key, value) ->
+                        properties.put(computeMongoDBCompliantKey(key), new DictionaryPropertyMongo(value.value(), value.encrypted()))
+                    );
                 dictionaryMongo.setProperties(properties);
             }
 
@@ -144,7 +150,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
             final Dictionary res = mapper.map(dictionaryMongoUpdated);
 
             if (res != null && res.getProperties() != null) {
-                final Map<String, String> properties = new HashMap<>(res.getProperties().size());
+                final Map<String, DictionaryProperty> properties = new HashMap<>(res.getProperties().size());
                 res.getProperties().forEach((key, value) -> properties.put(computeOriginalKey(key), value));
                 res.setProperties(properties);
             }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/converters/LegacyDictionaryPropertyReadingConverter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/converters/LegacyDictionaryPropertyReadingConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.converters;
+
+import io.gravitee.repository.mongodb.management.internal.model.DictionaryPropertyMongo;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+/**
+ * Dictionaries written before this dictionary carried per-property encryption status
+ * store {@code properties} as a raw string per key. Read one such value as the
+ * (unencrypted) property it always was.
+ *
+ * @author GraviteeSource Team
+ */
+@ReadingConverter
+public class LegacyDictionaryPropertyReadingConverter implements Converter<String, DictionaryPropertyMongo> {
+
+    @Override
+    public DictionaryPropertyMongo convert(String source) {
+        return new DictionaryPropertyMongo(source, false);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DictionaryMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DictionaryMongo.java
@@ -50,7 +50,7 @@ public class DictionaryMongo extends DeprecatedAuditable {
 
     private DictionaryTriggerMongo trigger;
 
-    private Map<String, String> properties;
+    private Map<String, DictionaryPropertyMongo> properties;
 
     private Date deployedAt;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DictionaryPropertyMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DictionaryPropertyMongo.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+/**
+ * Mirrors {@code io.gravitee.repository.management.model.DictionaryProperty} — a plain
+ * record embedded inside the mutable {@code @Document} class {@link DictionaryMongo},
+ * the same pattern already used by {@link IntegrationMongo}'s nested {@code A2aWellKnownUrl}.
+ *
+ * @author GraviteeSource Team
+ */
+public record DictionaryPropertyMongo(String value, boolean encrypted) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
@@ -26,6 +26,7 @@ import com.mongodb.client.vault.ClientEncryptions;
 import io.gravitee.repository.mongodb.common.AbstractRepositoryConfiguration;
 import io.gravitee.repository.mongodb.common.MongoFactory;
 import io.gravitee.repository.mongodb.encryption.EncryptionEnabledCondition;
+import io.gravitee.repository.mongodb.management.converters.LegacyDictionaryPropertyReadingConverter;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.config.MongoUpgraderConfiguration;
 import jakarta.inject.Inject;
 import java.util.Arrays;
@@ -88,6 +89,11 @@ public class MongoTestRepositoryConfiguration extends AbstractRepositoryConfigur
         final Resource yamlResource = new ClassPathResource("graviteeTest.yml");
         yaml.setResources(yamlResource);
         return yaml.getObject();
+    }
+
+    @Bean
+    public LegacyDictionaryPropertyReadingConverter legacyDictionaryPropertyReadingConverter() {
+        return new LegacyDictionaryPropertyReadingConverter();
     }
 
     @Bean(destroyMethod = "stop")

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/converters/LegacyDictionaryPropertyReadingConverterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/converters/LegacyDictionaryPropertyReadingConverterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.internal.model.DictionaryPropertyMongo;
+import org.junit.jupiter.api.Test;
+
+class LegacyDictionaryPropertyReadingConverterTest {
+
+    private final LegacyDictionaryPropertyReadingConverter cut = new LegacyDictionaryPropertyReadingConverter();
+
+    @Test
+    void should_convert_legacy_bare_string_to_unencrypted_property() {
+        DictionaryPropertyMongo result = cut.convert("localhost");
+
+        assertThat(result.value()).isEqualTo("localhost");
+        assertThat(result.encrypted()).isFalse();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/DictionaryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/DictionaryRepositoryTest.java
@@ -19,6 +19,7 @@ import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.DictionaryProperty;
 import io.gravitee.repository.management.model.DictionaryType;
 import java.util.*;
 import org.junit.jupiter.api.Assertions;
@@ -36,7 +37,7 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         final Set<Dictionary> dictionaries = dictionaryRepository.findAll();
 
         assertNotNull(dictionaries);
-        assertEquals(7, dictionaries.size());
+        assertEquals(8, dictionaries.size());
     }
 
     @Test
@@ -52,7 +53,7 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         final Set<Dictionary> dictionaries = dictionaryRepository.findAllByEnvironments(Collections.emptySet());
 
         assertNotNull(dictionaries);
-        assertEquals(7, dictionaries.size());
+        assertEquals(8, dictionaries.size());
     }
 
     @Test
@@ -96,7 +97,7 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         Assertions.assertTrue(compareDate(new Date(1000000000000L), dictionary.getCreatedAt()), "Invalid dictionary createdAt.");
         Assertions.assertTrue(compareDate(new Date(1439032010883L), dictionary.getUpdatedAt()), "Invalid dictionary updatedAt.");
         Assertions.assertEquals(3, dictionary.getProperties().size(), "Invalid dictionary properties.");
-        Assertions.assertEquals("127.0.0.1:8082", dictionary.getProperties().get("127.0.0.1:8082"), "Invalid dictionary property.");
+        Assertions.assertEquals("127.0.0.1:8082", dictionary.getProperties().get("127.0.0.1:8082").value(), "Invalid dictionary property.");
     }
 
     @Test
@@ -110,10 +111,10 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         dictionary.setCreatedAt(new Date(1000000000000L));
         dictionary.setUpdatedAt(new Date(1439032010883L));
         dictionary.setType(DictionaryType.MANUAL);
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("localhost", "localhost");
-        properties.put("localhost:8082", "localhost:8082");
-        properties.put("127.0.0.1:8082", "127.0.0.1:8082");
+        final Map<String, DictionaryProperty> properties = new HashMap<>();
+        properties.put("localhost", new DictionaryProperty("localhost", false));
+        properties.put("localhost:8082", new DictionaryProperty("localhost:8082", false));
+        properties.put("127.0.0.1:8082", new DictionaryProperty("127.0.0.1:8082", false));
         dictionary.setProperties(properties);
 
         int nbDictionariesBeforeCreation = dictionaryRepository.findAll().size();
@@ -149,10 +150,10 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         dictionary.setCreatedAt(new Date(1000000000000L));
         dictionary.setUpdatedAt(new Date(1486771200000L));
         dictionary.setType(DictionaryType.DYNAMIC);
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("localhost", "localhost");
-        properties.put("localhost:8082", "localhost:8082");
-        properties.put("127.0.0.1:8082", "127.0.0.1:8082");
+        final Map<String, DictionaryProperty> properties = new HashMap<>();
+        properties.put("localhost", new DictionaryProperty("localhost", false));
+        properties.put("localhost:8082", new DictionaryProperty("localhost:8082", false));
+        properties.put("127.0.0.1:8082", new DictionaryProperty("127.0.0.1:8082", false));
         dictionary.setProperties(properties);
 
         int nbDictionariesBeforeUpdate = dictionaryRepository.findAll().size();
@@ -240,5 +241,31 @@ public class DictionaryRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(2, nbBeforeDeletion);
         assertEquals(2, deleted);
         assertEquals(0, nbAfterDeletion);
+    }
+
+    @Test
+    public void shouldReadMixedLegacyAndTypedProperties() throws Exception {
+        final Optional<Dictionary> found = dictionaryRepository.findById("dic-mixed");
+
+        assertTrue(found.isPresent());
+        final Dictionary dictionary = found.get();
+
+        assertEquals("plain-value", dictionary.getProperties().get("plain-legacy").value());
+        assertFalse(dictionary.getProperties().get("plain-legacy").encrypted());
+
+        assertEquals("ENC(cipher)", dictionary.getProperties().get("already-encrypted").value());
+        assertTrue(dictionary.getProperties().get("already-encrypted").encrypted());
+    }
+
+    @Test
+    public void shouldRoundTripEncryptedFlagThroughUpdate() throws Exception {
+        final Dictionary dictionary = dictionaryRepository.findById("dic-mixed").orElseThrow();
+
+        // Simulate an unrelated field changing while properties are resubmitted unchanged.
+        dictionary.setDescription("Updated description");
+        final Dictionary updated = dictionaryRepository.update(dictionary);
+
+        assertTrue(updated.getProperties().get("already-encrypted").encrypted());
+        assertEquals("ENC(cipher)", updated.getProperties().get("already-encrypted").value());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/dictionary-tests/dictionarys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/dictionary-tests/dictionarys.json
@@ -128,5 +128,19 @@
     "createdAt": 1000000000000,
     "updatedAt": 1111111111111,
     "deployedAt": 1111111111111
+  },
+  {
+     "id":"dic-mixed",
+     "environmentId": "MIXED_ENV",
+     "name":"My mixed dic",
+     "key": "dic-mixed",
+     "description": "Legacy plaintext alongside a value already marked encrypted",
+     "type": "MANUAL",
+     "createdAt": 1000000000000,
+     "updatedAt": 1111111111111,
+     "properties" : {
+        "plain-legacy" : "plain-value",
+        "already-encrypted" : { "value": "ENC(cipher)", "encrypted": true }
+     }
   }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
@@ -17,6 +17,8 @@ package io.gravitee.apim.rest.api.automation.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.rest.api.automation.model.DictionaryPropertyValue;
+import io.gravitee.apim.rest.api.automation.model.DictionaryPropertyValueOneOf;
 import io.gravitee.apim.rest.api.automation.model.DictionaryProvider;
 import io.gravitee.apim.rest.api.automation.model.DictionarySpec;
 import io.gravitee.apim.rest.api.automation.model.DictionaryState;
@@ -47,10 +49,34 @@ public interface DictionaryMapper {
     // ===== DictionarySpec → Dictionary (core) =====
 
     @Mapping(source = "type", target = "type")
-    @Mapping(source = "manual.properties", target = "properties")
+    @Mapping(target = "properties", expression = "java(mapManualProperties(spec))")
     @Mapping(source = "dynamic.provider", target = "provider")
     @Mapping(source = "dynamic.trigger", target = "trigger")
     Dictionary toDictionary(DictionarySpec spec);
+
+    default Map<String, String> mapManualProperties(DictionarySpec spec) {
+        if (spec.getManual() == null || spec.getManual().getProperties() == null) {
+            return null;
+        }
+        Map<String, String> result = new java.util.HashMap<>();
+        spec
+            .getManual()
+            .getProperties()
+            .forEach((key, propertyValue) -> result.put(key, extractStringValue(propertyValue)));
+        return result;
+    }
+
+    default String extractStringValue(DictionaryPropertyValue propertyValue) {
+        if (propertyValue == null) return null;
+        Object actual = propertyValue.getActualInstance();
+        if (actual instanceof String legacy) {
+            return legacy;
+        }
+        if (actual instanceof DictionaryPropertyValueOneOf typed) {
+            return typed.getValue();
+        }
+        return null;
+    }
 
     io.gravitee.apim.core.dictionary.model.DictionaryType toCoreType(DictionaryType type);
 
@@ -85,7 +111,11 @@ public interface DictionaryMapper {
         if (entity.getType() == io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL) {
             state.setDeployed(entity.getDeployedAt() != null);
             ManualDictionarySpec manual = new ManualDictionarySpec();
-            manual.setProperties(entity.getProperties() != null ? entity.getProperties() : Map.of());
+            Map<String, DictionaryPropertyValue> properties = new java.util.HashMap<>();
+            if (entity.getProperties() != null) {
+                entity.getProperties().forEach((key, value) -> properties.put(key, toDictionaryPropertyValue(value, false)));
+            }
+            manual.setProperties(properties);
             state.setManual(manual);
         } else {
             state.setDeployed(isEntityStarted(entity));
@@ -95,6 +125,10 @@ public interface DictionaryMapper {
             state.setDynamic(dynamic);
         }
         return state;
+    }
+
+    default DictionaryPropertyValue toDictionaryPropertyValue(String value, boolean encrypted) {
+        return new DictionaryPropertyValue(new DictionaryPropertyValueOneOf(encrypted).value(value));
     }
 
     default DictionaryState toDictionaryState(DictionarySpec spec) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1649,11 +1649,30 @@ components:
       properties:
         properties:
           type: object
-          description: Dictionary data are key/value pairs for `MANUAL` properties
+          description: >-
+            Dictionary data are key/value pairs for `MANUAL` properties. Each value is
+            either a plain string (the pre-encryption-support shape, always unencrypted)
+            or an object carrying the value plus its encryption status.
           additionalProperties:
-            type: string
+            $ref: "#/components/schemas/DictionaryPropertyValue"
       required:
         - properties
+    DictionaryPropertyValue:
+      description: >-
+        A single MANUAL dictionary property value. Accepts a bare string for
+        backward compatibility with dictionaries declared before encryption support;
+        always returned as the typed object.
+      oneOf:
+        - type: string
+        - type: object
+          properties:
+            value:
+              type: string
+            encrypted:
+              type: boolean
+              readOnly: true
+          required:
+            - value
     DynamicDictionarySpec:
       description: A dynamic dictionary populated from an external provider on a schedule.
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapperTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.rest.api.automation.model.DictionaryPropertyValue;
+import io.gravitee.apim.rest.api.automation.model.DictionaryPropertyValueOneOf;
+import io.gravitee.apim.rest.api.automation.model.DictionarySpec;
+import io.gravitee.apim.rest.api.automation.model.DictionaryState;
+import io.gravitee.apim.rest.api.automation.model.DictionaryType;
+import io.gravitee.apim.rest.api.automation.model.ManualDictionarySpec;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DictionaryMapperTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("organization-id", "environment-id");
+
+    @Test
+    void should_map_legacy_bare_string_property_to_state() {
+        DictionaryEntity entity = DictionaryEntity.builder()
+            .id("dic-1")
+            .name("My dic")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .properties(Map.of("legacy-key", "legacy-value"))
+            .build();
+
+        DictionaryState state = DictionaryMapper.INSTANCE.toDictionaryState(entity, EXECUTION_CONTEXT);
+
+        DictionaryPropertyValue value = state.getManual().getProperties().get("legacy-key");
+        assertThat(value.getDictionaryPropertyValueOneOf().getValue()).isEqualTo("legacy-value");
+        assertThat(value.getDictionaryPropertyValueOneOf().getEncrypted()).isFalse();
+    }
+
+    @Test
+    void should_map_dictionary_with_legacy_bare_string_property_to_core_dictionary() {
+        DictionarySpec spec = new DictionarySpec()
+            .type(DictionaryType.MANUAL)
+            .manual(new ManualDictionarySpec().properties(Map.of("legacy-key", new DictionaryPropertyValue("legacy-value"))));
+
+        var dictionary = DictionaryMapper.INSTANCE.toDictionary(spec);
+
+        assertThat(dictionary.getProperties()).containsEntry("legacy-key", "legacy-value");
+    }
+
+    @Test
+    void should_map_dictionary_with_typed_property_to_core_dictionary() {
+        DictionarySpec spec = new DictionarySpec()
+            .type(DictionaryType.MANUAL)
+            .manual(
+                new ManualDictionarySpec().properties(
+                    Map.of("typed-key", new DictionaryPropertyValue(new DictionaryPropertyValueOneOf(true).value("cipher")))
+                )
+            );
+
+        var dictionary = DictionaryMapper.INSTANCE.toDictionary(spec);
+
+        assertThat(dictionary.getProperties()).containsEntry("typed-key", "cipher");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResourceTest.java
@@ -125,7 +125,10 @@ class DictionariesResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
                     soft.assertThat(state.getDeployed()).isTrue();
                     soft.assertThat(state.getManual()).isNotNull();
-                    soft.assertThat(state.getManual().getProperties()).containsEntry("key1", "value1");
+                    soft.assertThat(state.getManual().getProperties()).containsKey("key1");
+                    soft
+                        .assertThat(state.getManual().getProperties().get("key1").getDictionaryPropertyValueOneOf().getValue())
+                        .isEqualTo("value1");
                 });
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResourceTest.java
@@ -98,7 +98,10 @@ class DictionaryResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getDeployed()).isTrue();
                     soft.assertThat(state.getManual()).isNotNull();
                     soft.assertThat(state.getManual().getProperties()).isNotNull();
-                    soft.assertThat(state.getManual().getProperties()).containsEntry("key1", "value1");
+                    soft.assertThat(state.getManual().getProperties()).containsKey("key1");
+                    soft
+                        .assertThat(state.getManual().getProperties().get("key1").getDictionaryPropertyValueOneOf().getValue())
+                        .isEqualTo("value1");
                 });
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.DictionaryProperty;
 import io.gravitee.repository.management.model.DictionaryProvider;
 import io.gravitee.repository.management.model.DictionaryTrigger;
 import io.gravitee.repository.management.model.DictionaryType;
@@ -280,7 +281,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 .filter(d -> d.getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId()))
                 .orElseThrow(() -> new DictionaryNotFoundException(updateDictionaryEntity.getName()));
 
-            Dictionary dictionary = convert(updateDictionaryEntity);
+            Dictionary dictionary = convert(updateDictionaryEntity, dictionaryToUpdate);
 
             dictionary.setId(id);
             dictionary.setKey(dictionaryToUpdate.getKey());
@@ -331,7 +332,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 log.warn("Update dictionary {} properties not applied: dictionary is {}", id, dictionary.getState());
                 return convert(dictionary);
             }
-            dictionary.setProperties(properties);
+            dictionary.setProperties(toTypedProperties(properties, dictionary.getProperties()));
             dictionary.setUpdatedAt(new Date());
             dictionary.setDeployedAt(dictionary.getUpdatedAt());
             Dictionary updatedDictionary = dictionaryRepository.update(dictionary);
@@ -446,7 +447,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             .updatedAt(dictionary.getUpdatedAt())
             .deployedAt(dictionary.getDeployedAt())
             .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.valueOf(dictionary.getType().name()))
-            .properties(dictionary.getProperties())
+            .properties(toFlatProperties(dictionary.getProperties()))
             .state(Lifecycle.State.valueOf(dictionary.getState().name()));
 
         if (dictionary.getType() == DictionaryType.DYNAMIC) {
@@ -480,12 +481,37 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         }
     }
 
-    private Dictionary convert(UpdateDictionaryEntity updateDictionaryEntity) {
+    private static Map<String, DictionaryProperty> toTypedProperties(
+        Map<String, String> incoming,
+        Map<String, DictionaryProperty> existing
+    ) {
+        if (incoming == null) {
+            return null;
+        }
+        Map<String, DictionaryProperty> result = new java.util.HashMap<>(incoming.size());
+        incoming.forEach((key, value) -> {
+            DictionaryProperty previous = existing == null ? null : existing.get(key);
+            boolean unchanged = previous != null && java.util.Objects.equals(previous.value(), value);
+            result.put(key, new DictionaryProperty(value, unchanged && previous.encrypted()));
+        });
+        return result;
+    }
+
+    private static Map<String, String> toFlatProperties(Map<String, DictionaryProperty> typed) {
+        if (typed == null) {
+            return null;
+        }
+        Map<String, String> result = new java.util.HashMap<>(typed.size());
+        typed.forEach((key, property) -> result.put(key, property.value()));
+        return result;
+    }
+
+    private Dictionary convert(UpdateDictionaryEntity updateDictionaryEntity, Dictionary existing) {
         Dictionary dictionary = new Dictionary();
 
         dictionary.setName(updateDictionaryEntity.getName());
         dictionary.setDescription(updateDictionaryEntity.getDescription());
-        dictionary.setProperties(updateDictionaryEntity.getProperties());
+        dictionary.setProperties(toTypedProperties(updateDictionaryEntity.getProperties(), existing.getProperties()));
 
         final io.gravitee.rest.api.model.configuration.dictionary.DictionaryType type = updateDictionaryEntity.getType();
         if (type != null) {
@@ -515,7 +541,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         }
 
         if (type == io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL) {
-            dictionary.setProperties(newDictionaryEntity.getProperties());
+            dictionary.setProperties(toTypedProperties(newDictionaryEntity.getProperties(), null));
         } else {
             dictionary.setProvider(convert(newDictionaryEntity.getProvider()));
             dictionary.setTrigger(convert(newDictionaryEntity.getTrigger()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DictionaryRepository;
 import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.DictionaryProperty;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
@@ -40,6 +41,8 @@ import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,7 +106,15 @@ public class DictionaryServiceImpl_UpdateTest {
                         arg.getEnvironmentId().equals(ENVIRONMENT_ID) &&
                         arg.getName().equals(updateDictionaryEntity.getName()) &&
                         arg.getDescription().equals(updateDictionaryEntity.getDescription()) &&
-                        arg.getProperties().equals(updateDictionaryEntity.getProperties()) &&
+                        arg
+                            .getProperties()
+                            .entrySet()
+                            .stream()
+                            .allMatch(
+                                e ->
+                                    !e.getValue().encrypted() &&
+                                    e.getValue().value().equals(updateDictionaryEntity.getProperties().get(e.getKey()))
+                            ) &&
                         arg.getType().name().equals(updateDictionaryEntity.getType().name())
                 )
             )
@@ -165,7 +176,15 @@ public class DictionaryServiceImpl_UpdateTest {
                         arg.getEnvironmentId().equals(ENVIRONMENT_ID) &&
                         arg.getName().equals(updateDictionaryEntity.getName()) &&
                         arg.getDescription().equals(updateDictionaryEntity.getDescription()) &&
-                        arg.getProperties().equals(updateDictionaryEntity.getProperties()) &&
+                        arg
+                            .getProperties()
+                            .entrySet()
+                            .stream()
+                            .allMatch(
+                                e ->
+                                    !e.getValue().encrypted() &&
+                                    e.getValue().value().equals(updateDictionaryEntity.getProperties().get(e.getKey()))
+                            ) &&
                         arg.getType().name().equals(updateDictionaryEntity.getType().name())
                 )
             )
@@ -221,5 +240,42 @@ public class DictionaryServiceImpl_UpdateTest {
             updateDictionaryEntity.setName("UpdatedName");
             dictionaryService.update(GraviteeContext.getExecutionContext(), DICTIONARY_ID, updateDictionaryEntity);
         });
+    }
+
+    @Test
+    public void shouldPreserveEncryptedFlagWhenValueUnchanged() throws TechnicalException {
+        Dictionary existing = new Dictionary();
+        existing.setId(DICTIONARY_ID);
+        existing.setName("My Dictionary");
+        existing.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        existing.setType(io.gravitee.repository.management.model.DictionaryType.MANUAL);
+        existing.setState(LifecycleState.STOPPED);
+        Map<String, DictionaryProperty> existingProperties = new HashMap<>();
+        existingProperties.put("already-encrypted", new DictionaryProperty("ENC(cipher)", true));
+        existingProperties.put("plain", new DictionaryProperty("plain-value", false));
+        existing.setProperties(existingProperties);
+
+        when(dictionaryRepository.findById(DICTIONARY_ID)).thenReturn(Optional.of(existing));
+        when(dictionaryRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateDictionaryEntity updateDictionaryEntity = new UpdateDictionaryEntity();
+        updateDictionaryEntity.setName("My Dictionary");
+        updateDictionaryEntity.setType(DictionaryType.MANUAL);
+        Map<String, String> incoming = new HashMap<>();
+        incoming.put("already-encrypted", "ENC(cipher)"); // resubmitted unchanged, e.g. Console round-trip
+        incoming.put("plain", "new-plain-value"); // genuinely changed
+        updateDictionaryEntity.setProperties(incoming);
+
+        dictionaryService.update(GraviteeContext.getExecutionContext(), DICTIONARY_ID, updateDictionaryEntity);
+
+        verify(dictionaryRepository).update(
+            argThat(
+                dict ->
+                    dict.getProperties().get("already-encrypted").encrypted() &&
+                    dict.getProperties().get("already-encrypted").value().equals("ENC(cipher)") &&
+                    !dict.getProperties().get("plain").encrypted() &&
+                    dict.getProperties().get("plain").value().equals("new-plain-value")
+            )
+        );
     }
 }


### PR DESCRIPTION
## Issue

[EXT-153](https://gravitee.atlassian.net/browse/EXT-153)

## Description

Introduces a typed `DictionaryProperty { value, encrypted }` in place of the flat `Map<String, String>` used for dictionary properties, across every storage layer (repository-api, JDBC, MongoDB, gateway), with existing plaintext data readable everywhere with **no migration required**. This is the foundational story other dictionary-encryption work builds on; it does not itself add encryption.

Key points:
- **Repository layer**: `Dictionary.properties` is now `Map<String, DictionaryProperty>` in both the repository-api model and the gateway model. JDBC gets a new `encrypted` column (default `false`, so existing rows are correct by construction, no backfill needed). MongoDB dual-reads legacy untyped documents via a new `@ReadingConverter`.
- **REST API boundary unchanged**: `DictionaryEntity`/`NewDictionaryEntity`/`UpdateDictionaryEntity` keep `properties: Map<String, String>` — the live AngularJS Console round-trips this shape today and isn't touched by this change. `DictionaryServiceImpl` translates at the boundary and preserves an existing property's `encrypted` flag whenever an update resubmits the same value, so a future encrypted value can't be silently downgraded to plaintext by an unrelated save.
- **Automation API** is the one wire contract that does change: `ManualDictionarySpec.properties` now accepts either a bare string (existing GitOps manifests keep validating unchanged) or a typed `{value, encrypted}` object.
- **Gateway**: dictionary sync event payloads dual-read the same way, so a gateway running this code can consume events from a not-yet-upgraded Management API.

## Compatibility-sensitive surfaces

- **Deserialization**: two custom Jackson deserializers (repository-api and gateway `DictionaryProperty`) accept externally-influenced input (event payloads); both tolerate an unrecognised shape rather than throwing, consistent with existing precedent.
- **Persistence schema**: new JDBC column `dictionary_property.encrypted` (Liquibase, additive, defaulted, non-breaking).
- **Generated API models / OpenAPI**: Automation API `open-api.yaml` gains `DictionaryPropertyValue` (`oneOf: [string, object]`); regenerated models are backward compatible with existing manifests.

## Known downgrade asymmetry (informational, not a blocker)

Rolling back to a pre-this-PR build is safe on JDBC, but **not safe on MongoDB** once any dictionary property has `encrypted: true` — older code expects every property value to be a raw string and can't read a `{value, encrypted}` sub-document. No property can be encrypted yet (that lands in a later story), so this is latent, not live, today. Flag it again when encryption actually ships.

## Additional context

- No forced migration, no deprecation warnings; existing plaintext dictionaries on both JDBC and MongoDB continue to work with zero manual steps.
- The EL-facing map (`#dictionaries[...]`) stays a plain `Map<String, String>` — the typed shape never leaks into template-expression evaluation.

[EXT-153]: https://gravitee.atlassian.net/browse/EXT-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ