### PR TITLE
fix: drop the duplicated property shadowing the circuit-breaker pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,6 @@
     <!-- Management API & Gateway -->
     <!-- Community plugins -->
     <gravitee-policy-aws-lambda.version>3.4.1</gravitee-policy-aws-lambda.version>
-    <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
     <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
     <gravitee-resource-auth-provider-http.version>2.0.0</gravitee-resource-auth-provider-http.version>
     <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15085

## Description

`gravitee-policy-circuit-breaker.version` was declared twice in this pom, inside the same `properties` block: line 190 in the plugin list at `2.1.0`, and line 284 in the "full distribution on dev environment" block at `2.0.0`. Maven keeps the last declaration, so the effective version was `2.0.0` and the pin set by APIM-15013 has been inert since 31 August.

That matters beyond hygiene: APIM-15013 ("policy-circuit-breaker opens on a single call and ignores interrupted calls") is closed with fix version 4.12.18, released the same day, and both 4.12.18 and 4.12.19 actually ship 2.0.0. The reported behaviour is still present on the released branch.

This removes the duplicate, so the branch ships 2.1.0 as intended. It is a deliberate change of what the distribution bundles, hence a dedicated PR rather than a silent cleanup.

## Additional context

Evaluated with `mvn -N help:evaluate -Dexpression=gravitee-policy-circuit-breaker.version`:

| | before | after |
| --- | --- | --- |
| tag 4.12.18 | 2.0.0 | — |
| tag 4.12.19 | 2.0.0 | — |
| this branch | 2.0.0 | 2.1.0 |

Circuit-breaker 2.1.0 was released on 2026-08-31 against `gravitee-apim-bom` 4.12.0 and gravitee-parent 24.0.1, so it targets this stack, and its Vert.x usage is confined to its own integration tests. The artifact resolves from Artifactory.

Scope: master is unaffected, the property is declared once there, in `gravitee-apim-distribution/pom.xml`, already at 2.1.0. 4.11.x carries the same duplicate but with 2.0.0 on both lines, so nothing is shadowed; note 2.1.0 is built against the 4.12 BOM and is not a drop-in there.

The duplicate dates back to `c2c088fc65` (2023-07-21), which added the second block by copying entries that already existed above.

Heads-up for whoever merges: [#19807](https://github.com/gravitee-io/gravitee-api-management/pull/19807) removes the `geoip-filtering` duplicate on the adjacent line, so whichever lands second may need a trivial rebase.
