### PR TITLE
fix(gamma): make the password requirement checklist fail safe

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
@@ -16,11 +16,22 @@
 import { cn } from '@gravitee/graphene-core';
 import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
 
-import type { PasswordPolicyRule } from './types';
-import { evaluatePasswordPolicyRule, resolvePasswordStrengthLabel, resolvePasswordStrengthLevel } from './passwordPolicyRules';
+import type { PasswordPolicy } from './types';
+import {
+    assessPassword,
+    describablePasswordRules,
+    evaluatePasswordPolicyRule,
+    resolvePasswordStrengthLabel,
+    resolvePasswordStrengthLevel,
+} from './passwordPolicyRules';
 
 interface PasswordRequirementsProps {
-    readonly rules: PasswordPolicyRule[];
+    /**
+     * The whole policy, not only its rules, so the checklist cannot contradict the verdict that gates
+     * submission. Its description is shown where no rule can be listed, and where the pattern refuses
+     * a password every listed rule accepts; anywhere else a checklist says the same thing item by item.
+     */
+    readonly policy: PasswordPolicy;
     readonly password?: string;
     readonly showStrengthMeter?: boolean;
     readonly className?: string;
@@ -47,19 +58,27 @@ const STRENGTH_FILLED_BARS: Record<ReturnType<typeof resolvePasswordStrengthLeve
     strong: 4,
 };
 
