### PR TITLE
ci: wake the suites that consume a module at test scope

### DIFF
--- a/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
@@ -40,6 +40,8 @@ describe('Pull requests workflow tests', () => {
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway/pom.xml']}                                           | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution/pom.xml']}                                      | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
     ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['.github/renovate.json5']}                                                  | ${'pull-requests-custom-branch-no-source-changes.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch']}             | ${'pull-requests-custom-branch-backend-reporter-es-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway/gravitee-apim-gateway-services/']}                   | ${'pull-requests-custom-branch-backend-gateway-services-only.yml'}
   `(
     'should generate pull-requests config for branch $branchName with changedFiles $changedFiles',
     ({ baseBranch, branch, changedFiles, expectedFileName }) => {

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -74,62 +74,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-install-jdk:
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-temurin-25
-      - run:
-          name: Install JDK 25
-          command: |-
-            JDK_HOME=/usr/lib/jvm/temurin-25
-            CACHE_DIR="${HOME}/.cache/temurin"
-            TARBALL="${CACHE_DIR}/temurin-25.tar.gz"
-
-            if java -version 2>&1 | head -1 | grep -q '"25\.'; then
-              # Still export JAVA_HOME, so both paths leave the environment in the same state.
-              RESOLVED_HOME="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")"
-              echo "JDK 25 already installed at ${RESOLVED_HOME}"
-              echo "export JAVA_HOME=${RESOLVED_HOME}" >> "$BASH_ENV"
-              exit 0
-            fi
-
-            # x64 is hardcoded because MachineResourceClass models no Arm variant, so a
-            # machine job cannot run on Arm without widening that type first.
-            # Resolve the latest GA of the feature release rather than pinning a build number:
-            # patch drift inside a major is harmless here, a stale pin is not. The cache key
-            # holds a major, so a pipeline that restores the cache stays on one patch anyway.
-            mkdir -p "${CACHE_DIR}"
-
-            if [ -f "${TARBALL}" ]; then
-              echo "Reusing the cached Temurin 25 archive"
-            else
-              META="$(curl --retry 3 --retry-all-errors --retry-delay 5 -fsSL \
-                "https://api.adoptium.net/v3/assets/latest/25/hotspot?os=linux&architecture=x64&image_type=jdk")"
-              JDK_URL="$(echo "${META}" | jq -r '.[0].binary.package.link')"
-              JDK_SHA="$(echo "${META}" | jq -r '.[0].binary.package.checksum')"
-
-              echo "Downloading $(echo "${META}" | jq -r '.[0].version.semver')"
-              curl --retry 3 --retry-all-errors --retry-delay 5 -fsSL "${JDK_URL}" -o "${TARBALL}"
-              # HTTPS gives transport security, not artifact provenance: verify before extracting as root.
-              echo "${JDK_SHA}  ${TARBALL}" | sha256sum -c -
-            fi
-
-            echo "Replacing $(java -version 2>&1 | head -1)"
-            sudo mkdir -p "${JDK_HOME}"
-            sudo tar -xzf "${TARBALL}" -C "${JDK_HOME}" --strip-components=1 --no-same-owner
-
-            echo "export JAVA_HOME=${JDK_HOME}" >> "$BASH_ENV"
-            echo "export PATH=${JDK_HOME}/bin:\$PATH" >> "$BASH_ENV"
-            source "$BASH_ENV"
-
-            java -version
-      - save_cache:
-          key: gravitee-api-management-v15-temurin-25
-          paths:
-            - ~/.cache/temurin
-          when: on_success
-    description: Install the JDK on machine executors, which ship an older one
 jobs:
   job-danger-js:
     docker:
@@ -338,39 +282,6 @@ jobs:
             - /opt/sonar-scanner/.sonar/cache
           key: gravitee-api-management-v15-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
-  job-test-plugin:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: medium
-    steps:
-      - checkout
-      - cmd-install-jdk
-      - attach_workspace:
-          at: .
-      - cmd-restore-maven-job-cache:
-          jobName: job-test-plugin
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
-      - run:
-          name: Run plugin tests
-          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
-      - run:
-          name: Save test results
-          command: |-
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-      - cmd-notify-on-failure
-      - cmd-save-maven-job-cache:
-          jobName: job-test-plugin
-      - store_test_results:
-          path: ~/test-results
-      - persist_to_workspace:
-          root: .
-          paths:
-            - gravitee-apim-plugin/gravitee-apim-plugin-coverage/target/site/jacoco-aggregate/
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -422,27 +333,12 @@ workflows:
             - Test gateway
           working_directory: gravitee-apim-gateway
           cache_type: backend
-      - job-test-plugin:
-          name: Test plugins
-          context:
-            - cicd-orchestrator
-          requires:
-            - Build backend
-      - job-sonarcloud-analysis:
-          name: Sonar - gravitee-apim-plugin
-          context:
-            - cicd-orchestrator
-          requires:
-            - Test plugins
-          working_directory: gravitee-apim-plugin
-          cache_type: backend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
             - Build backend
             - Check graphene versions
             - Test gateway
-            - Test plugins
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -269,22 +269,24 @@ jobs:
           name: Check graphene versions across bundled Gamma modules
           command: npx ts-node src/graphene-versions/check.ts
           working_directory: .circleci/ci
-  job-test-gateway:
-    docker:
-      - image: cimg/openjdk:25.0.3
-    resource_class: large
+  job-test-reporter:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: medium
     steps:
       - checkout
+      - cmd-install-jdk
       - attach_workspace:
           at: .
       - cmd-restore-maven-job-cache:
-          jobName: job-test-gateway
+          jobName: job-test-reporter
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
-          name: Run gateway tests
-          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
+          name: Run reporter tests
+          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
       - run:
           name: Save test results
           command: |-
@@ -293,13 +295,13 @@ jobs:
           when: always
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
-          jobName: job-test-gateway
+          jobName: job-test-reporter
       - store_test_results:
           path: ~/test-results
       - persist_to_workspace:
           root: .
           paths:
-            - gravitee-apim-gateway/gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/
+            - gravitee-apim-reporter/gravitee-apim-reporter-coverage/target/site/jacoco-aggregate/
   job-sonarcloud-analysis:
     parameters:
       working_directory:
@@ -338,24 +340,24 @@ jobs:
             - /opt/sonar-scanner/.sonar/cache
           key: gravitee-api-management-v15-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
-  job-test-plugin:
+  job-test-repository:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - cmd-install-jdk
       - attach_workspace:
           at: .
       - cmd-restore-maven-job-cache:
-          jobName: job-test-plugin
+          jobName: job-test-repository
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
-          name: Run plugin tests
-          command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
+          name: Run repository tests
+          command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
       - run:
           name: Save test results
           command: |-
@@ -364,13 +366,13 @@ jobs:
           when: always
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
-          jobName: job-test-plugin
+          jobName: job-test-repository
       - store_test_results:
           path: ~/test-results
       - persist_to_workspace:
           root: .
           paths:
-            - gravitee-apim-plugin/gravitee-apim-plugin-coverage/target/site/jacoco-aggregate/
+            - gravitee-apim-repository/gravitee-apim-repository-coverage/target/site/jacoco-aggregate/
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -408,41 +410,41 @@ workflows:
             - cicd-orchestrator
           requires:
             - Build backend
-      - job-test-gateway:
-          name: Test gateway
+      - job-test-reporter:
+          name: Test reporters
           context:
             - cicd-orchestrator
           requires:
             - Build backend
       - job-sonarcloud-analysis:
-          name: Sonar - gravitee-apim-gateway
+          name: Sonar - gravitee-apim-reporter
           context:
             - cicd-orchestrator
           requires:
-            - Test gateway
-          working_directory: gravitee-apim-gateway
+            - Test reporters
+          working_directory: gravitee-apim-reporter
           cache_type: backend
-      - job-test-plugin:
-          name: Test plugins
+      - job-test-repository:
+          name: Test repository
           context:
             - cicd-orchestrator
           requires:
             - Build backend
       - job-sonarcloud-analysis:
-          name: Sonar - gravitee-apim-plugin
+          name: Sonar - gravitee-apim-repository
           context:
             - cicd-orchestrator
           requires:
-            - Test plugins
-          working_directory: gravitee-apim-plugin
+            - Test repository
+          working_directory: gravitee-apim-repository
           cache_type: backend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
             - Build backend
             - Check graphene versions
-            - Test gateway
-            - Test plugins
+            - Test reporters
+            - Test repository
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/groups/changed-files.ts
+++ b/.circleci/ci/src/workflows/groups/changed-files.ts
@@ -144,17 +144,42 @@ export function shouldTestReporter(changedFiles: string[]): boolean {
 
 export function shouldTestRepository(changedFiles: string[]): boolean {
   const mavenProjectsIdentifiers = ['gravitee-apim-definition', 'gravitee-apim-repository'];
+  // gravitee-apim-repository-elasticsearch takes these two at test scope: it seeds its fixtures
+  // through the reporter's index templates. A reporter-only change can therefore turn this suite
+  // red while waking only `Test reporters` — which is how the v4-metrics templates were changed
+  // without anything verifying the queries that read them.
+  const testScopeDependencies = ['gravitee-apim-reporter-common', 'gravitee-apim-reporter-elasticsearch'];
   return (
     shouldTestAllBackend(changedFiles) ||
-    changedFiles.some((file) => mavenProjectsIdentifiers.some((identifier) => file.includes(identifier)))
+    changedFiles.some((file) => [...mavenProjectsIdentifiers, ...testScopeDependencies].some((identifier) => file.includes(identifier)))
   );
+}
+
+/**
+ * The gateway subtree the plugin test suite cannot be affected by.
+ *
+ * The plugin modules take gravitee-apim-gateway-core and gravitee-apim-gateway-tests-sdk at test
+ * scope, and those two reach 24 of the 36 gateway modules transitively — so most of the tree can
+ * turn `Test plugins` red. gravitee-apim-gateway-services is the one subtree none of them reach:
+ * sync, healthcheck, heartbeat, debug and endpoint-discovery are loaded by the gateway at runtime,
+ * never by a plugin test. They are also 28% of the gateway commits on master over the last six
+ * months, which is what makes the exception worth stating rather than taking the whole tree.
+ *
+ * Excluding a subtree rather than listing the 24 modules errs the safe way: a gateway module added
+ * anywhere else wakes the suite without anyone remembering to add it here.
+ */
+const GATEWAY_SUBTREE_WITHOUT_PLUGIN_TESTS = 'gravitee-apim-gateway/gravitee-apim-gateway-services/';
+
+function affectsPluginTests(file: string): boolean {
+  return file.includes('gravitee-apim-gateway') && !file.startsWith(GATEWAY_SUBTREE_WITHOUT_PLUGIN_TESTS);
 }
 
 export function shouldTestPlugin(changedFiles: string[]): boolean {
   const mavenProjectsIdentifiers = ['gravitee-apim-definition', 'gravitee-apim-plugin'];
   return (
     shouldTestAllBackend(changedFiles) ||
-    changedFiles.some((file) => mavenProjectsIdentifiers.some((identifier) => file.includes(identifier)))
+    changedFiles.some((file) => mavenProjectsIdentifiers.some((identifier) => file.includes(identifier))) ||
+    changedFiles.some(affectsPluginTests)
   );
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-387

## Description

Two test suites could be turned red by a change that never woke them, because the dependency runs
the other way from the predicate that selects the suite.

**`Test repository` on a reporter change.** `gravitee-apim-repository-elasticsearch` takes
`gravitee-apim-reporter-common` and `gravitee-apim-reporter-elasticsearch` at test scope — its pom
says why: *"Needed to define the mapping when seeding the tests data"*. It builds its Elasticsearch
fixtures through the reporter's index templates. `shouldTestRepository` never mentioned the reporter,
so a reporter-only change ran `Test reporters` alone. #19713 changed the four `v4-metrics` index
templates and ran exactly one test job; nothing exercised the queries that read them.

**`Test plugins` on a gateway change.** `gravitee-apim-plugin` takes `gravitee-apim-gateway-core` and
`gravitee-apim-gateway-tests-sdk` at test scope. Neither `shouldTestPlugin` nor `shouldTestAllBackend`
lists the gateway, so a gateway-only change never ran `Test plugins`.

**These are the only two.** A scan of every test-scope dependency crossing a module tree found the
rest already covered: gateway → definition, plugin → definition, rest-api → definition and
distribution → repository-api all fall under `shouldTestAllBackend`, which lists definition and
repository. distribution → gateway and distribution → plugin are excluded on purpose and documented
in `shouldTestIntegrationTests`, with the scheduled nightly as the backstop.

## Additional context

**Each side is scoped from its own dependency graph, not by symmetry.**

On the reporter side the two consumed modules are named, so a change elsewhere in the reporter tree
still costs nothing.

On the gateway side, `gateway-core` and `gateway-tests-sdk` reach **24 of the 36** gateway modules
transitively — handlers-api, reactor, platform, standalone-container among them — so naming a couple
of them would be false precision: a change in `gateway-reactor` would still slip through. The tree
therefore wakes the suite, with one exception.

**`gravitee-apim-gateway-services` is genuinely out of reach**, and excluding it is not cosmetic.
Sync, healthcheck, heartbeat, debug and endpoint-discovery are loaded by the gateway at runtime and
by no plugin test. Measured on `master` over the last six months: **243 commits touch the gateway
tree, and 69 of them — 28% — touch nothing outside `gateway-services`.** Without the exception, more
than a quarter of gateway pull requests would run `Test plugins` for nothing.

It is the only subtree that can be excluded. `gravitee-apim-gateway-standalone` holds
`standalone-container`, which *is* in the closure, next to `standalone-bootstrap`, which is not;
every child of `gravitee-apim-gateway-handlers` is in the closure.

Excluding one subtree rather than listing the 24 modules also errs the safe way: a gateway module
added anywhere else wakes the suite without anyone remembering to add it here.

**Out of scope: running only the Elasticsearch repository tests.** The instinct is right — the
reporter affects one repository submodule out of many — but `TestRepositoryJob` runs
`mvn verify -Drepository-modules` over the whole reactor and persists the aggregated JaCoCo report
that the `gravitee-apim-repository` Sonar project reads. A module-limited run would not build the
aggregation module, so either the job fails on the missing path or Sonar loses coverage for the whole
reactor. A separate suite with no `sonar` entry is what `analysed-projects.ts` warns about in its own
header comment — it is how the integration tests fell out of the nightly unnoticed. The cost of the
blunt version is bounded: roughly 8 minutes, on a pull request touching those two reporter modules.

**The missing fixtures are why both gaps survived.** Every scenario in
`pipeline-pull-requests.spec.ts` covered a path that already produced the jobs it expected, so
neither hole could fail a test. Three golden fixtures now pin the behaviour.

### Verification

`npm test` in `.circleci/ci`: **170 passing**, up from 168.

| changed files | `Test repository` | `Test plugins` |
| --- | --- | --- |
| `gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch` | ✅ new | — |
| `gravitee-apim-reporter` alone (the parent directory) | unchanged, still no | — |
| `gravitee-apim-gateway` | — | ✅ new |
| `gravitee-apim-gateway/gravitee-apim-gateway-services/` | — | excluded, `Test gateway` only |

- `npm run lint`: clean (eslint, prettier, license headers).
- `circleci config validate`: valid on all three fixtures.
