### PR TITLE
ci(renovate): propose Gravitee Maven bumps again, on their own release channel

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,6 +76,16 @@
             // Separate release cycle from graphene; adoption is a deliberate decision
             "matchPackageNames": ["@gravitee/gamma-lib-observability"],
             "groupName": "gamma-lib-observability"
+        },
+        {
+            // Gravitee Maven artifacts are released by us and bumped here on purpose, so they
+            // must not queue behind the shared PR budget. Renovate resolves prConcurrentLimit
+            // and prHourlyLimit per branch from the matching packageRules, and 0 means "no
+            // limit" — branchConcurrentLimit inherits prConcurrentLimit, so it needs no entry.
+            "matchDatasources": ["maven"],
+            "matchPackageNames": ["com.graviteesource{/,}**", "io.gravitee{/,}**"],
+            "prConcurrentLimit": 0,
+            "prHourlyLimit": 0
         }
     ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,6 +86,23 @@
             "matchPackageNames": ["com.graviteesource{/,}**", "io.gravitee{/,}**"],
             "prConcurrentLimit": 0,
             "prHourlyLimit": 0
+        },
+        {
+            // A prerelease stays on its own channel. Moving from alpha to beta, or out of a
+            // prerelease altogether, is a decision about the release line rather than a dependency
+            // update — it is taken once, by hand, when the line itself moves. matchCurrentVersion
+            // reads what the pom already holds, so this needs no per-module list and nothing to
+            // maintain when a module appears.
+            "matchDatasources": ["maven"],
+            "matchPackageNames": ["com.graviteesource{/,}**", "io.gravitee{/,}**"],
+            "matchCurrentVersion": "/-alpha\\./",
+            "allowedVersions": "/-alpha\\./"
+        },
+        {
+            "matchDatasources": ["maven"],
+            "matchPackageNames": ["com.graviteesource{/,}**", "io.gravitee{/,}**"],
+            "matchCurrentVersion": "/-beta\\./",
+            "allowedVersions": "/-beta\\./"
         }
     ]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-388

## Description

Renovate has not proposed a bump for a Gravitee Maven artifact on this repo since **March 2025**. The
debug log of the 8 September run says why, and the scale is larger than the symptom suggests:

> **Renovate wanted 258 branches. It created 4 and skipped 252.**

```
Open PR Count: 1, Existing Branch Count: 5, Hourly PR Count: 1
Branches limit reached          limitKey=branchConcurrentLimit  currentCount=5
Reached branch limit - skipping branch creation
```

`gravitee-io/renovate-config`'s `default.json` sets `prConcurrentLimit: 5`, and
`branchConcurrentLimit` inherits it when left unset — the log shows exactly that:
`branchConcurrentLimit: null` resolved to `5`. The five slots went to the first branches processed,
and everything after them was dropped.

Among the 252 skipped: `gravitee-gamma-module-aim`, `-authz`, `-edge`, `-esm`, `gravitee-node`,
`apim.server`, and every `gravitee-policy-*`. Which four survive is a matter of processing order, not
of importance — this run happened to spend its budget on `@dagrejs/dagre`, `angular-gridster2`,
`angular-oauth2-oidc` and `gravitee-gamma-modules-sdk`.

Two commits: the first exempts Gravitee Maven artifacts from that budget, the second decides what
those newly-unblocked updates are allowed to propose.

**Keeping a prerelease on its own channel.** The listing above shows `gravitee-gamma-module-aim` being
offered `4.3.0-alpha.26 -> 4.3.0-beta.6`. Crossing a prerelease channel is a decision about the release
line, not a dependency update — so the second commit restricts an alpha to alphas and a beta to betas:

```json5
{
    "matchCurrentVersion": "/-alpha\\./",
    "allowedVersions": "/-alpha\\./"
}
```

`matchCurrentVersion` reads the version the pom already holds, which is what makes this a policy rather
than a per-module list: nothing to add when a module appears, nothing to drift.