-export function PasswordRequirements({ rules, password = '', showStrengthMeter = false, className }: PasswordRequirementsProps) {
-    // No rules means the policy could not be loaded. Nothing here can say anything about the
-    // password in that state: a heading over an empty list reads as "there are no requirements",
-    // and a meter scored against no rules reports "Weak" for every password ever typed. The
-    // caller surfaces the failure.
-    const hasRules = rules.length > 0;
-    const strengthLevel = resolvePasswordStrengthLevel(password, rules);
+const UNLISTED_REQUIREMENT = "This password doesn't meet the full policy yet. One of its requirements isn't listed here.";
+
+export function PasswordRequirements({ policy, password = '', showStrengthMeter = false, className }: PasswordRequirementsProps) {
+    // Nothing listable means either the policy could not be loaded or its pattern defeated the
+    // parser. Nothing here can say anything about the password in that state: a heading over an
+    // empty list reads as "there are no requirements", and a meter scored against no rules reports
+    // "Weak" for every password ever typed.
+    const listedRules = describablePasswordRules(policy.rules);
+    // Every box ticked and still refused: what the password lacks is a requirement no rule could list.
+    const refusedDespiteChecklist =
+        listedRules.length > 0 &&
+        listedRules.every(rule => evaluatePasswordPolicyRule(rule, password)) &&
+        assessPassword(password, policy) === 'unsatisfied';
+    // "Strong" tells the reader they are done, which the policy says they are not.
+    const strengthLevel = refusedDespiteChecklist ? 'good' : resolvePasswordStrengthLevel(password, listedRules);
     const strengthLabel = resolvePasswordStrengthLabel(strengthLevel);
     const filledBars = showStrengthMeter ? STRENGTH_FILLED_BARS[strengthLevel] : 0;
 
     return (
         <div className={cn('space-y-3', className)}>
-            {showStrengthMeter && password && hasRules ? (
+            {showStrengthMeter && password && listedRules.length > 0 ? (
                 <div className="space-y-1">
                     <div className="flex gap-1" aria-hidden>
                         {Array.from({ length: 4 }, (_, index) => (
@@ -76,11 +95,14 @@ export function PasswordRequirements({ rules, password = '', showStrengthMeter =
                 </div>
             ) : null}
 
-            {hasRules ? (
+            {/* Where the operator wrote a sentence of their own, it is the only guidance left. */}
+            {listedRules.length === 0 && policy.description ? <p className="text-sm text-muted-foreground">{policy.description}</p> : null}
+
+            {listedRules.length > 0 ? (
                 <div className="space-y-2">
                     <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requirements</p>
                     <ul className="space-y-1.5">
-                        {rules.map(rule => {
+                        {listedRules.map(rule => {
                             const satisfied = password ? evaluatePasswordPolicyRule(rule, password) : false;
                             return (
                                 <li key={rule.id} className="flex items-start gap-2 text-sm">
@@ -99,6 +121,13 @@ export function PasswordRequirements({ rules, password = '', showStrengthMeter =
                             );
                         })}
                     </ul>
+                </div>
+            ) : null}
+
+            {refusedDespiteChecklist ? (
+                <div className="space-y-1">
+                    <p className="text-sm text-destructive">{UNLISTED_REQUIREMENT}</p>
+                    {policy.description ? <p className="text-sm text-muted-foreground">{policy.description}</p> : null}
                 </div>
             ) : null}
         </div>

--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/passwordPolicyRules.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { PasswordPolicyRule } from './types';
+import type { PasswordPolicy, PasswordPolicyRule } from './types';
 
 export function evaluatePasswordPolicyRule(rule: PasswordPolicyRule, password: string): boolean {
     if (!password || !rule.pattern) {
@@ -37,6 +37,111 @@ export function isPasswordPolicySatisfied(password: string, rules: PasswordPolic
     }
 
     return countSatisfiedPasswordRules(password, rules) === rules.length;
+}
+
+/**
+ * The rule the API sends when its parser could read nothing at all. Its label says only that the
+ * password must match the policy, and its pattern is the raw policy itself, so it is neither
+ * something a reader can act on nor something that may reach the DOM.
+ */
+const OPAQUE_RULE_ID = 'policyPattern';
+
+/** Rules worth showing someone: the opaque whole-pattern fallback is not one. */
+export function describablePasswordRules(rules: PasswordPolicyRule[]): PasswordPolicyRule[] {
+    return rules.filter(rule => rule.id !== OPAQUE_RULE_ID);
+}
+
+export type PasswordPolicyVerdict = 'satisfied' | 'unsatisfied' | 'undecidable';
+
+/**
+ * Whether a password meets the policy, as far as this browser can tell.
+ *
+ * The configured pattern decides, because it is what the server enforces. The derived rules exist
+ * to explain that pattern and the parser recognises only a handful of regex shapes, so a policy it
+ * read incompletely would otherwise report every rule green on a password the server rejects.
+ *
+ * `undecidable` means this browser cannot read the pattern as the server does. The server compiles
+ * with Java's engine and this runs on JavaScript's, so a construct valid there can be a syntax error
+ * here, or compile to something else. Reading that as unsatisfied would permanently block a password
+ * the server would accept, so the caller should let it through and let the server answer. Only a
+ * difference visible in the pattern's text is caught; one that leaves no trace there, such as `\s`
+ * matching a slightly different set of characters, is not.
+ */
+export function assessPassword(password: string, policy: PasswordPolicy): PasswordPolicyVerdict {
+    if (!password) {
+        return 'unsatisfied';
+    }
+
+    if (policy.pattern) {
+        if (readsDifferentlyInJavaScript(policy.pattern)) {
+            return 'undecidable';
+        }
+        let configured: RegExp;
+        try {
+            // Java's Matcher.matches() must consume the whole password, where test() settles for any
+            // substring: unanchored, a pattern's length limit would stop applying here.
+            configured = new RegExp(`^(?:${policy.pattern})$`);
+        } catch {
+            return 'undecidable';
+        }
+        return configured.test(password) ? 'satisfied' : 'unsatisfied';
+    }
+
+    const rules = describablePasswordRules(policy.rules);
+    if (rules.length === 0) {
+        return 'undecidable';
+    }
+    return isPasswordPolicySatisfied(password, rules) ? 'satisfied' : 'unsatisfied';
+}
+
+/** Letter escapes JavaScript, without the u flag, reads exactly as Java does. */
+const SHARED_LETTER_ESCAPES = new Set(['d', 'D', 'w', 'W', 's', 'S', 'b', 'B', 't', 'n', 'r', 'f']);
+
+function escapeReadAlike(escaped: string, following: string): boolean {
+    if (!/[A-Za-z0-9]/.test(escaped)) {
+        // An escaped symbol stands for that symbol in both engines.
+        return true;
+    }
+    if (SHARED_LETTER_ESCAPES.has(escaped) || /[1-9]/.test(escaped)) {
+        return true;
+    }
+    if (escaped === 'u') {
+        return /^[0-9A-Fa-f]{4}/.test(following);
+    }
+    if (escaped === 'x') {
+        return /^[0-9A-Fa-f]{2}/.test(following);
+    }
+    return false;
+}
+
+/**
+ * Whether the pattern holds a construct that compiles here but means something else than on the
+ * server. Without the u flag an escape JavaScript does not know (`\p{Upper}`, `\Q`, `\A`, `\z`...)
+ * reads as its bare letter, and Java's class intersection (`&&`) or nested class (`[`) reads as
+ * literals. An escape not known to read alike counts, so an unfamiliar one leaves the server to
+ * decide. The u flag is no way out: it refuses escapes such as `\"` that the shipped default uses.
+ */
+function readsDifferentlyInJavaScript(pattern: string): boolean {
+    let inClass = false;
+    for (let i = 0; i < pattern.length; i++) {
+        const char = pattern[i];
+        if (char === '\\') {
+            if (!escapeReadAlike(pattern[i + 1] ?? '', pattern.slice(i + 2))) {
+                return true;
+            }
+            i++;
+        } else if (char === '[') {
+            if (inClass) {
+                return true;
+            }
+            inClass = true;
+        } else if (char === ']') {
+            inClass = false;
+        } else if (inClass && char === '&' && pattern[i + 1] === '&') {
+            return true;
+        }
+    }
+    return false;
 }
 
 const PASSWORD_STRENGTH_FAIR_THRESHOLD = 0.5;

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
@@ -157,6 +157,65 @@ describe('ResetPasswordPage', () => {
         expect(await screen.findByText('Password does not meet policy requirements.')).toBeTruthy();
     });
 
+    it('keeps submit disabled, and says why, when the pattern refuses a password every listed rule accepts', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                // '\\d' defeats the parser, so only the length rule is derived: the false green this page used to show.
+                HttpResponse.json({
+                    description: '',
+                    pattern: '^(?=.*\\d).{8,}$',
+                    rules: [{ id: 'minLength', label: 'At least 8 characters', pattern: '^.{8,}$' }],
+                }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 8 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'abcdefghij');
+        await user.type(screen.getByLabelText('Confirm password'), 'abcdefghij');
+
+        expect(screen.getByText("This password doesn't meet the full policy yet. One of its requirements isn't listed here.")).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it.each([
+        ['cannot compile', '^[a-z]++$'],
+        ['would misread', '^\\p{Lower}{8,}$'],
+    ])('leaves the verdict to the server for a pattern JavaScript %s', async (_, pattern) => {
+        const user = userEvent.setup();
+        const changePasswordTracker = trackHandler('post', `${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, null, 204);
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                HttpResponse.json({
+                    description: '',
+                    pattern,
+                    rules: [{ id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' }],
+                }),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('Contains lowercase letter')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'abcdefgh');
+        await user.type(screen.getByLabelText('Confirm password'), 'abcdefgh');
+
+        // Only the server can read this pattern, so the page must not refuse on its behalf.
+        const submitButton = screen.getByRole('button', { name: 'Reset password' }) as HTMLButtonElement;
+        expect(submitButton.disabled).toBe(false);
+        await user.click(submitButton);
+
+        await waitFor(() => expect(changePasswordTracker.callCount).toBe(1));
+    });
+
     it('blocks submit when password policy cannot be loaded', async () => {
         server.use(
             http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.spec.tsx
@@ -157,6 +157,67 @@ describe('ResetPasswordPage', () => {
         expect(await screen.findByText('Password does not meet policy requirements.')).toBeTruthy();
     });
 
+    it('renders a rejected password against the field rather than as a page-level alert', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.post(`${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, () =>
+                HttpResponse.json(
+                    { message: 'The password is not valid according to policy rules.', technicalCode: 'passwordFormat.invalid' },
+                    { status: 400 },
+                ),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+        await user.click(screen.getByRole('button', { name: 'Reset password' }));
+
+        // The reader's next action is in the password field, so the message belongs beside it.
+        const rejection = await screen.findByText('The password is not valid according to policy rules.');
+        expect(screen.queryByText('Reset failed')).toBeNull();
+
+        // Out of the page-level alert, it has to announce itself and be tied to the field.
+        expect(rejection.getAttribute('role')).toBe('alert');
+        const passwordInput = screen.getByLabelText('Password');
+        expect(passwordInput.getAttribute('aria-describedby')).toBe(rejection.id);
+        expect(passwordInput.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('withdraws a rejected password once the reader edits it', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.post(`${TEST_MANAGEMENT_BASE}/users/user-1/changePassword`, () =>
+                HttpResponse.json(
+                    { message: 'The password is not valid according to policy rules.', technicalCode: 'passwordFormat.invalid' },
+                    { status: 400 },
+                ),
+            ),
+        );
+
+        renderResetPasswordPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        });
+
+        await user.type(screen.getByLabelText('Password'), 'NewPassword1!a');
+        await user.type(screen.getByLabelText('Confirm password'), 'NewPassword1!a');
+        await user.click(screen.getByRole('button', { name: 'Reset password' }));
+        await screen.findByText('The password is not valid according to policy rules.');
+
+        await user.type(screen.getByLabelText('Password'), 'b');
+
+        // The verdict was on the password that was sent, not on the one now in the field.
+        expect(screen.queryByText('The password is not valid according to policy rules.')).toBeNull();
+        expect(screen.getByLabelText('Password').getAttribute('aria-invalid')).not.toBe('true');
+    });
+
     it('keeps submit disabled, and says why, when the pattern refuses a password every listed rule accepts', async () => {
         const user = userEvent.setup();
         server.use(

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
@@ -18,7 +18,7 @@ import { useMemo, useState, type ReactNode, type SubmitEvent } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 import { AuthPageShell } from './AuthPageShell';
-import { PasswordRequirements, isPasswordPolicySatisfied } from '../../../shared/password-policy';
+import { PasswordRequirements, assessPassword } from '../../../shared/password-policy';
 import { usePasswordPolicy } from '../hooks/usePasswordPolicy';
 import { finalizeResetPassword } from '../services/resetPassword.service';
 import { isAuthTokenExpired, parseAuthToken, type AuthTokenClaims } from '../utils/authToken';
@@ -88,13 +88,15 @@ export function ResetPasswordPage() {
 
     const accountName = [tokenClaims?.firstname, tokenClaims?.lastname].filter(Boolean).join(' ');
     const passwordMismatch = confirmPassword.length > 0 && password !== confirmPassword;
-    const passwordPolicySatisfied = isPasswordPolicySatisfied(password, passwordPolicy.rules);
+    // 'undecidable' means the browser cannot read the configured pattern as the server does. Blocking on that
+    // would refuse a password the server would accept, so only an outright failure stops submission.
+    const policyRefusesPassword = assessPassword(password, passwordPolicy) === 'unsatisfied';
     const canSubmit =
         Boolean(tokenClaims?.sub) &&
         password.length > 0 &&
         confirmPassword.length > 0 &&
         passwordsMatch(password, confirmPassword) &&
-        passwordPolicySatisfied &&
+        !policyRefusesPassword &&
         !passwordPolicyLoading &&
         !passwordPolicyError &&
         !loading &&
@@ -109,7 +111,7 @@ export function ResetPasswordPage() {
             passwordPolicyLoading ||
             loading ||
             !passwordsMatch(password, confirmPassword) ||
-            !isPasswordPolicySatisfied(password, passwordPolicy.rules)
+            policyRefusesPassword
         ) {
             return;
         }
@@ -195,7 +197,7 @@ export function ResetPasswordPage() {
                         // eslint-disable-next-line jsx-a11y/no-autofocus
                         autoFocus
                     />
-                    <PasswordRequirements rules={passwordPolicy.rules} password={password} showStrengthMeter />
+                    <PasswordRequirements policy={passwordPolicy} password={password} showStrengthMeter />
                 </Field>
 
                 <Field orientation="vertical" className="gap-2">

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ResetPasswordPage.tsx
@@ -20,11 +20,12 @@ import { Link, useParams } from 'react-router-dom';
 import { AuthPageShell } from './AuthPageShell';
 import { PasswordRequirements, assessPassword } from '../../../shared/password-policy';
 import { usePasswordPolicy } from '../hooks/usePasswordPolicy';
-import { finalizeResetPassword } from '../services/resetPassword.service';
+import { PasswordRejectedError, finalizeResetPassword } from '../services/resetPassword.service';
 import { isAuthTokenExpired, parseAuthToken, type AuthTokenClaims } from '../utils/authToken';
 
 const INVALID_LINK = "This reset link isn't valid. Ask your administrator to send a new one.";
 const EXPIRED_LINK = 'This reset link has expired. Ask your administrator to send a new one.';
+const PASSWORD_REJECTION_ID = 'reset-password-rejection';
 
 function passwordsMatch(password: string, confirmPassword: string): boolean {
     return password.length > 0 && password === confirmPassword;
@@ -82,6 +83,7 @@ export function ResetPasswordPage() {
     const [password, setPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
     const [error, setError] = useState('');
+    const [passwordRejection, setPasswordRejection] = useState('');
     const [success, setSuccess] = useState(false);
     const [loading, setLoading] = useState(false);
     const { policy: passwordPolicy, loading: passwordPolicyLoading, error: passwordPolicyError } = usePasswordPolicy();
@@ -117,6 +119,7 @@ export function ResetPasswordPage() {
         }
 
         setError('');
+        setPasswordRejection('');
         setLoading(true);
         try {
             await finalizeResetPassword(tokenClaims.sub, {
@@ -131,7 +134,11 @@ export function ResetPasswordPage() {
                 console.error('Password reset failed', submitError);
             }
             const message = submitError instanceof Error ? submitError.message : 'An error occurred while resetting your password.';
-            setError(message);
+            if (submitError instanceof PasswordRejectedError) {
+                setPasswordRejection(message);
+            } else {
+                setError(message);
+            }
         } finally {
             setLoading(false);
         }
@@ -191,13 +198,24 @@ export function ResetPasswordPage() {
                     <PasswordInput
                         id="reset-password"
                         value={password}
-                        onChange={event => setPassword(event.target.value)}
+                        onChange={event => {
+                            setPassword(event.target.value);
+                            // The server's verdict was on the password it was sent, not on this one.
+                            setPasswordRejection('');
+                        }}
+                        aria-invalid={Boolean(passwordRejection)}
+                        aria-describedby={passwordRejection ? PASSWORD_REJECTION_ID : undefined}
                         required
                         autoComplete="new-password"
                         // eslint-disable-next-line jsx-a11y/no-autofocus
                         autoFocus
                     />
                     <PasswordRequirements policy={passwordPolicy} password={password} showStrengthMeter />
+                    {passwordRejection ? (
+                        <p id={PASSWORD_REJECTION_ID} role="alert" className="text-sm text-destructive">
+                            {passwordRejection}
+                        </p>
+                    ) : null}
                 </Field>
 
                 <Field orientation="vertical" className="gap-2">

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/resetPassword.service.ts
@@ -25,6 +25,22 @@ export interface FinalizeResetPasswordPayload {
 
 const RESET_PASSWORD_FALLBACK_ERROR = 'An error occurred while resetting your password.';
 
+/** The server's identifier for a password the policy refuses. */
+const PASSWORD_FORMAT_INVALID = 'passwordFormat.invalid';
+
+/**
+ * The server refused the password itself, rather than the request around it.
+ *
+ * Worth its own type because the reader's next action is in the password field: the caller can put
+ * the message where they are looking instead of at the top of the page.
+ */
+export class PasswordRejectedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PasswordRejectedError';
+    }
+}
+
 export async function finalizeResetPassword(userId: string, payload: FinalizeResetPasswordPayload): Promise<void> {
     const reCaptchaToken = await resolveReCaptchaToken('register');
     const extraHeaders: Record<string, string> = {};
@@ -45,7 +61,8 @@ export async function finalizeResetPassword(userId: string, payload: FinalizeRes
         );
     } catch (error) {
         if (error instanceof ApiError) {
-            throw new Error(error.message || RESET_PASSWORD_FALLBACK_ERROR);
+            const message = error.message || RESET_PASSWORD_FALLBACK_ERROR;
+            throw error.technicalCode === PASSWORD_FORMAT_INVALID ? new PasswordRejectedError(message) : new Error(message);
         }
         throw error;
     }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/api/api-client.ts
@@ -41,17 +41,23 @@ function setCsrfToken(value: string) {
     localStorage.setItem('XSRF-TOKEN', value);
 }
 
-async function resolveErrorMessage(res: Response, fallback: string): Promise<string> {
+interface ResolvedError {
+    readonly message: string;
+    /** The server's stable identifier for this failure, where it sent one. */
+    readonly technicalCode?: string;
+}
+
+async function resolveError(res: Response, fallback: string): Promise<ResolvedError> {
     const text = await res.text().catch(() => '');
     if (!text) {
-        return fallback;
+        return { message: fallback };
     }
 
     try {
-        const parsed = JSON.parse(text) as { message?: string };
-        return parsed.message?.trim() || fallback;
+        const parsed = JSON.parse(text) as { message?: string; technicalCode?: string };
+        return { message: parsed.message?.trim() || fallback, technicalCode: parsed.technicalCode };
     } catch {
-        return text.trim() || fallback;
+        return { message: text.trim() || fallback };
     }
 }
 
@@ -72,7 +78,8 @@ export async function request<T>(backend: Backend, path: string, init?: RequestI
 
     if (!res.ok) {
         const fallback = `${init?.method ?? 'GET'} ${path} failed`;
-        throw new ApiError(res.status, await resolveErrorMessage(res, fallback));
+        const resolved = await resolveError(res, fallback);
+        throw new ApiError(res.status, resolved.message, resolved.technicalCode);
     }
 
     if (res.status === 204) return undefined as T;
@@ -85,6 +92,9 @@ export class ApiError extends Error {
     constructor(
         public readonly status: number,
         message: string,
+        /** The server's stable identifier for this failure, so callers can branch on the cause
+         *  rather than on wording that is free to change. */
+        public readonly technicalCode?: string,
     ) {
         super(message);
         this.name = 'ApiError';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
@@ -18,6 +18,8 @@ import { screen } from '@testing-library/react';
 
 import { PasswordRequirements } from './index';
 
+const UNLISTED_REQUIREMENT = "This password doesn't meet the full policy yet. One of its requirements isn't listed here.";
+
 const TEST_RULES = [
     { id: 'minLength', label: 'At least 12 characters', pattern: '.{12,}' },
     { id: 'uppercase', label: 'Contains uppercase letter', pattern: '[A-Z]' },
@@ -45,7 +47,7 @@ beforeAll(() => {
 
 describe('PasswordRequirements', () => {
     it('renders policy rules and marks satisfied requirements when a password is provided', () => {
-        renderWithGraphene(<PasswordRequirements rules={TEST_RULES} password="LongEnough1!a" showStrengthMeter />);
+        renderWithGraphene(<PasswordRequirements policy={{ rules: TEST_RULES }} password="LongEnough1!a" showStrengthMeter />);
 
         expect(screen.getByText('Requirements')).toBeTruthy();
         expect(screen.getByText('Strong')).toBeTruthy();
@@ -53,14 +55,14 @@ describe('PasswordRequirements', () => {
     });
 
     it('renders no heading when the policy could not be loaded', () => {
-        renderWithGraphene(<PasswordRequirements rules={[]} password="" showStrengthMeter />);
+        renderWithGraphene(<PasswordRequirements policy={{ rules: [] }} password="" showStrengthMeter />);
 
         // A heading over an empty list reads as "no requirements" rather than "unknown".
         expect(screen.queryByText('Requirements')).toBeNull();
     });
 
     it('scores no strength when the policy could not be loaded', () => {
-        renderWithGraphene(<PasswordRequirements rules={[]} password="LongEnough1!a" showStrengthMeter />);
+        renderWithGraphene(<PasswordRequirements policy={{ rules: [] }} password="LongEnough1!a" showStrengthMeter />);
 
         // Every password scores "Weak" against an empty rule set, which reads as a verdict on
         // the password rather than on the missing policy.
@@ -68,9 +70,94 @@ describe('PasswordRequirements', () => {
     });
 
     it('shows a weaker strength label when only some rules are satisfied', () => {
-        renderWithGraphene(<PasswordRequirements rules={TEST_RULES} password="LongEnough1" showStrengthMeter />);
+        renderWithGraphene(<PasswordRequirements policy={{ rules: TEST_RULES }} password="LongEnough1" showStrengthMeter />);
 
         expect(screen.getByText('Fair')).toBeTruthy();
         expect(screen.queryByText('Strong')).toBeNull();
+    });
+});
+
+describe('PasswordRequirements, when the parser derived nothing usable', () => {
+    const OPAQUE_RULE = { id: 'policyPattern', label: 'Matches the configured password policy', pattern: '^\\d{8,}$' };
+
+    it("shows the operator's own words instead of the opaque fallback rule", () => {
+        renderWithGraphene(<PasswordRequirements policy={{ rules: [OPAQUE_RULE], description: 'Ask IT for the house rules.' }} />);
+
+        expect(screen.getByText('Ask IT for the house rules.')).toBeTruthy();
+        expect(screen.queryByText('Matches the configured password policy')).toBeNull();
+        expect(screen.queryByText('Requirements')).toBeNull();
+    });
+
+    it('never puts the raw policy pattern in the DOM', () => {
+        const { container } = renderWithGraphene(
+            <PasswordRequirements policy={{ rules: [OPAQUE_RULE], description: 'Ask IT for the house rules.' }} />,
+        );
+
+        expect(container.innerHTML).not.toContain('\\d{8,}');
+    });
+
+    it('renders nothing at all when there is no description either', () => {
+        const { container } = renderWithGraphene(<PasswordRequirements policy={{ rules: [OPAQUE_RULE] }} />);
+
+        expect(container.textContent?.trim()).toBe('');
+    });
+
+    it('does not repeat the description when there is a checklist to read', () => {
+        const rules = [{ id: 'minLength', label: 'At least 12 characters', pattern: '^.{12,}$' }];
+
+        renderWithGraphene(<PasswordRequirements policy={{ rules, description: 'Ask IT for the house rules.' }} />);
+
+        expect(screen.getByText('At least 12 characters')).toBeTruthy();
+        expect(screen.queryByText('Ask IT for the house rules.')).toBeNull();
+    });
+});
+
+describe('PasswordRequirements, when the pattern holds a requirement no rule lists', () => {
+    const DESCRIPTION = 'Use at least 8 characters, including a number.';
+    // '\\d' defeats the parser, so only the length rule is derived from this pattern.
+    const POLICY = {
+        pattern: '^(?=.*\\d).{8,}$',
+        rules: [{ id: 'minLength', label: 'At least 8 characters', pattern: '^.{8,}$' }],
+    };
+
+    it('says the password still falls short once every listed rule is met', () => {
+        renderWithGraphene(<PasswordRequirements policy={POLICY} password="abcdefghij" showStrengthMeter />);
+
+        expect(screen.getByText(UNLISTED_REQUIREMENT)).toBeTruthy();
+    });
+
+    it('does not call a password the policy refuses strong', () => {
+        renderWithGraphene(<PasswordRequirements policy={POLICY} password="abcdefghij" showStrengthMeter />);
+
+        expect(screen.queryByText('Strong')).toBeNull();
+    });
+
+    it('stays quiet while a listed rule is still unmet, since the list already explains it', () => {
+        renderWithGraphene(<PasswordRequirements policy={POLICY} password="abc" showStrengthMeter />);
+
+        expect(screen.queryByText(UNLISTED_REQUIREMENT)).toBeNull();
+    });
+
+    it("names what is missing in the operator's own words, where they wrote some", () => {
+        renderWithGraphene(
+            <PasswordRequirements policy={{ ...POLICY, description: DESCRIPTION }} password="abcdefghij" showStrengthMeter />,
+        );
+
+        // The one state where the checklist admits a gap is the one where the description is not a repeat.
+        expect(screen.getByText(UNLISTED_REQUIREMENT)).toBeTruthy();
+        expect(screen.getByText(DESCRIPTION)).toBeTruthy();
+    });
+
+    it('keeps the description back while the checklist still explains what is missing', () => {
+        renderWithGraphene(<PasswordRequirements policy={{ ...POLICY, description: DESCRIPTION }} password="abc" showStrengthMeter />);
+
+        expect(screen.queryByText(DESCRIPTION)).toBeNull();
+    });
+
+    it('stays quiet once the pattern accepts the password', () => {
+        renderWithGraphene(<PasswordRequirements policy={POLICY} password="abcdefghi1" showStrengthMeter />);
+
+        expect(screen.queryByText(UNLISTED_REQUIREMENT)).toBeNull();
+        expect(screen.getByText('Strong')).toBeTruthy();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/passwordPolicyRules.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/passwordPolicyRules.spec.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 import {
+    assessPassword,
     countSatisfiedPasswordRules,
+    describablePasswordRules,
     evaluatePasswordPolicyRule,
     isPasswordPolicySatisfied,
     resolvePasswordStrengthLevel,
@@ -51,5 +53,91 @@ describe('passwordPolicyRules', () => {
         expect(isPasswordPolicySatisfied('', TEST_RULES)).toBe(false);
         expect(isPasswordPolicySatisfied('Short1!a', TEST_RULES)).toBe(false);
         expect(isPasswordPolicySatisfied('LongEnough1!a', TEST_RULES)).toBe(true);
+    });
+});
+
+describe('assessPassword', () => {
+    const DIGIT_RULE = { id: 'digit', label: 'Contains a number', pattern: '[0-9]' };
+
+    it('refuses a password the derived rules accept but the configured pattern rejects', () => {
+        // The parser reads a handful of regex shapes. A policy it read incompletely used to go
+        // all-green here and be rejected by the server -- the false green this ticket exists for.
+        const policy = { pattern: '^(?=.*[0-9])(?=.*[!@#$]).{8,}$', rules: [DIGIT_RULE] };
+
+        expect(evaluatePasswordPolicyRule(DIGIT_RULE, 'password1')).toBe(true);
+        expect(assessPassword('password1', policy)).toBe('unsatisfied');
+    });
+
+    it('accepts a password the configured pattern accepts', () => {
+        const policy = { pattern: '^(?=.*[0-9])(?=.*[!@#$]).{8,}$', rules: [DIGIT_RULE] };
+
+        expect(assessPassword('password1!', policy)).toBe('satisfied');
+    });
+
+    it('matches the configured pattern against the whole password, as the server does', () => {
+        // Java's Matcher.matches() must consume the whole password; RegExp.test() settles for any
+        // substring. Unanchored, the 20-character limit here would stop applying.
+        const policy = { pattern: '(?=.*[0-9])(?=.*[A-Z]).{8,20}', rules: [DIGIT_RULE] };
+
+        expect(assessPassword(`A1${'x'.repeat(28)}`, policy)).toBe('unsatisfied');
+        expect(assessPassword('Abcdefg1', policy)).toBe('satisfied');
+    });
+
+    it('cannot decide when the browser refuses to compile the pattern', () => {
+        // The server compiles with Java's engine and we compile with JavaScript's. A possessive
+        // quantifier is valid Java and a syntax error here; reading that as "unsatisfied" would
+        // block a password the server would accept, forever.
+        const policy = { pattern: '^[a-z]++$', rules: [DIGIT_RULE] };
+
+        expect(assessPassword('abcdef', policy)).toBe('undecidable');
+    });
+
+    it.each([
+        ['a Unicode property class', '^\\p{Upper}.{7,}$', 'Abcdefgh'],
+        ['a horizontal-whitespace class', '^\\h*[A-Z].{7,}$', 'Abcdefgh'],
+        ['a quoted literal', '^\\QA.\\E.{6,}$', 'A.bcdefg'],
+        ['input-boundary anchors', '\\A[A-Z].{7,}\\z', 'Abcdefgh'],
+        ['a nested character-class intersection', '^[a-z&&[^x]]{8,}$', 'abcdefgh'],
+        ['a character-class intersection', '^[a-z&&def]{8,}$', 'abcdefgh'],
+    ])('cannot decide on %s, which JavaScript compiles to something else', (_, pattern, password) => {
+        // Without the u flag an escape JavaScript does not know reads as its letter, and '&&' or a
+        // nested '[' in a class read as literals. These compile here and demand something else,
+        // which would block passwords the server accepts or accept ones it refuses.
+        expect(assessPassword(password, { pattern, rules: [DIGIT_RULE] })).toBe('undecidable');
+    });
+
+    it('still decides on escapes both engines read alike', () => {
+        const policy = { pattern: '^(?=.*\\d)(?=.*[\\-_])\\w[\\w\\-]{7,}$', rules: [DIGIT_RULE] };
+
+        expect(assessPassword('abc-defg1', policy)).toBe('satisfied');
+        expect(assessPassword('abc-defgh', policy)).toBe('unsatisfied');
+    });
+
+    it('cannot decide when there is no pattern and no rule to check', () => {
+        expect(assessPassword('anything', { rules: [] })).toBe('undecidable');
+    });
+
+    it('falls back to the derived rules when no pattern was returned', () => {
+        expect(assessPassword('password1', { rules: [DIGIT_RULE] })).toBe('satisfied');
+        expect(assessPassword('password', { rules: [DIGIT_RULE] })).toBe('unsatisfied');
+    });
+
+    it('treats an empty password as unsatisfied rather than undecidable', () => {
+        expect(assessPassword('', { pattern: '^.{8,}$', rules: [] })).toBe('unsatisfied');
+    });
+});
+
+describe('describablePasswordRules', () => {
+    it('drops the opaque whole-pattern fallback the server sends when it derives nothing', () => {
+        const rules = [{ id: 'policyPattern', label: 'Matches the configured password policy', pattern: '^\\d{8,}$' }];
+
+        // Nothing to tick off, and its pattern is the raw policy, which must not reach the DOM.
+        expect(describablePasswordRules(rules)).toEqual([]);
+    });
+
+    it('keeps rules a reader can act on', () => {
+        const rules = [{ id: 'minLength', label: 'At least 12 characters', pattern: '^.{12,}$' }];
+
+        expect(describablePasswordRules(rules)).toEqual(rules);
     });
 });


### PR DESCRIPTION
PR 3 of 7 for [FOUND-249](https://gravitee.atlassian.net/browse/FOUND-249) (Gamma sign-up parity). Story: [FOUND-260](https://gravitee.atlassian.net/browse/FOUND-260).

## Problem

The checklist's rules are parsed from `user.password.policy.pattern`, and the parser recognises only a few regex shapes. A requirement it can't read, such as `(?=.*\d)`, gets no rule. The checklist went all green, submit was enabled, and the server rejected the password.

## Change

- The configured pattern decides whether submit is enabled. It is matched against the whole password, as the server's `Matcher.matches()` does. The derived rules only explain it.
- A pattern the browser can't read the way Java does is `undecidable`: submit stays enabled and the server decides. That covers a pattern that won't compile here, and one that compiles to something else (`\p{…}`, `\Q…\E`, `\A`, a class intersection).
- When the pattern refuses a password that every listed rule accepts, the checklist says a requirement isn't listed, and the strength meter stops at "Good". The operator's description, if they wrote one, is shown with it.
- The opaque `policyPattern` rule is no longer listed. When no rule can be listed, the operator's description is shown instead.
- A server format rejection (`passwordFormat.invalid`, now exposed as `ApiError.technicalCode`) renders under the password field with `role="alert"`, and clears once the password is edited.

## Scope

Reset-password page only. The activation page ([FOUND-263](https://gravitee.atlassian.net/browse/FOUND-263)) inherits this through the shared `PasswordRequirements`.

AC change: the description now also appears next to a checklist, but only in the "isn't listed" state. FOUND-260 needs updating to match.

## Verification

`nx test gamma-console`: 31 suites, 233 tests pass (the first commit alone passes 231). `tsc`, lint, and prettier are clean.

Before undrafting: screenshots of the new states.

**Security-sensitive:** changes client-side password-policy evaluation and error-response parsing. The client check is advisory; the server still enforces the policy.


[FOUND-249]: https://gravitee.atlassian.net/browse/FOUND-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-260]: https://gravitee.atlassian.net/browse/FOUND-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-263]: https://gravitee.atlassian.net/browse/FOUND-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
