### PR TITLE
chore(deps): bump gravitee-policy-geoip-filtering from 2.2.2 to 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <gravitee-policy-generate-http-signature.version>1.5.1</gravitee-policy-generate-http-signature.version>
     <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
     <gravitee-policy-generate-wssecurity.version>1.0.0</gravitee-policy-generate-wssecurity.version>
-    <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
+    <gravitee-policy-geoip-filtering.version>2.2.3</gravitee-policy-geoip-filtering.version>
     <gravitee-policy-groovy.version>5.1.0</gravitee-policy-groovy.version>
     <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
     <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
@@ -281,7 +281,7 @@
     <!-- Management API & Gateway -->
     <!-- Community plugins -->
     <gravitee-policy-aws-lambda.version>3.4.1</gravitee-policy-aws-lambda.version>
-    <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
+    <gravitee-policy-geoip-filtering.version>2.2.3</gravitee-policy-geoip-filtering.version>
     <gravitee-resource-auth-provider-http.version>2.0.0</gravitee-resource-auth-provider-http.version>
     <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
     <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,6 @@
     <!-- Management API & Gateway -->
     <!-- Community plugins -->
     <gravitee-policy-aws-lambda.version>3.4.1</gravitee-policy-aws-lambda.version>
-    <gravitee-policy-geoip-filtering.version>2.2.3</gravitee-policy-geoip-filtering.version>
     <gravitee-resource-auth-provider-http.version>2.0.0</gravitee-resource-auth-provider-http.version>
     <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
     <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15084

## Description

Bumps the GeoIP Filtering policy shipped by the distribution from 2.2.2 to 2.2.3.

2.2.2 calls the `EventBus.request(String, Object, Handler)` overload that Vert.x 5 removed, so on 4.12 the policy throws `NoSuchMethodError` on every request and the gateway answers 500. A customer hit it on a 4.11 -> 4.12 upgrade and had to roll back. 2.2.3 (gravitee-io/gravitee-policy-geoip-filtering#66) switches to `request(address, ip).onComplete(handler)`.

The property was declared twice in this pom, at lines 199 and 285. Maven keeps the last declaration, so the first commit updates both — bumping only the first would leave the build on 2.2.2 while looking correct. The second commit then removes the duplicate, so the next bump cannot be shadowed again. The duplicate dates back to `c2c088fc65` (2023-07-21), which added a "full distribution on dev environment" block copying two entries that already existed above.

Both declarations hold the same value here, so removing one changes nothing in this build.

## Additional context

Done by hand rather than through Renovate and a backport. Renovate has no `baseBranches` here, so it only opens PRs on master, where this pin lives in `gravitee-apim-distribution/pom.xml` instead of the root pom — a Mergify backport of that PR would not apply, the same way the recent `groovy` and `data-logging-masking` bumps had to be resolved by hand on this branch.

Checks done before opening:

- `mvn -N help:evaluate -Dexpression=gravitee-policy-geoip-filtering.version` returns `2.2.3` on this branch
- `com.graviteesource.policy:gravitee-policy-geoip-filtering:2.2.3:zip` resolves from Artifactory
- unzipping that published artifact and disassembling `GeoIPFilteringPolicy` shows the fixed call sites (`EventBus.request(String, Object) -> Future` then `Future.onComplete(Handler)`, both present in Vert.x 4 and 5) and Java 17 bytecode, so it stays loadable on the older lines too

Nothing to do for `gravitee-service-geoip`: it only uses `consumer`, `reply`, `fail` and `unregister`, whose descriptors are unchanged between Vert.x 4 and 5, and it stays at 3.0.0.