It blocks leaving a prerelease for the matching release too, and deliberately: that is the same one-off
decision seen from its other end, and it belongs to whoever moves the line rather than to a dependency
bot.

| current | offered | after this change |
| --- | --- | --- |
| `4.3.0-alpha.26` | `4.3.0-alpha.28` | proposed |
| `4.3.0-alpha.26` | `4.3.0-beta.6` | blocked |
| `2.0.0-alpha.12` | `2.0.0-alpha.13` | proposed |
| `1.16.0` | `1.22.0`, `2.1.0` | unaffected, the rules do not match |

## Additional context

**Why `0`, and why two limits.** Both `prConcurrentLimit` and `prHourlyLimit` are resolved *per branch*
from the matching `packageRules` — `calcLimit` over `config.upgrades` in
`lib/workers/global/limits.ts` — and `0` short-circuits to "no limit" rather than "zero allowed". So the
exemption is scoped to the matched packages instead of lifting the cap for everyone. `prHourlyLimit`
defaults to `2` and goes through the same path, which is why it is set too.

`branchConcurrentLimit` needs no entry of its own precisely because it inherits `prConcurrentLimit`,
and the log confirms that inheritance is what is biting today — so setting `prConcurrentLimit: 0` on
the matched packages lifts the branch limit for them as well.

The counters stay global, so this is genuinely one-way: the exempted branches ignore the limit, while
the frontend queue still counts every open Renovate PR, its own cap unchanged at 5.

**This is throughput, not capability, and it is observable rather than inferred.** Renovate's own page
for this repository already lists the updates it has resolved and is not creating:

```
io.gravitee.apim.repository:gravitee-apim-repository-jdbc  4.12.14        -> [4.12.19]
com.graviteesource.gamma.module:gravitee-gamma-module-aim  4.3.0-alpha.26 -> [4.3.0-beta.6]
com.graviteesource.gamma.module:gravitee-gamma-module-authz 1.16.0        -> [1.22.0, 2.1.0]
com.graviteesource.gamma.module:gravitee-gamma-module-edge 2.0.0-alpha.12 -> [2.0.0-alpha.13]
com.graviteesource.gamma.module:gravitee-gamma-module-esm  1.5.0-alpha.6  -> [1.5.0-alpha.14]
```

Those are `com.graviteesource` artifacts, from the private Artifactory, with versions resolved *today*.
The plumbing works; the pull requests are the only thing missing. Note `authz`, where Renovate offers
the minor and the major as two separate updates rather than one jump — that separation is per
dependency and automatic.

The mechanism has also produced merged pull requests before, on this exact pom shape: #7390 bumped
`gravitee-policy-ratelimit.version`, declared in `gravitee-apim-distribution/pom.xml` and consumed by a
`<type>zip</type>` bundled-plugin dependency in the standalone pom — property in the parent, dependency
in a child, packaged as a zip, which is how every bundled plugin is declared.

**What has no automated path today.** The only automated bump is `bump-from-module.yml`, dispatched from
the CircleCI orb, and it covers **4 repos**: `gamma-module-aim`, `-esm`, `-authz`, `-edge`. Of the 299
`<X.version>` properties in the poms, 190 resolve a Gravitee artifact. The other 186 are bumped by hand
or not at all.

**Deliberately not in this pull request.** Whether Renovate should *replace* `bump-from-module.yml`, and
whether it should follow the supported branches, are separate decisions — better taken on what this
change actually produces than argued in advance. The workflow does not touch maintenance branches
either, so nothing regresses by leaving that for later.

### Verification

- `renovate-config-validator .github/renovate.json5` — passes on Renovate 44.66.1.
- After merge, watch the next Renovate run for a Gravitee Maven pull request created **while the five
  frontend ones are still open**. That is the whole point, and it is observable without waiting for a
  module release: `gamma-module-aim` is two versions behind.
- The frontend queue should keep its limit of 5.
- No pull request should propose a move from an alpha to a beta, or out of a prerelease.
