### PR TITLE
feat(rest-api): let registration send its activation email to Gamma

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,6 +36,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
@@ -70,8 +72,19 @@ public class UsersRegistrationResource extends AbstractResource {
         content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = UserEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public Response registerUser(@Valid NewExternalUserEntity newExternalUserEntity) {
-        UserEntity newUser = userService.register(GraviteeContext.getExecutionContext(), newExternalUserEntity);
+    public Response registerUser(
+        @Parameter(
+            description = "Optional activation page target. When set to `gamma`, the activation email link targets the " +
+                "Gravitee Gamma console registration page. When omitted, the APIM Console page is used. Only this fixed " +
+                "keyword is accepted; a URL is rejected."
+        ) @QueryParam("registrationTarget") String registrationTarget,
+        @Valid NewExternalUserEntity newExternalUserEntity
+    ) {
+        UserEntity newUser = userService.registerWithTarget(
+            GraviteeContext.getExecutionContext(),
+            newExternalUserEntity,
+            registrationTarget
+        );
         if (newUser != null) {
             return Response.ok().entity(newUser).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
@@ -71,6 +71,7 @@ public class UsersRegistrationResource extends AbstractResource {
         description = "User successfully registered",
         content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = UserEntity.class))
     )
+    @ApiResponse(responseCode = "400", description = "Unsupported registration target, or no Gamma URL configured")
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response registerUser(
         @Parameter(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -70,6 +70,19 @@ public interface UserService {
 
     UserEntity register(ExecutionContext executionContext, NewExternalUserEntity newExternalUserEntity, String confirmationPageUrl);
 
+    /**
+     * Register a user, sending the activation link to a named product rather than a caller-supplied URL.
+     *
+     * @param registrationTarget {@code gamma}, or null/blank for the classic console. Anything else is
+     *     rejected: this endpoint is anonymous and the link carries a signed token, so a caller who could
+     *     name the destination could have it emailed to themselves.
+     */
+    UserEntity registerWithTarget(
+        ExecutionContext executionContext,
+        NewExternalUserEntity newExternalUserEntity,
+        String registrationTarget
+    );
+
     UserEntity finalizeRegistration(ExecutionContext executionContext, RegisterUserEntity registerUserEntity);
 
     UserEntity finalizeResetPassword(ExecutionContext executionContext, ResetPasswordUserEntity registerUserEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -323,8 +323,8 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
      * falls back to its default link instead of exfiltrating the token to an attacker-controlled domain.
      * Only {@link #register} and the caller-facing {@link #resetPassword(ExecutionContext, String, String)}
      * receive an externally-supplied redirect URL; other callers of {@code getTokenRegistrationParams} (gamma
-     * reset target, registration-approval flow) build their target page URL themselves from trusted installation
-     * configuration and must not be sanitized here.
+     * reset target, gamma registration target, registration-approval flow) build their target page URL themselves
+     * from trusted installation configuration and must not be sanitized here.
      */
     private String sanitizePortalRedirectUrl(ExecutionContext executionContext, String url) {
         if (url == null || url.isBlank()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -30,6 +30,7 @@ import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_CREATION
 import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.USER_REGISTRATION;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_EMAIL_REGISTRATION_EXPIRE_AFTER;
 import static io.gravitee.rest.api.service.common.JWTHelper.DefaultValues.DEFAULT_JWT_ISSUER;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.GAMMA_REGISTRATION_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.GAMMA_RESET_PASSWORD_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
 import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.RESET_PASSWORD_PATH;
@@ -173,6 +174,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
@@ -200,6 +202,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
      * A default source used for user registration.
      */
     private static final String IDP_SOURCE_GRAVITEE = "gravitee";
+
+    /** The only email link destination a caller may name. Never a URL -- see registerWithTarget. */
+    private static final String GAMMA_TARGET = "gamma";
     private static final String TEMPLATE_ENGINE_PROFILE_ATTRIBUTE = "profile";
     private static final String TEMPLATE_ENGINE_ACCESSTOKEN_ATTRIBUTE = "accessToken";
     private static final String TEMPLATE_ENGINE_IDTOKEN_ATTRIBUTE = "idToken";
@@ -892,6 +897,42 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         final NewExternalUserEntity newExternalUserEntity,
         final String confirmationPageUrl
     ) {
+        return doRegister(executionContext, newExternalUserEntity, () -> sanitizePortalRedirectUrl(executionContext, confirmationPageUrl));
+    }
+
+    @Override
+    public UserEntity registerWithTarget(
+        ExecutionContext executionContext,
+        final NewExternalUserEntity newExternalUserEntity,
+        final String registrationTarget
+    ) {
+        if (registrationTarget == null || registrationTarget.isBlank()) {
+            return register(executionContext, newExternalUserEntity, null);
+        }
+
+        if (GAMMA_TARGET.equalsIgnoreCase(registrationTarget.trim())) {
+            // Built from installation configuration rather than from the caller, so it deliberately does
+            // not pass through sanitizePortalRedirectUrl: that whitelist exists for caller-supplied portal
+            // URLs and would drop a trusted one built here.
+            return doRegister(executionContext, newExternalUserEntity, () ->
+                buildGammaRegistrationPageUrl(executionContext.getOrganizationId())
+            );
+        }
+
+        throw new ValidationDomainException("Unsupported registration target: " + registrationTarget);
+    }
+
+    /**
+     * @param confirmationPageUrl resolved only once registration is known to be enabled, and trusted by
+     *     then -- either sanitised from a caller or built here from installation configuration. It is a
+     *     supplier so a request rejected for a disabled registration does no whitelist lookup and no
+     *     installation lookup on its way out.
+     */
+    private UserEntity doRegister(
+        ExecutionContext executionContext,
+        final NewExternalUserEntity newExternalUserEntity,
+        final Supplier<String> confirmationPageUrl
+    ) {
         final ReferenceContext currentContext = executionContext.getReferenceContext();
 
         checkUserRegistrationEnabled(executionContext);
@@ -901,7 +942,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             executionContext,
             newExternalUserEntity,
             USER_REGISTRATION,
-            sanitizePortalRedirectUrl(executionContext, confirmationPageUrl),
+            confirmationPageUrl.get(),
             autoRegistrationEnabled,
             false
         );
@@ -1543,7 +1584,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             return;
         }
 
-        if ("gamma".equalsIgnoreCase(resetTarget.trim())) {
+        if (GAMMA_TARGET.equalsIgnoreCase(resetTarget.trim())) {
             doResetPassword(executionContext, id, buildGammaResetPasswordPageUrl(executionContext.getOrganizationId()));
             return;
         }
@@ -1552,6 +1593,14 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     }
 
     private String buildGammaResetPasswordPageUrl(final String organizationId) {
+        return buildGammaPageUrl(organizationId, GAMMA_RESET_PASSWORD_PATH);
+    }
+
+    private String buildGammaRegistrationPageUrl(final String organizationId) {
+        return buildGammaPageUrl(organizationId, GAMMA_REGISTRATION_PATH);
+    }
+
+    private String buildGammaPageUrl(final String organizationId, final String path) {
         String gammaUrl = installationAccessQueryService.getGammaUrl(organizationId);
         if (gammaUrl == null || gammaUrl.isBlank()) {
             throw new ValidationDomainException("Gamma URL is not configured for organization: " + organizationId);
@@ -1559,7 +1608,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         if (gammaUrl.endsWith("/")) {
             gammaUrl = gammaUrl.substring(0, gammaUrl.length() - 1);
         }
-        return gammaUrl + GAMMA_RESET_PASSWORD_PATH;
+        return gammaUrl + path;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
@@ -50,6 +50,7 @@ public class NotificationParamsBuilder {
     public static final String REGISTRATION_PATH = "/#!/_sign-up-confirm/";
     public static final String RESET_PASSWORD_PATH = "/#!/_reset-password/";
     public static final String GAMMA_RESET_PASSWORD_PATH = "/reset-password";
+    public static final String GAMMA_REGISTRATION_PATH = "/registration";
     private final Map<String, Object> params = new HashMap<>();
 
     public Map<String, Object> build() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -318,6 +319,36 @@ class UserServiceRegistrationApprovalTest {
             .orElseThrow(() -> new AssertionError("no registration email has been sent"));
 
         assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(CONSOLE_URL + REGISTRATION_PATH);
+    }
+
+    @Test
+    void should_link_the_registration_email_to_gamma_when_the_gamma_target_is_named() throws TechnicalException {
+        givenUserRegistrationEnabled(true);
+        when(installationAccessQueryService.getGammaUrl(ORGANIZATION)).thenReturn("https://gamma.example.com");
+
+        userService.registerWithTarget(PORTAL_CONTEXT, newExternalUser(), "gamma");
+
+        EmailNotification registrationEmail = capturedEmails()
+            .stream()
+            .filter(this::isRegistrationEmail)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no registration email has been sent"));
+
+        assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(
+            "https://gamma.example.com/registration/"
+        );
+    }
+
+    @Test
+    void should_reject_the_gamma_target_when_no_gamma_url_is_configured() throws TechnicalException {
+        givenUserRegistrationEnabled(true);
+        when(installationAccessQueryService.getGammaUrl(ORGANIZATION)).thenReturn(null);
+
+        assertThatThrownBy(() -> userService.registerWithTarget(PORTAL_CONTEXT, newExternalUser(), "gamma"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Gamma URL is not configured");
+
+        verify(userRepository, never()).create(any(User.class));
     }
 
     private void givenUserRegistrationEnabled(boolean automaticValidation) throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
@@ -351,6 +351,24 @@ class UserServiceRegistrationApprovalTest {
         verify(userRepository, never()).create(any(User.class));
     }
 
+    @Test
+    void should_link_the_registration_email_to_the_console_when_no_target_is_named() throws TechnicalException {
+        givenUserRegistrationEnabled(true);
+        when(installationAccessQueryService.getPortalUrl(ENVIRONMENT)).thenReturn(InstallationAccessQueryService.DEFAULT_PORTAL_URL);
+        when(installationAccessQueryService.getConsoleUrl(ORGANIZATION)).thenReturn(CONSOLE_URL);
+
+        userService.registerWithTarget(PORTAL_CONTEXT, newExternalUser(), null);
+
+        EmailNotification registrationEmail = capturedEmails()
+            .stream()
+            .filter(this::isRegistrationEmail)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no registration email has been sent"));
+
+        assertThat((String) registrationEmail.getParams().get(PARAM_REGISTRATION_URL)).startsWith(CONSOLE_URL + REGISTRATION_PATH);
+        verify(installationAccessQueryService, never()).getGammaUrl(any());
+    }
+
     private void givenUserRegistrationEnabled(boolean automaticValidation) throws TechnicalException {
         when(
             parameterService.findAsBoolean(PORTAL_CONTEXT, Key.PORTAL_USERCREATION_ENABLED, ENVIRONMENT, ParameterReferenceType.ENVIRONMENT)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationTargetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationTargetTest.java
@@ -15,14 +15,10 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_REGISTRATION_URL;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
@@ -37,10 +33,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * The registration email's link target, mirroring {@link UserServiceResetPasswordTargetTest}.
+ * Which registration targets are refused, mirroring {@link UserServiceResetPasswordTargetTest}.
  *
- * <p>These cases stop before the email is composed. What matters here is which URL the target
- * resolves to and that nothing else is accepted; {@code UserServiceTest} already covers the send.
+ * <p>Only the rejections live here: they are the cases that never reach registration, so no fixture
+ * beyond the installation lookup is needed to state them. The accepted {@code gamma} target is
+ * covered end-to-end in {@code UserServiceRegistrationApprovalTest}, on the emitted email.
  */
 @ExtendWith(MockitoExtension.class)
 class UserServiceRegistrationTargetTest {
@@ -59,27 +56,6 @@ class UserServiceRegistrationTargetTest {
         SecurityContextHolder.clearContext();
         userService = new UserServiceImpl();
         ReflectionTestUtils.setField(userService, "installationAccessQueryService", installationAccessQueryService);
-    }
-
-    @Test
-    void should_build_the_gamma_registration_url_from_installation_config() {
-        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn("http://gamma.example.com/");
-
-        String url = ReflectionTestUtils.invokeMethod(userService, "buildGammaRegistrationPageUrl", "DEFAULT");
-
-        assertThat(url).isEqualTo("http://gamma.example.com/registration");
-    }
-
-    @Test
-    void should_reject_registration_when_no_gamma_url_is_configured() {
-        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn(null);
-
-        // Failing loudly beats silently emailing a classic-console link the recipient cannot use.
-        // Asserted on the builder because the URL is resolved only after registration is known to be
-        // enabled -- a disabled registration should say so rather than blame the Gamma configuration.
-        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(userService, "buildGammaRegistrationPageUrl", "DEFAULT"))
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessageContaining("Gamma URL is not configured");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationTargetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationTargetTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_REGISTRATION_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.rest.api.model.NewExternalUserEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The registration email's link target, mirroring {@link UserServiceResetPasswordTargetTest}.
+ *
+ * <p>These cases stop before the email is composed. What matters here is which URL the target
+ * resolves to and that nothing else is accepted; {@code UserServiceTest} already covers the send.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceRegistrationTargetTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("DEFAULT", "DEFAULT");
+
+    private UserServiceImpl userService;
+
+    @Mock
+    private InstallationAccessQueryService installationAccessQueryService;
+
+    @BeforeEach
+    void setUp() {
+        // The holder is a thread-local other test classes in the same fork leave a principal in,
+        // which would route this unauthenticated path through the permission check instead.
+        SecurityContextHolder.clearContext();
+        userService = new UserServiceImpl();
+        ReflectionTestUtils.setField(userService, "installationAccessQueryService", installationAccessQueryService);
+    }
+
+    @Test
+    void should_build_the_gamma_registration_url_from_installation_config() {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn("http://gamma.example.com/");
+
+        String url = ReflectionTestUtils.invokeMethod(userService, "buildGammaRegistrationPageUrl", "DEFAULT");
+
+        assertThat(url).isEqualTo("http://gamma.example.com/registration");
+    }
+
+    @Test
+    void should_reject_registration_when_no_gamma_url_is_configured() {
+        when(installationAccessQueryService.getGammaUrl("DEFAULT")).thenReturn(null);
+
+        // Failing loudly beats silently emailing a classic-console link the recipient cannot use.
+        // Asserted on the builder because the URL is resolved only after registration is known to be
+        // enabled -- a disabled registration should say so rather than blame the Gamma configuration.
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(userService, "buildGammaRegistrationPageUrl", "DEFAULT"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Gamma URL is not configured");
+    }
+
+    @Test
+    void should_reject_an_unknown_registration_target() {
+        assertThatThrownBy(() -> userService.registerWithTarget(EXECUTION_CONTEXT, new NewExternalUserEntity(), "portal"))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("portal");
+    }
+
+    @Test
+    void should_reject_a_url_shaped_registration_target() {
+        // The endpoint is anonymous and the link carries a signed token, so a caller-supplied
+        // destination would exfiltrate it. Only the fixed keyword is accepted.
+        assertThatThrownBy(() ->
+            userService.registerWithTarget(EXECUTION_CONTEXT, new NewExternalUserEntity(), "https://attacker.example.com")
+        ).isInstanceOf(ValidationDomainException.class);
+
+        verify(installationAccessQueryService, never()).getGammaUrl(any());
+    }
+}


### PR DESCRIPTION
PR 7 of 7 for [FOUND-249](https://gravitee.atlassian.net/browse/FOUND-249) — Gamma sign-up parity.
Story: [FOUND-264](https://gravitee.atlassian.net/browse/FOUND-264)

Backend only, fully parallel. Nothing in the frontend stack depends on it — every page above can be
built and specced against a hand-crafted token. This only changes which host the email points at.

## The gap

The registration link is hard-wired to the classic console: `consoleUrl + REGISTRATION_PATH`.
Someone signing up on Gamma receives a link into a console they were never given access to.

The reset-password flow solved this already, so this mirrors it rather than inventing anything.

## What changed

The registration endpoint takes an optional `registrationTarget`. The only accepted value is the
fixed keyword `gamma`, which resolves server-side to the organization's configured Gamma URL plus
`/registration`. Omitting it keeps today's classic-console behaviour exactly.

With no Gamma URL configured the request fails rather than silently emailing a classic-console link
the recipient cannot use.

Two consolidations rather than new copies: `buildGammaPageUrl` now backs both the reset and
registration URLs, and `GAMMA_TARGET` names the keyword both flows compare against.

## Security-sensitive

Flagged per `AGENTS.md`. **Anonymous endpoint, email-embedded signed token.**

- **No caller-supplied URL is ever accepted.** A caller who could name the destination could have
  the token emailed wherever they liked. Only the keyword is accepted; a URL-shaped value is
  rejected before any lookup happens, which `should_reject_a_url_shaped_registration_target` pins
  by also asserting the installation service is never touched.
- **The resolved URL deliberately bypasses `sanitizePortalRedirectUrl`.** That whitelist exists for
  caller-supplied portal URLs; a trusted URL built from installation configuration would be dropped
  by it. Same treatment the reset flow already gives its Gamma URL.
- No authorization decision changes, and the classic-console path is untouched.

## Worth a reviewer's attention

The confirmation URL is resolved through a `Supplier`. That is not decoration, and it buys two things.

It preserves an ordering the straight-line version I wrote first had lost: that version sanitised the
URL *before* `checkUserRegistrationEnabled`, so a request with registration disabled started doing
whitelist and installation lookups before bailing out.
`UserServiceTest.shouldNotBlockRegistrationOnRedirectUrlNotMatchingWhitelist` asserts
`verifyNoInteractions(installationAccessQueryService)` and caught it.

The stronger property, which review surfaced: the supplier is evaluated as an argument to
`createAndSendEmail`, so a missing Gamma URL fails *before* any user is created — there is no
half-registration to clean up. `should_reject_the_gamma_target_when_no_gamma_url_is_configured`
now asserts that directly with `verify(userRepository, never()).create(any(User.class))`.

**One contract I am defining here:** the Gamma activation route is `/registration/:token`, mirroring
`/reset-password/:token`. That page does not exist yet — it arrives with
[FOUND-263](https://gravitee.atlassian.net/browse/FOUND-263) — so if you would rather it were named
something else, now is the cheap moment to say so.

## Verification

- `mvn test -Dtest='UserService*Test'` — **128 tests, 0 failures** across four classes
- The `gamma` branch is covered end-to-end in `UserServiceRegistrationApprovalTest`, on the emitted
  email: the link is `https://gamma.example.com/registration/<token>`, and an unconfigured
  organization fails before a user is created. Both were verified red against two mutations —
  swapping in `buildGammaResetPasswordPageUrl`, and deleting the gamma branch outright.
- The no-target path is pinned too: omitting `registrationTarget` still resolves the classic-console
  link and never looks up a Gamma URL. Verified red against rerouting that branch to the Gamma
  builder, which would 400 every ordinary sign-up in an organization without one.
- `UserServiceRegistrationTargetTest` keeps the two rejections; its two reflection-based cases were
  replaced by the behavioural ones above.
- Both touched modules build and are prettier-formatted

The email templates need no change — `userRegistration.html` interpolates `${registrationUrl}` and
names no product.


[FOUND-249]: https://gravitee.atlassian.net/browse/FOUND-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-264]: https://gravitee.atlassian.net/browse/FOUND-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-263]: https://gravitee.atlassian.net/browse/FOUND-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

