### PR TITLE
feat(rest-api): carry the operator's password policy description, and warn when there is none

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/config/gravitee.yml
@@ -677,8 +677,15 @@ user:
   # Passwords should require a minimum level of complexity that makes sense for the application and its user population.
   password:
     policy:
-      # description field is used to display a message to the user enter a password that does not match the policy. Leave it blank to disable the message.
-      description: Password must be at least 12 characters long, contain at least one digit, one upper case letter, one lower case letter, one special character, and no more than 2 consecutive equal characters.
+      # description is your own explanation of the policy. GET /configuration/password-policy carries
+      # it exactly as written here, and carries it empty when you leave it blank -- Gravitee never
+      # writes one for you, so a client can treat any text here as yours and show it. The response
+      # also carries the rules this service can derive from the pattern below, which will not cover
+      # a requirement the pattern states in a way the parser cannot read: write a description
+      # whenever you change the pattern. Changing the pattern without writing one logs a warning at
+      # startup. Left blank by default because the rules already say what the example below says.
+      # Example : Password must be at least 12 characters long, contain at least one digit, one upper case letter, one lower case letter, one special character, and no more than 2 consecutive equal characters.
+      description:
       pattern: ^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\-#\"'&§`£€%°()|\[\]$^@])(?!.*(.)\1{2,}).{12,128}$
               # Example : ^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\-#\"'&§`£€%°()|\[\]$^@])(?!.*(.)\1{2,}).{12,128}$
               # ^                                            # start-of-string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PasswordPolicyEntity.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PasswordPolicyEntity {
 
+    @Schema(
+        description = "The operator's own explanation of the policy, carried exactly as configured. " +
+            "Empty when none was configured: this service never writes one on their behalf."
+    )
     private String description;
+
     private String pattern;
     private List<PasswordPolicyRuleEntity> rules;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParser.java
@@ -17,8 +17,10 @@ package io.gravitee.rest.api.service.impl;
 
 import io.gravitee.rest.api.model.PasswordPolicyRuleEntity;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,8 +68,10 @@ public class PasswordPolicyPatternParser {
             }
         }
 
