### PR TITLE
test(analytics): count the mcp-studio request in the path facet

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -1706,7 +1706,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
                 assertThat(result.metrics().getFirst().buckets())
                     .extracting(bucket -> bucket.key(), bucket -> bucket.measures().get(Measure.COUNT).longValue())
-                    .contains(tuple("/tools/call", 2L), tuple("/chat", 2L), tuple("/", 13L));
+                    .contains(tuple("/tools/call", 2L), tuple("/chat", 2L), tuple("/", 14L));
             }
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/freemarker-v4-analytics/v4-metrics.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/freemarker-v4-analytics/v4-metrics.ftl
@@ -78,7 +78,9 @@
 
 <#-- The entrypoints promoted to the HTTP request scope (OBS-18), plus an sse subscription of the same
      API that must stay out of it, so the default scope is proven on documents and not only on the
-     query body. A dedicated api-id keeps every environment-wide assertion above unchanged. -->
+     query body. The dedicated api-id only shields the assertions that filter by api: the facet
+     assertions above pass no filter at all and count the whole environment, so mcp-studio's
+     "/" request lands in their buckets. Adding a document here means re-checking them. -->
 { "index" :{ ${indexNameToday}, "_id": "promoted-entrypoint-001"}}
 { "entrypoint-id": "mcp", "gateway": "2c99d50d-d318-42d3-99d5-0dd31862d3d2", "@timestamp": "${dateToday}T12:00:00.000Z", "request-id": "promoted-entrypoint-001", "transaction-id": "promoted-entrypoint-001", "api-id": "promoted-entrypoints-api-001", "plan-id": "733b78f1-1a16-4c16-bb78-f11a16ac1693", "application-id": "613dc986-41ce-4b5b-bdc9-8641cedb5bdb", "subscription-id": "127.0.0.1", "http-method": 7, "local-address": "10.0.2.208", "remote-address": "127.0.0.1", "host": "apim-master-gateway.team-apim.gravitee.dev", "uri": "/promoted/mcp", "path-info": "/mcp", "user-agent": "", "request-ended": "true", "status": 200, "response-content-length": 10, "gateway-response-time-ms": 20 }
 { "index" :{ ${indexNameToday}, "_id": "promoted-entrypoint-002"}}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15072

## Description

`master` is red on `ci/circleci: Test repository`. One assertion fails:

```
[ERROR]   AnalyticsElasticsearchRepositoryTest.should_bucket_the_requests_by_path
Expecting ArrayList:
  [("/", 14L), ("", 2L), ("/chat", 2L), ("/tools/call", 2L), ("/completions", 1L),
   ("/mcp", 1L), ("/prompts/get", 1L), ("/resources/read", 1L)]
to contain:
  [("/tools/call", 2L), ("/chat", 2L), ("/", 13L)]
but could not find the following element(s):
  [("/", 13L)]
```

The assertion was born with a stale value. `bd6b52cdc7` (#19668) moved `HTTP_PATH` from `path` to
`path-info.keyword`:

```diff
-            case HTTP_PATH -> "path";
+            case HTTP_PATH -> "path-info.keyword";
```

and added `should_bucket_the_requests_by_path` expecting `("/", 13L)` in the same commit. But `13`
was the count from *before* that switch. Four `promoted-entrypoint` documents already sat in the
shared `freemarker-v4-analytics/v4-metrics.ftl` fixture, and they carry `path-info` with no `path`
field, so they were invisible to a facet reading `path` and became visible to one reading
`path-info`:

| doc | entrypoint | `path-info` | counted in the HTTP scope? |
| --- | --- | --- | --- |
| `promoted-entrypoint-001` | `mcp` | `/mcp` | yes |
| `promoted-entrypoint-002` | `mcp-studio` | `/` | yes |
| `promoted-entrypoint-003` | `agent-to-agent` | `/` | no |
| `promoted-entrypoint-004` | `sse` | `/` | no |

So the `/` bucket gains exactly one request — `mcp-studio` — and `/mcp` appears with 1. Both are
visible in the actual list above. The right value was 14 the moment the assertion was written.

## Additional context

**The fixture comment states an invariant it does not hold.** It reads:

> A dedicated api-id keeps every environment-wide assertion above unchanged.

The dedicated api-id shields the assertions that filter *by api*. These facet assertions pass
`List.of()` — no filter at all — so they count the whole environment and the api-id changes nothing
for them. The comment is corrected here rather than left to mislead whoever adds the next document.

**The underlying fragility is not fixed, deliberately.** An environment-wide assertion over a shared
fixture breaks every time a document is added, and the two mistakes above are the same mistake seen
from either end. Scoping these facets by api-id would make them immune, but it would also change what
they assert. That belongs in its own discussion rather than inside a red-CI fix.

**Branches carrying their own copy of this test will need the same treatment.**
`build/AIAM-514-observability-lib-beta` and `build/AIAM-514-aim-module-4-3-0-beta-4` add a
`should_bucket_the_requests_by_http_method_name` that does not exist on `master`, and it fails the
same way for the same reason: the two counted documents both carry `http-method: 7`, so `POST` goes
from 4 to 6 there. Not fixable from here — flagging it so it is not diagnosed twice.

### Verification

Reproduced and fixed locally against the real containers, on `master`, JDK 25:

- without the change: `Tests run: 89, Failures: 1` — `should_bucket_the_requests_by_path`, the exact
  CI failure.
- with it: `Tests run: 89, Failures: 0`.
