### PR TITLE
ci: enable corepack in the backend build so yarn reads the lockfile

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -15,7 +15,7 @@
  */
 import { commands, Config, Job, reusable } from '@circleci/circleci-config-sdk';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
@@ -28,14 +28,20 @@ export class BuildBackendJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    // The reactor installs the yarn workspace (gravitee-gamma runs `yarn install` in
+    // generate-resources). Without corepack the image's yarn 1 cannot read the berry lockfile
+    // and resolves the whole workspace from the registry instead.
+    const installYarnCmd = InstallYarnCommand.get();
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(installYarnCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
+      new reusable.ReusedCommand(installYarnCmd),
       new commands.Run({
         name: 'Build project',
         command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc`,

--- a/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
@@ -15,7 +15,7 @@
  */
 import { commands, Config, Job, reusable } from '@circleci/circleci-config-sdk';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -27,13 +27,19 @@ export class CommunityBuildBackendJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    // The reactor installs the yarn workspace (gravitee-gamma runs `yarn install` in
+    // generate-resources). Without corepack the image's yarn 1 cannot read the berry lockfile
+    // and resolves the whole workspace from the registry instead.
+    const installYarnCmd = InstallYarnCommand.get();
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(installYarnCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
+      new reusable.ReusedCommand(installYarnCmd),
       new commands.Run({
         name: 'Build project',
         command: `mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')}`,

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -156,6 +156,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -162,6 +162,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -163,6 +163,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -162,6 +162,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -243,6 +243,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1062,6 +1062,7 @@ jobs:
       - checkout
       - cmd-restore-maven-job-cache:
           jobName: job-community-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -127,6 +127,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -142,6 +142,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -201,6 +201,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -243,6 +243,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1062,6 +1062,7 @@ jobs:
       - checkout
       - cmd-restore-maven-job-cache:
           jobName: job-community-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -201,6 +201,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -226,6 +226,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -64,6 +64,13 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
 jobs:
   job-setup:
     docker:
@@ -90,6 +97,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -163,6 +163,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-build
+      - cmd-install-yarn
       - run:
           name: Build project
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -P all-modules,integration-tests-modules -DwithJavadoc


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-392

## Description

Backport of the fix master already carries: the `Build backend` job now runs `InstallYarnCommand` (corepack enable, then `yarn set version` at the pinned release) before the maven build. Second commit applies the same three lines to `Check build as Community user`, which runs the same reactor and was failing the same way.

`gravitee-gamma` runs `yarn install` during `generate-resources`, so the workspace install is served by the CI image's yarn 1.22. Yarn 1 cannot read this repository's berry lockfile (`__metadata: version: 8`, `packageManager: yarn@4.1.1`); it does not fail on it, it ignores it and resolves the whole workspace from the registry instead. Every build therefore floats onto whatever npm published last.

That is what broke this branch on 9 September: `rolldown` 1.2.8 was published at 09:47 UTC without its `@rolldown/binding-openharmony-arm64` binding, and builds started failing with

```
error Couldn't find any versions for "@rolldown/binding-openharmony-arm64" that matches "1.2.8"
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:exec
        (yarn-workspace-install) on project gravitee-gamma
```

The branch head build (`2060005`) and two open pull requests were held up until upstream published the missing binding. The lockfile pins `rolldown` 1.0.3 and every one of its bindings at 1.0.3, so a build that actually reads it could not have resolved 1.2.8 in the first place.

## Additional context

The change is the same three lines and the same comment as `job-build-backend.ts` on master; `InstallYarnCommand` already exists on this branch and is used by other jobs here, so nothing new is introduced.

Checked locally in `.circleci/ci`:

- `npm run build` (tsc) passes
- `npm test` passes — the pipeline fixtures were regenerated, and the only change in them is the `- cmd-install-yarn` step plus the reusable command definition in the one pipeline that did not already have it
- `npm run lint` (license, eslint, prettier) passes
- `corepack yarn install --immutable` at the repository root completes in 50s on this branch, so the lockfile is in sync and the pinned yarn has nothing to complain about

Still open, tracked in BX-392: `Check build as Community user` has no corepack step on master either. This pull request only fixes 4.12.x; master needs the same one-job change.