-        for (String charClass : extractPositiveLookaheadCharClasses(policyPattern)) {
-            classifyLookahead(charClass).ifPresent(rule -> addRule(rules, seenRuleIds, rule));
+        for (PasswordPolicyRuleEntity lookaheadRule : lookaheadContributions(policyPattern).values()) {
+            if (lookaheadRule != null) {
+                addRule(rules, seenRuleIds, lookaheadRule);
+            }
         }
 
         if (policyPattern.contains("(?!.*(.)\\1{2,})")) {
@@ -83,6 +87,51 @@ public class PasswordPolicyPatternParser {
         }
 
         return List.copyOf(rules);
+    }
+
+    /**
+     * The lookaheads this parser examined without producing a rule for them.
+     *
+     * <p>A requirement it cannot express is one a user only discovers by having their password
+     * rejected, so the fragments are named rather than dropped in silence. A lookahead is reported
+     * whether it could not be classified at all or was classified onto a rule another lookahead had
+     * already claimed — {@code (?=.*[!@#])(?=.*[\-_])} yields one "special" rule, and the second
+     * requirement is as invisible as one the parser never recognised.
+     */
+    public List<String> untranslatedFragments(String policyPattern) {
+        if (policyPattern == null || policyPattern.isBlank()) {
+            return List.of();
+        }
+
+        List<String> untranslated = new ArrayList<>();
+        lookaheadContributions(policyPattern).forEach((charClass, rule) -> {
+            if (rule == null) {
+                untranslated.add(POSITIVE_LOOKAHEAD_PREFIX + charClass + "])");
+            }
+        });
+        return List.copyOf(untranslated);
+    }
+
+    /**
+     * Each distinct lookahead character class in the pattern, mapped to the rule it contributes to
+     * {@link #parse}, or {@code null} when it contributes none.
+     *
+     * <p>One walk answers both "which rules does this pattern produce?" and "which of its lookaheads
+     * produced nothing?", so the two cannot disagree about what was dropped.
+     */
+    private static Map<String, PasswordPolicyRuleEntity> lookaheadContributions(String policyPattern) {
+        Map<String, PasswordPolicyRuleEntity> contributions = new LinkedHashMap<>();
+        Set<String> claimedRuleIds = new LinkedHashSet<>();
+
+        for (String charClass : extractPositiveLookaheadCharClasses(policyPattern)) {
+            if (contributions.containsKey(charClass)) {
+                continue;
+            }
+            PasswordPolicyRuleEntity rule = classifyLookahead(charClass).orElse(null);
+            contributions.put(charClass, rule != null && claimedRuleIds.add(rule.getId()) ? rule : null);
+        }
+
+        return contributions;
     }
 
     private static List<String> extractPositiveLookaheadCharClasses(String policyPattern) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImpl.java
@@ -18,12 +18,15 @@ package io.gravitee.rest.api.service.impl;
 import io.gravitee.rest.api.model.PasswordPolicyEntity;
 import io.gravitee.rest.api.model.PasswordPolicyRuleEntity;
 import io.gravitee.rest.api.service.PasswordPolicyService;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@CustomLog
 @Component
 public class PasswordPolicyServiceImpl implements PasswordPolicyService {
 
@@ -32,16 +35,80 @@ public class PasswordPolicyServiceImpl implements PasswordPolicyService {
     @Value("${user.password.policy.description:}")
     private String passwordPolicyDescription;
 
-    @Value(
-        "${user.password.policy.pattern:^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$}"
-    )
+    /**
+     * The pattern shipped in gravitee.yml since Nov 2023, named here because the startup check has to
+     * compare the configured pattern against it to tell a policy an operator chose from one they
+     * inherited. {@code RegexPasswordValidator} still holds its own copy of the same literal.
+     */
+    static final String DEFAULT_PATTERN =
+        "^(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[!~<>.,;:_=?/*+\\-#\\\"'&§`£€%°()|\\[\\]$^@])(?!.*(.)\\1{2,}).{12,128}$";
+
+    @Value("${user.password.policy.pattern:" + DEFAULT_PATTERN + "}")
     private String passwordPolicyPattern;
 
+    /**
+     * The configured policy, reported rather than embellished.
+     *
+     * <p>{@code description} carries the operator's own sentence and nothing else. It used to fall
+     * back to a join of the rule labels, which left a client unable to tell a sentence someone wrote
+     * from one this service invented, and so unable to decide whether it was worth showing. An empty
+     * description now means exactly one thing: nobody wrote one.
+     */
     @Override
     public PasswordPolicyEntity getPasswordPolicy() {
-        String pattern = passwordPolicyPattern == null ? null : passwordPolicyPattern.trim();
-        List<PasswordPolicyRuleEntity> rules = resolveRules(pattern);
-        return PasswordPolicyEntity.builder().description(resolveDescription(rules)).pattern(pattern).rules(rules).build();
+        String pattern = trimmedPattern();
+        return PasswordPolicyEntity.builder()
+            .description(StringUtils.hasText(passwordPolicyDescription) ? passwordPolicyDescription.trim() : "")
+            .pattern(pattern)
+            .rules(resolveRules(pattern))
+            .build();
+    }
+
+    /**
+     * Ways this configuration will leave users guessing, reported once at startup.
+     *
+     * <p>Package-private and pure so the conditions can be exercised without a log appender.
+     */
+    @PostConstruct
+    void reportConfiguration() {
+        configurationWarnings().forEach(log::warn);
+    }
+
+    List<String> configurationWarnings() {
+        List<String> warnings = new ArrayList<>();
+        String pattern = trimmedPattern();
+
+        if (!StringUtils.hasText(pattern)) {
+            warnings.add(
+                "user.password.policy.pattern is set but blank. The password policy carries no rule at all, and the " +
+                    "validator built from the same property accepts no password. Set a pattern, or remove the key to " +
+                    "fall back to the shipped default."
+            );
+        } else if (!DEFAULT_PATTERN.equals(pattern) && !StringUtils.hasText(passwordPolicyDescription)) {
+            warnings.add(
+                "user.password.policy.pattern is customized but user.password.policy.description is blank. The password " +
+                    "policy then carries only the rules this service can derive from the pattern, so a requirement it " +
+                    "cannot express reaches no client before a password is rejected. Write a description to explain the " +
+                    "policy in your own words."
+            );
+        }
+
+        List<String> untranslated = patternParser.untranslatedFragments(pattern);
+        if (!untranslated.isEmpty()) {
+            warnings.add(
+                "user.password.policy.pattern contains requirements that could not be turned into a readable rule: " +
+                    String.join(", ", untranslated) +
+                    ". The password policy carries no rule for them. This check only inspects '(?=.*[...])' groups, so " +
+                    "it finds gaps rather than proving there are none: a requirement written another way can be just as " +
+                    "invisible without appearing here."
+            );
+        }
+
+        return warnings;
+    }
+
+    private String trimmedPattern() {
+        return passwordPolicyPattern == null ? null : passwordPolicyPattern.trim();
     }
 
     private List<PasswordPolicyRuleEntity> resolveRules(String policyPattern) {
@@ -58,18 +125,5 @@ public class PasswordPolicyServiceImpl implements PasswordPolicyService {
             .label("Matches the configured password policy")
             .pattern(policyPattern)
             .build();
-    }
-
-    private String resolveDescription(List<PasswordPolicyRuleEntity> rules) {
-        if (StringUtils.hasText(passwordPolicyDescription)) {
-            return passwordPolicyDescription.trim();
-        }
-        if (rules.isEmpty()) {
-            return "";
-        }
-        return rules
-            .stream()
-            .map(PasswordPolicyRuleEntity::getLabel)
-            .collect(Collectors.joining(", ", "Password must meet the following requirements: ", "."));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyPatternParserTest.java
@@ -162,6 +162,45 @@ class PasswordPolicyPatternParserTest {
         assertThat(parser.parse("(?=.*[unclosed")).isEmpty();
     }
 
+    @Test
+    void should_report_no_untranslated_fragments_for_the_default_pattern() {
+        assertThat(parser.untranslatedFragments(DEFAULT_PATTERN)).isEmpty();
+    }
+
+    @Test
+    void should_report_a_lookahead_it_cannot_turn_into_a_rule() {
+        // Letters outside a-z / A-Z classify as neither case nor special, so no rule describes them.
+        assertThat(parser.untranslatedFragments("^(?=.*[0-9])(?=.*[\u00e0\u00e9\u00ee]).{8,}$")).containsExactly(
+            "(?=.*[\u00e0\u00e9\u00ee])"
+        );
+    }
+
+    @Test
+    void should_report_nothing_when_there_is_no_pattern() {
+        assertThat(parser.untranslatedFragments(null)).isEmpty();
+        assertThat(parser.untranslatedFragments("   ")).isEmpty();
+    }
+
+    @Test
+    void should_report_a_lookahead_whose_rule_an_earlier_one_already_claimed() {
+        // Both classes are "special", so parse keeps the first and drops the second: the requirement
+        // to include a hyphen or underscore reaches no rule, and a password without one is refused
+        // after every rule the client did receive was satisfied.
+        assertThat(parser.parse("^(?=.*[!@#])(?=.*[\\-_]).{12,}$")).extracting("id").containsExactly("minLength", "special");
+
+        assertThat(parser.untranslatedFragments("^(?=.*[!@#])(?=.*[\\-_]).{12,}$")).containsExactly("(?=.*[\\-_])");
+    }
+
+    @Test
+    void should_not_report_a_lookahead_that_merely_repeats_one_it_already_translated() {
+        assertThat(parser.untranslatedFragments("^(?=.*[A-Z])(?=.*[A-Z]).{12,}$")).isEmpty();
+    }
+
+    @Test
+    void should_report_a_repeated_untranslatable_lookahead_once() {
+        assertThat(parser.untranslatedFragments("^(?=.*[àéî])(?=.*[àéî]).{8,}$")).containsExactly("(?=.*[àéî])");
+    }
+
     private static String buildPasswordWithoutTripleConsecutive(String prefix, int targetLength) {
         StringBuilder password = new StringBuilder(prefix);
         char[] alternates = { 'y', 'z' };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PasswordPolicyServiceImplTest.java
@@ -43,9 +43,7 @@ class PasswordPolicyServiceImplTest {
 
         PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
 
-        assertThat(policy.getDescription()).contains("At least 10 characters");
-        assertThat(policy.getDescription()).contains("At most 64 characters");
-        assertThat(policy.getDescription()).doesNotContain("At least 12 characters");
+        assertThat(policy.getDescription()).isEmpty();
         assertThat(policy.getPattern()).contains(".{10,64}");
         assertThat(policy.getRules())
             .extracting("id")
@@ -63,7 +61,7 @@ class PasswordPolicyServiceImplTest {
         assertThat(policy.getRules()).hasSize(1);
         assertThat(policy.getRules().getFirst().getId()).isEqualTo("policyPattern");
         assertThat(policy.getRules().getFirst().getPattern()).isEqualTo("^\\d{8,}$");
-        assertThat(policy.getDescription()).contains("Matches the configured password policy");
+        assertThat(policy.getRules().getFirst().getLabel()).isEqualTo("Matches the configured password policy");
     }
 
     @Test
@@ -123,5 +121,75 @@ class PasswordPolicyServiceImplTest {
         PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
 
         assertThat(policy.getDescription()).isEqualTo("Custom password policy description.");
+    }
+
+    @Test
+    void should_carry_the_operator_description_verbatim() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "  Ask IT for the house rules.  ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", PasswordPolicyServiceImpl.DEFAULT_PATTERN);
+
+        assertThat(passwordPolicyService.getPasswordPolicy().getDescription()).isEqualTo("Ask IT for the house rules.");
+    }
+
+    @Test
+    void should_leave_the_description_empty_when_nobody_wrote_one() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", PasswordPolicyServiceImpl.DEFAULT_PATTERN);
+
+        PasswordPolicyEntity policy = passwordPolicyService.getPasswordPolicy();
+
+        // The rules are the guidance. Restating them here would leave a client unable to tell a
+        // sentence someone wrote from one this service invented.
+        assertThat(policy.getDescription()).isEmpty();
+        assertThat(policy.getRules()).isNotEmpty();
+    }
+
+    @Test
+    void should_warn_when_a_customized_pattern_leaves_users_without_authored_guidance() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^\\d{8,}$");
+
+        assertThat(passwordPolicyService.configurationWarnings()).anySatisfy(warning ->
+            assertThat(warning).contains("user.password.policy.description")
+        );
+    }
+
+    @Test
+    void should_warn_that_a_blank_pattern_carries_no_rule_rather_than_calling_it_customized() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "   ");
+
+        assertThat(passwordPolicyService.configurationWarnings())
+            .singleElement()
+            .satisfies(warning -> {
+                assertThat(warning).contains("user.password.policy.pattern is set but blank");
+                assertThat(warning).doesNotContain("customized");
+            });
+    }
+
+    @Test
+    void should_not_warn_about_a_blank_description_on_the_default_pattern() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "   ");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", PasswordPolicyServiceImpl.DEFAULT_PATTERN);
+
+        assertThat(passwordPolicyService.configurationWarnings()).isEmpty();
+    }
+
+    @Test
+    void should_not_warn_when_the_operator_wrote_a_description() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "Ask IT for the house rules.");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^\\d{8,}$");
+
+        assertThat(passwordPolicyService.configurationWarnings()).isEmpty();
+    }
+
+    @Test
+    void should_name_the_pattern_fragments_it_could_not_translate() {
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyDescription", "Ask IT for the house rules.");
+        ReflectionTestUtils.setField(passwordPolicyService, "passwordPolicyPattern", "^(?=.*[0-9])(?=.*[\u00e0\u00e9\u00ee]).{8,}$");
+
+        assertThat(passwordPolicyService.configurationWarnings()).anySatisfy(warning ->
+            assertThat(warning).contains("(?=.*[\u00e0\u00e9\u00ee])")
+        );
     }
 }


