### PR TITLE
chore(distribution): bump gravitee-gamma-module-authz to 2.2.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -275,7 +275,7 @@
 
     <!-- Gamma plugins -->
     <gravitee-gamma-module-aim.version>4.3.0-alpha.30</gravitee-gamma-module-aim.version>
-    <gravitee-gamma-module-authz.version>1.22.0</gravitee-gamma-module-authz.version>
+    <gravitee-gamma-module-authz.version>2.2.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.13</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.14</gravitee-gamma-module-esm.version>
 


### PR DESCRIPTION
## Issue

No ticket, straight version bump.

## Description

Bumps the gamma authz module in the distribution from 1.22.0 to 2.2.0. That's the latest release on artifactory, confirmed with versions:display-dependency-updates.

## Additional context

Only the property in `gravitee-apim-distribution/pom.xml` changes. Both places that consume it (standalone and jdbc-migrations) already read the property.
