### PR TITLE
fix(e2e): restore the e2e build against the ESM-only faker v10

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-e2e/jest.config.ci.js
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-e2e/jest.config.ci.js
@@ -24,7 +24,18 @@ module.exports = {
   // A map from regular expressions to paths to transformers
   transform: {
     '^.+\\.xml$': '<rootDir>/lib/jest-raw-loader.js',
+    // @faker-js/faker dropped its CommonJS build in v10. These suites run as CommonJS, and
+    // Jest's module registry cannot `require` an ES module, so the package is transpiled on
+    // the way in. The pattern stays on the package itself: transpiling all of node_modules
+    // would cost far more than it buys.
+    '/node_modules/@faker-js/faker/.+\\.js$': [
+      'ts-jest',
+      { tsconfig: { allowJs: true, module: 'CommonJS', moduleResolution: 'Node10', target: 'ES2020' } },
+    ],
   },
+
+  // The default would skip node_modules entirely, faker included.
+  transformIgnorePatterns: ['/node_modules/(?!(@faker-js)/)', '\\.pnp\\.[^\\/]+$'],
 
   setupFilesAfterEnv: ['<rootDir>/dist/api-test/jest.setup.js'],
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-e2e/jest.config.js
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-e2e/jest.config.js
@@ -173,13 +173,21 @@ module.exports = {
   // A map from regular expressions to paths to transformers
   transform: {
     '^.+\\.xml$': '<rootDir>/lib/jest-raw-loader.js',
+    // @faker-js/faker dropped its CommonJS build in v10. These suites run as CommonJS, and
+    // Jest's module registry cannot `require` an ES module, so the package is transpiled on
+    // the way in. The pattern stays on the package itself: transpiling all of node_modules
+    // would cost far more than it buys.
+    '/node_modules/@faker-js/faker/.+\\.js$': [
+      'ts-jest',
+      { tsconfig: { allowJs: true, module: 'CommonJS', moduleResolution: 'Node10', target: 'ES2020' } },
+    ],
   },
 
   testTimeout: 30000,
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: ["/node_modules/", "\\.pnp\\.[^\\\/]+$"],
-  transformIgnorePatterns: ['/node_modules/(?!(@gravitee)/)', '\\.pnp\\.[^\\/]+$'],
+  transformIgnorePatterns: ['/node_modules/(?!(@gravitee|@faker-js)/)', '\\.pnp\\.[^\\/]+$'],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/gravitee-apim-distribution/gravitee-apim-distribution-e2e/tsconfig.json
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-e2e/tsconfig.json
@@ -7,8 +7,8 @@
     "baseUrl": ".",
     "allowJs": true,
     "resolveJsonModule": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "paths": {


### PR DESCRIPTION
## Issue

No JIRA ticket. This repairs the e2e build broken on `master` by #19571.

## Description

`@faker-js/faker` dropped its CommonJS build in v10: `exports["."]` no longer carries a `require` condition, only the ESM entry. The e2e module compiles as CommonJS (no `"type": "module"`), so every file importing faker — 73 of them — fails the `Lint & Build APIM e2e` job with `TS1479`.

Two layers had to move, one commit each:

- **`tsconfig.json`**: `module` and `moduleResolution` go from `Node16` to `NodeNext`. TypeScript 5.8 — the version this project already pins — allows a CommonJS emit to `require()` an ES module under `nodenext`, matching what Node itself has done since 22.12. The 73 errors go away with no other change to the build output.
- **jest configs**: compiling is not enough. Jest's module registry does not implement `require(esm)`, so the suites would compile and then die at load time on `SyntaxError: Cannot use import statement outside a module`. `jest.config.js` (sources, via ts-jest) and `jest.config.ci.js` (which runs the compiled `dist/`) now transpile the package on the way in. The transform pattern is scoped to `node_modules/@faker-js/faker/` — transpiling all of `node_modules` would cost far more than it buys.

## Additional context

**Why the bump landed green.** The e2e jobs only run on branches matching `/.*-run-e2e.*/` ([`branch.ts`](.circleci/ci/src/utils/branch.ts#L25-L28)), and `renovate/npm-faker-js-faker-vulnerability` is not one. `Lint & Build APIM e2e` never ran on that PR.

**Why not go back to 9.x.** 9.9.0 is the last dual CJS/ESM release, but GHSA-qxc2-j82w-r537 — the advisory behind the bump — covers everything `<= 10.4.0`, with no 9.x patch. Reverting would reopen it and Renovate would reopen the PR. (For the record, `helpers.fake`, the vulnerable entry point, is not used anywhere in this repo.)

**Why not `moduleResolution: node10`.** It also silences `TS1479`, by ignoring the `exports` field altogether — and it breaks Cypress's own types along the way: 293 extra errors, `Type 'Chainable' is not generic` and friends. `NodeNext` keeps modern resolution intact.

**How this was verified**, locally, with the SDKs ungenerated (`yarn build` therefore still reports the usual `TS2307`/`TS2339` noise from the missing `@gravitee/*` packages — unchanged before and after):

- `yarn build`: 73 × `TS1479` before, 0 after, no other difference in the error set.
- A synthetic spec importing faker, run through the real `jest.config.js` and through `jest.config.ci.js` against a compiled `dist/`: fails with `SyntaxError` on the current configs, passes on these. Added run time is under a second.
- `yarn prettier` and `yarn lint:license` pass.

The full matrix runs here — the branch name carries `-run-e2e` on purpose.