### PR DESCRIPTION
PR 2 of 7 for [FOUND-249](https://gravitee.atlassian.net/browse/FOUND-249) — Gamma sign-up parity.
Story: [FOUND-259](https://gravitee.atlassian.net/browse/FOUND-259)

Backend only. Shares no file with the Gamma branch, so it can merge whenever it is ready.

## What changed

**`description` carries the operator's value and nothing else, empty when it was not set.** It used
to fall back to a join of the derived rule labels, so a client could not tell a sentence someone
wrote from one this service invented, and therefore showed neither. An empty description now means
exactly one thing: nobody wrote one.

**The shipped `gravitee.yml` leaves `description` blank**, keeping its sentence as a commented
example. That sentence restated the seven rules the parser derives from the shipped pattern, so a
client honouring the invariant above would have printed it directly over a checklist saying the same
things — on the bundle and Docker images, but not under Helm, whose configmap emits the key only
when `api.user.password` is set. Upgrades keep their own file.

**Three startup warnings**, because a policy the parser cannot fully read is one users only discover
by having a password rejected: a pattern set but blank; a customized pattern with no authored
description; the lookaheads that produced no rule, quoted.

**The third now reports what `parse` actually dropped.** It used to ask "can this lookahead be
classified?" while `parse` asked "has this rule id already been claimed?", so a second lookahead
landing on a rule an earlier one had taken was dropped by `parse` and reported as translated.
`^(?=.*[!@#])(?=.*[\-_]).{12,}$` — a symbol *and* a hyphen or underscore — produced no rule and no
warning for the second requirement: `Abcdefgh!jkl` satisfied every rule the client received and was
refused anyway. One walk now answers both questions. The warning still states its own limit: it
inspects `(?=.*[...])` groups only, so it finds gaps rather than proving there are none.

**The `gravitee.yml` comment was wrong.** It said the description is shown when a password fails the
policy. It never was.

## Worth a reviewer's attention

This **changes what the endpoint returns** where the description was blank: previously the joined
labels, now `""`. No code in this repository renders or acts on the field — `PasswordPolicyResource`
returns the entity untouched, and the Gamma control plane reads it into state without displaying it.
Any consumer wanting that sentence can build it from the `rules` array in the same response. The
field now carries an `@Schema` description so the contract reaches the generated spec.

`DEFAULT_PATTERN` exists because the startup check has to compare against the default. It does not
unify the copies: `RegexPasswordValidator` still holds the same literal, and reaching into
`service.impl` for the constant would make a today-one-way package dependency bidirectional.

## Security-sensitive surface

Flagged per `AGENTS.md`: adds logging and touches password-policy configuration.

- No authentication or authorization decision changes, and no endpoint is added.
- The warnings quote fragments of `user.password.policy.pattern`. `GET /configuration/password-policy`
  is `permitAll` and already returns that pattern in full, so nothing reaches the log that was not
  already public without authentication. No password, secret or user data is logged.

## Out of scope

FOUND-259's fourth acceptance criterion — public documentation reflecting that `description` has a
visible effect — is not met here: those docs live outside this repository. No separate doc ticket is
being raised; FOUND-259 moves to **Ready for Docs** once this is merged and tested, and the
documentation change is picked up from there. Recorded on the story.

Noted for follow-up, untouched: `classifyLookahead` labels `(?=.*[\p{Lu}])` "Contains a special
character" and emits `[\p{Lu}]` as the client-side rule pattern, which `new RegExp` without the `u`
flag matches against the literal `p`.

## Verification

- `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service test -Dtest='PasswordPolicy*Test'` —
  **30 tests, 0 failures**, up from 17 on `master`
- RED confirmed before each new behaviour: `should_report_a_lookahead_whose_rule_an_earlier_one_already_claimed`,
  `should_report_a_repeated_untranslatable_lookahead_once`, and
  `should_warn_that_a_blank_pattern_carries_no_rule_rather_than_calling_it_customized` all failed first
- `prettier-java` applied to both touched modules

## Note for the frontend side

PR 3 consumes this at runtime but does not code-depend on it: its specs mock the response shape. Its
mock still carries the old shipped description and should be updated on that branch. Deploy together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FOUND-249]: https://gravitee.atlassian.net/browse/FOUND-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-259]: https://gravitee.atlassian.net/browse/FOUND-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
