### PR TITLE
fix(e2e): use the CreateApi union in the V4 subscription plan test

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-e2e/api-test/src/apis/plans/mapi-v1/subscribe-to-V4-subscription-plan-with-publisher-approval.spec.ts
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-e2e/api-test/src/apis/plans/mapi-v1/subscribe-to-V4-subscription-plan-with-publisher-approval.spec.ts
@@ -29,7 +29,7 @@ import { verifyWiremockRequest } from '@gravitee/utils/wiremock';
 import { faker } from '@faker-js/faker';
 import { sleep } from '@gravitee/utils/apim-http';
 import { describeIfV4EmulationEngine } from '@lib/jest-utils';
-import { Api, APIPlansApi, APIsApi, Plan, PlanMode, PlanValidation } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { Api, APIPlansApi, APIsApi, CreateApi, Plan, PlanMode, PlanValidation } from '@gravitee/management-v2-webclient-sdk/src/lib';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -50,7 +50,7 @@ describeIfV4EmulationEngine('V4 subscription plan subscription and approval work
     // create a V4 API with a webhook entrypoint and a mock endpoint
     api = await apisResource.createApi({
       envId,
-      createApiV4: MAPIV2ApisFaker.newApi({
+      createApi: MAPIV2ApisFaker.newApi({
         listeners: [
           MAPIV2ApisFaker.newSubscriptionListener({
             entrypoints: [
@@ -75,7 +75,7 @@ describeIfV4EmulationEngine('V4 subscription plan subscription and approval work
             ],
           },
         ],
-      }),
+      }) as CreateApi,
     });
 
     // create a subscription plan


### PR DESCRIPTION
## Issue

No JIRA ticket: this is a CI fix for the nightly on `amp_demo`, opened from the failing build.

## Description

The nightly `Lint & Build APIM e2e` job fails on `amp_demo` — it is the only red job of the 39 in the workflow — on a single TypeScript error:

```
api-test/src/apis/plans/mapi-v1/subscribe-to-V4-subscription-plan-with-publisher-approval.spec.ts:53:7
error TS2561: Object literal may only specify known properties, but 'createApiV4' does not exist
in type 'CreateApiRequest'. Did you mean to write 'createApi'?
```

Commit f2e350d0f (`feat: support standalone agent definition`) pointed the `POST /environments/{envId}/apis` request body at the `CreateApi` union, so that `CreateApiAgent` could join `CreateApiV2` and `CreateApiV4`:

```diff
-  $ref: "#/components/schemas/CreateApiV4"
+  $ref: "#/components/schemas/CreateApi"
```

The e2e SDK is regenerated from that spec on every run, and `openapi-generator` names the body parameter after the referenced schema, so `CreateApiRequest.createApiV4` became `CreateApiRequest.createApi`. This spec file is the only e2e caller of the management-v2 `createApi` operation, hence the single error.

Renaming the property alone does not compile. The generated union is discriminated on a string literal:

```ts
export type CreateApi =
  | { definitionVersion: 'AGENT' } & CreateApiAgent
  | { definitionVersion: 'V2' } & CreateApiV2
  | { definitionVersion: 'V4' } & CreateApiV4;
```

whereas `MAPIV2ApisFaker.newApi()` returns a `CreateApiV4` whose `definitionVersion` is widened to the whole `DefinitionVersion` union, which is not assignable to `'V4'`. The faker result therefore needs an explicit cast — the same pattern already used for `updateApi` in `create-tcp-api-plan.spec.ts` and `api-v4-rollback.spec.ts`.

## Additional context

- **The regression is old and silent.** `f2e350d0f` landed on 2026-07-08; the nightlies of 3, 4, 7 and 8 September all fail with this exact single error. The e2e jobs do not run on pull requests unless the branch name matches `.*-run-e2e.*`, so the change was never exercised in review — only the nightly Slack notification carried it.
- **Verification.** The management-v2 SDK was regenerated locally from this branch's `openapi-apis.yaml` with the same generator and options as `scripts/update-management-v2-sdk.sh` (`openapi-generator-cli@2.13.1`, `typescript-fetch`), confirming `CreateApiRequest.createApi: CreateApi`; the call site was then typechecked against it. This branch is named `…-run-e2e` so the full e2e pipeline runs on this PR rather than waiting for the next nightly.
- **`master` will hit the same wall** when `amp_demo` is merged, and there too only the nightly would catch it.
- @guillaumesala — heads-up, since this follows your f2e350d0f: the spec change is right, the e2e suite just had one call site left behind.
