### PR TITLE
fix(rest-api): reconcile the scheduler state with what other nodes stored

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainService.java
@@ -32,6 +32,11 @@ import java.util.function.Supplier;
  * evaluation can update it: an on-demand evaluation that finds traffic ends a backoff on the spot instead of at the
  * next backed-off slot, and an updated target starts a fresh schedule instead of inheriting the backoff of the
  * definition it replaced.
+ *
+ * <p>Each node holds its own map, and only the primary schedules, while an on-demand evaluation or an update is served
+ * by whichever node answers the request. What those nodes did reaches the primary through the store: before judging a
+ * target the scheduler {@link #reconcile reconciles} its memory with the stored latest evaluation and the target's
+ * update time.
  */
 @DomainService
 public class PerformanceTargetScheduleStateDomainService {
@@ -60,6 +65,38 @@ public class PerformanceTargetScheduleStateDomainService {
     /** The target was redefined: its next slot is due at once and its backoff is forgotten. */
     public void reset(String targetId) {
         states.put(targetId, State.FRESH);
+    }
+
+    /**
+     * Folds in what this node did not see happen. A target redefined since this node's last evaluation of it starts
+     * a fresh schedule, as {@link #reset} does on the node that saved it. An evaluation stored since this node's last
+     * one, by another node's on-demand run or by a previous primary, moves the state as if recorded here, so a backoff
+     * ends where the traffic was found and not at the next backed-off slot. Evaluations that predate a redefinition
+     * belong to the definition it replaced and are ignored.
+     *
+     * @param redefinedAt  when the target was last updated, {@code null} when unknown
+     * @param storedLatest the target's latest stored evaluation, {@code null} when it has none
+     * @return the reconciled state, which is now this node's state for the target
+     */
+    public State reconcile(String targetId, Instant redefinedAt, PerformanceTargetEvaluation storedLatest) {
+        return states.compute(targetId, (id, known) -> {
+            var state = known == null ? State.FRESH : known;
+            if (redefinedAt != null && state.lastEvaluatedAt() != null && redefinedAt.isAfter(state.lastEvaluatedAt())) {
+                state = State.FRESH;
+            }
+            if (storedLatest != null && isNewerThan(storedLatest, state) && !predates(storedLatest, redefinedAt)) {
+                state = state.after(storedLatest);
+            }
+            return state;
+        });
+    }
+
+    private static boolean isNewerThan(PerformanceTargetEvaluation evaluation, State state) {
+        return state.lastEvaluatedAt() == null || evaluation.evaluatedAt().isAfter(state.lastEvaluatedAt());
+    }
+
+    private static boolean predates(PerformanceTargetEvaluation evaluation, Instant redefinedAt) {
+        return redefinedAt != null && evaluation.evaluatedAt().isBefore(redefinedAt);
     }
 
     /** Forgets every target not in the set, so a deleted target does not linger. */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCase.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.performance_target.use_case;
 
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
@@ -34,7 +36,10 @@ import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -44,8 +49,9 @@ import lombok.RequiredArgsConstructor;
  * <p>The schedule state of a target, when it was last evaluated and how many times in a row it was not evaluable,
  * lives in {@link PerformanceTargetScheduleStateDomainService} and is seeded from its stored evaluations the first
  * time the target is seen, so a restart resumes where the previous node left off instead of evaluating everything at
- * once. A target the evaluator leaves out is still counted as attempted: it is retried at its next slot, not at every
- * tick.
+ * once. Every tick then reconciles that memory with the store, one query per environment, so an on-demand evaluation
+ * or an update served by another node counts here too. A target the evaluator leaves out is still counted as
+ * attempted: it is retried at its next slot, not at every tick.
  */
 @RequiredArgsConstructor
 @UseCase
@@ -62,11 +68,13 @@ public class EvaluateDuePerformanceTargetsUseCase {
         var now = TimeProvider.instantNow();
         var targets = performanceTargetQueryService.findAll();
         scheduleState.retain(targets.stream().map(PerformanceTarget::id).collect(toSet()));
+        var storedLatest = storedLatestByTarget(targets);
 
         var due = targets
             .stream()
             .filter(target -> {
-                var state = scheduleState.stateOf(target.id(), () -> seed(target, schedule));
+                scheduleState.stateOf(target.id(), () -> seed(target, schedule));
+                var state = scheduleState.reconcile(target.id(), redefinedAt(target), storedLatest.get(target.id()));
                 return schedule.isDue(target, state.lastEvaluatedAt(), state.consecutiveNotEvaluable(), now);
             })
             .toList();
@@ -105,6 +113,30 @@ public class EvaluateDuePerformanceTargetsUseCase {
      */
     private static String evaluationId(PerformanceTarget target, Instant slotStart) {
         return UuidString.generateForEnvironment(target.environmentId(), target.id(), String.valueOf(slotStart.getEpochSecond()));
+    }
+
+    /**
+     * The latest stored evaluation of every target, whichever node stored it: one query per environment, since the
+     * store indexes latest evaluations by environment and subject reference.
+     */
+    private Map<String, PerformanceTargetEvaluation> storedLatestByTarget(List<PerformanceTarget> targets) {
+        var referencesByEnvironment = targets
+            .stream()
+            .filter(target -> target.subject() != null && target.subject().reference() != null)
+            .collect(groupingBy(PerformanceTarget::environmentId, mapping(target -> target.subject().reference(), toSet())));
+        var latest = new HashMap<String, PerformanceTargetEvaluation>();
+        referencesByEnvironment.forEach((environmentId, references) ->
+            performanceTargetEvaluationQueryService
+                .findLatestByReferences(environmentId, references)
+                .forEach(evaluation ->
+                    latest.merge(evaluation.targetId(), evaluation, (a, b) -> a.evaluatedAt().isAfter(b.evaluatedAt()) ? a : b)
+                )
+        );
+        return latest;
+    }
+
+    private static Instant redefinedAt(PerformanceTarget target) {
+        return Objects.isNull(target.updatedAt()) ? null : target.updatedAt().toInstant();
     }
 
     private State seed(PerformanceTarget target, PerformanceTargetSchedule schedule) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/PerformanceTargetScheduleStateDomainServiceTest.java
@@ -90,6 +90,58 @@ class PerformanceTargetScheduleStateDomainServiceTest {
         assertThat(service.current("gone")).isEmpty();
     }
 
+    @Test
+    void should_adopt_an_evaluation_another_node_stored_after_its_own_last_one() {
+        service.stateOf("t", () -> new State(T0, 5));
+
+        var state = service.reconcile("t", null, evaluation(PerformanceTargetEvaluation.Status.PASS, T0.plusSeconds(90)));
+
+        assertThat(state).isEqualTo(new State(T0.plusSeconds(90), 0));
+        assertThat(service.current("t")).contains(state);
+    }
+
+    @Test
+    void should_keep_its_state_when_the_stored_latest_is_not_newer_than_what_it_knows() {
+        service.stateOf("t", () -> new State(T0, 5));
+
+        var same = service.reconcile("t", null, evaluation(PerformanceTargetEvaluation.Status.NOT_EVALUABLE, T0));
+        var older = service.reconcile("t", null, evaluation(PerformanceTargetEvaluation.Status.PASS, T0.minusSeconds(60)));
+
+        assertThat(same).isEqualTo(new State(T0, 5));
+        assertThat(older).isEqualTo(new State(T0, 5));
+    }
+
+    @Test
+    void should_start_afresh_when_the_target_was_redefined_after_its_last_evaluation() {
+        service.stateOf("t", () -> new State(T0, 5));
+
+        assertThat(service.reconcile("t", T0.minusSeconds(10), null)).isEqualTo(new State(T0, 5));
+        assertThat(service.reconcile("t", T0.plusSeconds(10), null)).isEqualTo(State.FRESH);
+    }
+
+    @Test
+    void should_adopt_only_the_evaluations_that_followed_a_redefinition() {
+        service.stateOf("t", () -> new State(T0, 5));
+
+        var before = service.reconcile("t", T0.plusSeconds(10), evaluation(PerformanceTargetEvaluation.Status.PASS, T0.plusSeconds(5)));
+        var after = service.reconcile(
+            "t",
+            T0.plusSeconds(10),
+            evaluation(PerformanceTargetEvaluation.Status.NOT_EVALUABLE, T0.plusSeconds(40))
+        );
+
+        assertThat(before).isEqualTo(State.FRESH);
+        assertThat(after).isEqualTo(new State(T0.plusSeconds(40), 1));
+    }
+
+    @Test
+    void should_reconcile_a_target_it_has_not_seen_yet_from_the_stored_latest() {
+        var state = service.reconcile("t", null, evaluation(PerformanceTargetEvaluation.Status.BREACH, T0));
+
+        assertThat(state).isEqualTo(new State(T0, 0));
+        assertThat(service.current("t")).contains(state);
+    }
+
     private static PerformanceTargetEvaluation evaluation(PerformanceTargetEvaluation.Status status, Instant evaluatedAt) {
         return PerformanceTargetFixtures.anEvaluation("e-" + evaluatedAt.getEpochSecond(), "t", status, evaluatedAt);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
@@ -360,6 +360,63 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         assertThat(tick(now.plus(TICK)).evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
     }
 
+    /**
+     * Only the primary node schedules, but an on-demand evaluation is served by whichever node answers the request:
+     * its result reaches the primary through the store, not through the primary's memory.
+     */
+    @Test
+    void should_end_the_backoff_when_another_node_ran_the_on_demand_evaluation() {
+        var target = aTarget("idle");
+        targetCrudService.initWith(List.of(target));
+        evaluator.status(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+        var now = T0;
+        while (now.isBefore(T0.plus(Duration.ofHours(5)))) {
+            tick(now);
+            now = now.plus(TICK);
+        }
+        var lastScheduled = evaluationCrudService
+            .storage()
+            .stream()
+            .map(PerformanceTargetEvaluation::evaluatedAt)
+            .max(Instant::compareTo)
+            .get();
+        assertThat(tick(lastScheduled.plus(INTERVAL.multipliedBy(2))).evaluations()).isEmpty();
+
+        evaluator.status(PerformanceTargetEvaluation.Status.PASS);
+        var onAnotherNode = new EvaluatePerformanceTargetUseCase(
+            targetCrudService,
+            evaluationQueryService,
+            evaluationCrudService,
+            evaluator,
+            new PerformanceTargetScheduleStateDomainService()
+        );
+        var clicked = lastScheduled.plus(INTERVAL.multipliedBy(2)).plusSeconds(30);
+        input(clicked);
+        onAnotherNode.execute(new EvaluatePerformanceTargetUseCase.Input(target.environmentId(), target.id()));
+
+        var nextSlot = tick(clicked.plus(INTERVAL).plus(TICK));
+
+        assertThat(nextSlot.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
+    }
+
+    @Test
+    void should_evaluate_a_target_another_node_redefined_at_the_next_tick() {
+        var target = aTarget("idle");
+        targetCrudService.initWith(List.of(target));
+        evaluator.status(PerformanceTargetEvaluation.Status.NOT_EVALUABLE);
+        var now = T0;
+        while (now.isBefore(T0.plus(Duration.ofHours(5)))) {
+            tick(now);
+            now = now.plus(TICK);
+        }
+        assertThat(tick(now).evaluations()).isEmpty();
+
+        // the store holds the new definition; this node's memory still holds the backoff
+        targetCrudService.update(target.toBuilder().updatedAt(now.atZone(ZoneId.systemDefault())).build());
+
+        assertThat(tick(now.plus(TICK)).evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
+    }
+
     /** Another node: its own schedule state, the same stores. */
     private EvaluateDuePerformanceTargetsUseCase newUseCase(PerformanceTargetEvaluatorInMemory evaluator) {
         return newUseCase(evaluator, new PerformanceTargetScheduleStateDomainService());


### PR DESCRIPTION
## What

On the amp-demo environment the management API runs three replicas. Only the primary runs the scheduler, but **Evaluate now** and **Edit** are served by whichever replica answers, and each node keeps its schedule state in memory. So #19697 fixed the single-node case only: on the demo, a target that had backed off while idle kept its hourly slot on the primary even after a manual evaluation found traffic on another node. Observed today at 12:15 and 12:18 with load on and no scheduled evaluation in between.

The scheduler now reconciles its memory with the store on every tick:

- `PerformanceTargetScheduleStateDomainService.reconcile(targetId, redefinedAt, storedLatest)`: a stored evaluation newer than what the node knows is adopted as if recorded here (so an evaluable one ends the backoff), and a target updated since its last evaluation starts a fresh schedule, exactly as `reset` does on the node that saved it. Evaluations that predate a redefinition are ignored.
- `EvaluateDuePerformanceTargetsUseCase` fetches the latest stored evaluation of every target with one `findLatestByReferences` query per environment (the query the list badges already use) and reconciles before judging due-ness. No new repository method, no schema change.

## Tests

TDD, RED then GREEN: five new tests on the state service (adopt newer, keep same or older, fresh after redefinition, adopt only what followed the redefinition, unseen target) and two on the scheduler use case simulating another node (on-demand evaluation through a second state instance ends the backoff at the next slot; a redefinition saved to the store is evaluated at the next tick). Scoped run: 34 tests green including `CoreRulesTest`; `prettier:check` and `verify -DskipTests` clean.

Verified the single-node behaviour on a running stack beforehand: a target backed off to one evaluation per hour returned to its one-minute cadence at the first slot after a manual evaluation.

## Notes

One extra query per tick for all targets, negligible next to the analytics work. Not security-sensitive.

Relates to AIAM-511