### PR TITLE
feat(gamma): add API Logging settings page to platform module

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fileURLToPath } from 'node:url';
-
 export default {
     displayName: 'gravitee-gamma-module-platform',
     testEnvironment: 'jest-fixed-jsdom',
@@ -47,7 +45,7 @@ export default {
         [
             'jest-junit',
             {
-                outputDirectory: fileURLToPath(new URL('./coverage', import.meta.url)),
+                outputDirectory: '<rootDir>/coverage',
                 outputName: 'junit.xml',
                 addFileAttribute: 'true',
             },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -65,6 +65,7 @@ import { ENVIRONMENT_SHARED_POLICY_GROUP_READ_PERMISSION } from '../features/sha
 import { AccessManagementPage } from '../pages/AccessManagementPage';
 import { AlertsPage } from '../pages/AlertsPage';
 import { ApiHealthCheckPage } from '../pages/ApiHealthCheckPage';
+import { ApiLoggingSettingsPage } from '../pages/ApiLoggingSettingsPage';
 import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { AuthenticationPage } from '../pages/AuthenticationPage';
@@ -725,6 +726,14 @@ export function AppRoutes() {
                                 element={
                                     <NavPermissionGuard itemKey="policy-studio">
                                         <OrganizationPolicyStudioPage />
+                                    </NavPermissionGuard>
+                                }
+                            />
+                            <Route
+                                path="api-logging"
+                                element={
+                                    <NavPermissionGuard itemKey="api-logging">
+                                        <ApiLoggingSettingsPage />
                                     </NavPermissionGuard>
                                 }
                             />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.spec.ts
@@ -243,20 +243,27 @@ describe('platform nav visibility', () => {
         expect(isFederationAvailable({ federationEnabled: true, license: ENTITLED_LICENSE })).toBe(true);
     });
 
-    it('hides Management, CORS, and SMTP when the user has organization-settings-u without -r', () => {
+    it('hides Management, CORS, SMTP, and API Logging when the user has organization-settings-u without -r', () => {
         const onlyUpdate = visibility(['organization-settings-u']);
         expect(isNavItemVisible('management-and-schedulers', onlyUpdate)).toBe(false);
         expect(isNavItemVisible('cors', onlyUpdate)).toBe(false);
         expect(isNavItemVisible('smtp', onlyUpdate)).toBe(false);
+        expect(isNavItemVisible('api-logging', onlyUpdate)).toBe(false);
         expect(isNavItemVisible('users', visibility(['organization-settings-u', 'organization-user-r']))).toBe(true);
     });
 
-    it('shows Management, CORS, and SMTP when the user has organization-settings-r', () => {
+    it('shows Management, CORS, SMTP, and API Logging when the user has organization-settings-r', () => {
         const canRead = visibility(['organization-settings-r']);
         expect(isNavItemVisible('management-and-schedulers', canRead)).toBe(true);
         expect(isNavItemVisible('cors', canRead)).toBe(true);
         expect(isNavItemVisible('smtp', canRead)).toBe(true);
+        expect(isNavItemVisible('api-logging', canRead)).toBe(true);
         expect(isNavItemVisible('templates', canRead)).toBe(false);
+    });
+
+    it('hides API Logging for environment admin without org settings', () => {
+        expect(isNavItemVisible('api-logging', visibility([...ENVIRONMENT_ADMIN]))).toBe(false);
+        expect(isNavItemVisible('api-logging', visibility([...ORGANIZATION_USER, ...ENVIRONMENT_ADMIN]))).toBe(false);
     });
 
     it('gates Templates on organization-notification_templates-r after the org settings gate', () => {
@@ -327,6 +334,10 @@ describe('platform nav visibility', () => {
         expect(pageGuardForNavItem('applications')).toEqual({ anyOf: ['environment-application-r'] });
         expect(pageGuardForNavItem('access-management')).toEqual({ anyOf: ['environment-am_configuration-r'] });
         expect(pageGuardForNavItem('cors')).toEqual({
+            anyOf: ['organization-settings-r'],
+            alsoAnyOf: ['organization-settings-r', 'organization-settings-u'],
+        });
+        expect(pageGuardForNavItem('api-logging')).toEqual({
             anyOf: ['organization-settings-r'],
             alsoAnyOf: ['organization-settings-r', 'organization-settings-u'],
         });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navVisibility.ts
@@ -49,6 +49,7 @@ const ORGANIZATION_SETTINGS_GATED_ITEMS: ReadonlySet<string> = new Set([
     'cors',
     'smtp',
     'templates',
+    'api-logging',
     'organization-audit',
     'users',
 ]);
@@ -75,6 +76,7 @@ export const NAV_ITEM_PERMISSIONS: Readonly<Record<string, readonly string[]>> =
     cors: [ORGANIZATION_SETTINGS_READ_PERMISSION],
     smtp: [ORGANIZATION_SETTINGS_READ_PERMISSION],
     templates: [ORGANIZATION_NOTIFICATION_TEMPLATES_READ],
+    'api-logging': [ORGANIZATION_SETTINGS_READ_PERMISSION],
     'organization-audit': [ORGANIZATION_AUDIT_READ_PERMISSION],
     applications: [ENVIRONMENT_APPLICATION_READ_PERMISSION],
     integrations: [ENVIRONMENT_INTEGRATION_READ_PERMISSION],

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.spec.ts
@@ -88,7 +88,7 @@ describe('platform navigation config', () => {
         expect(assetItems.find(item => item.key === 'broadcasts')?.title).toBe('Broadcasts');
     });
 
-    it('places Access Management, Gateways, Alerts, Notifications, API Health Check, SMTP, Security Plan Types, and Audit under Environment / System & Security', () => {
+    it('places Access Management, Gateways, Alerts, Notifications, API Health Check, SMTP, API Logging, Security Plan Types, and Audit under Environment / System & Security', () => {
         expect(sectionKeys('Environment', 'System & Security')).toEqual([
             'access-management',
             'gateways',
@@ -96,6 +96,7 @@ describe('platform navigation config', () => {
             'notification-settings',
             'api-health-check',
             'environment-smtp',
+            'api-logging',
             'security-plan-types',
             'environment-audit',
         ]);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/navigation.ts
@@ -115,6 +115,7 @@ export const NAV_SECTIONS: PlatformNavSection[] = [
                     { key: 'notification-settings', title: ROUTES['notification-settings'].label, icon: MailIcon },
                     { key: 'api-health-check', title: ROUTES['api-health-check'].label, icon: ActivityIcon },
                     { key: 'environment-smtp', title: ROUTES['environment-smtp'].label, icon: SettingsIcon },
+                    { key: 'api-logging', title: ROUTES['api-logging'].label, icon: FileTextIcon },
                     { key: 'security-plan-types', title: ROUTES['security-plan-types'].label, icon: KeyIcon },
                     { key: 'environment-audit', title: ROUTES['environment-audit'].label, icon: ScrollTextIcon },
                 ],

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/routes.ts
@@ -42,6 +42,7 @@ export const ROUTE_KEYS: readonly string[] = [
     'environment-smtp',
     'smtp',
     'templates',
+    'api-logging',
     'no-access',
 ];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
@@ -75,6 +76,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     smtp: { path: 'smtp', label: 'SMTP' },
     'environment-smtp': { path: 'environment/smtp', label: 'SMTP' },
     templates: { path: 'templates', label: 'Templates' },
+    'api-logging': { path: 'api-logging', label: 'API Logging' },
     'no-access': { path: 'no-access', label: 'No access' },
 };
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/components/ApiLoggingSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/components/ApiLoggingSection.tsx
@@ -1,0 +1,327 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle, Input, Separator, Switch } from '@gravitee/graphene-core';
+
+import { SystemReadonlyHint } from '../../organization-settings/components/SystemReadonlyHint';
+import type { ApiLoggingFieldReadonly } from '../utils/apiLoggingFormState';
+import type { ApiLoggingFieldErrors, ApiLoggingFormState } from '../utils/apiLoggingValidators';
+
+function ToggleRow({
+    id,
+    label,
+    checked,
+    disabled,
+    systemReadonly,
+    onToggle,
+}: Readonly<{
+    id: string;
+    label: string;
+    checked: boolean;
+    disabled: boolean;
+    systemReadonly: boolean;
+    onToggle: (checked: boolean) => void;
+}>) {
+    const control = (
+        <Switch id={id} checked={checked} onCheckedChange={next => onToggle(next === true)} disabled={disabled} aria-label={label} />
+    );
+
+    return (
+        <div className="flex items-center justify-between gap-4 py-3">
+            <label htmlFor={id} className={`text-sm font-medium ${disabled ? 'cursor-default' : 'cursor-pointer'}`}>
+                {label}
+            </label>
+            <SystemReadonlyHint locked={systemReadonly} className="inline-flex">
+                {control}
+            </SystemReadonlyHint>
+        </div>
+    );
+}
+
+function Field({
+    id,
+    label,
+    value,
+    error,
+    disabled,
+    systemReadonly,
+    onChange,
+    type = 'text',
+}: Readonly<{
+    id: string;
+    label: string;
+    value: string;
+    error?: string;
+    disabled: boolean;
+    systemReadonly: boolean;
+    onChange: (value: string) => void;
+    type?: 'text' | 'number';
+}>) {
+    const errorId = `${id}-error`;
+    return (
+        <div className="space-y-1.5">
+            <label htmlFor={id} className="text-sm font-medium">
+                {label}
+            </label>
+            <SystemReadonlyHint locked={systemReadonly}>
+                <Input
+                    id={id}
+                    type={type}
+                    value={value}
+                    onChange={event => onChange(event.target.value)}
+                    disabled={disabled}
+                    aria-invalid={Boolean(error)}
+                    aria-describedby={error ? errorId : undefined}
+                />
+            </SystemReadonlyHint>
+            {error ? (
+                <p id={errorId} className="text-sm text-destructive" role="alert">
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+export function ApiLoggingSection({
+    value,
+    errors,
+    disabled,
+    readonly,
+    onChange,
+}: Readonly<{
+    value: ApiLoggingFormState;
+    errors: ApiLoggingFieldErrors;
+    disabled: boolean;
+    readonly: ApiLoggingFieldReadonly;
+    onChange: (next: ApiLoggingFormState) => void;
+}>) {
+    function updateField<K extends keyof ApiLoggingFormState>(key: K, fieldValue: ApiLoggingFormState[K]) {
+        onChange({ ...value, [key]: fieldValue });
+    }
+
+    function isFieldDisabled(key: keyof ApiLoggingFieldReadonly): boolean {
+        return disabled || readonly[key];
+    }
+
+    return (
+        <div className="space-y-6">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Duration</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                        Limit the duration of API full logging (0 means no max duration). This avoids API publishers logging headers and /
+                        or body payload for too long and consuming too much CPU and memory. By default, the calls are logged with the
+                        minimal information.
+                    </p>
+                    <Field
+                        id="api-logging-max-duration"
+                        type="number"
+                        label="Max Duration (in ms)"
+                        value={value.maxDurationMillis}
+                        error={errors.maxDurationMillis}
+                        disabled={isFieldDisabled('maxDurationMillis')}
+                        systemReadonly={readonly.maxDurationMillis}
+                        onChange={next => updateField('maxDurationMillis', next)}
+                    />
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Audit</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                        Enable to audit the consultation of log details to track who accessed a specific data from the audit view.
+                    </p>
+                    <ToggleRow
+                        id="api-logging-audit-enabled"
+                        label="Enable audit on API Logging consultation"
+                        checked={value.auditEnabled}
+                        disabled={isFieldDisabled('auditEnabled')}
+                        systemReadonly={readonly.auditEnabled}
+                        onToggle={checked => updateField('auditEnabled', checked)}
+                    />
+                    <Separator />
+                    <ToggleRow
+                        id="api-logging-audit-trail-enabled"
+                        label="Generate API Logging audit events (API_LOGGING_ENABLED, API_LOGGING_DISABLED, API_LOGGING_UPDATED)"
+                        checked={value.auditTrailEnabled}
+                        disabled={isFieldDisabled('auditTrailEnabled')}
+                        systemReadonly={readonly.auditTrailEnabled}
+                        onToggle={checked => updateField('auditTrailEnabled', checked)}
+                    />
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>User</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                        Display or not the end user in case of a OAuth2 / JWT plan (extracted from the sub claim).
+                    </p>
+                    <ToggleRow
+                        id="api-logging-user-displayed"
+                        label="Display end user on API Logging (in case of OAuth2/JWT plan)"
+                        checked={value.userDisplayed}
+                        disabled={isFieldDisabled('userDisplayed')}
+                        systemReadonly={readonly.userDisplayed}
+                        onToggle={checked => updateField('userDisplayed', checked)}
+                    />
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Message Sampling</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-8">
+                    <p className="text-sm text-muted-foreground">
+                        A sampling strategy is applied to prevent issues while logging messages.
+                    </p>
+
+                    <div className="space-y-4">
+                        <div className="space-y-1">
+                            <h3 className="text-sm font-semibold">Probabilistic</h3>
+                            <p className="text-sm text-muted-foreground">Samples messages based on a specified probability.</p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Field
+                                id="api-logging-probabilistic-default"
+                                type="number"
+                                label="Probabilistic default"
+                                value={value.probabilisticDefault}
+                                error={errors.probabilisticDefault}
+                                disabled={isFieldDisabled('probabilisticDefault')}
+                                systemReadonly={readonly.probabilisticDefault}
+                                onChange={next => updateField('probabilisticDefault', next)}
+                            />
+                            <Field
+                                id="api-logging-probabilistic-limit"
+                                type="number"
+                                label="Probabilistic limit"
+                                value={value.probabilisticLimit}
+                                error={errors.probabilisticLimit}
+                                disabled={isFieldDisabled('probabilisticLimit')}
+                                systemReadonly={readonly.probabilisticLimit}
+                                onChange={next => updateField('probabilisticLimit', next)}
+                            />
+                        </div>
+                        <p className="text-xs text-muted-foreground">The limit is the maximum allowed probability</p>
+                    </div>
+
+                    <div className="space-y-4">
+                        <div className="space-y-1">
+                            <h3 className="text-sm font-semibold">Count</h3>
+                            <p className="text-sm text-muted-foreground">Samples one message for every number of specified messages.</p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Field
+                                id="api-logging-count-default"
+                                type="number"
+                                label="Count default"
+                                value={value.countDefault}
+                                error={errors.countDefault}
+                                disabled={isFieldDisabled('countDefault')}
+                                systemReadonly={readonly.countDefault}
+                                onChange={next => updateField('countDefault', next)}
+                            />
+                            <Field
+                                id="api-logging-count-limit"
+                                type="number"
+                                label="Count limit"
+                                value={value.countLimit}
+                                error={errors.countLimit}
+                                disabled={isFieldDisabled('countLimit')}
+                                systemReadonly={readonly.countLimit}
+                                onChange={next => updateField('countLimit', next)}
+                            />
+                        </div>
+                        <p className="text-xs text-muted-foreground">The limit is the minimum messages number to sample</p>
+                    </div>
+
+                    <div className="space-y-4">
+                        <div className="space-y-1">
+                            <h3 className="text-sm font-semibold">Temporal</h3>
+                            <p className="text-sm text-muted-foreground">Samples messages based on time duration.</p>
+                            <p className="text-sm text-muted-foreground">
+                                The value should conform to ISO-8601 duration format, e.g. PT1S for a duration of 1 second.
+                            </p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Field
+                                id="api-logging-temporal-default"
+                                label="Temporal default"
+                                value={value.temporalDefault}
+                                error={errors.temporalDefault}
+                                disabled={isFieldDisabled('temporalDefault')}
+                                systemReadonly={readonly.temporalDefault}
+                                onChange={next => updateField('temporalDefault', next)}
+                            />
+                            <Field
+                                id="api-logging-temporal-limit"
+                                label="Temporal limit"
+                                value={value.temporalLimit}
+                                error={errors.temporalLimit}
+                                disabled={isFieldDisabled('temporalLimit')}
+                                systemReadonly={readonly.temporalLimit}
+                                onChange={next => updateField('temporalLimit', next)}
+                            />
+                        </div>
+                        <p className="text-xs text-muted-foreground">The limit is the minimum allowed period to sample</p>
+                    </div>
+
+                    <div className="space-y-4">
+                        <div className="space-y-1">
+                            <h3 className="text-sm font-semibold">Windowed count</h3>
+                            <p className="text-sm text-muted-foreground">Samples a count of messages during a sliding duration window.</p>
+                            <p className="text-sm text-muted-foreground">
+                                Format is COUNT/DURATION (duration should conform to ISO-8601 duration format). Example:{' '}
+                                <strong>2/PT15S</strong> will sample, at most, two messages during a 15-second sliding window.
+                            </p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Field
+                                id="api-logging-windowed-count-default"
+                                label="Windowed count default"
+                                value={value.windowedCountDefault}
+                                error={errors.windowedCountDefault}
+                                disabled={isFieldDisabled('windowedCountDefault')}
+                                systemReadonly={readonly.windowedCountDefault}
+                                onChange={next => updateField('windowedCountDefault', next)}
+                            />
+                            <Field
+                                id="api-logging-windowed-count-limit"
+                                label="Windowed count limit"
+                                value={value.windowedCountLimit}
+                                error={errors.windowedCountLimit}
+                                disabled={isFieldDisabled('windowedCountLimit')}
+                                systemReadonly={readonly.windowedCountLimit}
+                                onChange={next => updateField('windowedCountLimit', next)}
+                            />
+                        </div>
+                        <p className="text-xs text-muted-foreground">The limit is the minimum allowed period to sample</p>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingFormState.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingFormState.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ApiLoggingFormState } from './apiLoggingValidators';
+import type { ConsoleSettings } from '../../organization-settings/types/consoleSettings';
+import { isConsoleSettingReadonly } from '../../organization-settings/utils/isConsoleSettingReadonly';
+
+export interface ApiLoggingFieldReadonly {
+    maxDurationMillis: boolean;
+    auditEnabled: boolean;
+    auditTrailEnabled: boolean;
+    userDisplayed: boolean;
+    probabilisticDefault: boolean;
+    probabilisticLimit: boolean;
+    countDefault: boolean;
+    countLimit: boolean;
+    temporalDefault: boolean;
+    temporalLimit: boolean;
+    windowedCountDefault: boolean;
+    windowedCountLimit: boolean;
+}
+
+export function buildApiLoggingFormState(settings: ConsoleSettings | undefined): ApiLoggingFormState {
+    const logging = settings?.logging;
+    const sampling = logging?.messageSampling;
+
+    return {
+        maxDurationMillis: String(logging?.maxDurationMillis ?? 0),
+        auditEnabled: logging?.audit?.enabled ?? false,
+        auditTrailEnabled: logging?.audit?.trail?.enabled ?? false,
+        userDisplayed: logging?.user?.displayed ?? false,
+        probabilisticDefault: String(sampling?.probabilistic?.default ?? ''),
+        probabilisticLimit: String(sampling?.probabilistic?.limit ?? ''),
+        countDefault: String(sampling?.count?.default ?? ''),
+        countLimit: String(sampling?.count?.limit ?? ''),
+        temporalDefault: sampling?.temporal?.default ?? '',
+        temporalLimit: sampling?.temporal?.limit ?? '',
+        windowedCountDefault: sampling?.windowedCount?.default ?? '',
+        windowedCountLimit: sampling?.windowedCount?.limit ?? '',
+    };
+}
+
+export function getApiLoggingReadonlyState(settings: ConsoleSettings | undefined): ApiLoggingFieldReadonly {
+    return {
+        maxDurationMillis: isConsoleSettingReadonly(settings, 'logging.default.max.duration'),
+        auditEnabled: isConsoleSettingReadonly(settings, 'logging.audit.enabled'),
+        auditTrailEnabled: isConsoleSettingReadonly(settings, 'logging.audit.trail.enabled'),
+        userDisplayed: isConsoleSettingReadonly(settings, 'logging.user.displayed'),
+        probabilisticDefault: isConsoleSettingReadonly(settings, 'logging.messageSampling.probabilistic.default'),
+        probabilisticLimit: isConsoleSettingReadonly(settings, 'logging.messageSampling.probabilistic.limit'),
+        countDefault: isConsoleSettingReadonly(settings, 'logging.messageSampling.count.default'),
+        countLimit: isConsoleSettingReadonly(settings, 'logging.messageSampling.count.limit'),
+        temporalDefault: isConsoleSettingReadonly(settings, 'logging.messageSampling.temporal.default'),
+        temporalLimit: isConsoleSettingReadonly(settings, 'logging.messageSampling.temporal.limit'),
+        windowedCountDefault: isConsoleSettingReadonly(settings, 'logging.messageSampling.windowedCount.default'),
+        windowedCountLimit: isConsoleSettingReadonly(settings, 'logging.messageSampling.windowedCount.limit'),
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingValidators.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingValidators.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isApiLoggingFormValid, validateApiLoggingForm, type ApiLoggingFormState } from './apiLoggingValidators';
+
+const VALID_STATE: ApiLoggingFormState = {
+    maxDurationMillis: '15000',
+    auditEnabled: true,
+    auditTrailEnabled: true,
+    userDisplayed: true,
+    probabilisticDefault: '0.25',
+    probabilisticLimit: '0.5',
+    countDefault: '200',
+    countLimit: '20',
+    temporalDefault: 'PT5S',
+    temporalLimit: 'PT1S',
+    windowedCountDefault: '1/PT10S',
+    windowedCountLimit: '1/PT1S',
+};
+
+describe('apiLoggingValidators', () => {
+    it('accepts a valid form state', () => {
+        expect(isApiLoggingFormValid(VALID_STATE)).toBe(true);
+        expect(validateApiLoggingForm(VALID_STATE)).toEqual({});
+    });
+
+    it('reports invalid probabilistic values as non-numeric', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            probabilisticDefault: 'not-a-number',
+        });
+
+        expect(errors.probabilisticDefault).toBe('Value should be a number');
+    });
+
+    it('requires probabilistic default to stay below the limit', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            probabilisticDefault: '0.6',
+            probabilisticLimit: '0.5',
+        });
+
+        expect(errors.probabilisticDefault).toBe('Default should be lower than Limit');
+        expect(errors.probabilisticLimit).toBe('Default should be lower than Limit');
+    });
+
+    it('requires count default to stay above the limit', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            countDefault: '10',
+            countLimit: '20',
+        });
+
+        expect(errors.countDefault).toBe('Default should be greater than Limit');
+        expect(errors.countLimit).toBe('Default should be greater than Limit');
+    });
+
+    it('requires temporal default to stay above the limit', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            temporalDefault: 'PT1S',
+            temporalLimit: 'PT5S',
+        });
+
+        expect(errors.temporalDefault).toBe('Default should be greater than Limit');
+        expect(errors.temporalLimit).toBe('Default should be greater than Limit');
+    });
+
+    it('requires windowed count default rate to stay below the limit rate', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            windowedCountDefault: '2/PT1S',
+            windowedCountLimit: '1/PT1S',
+        });
+
+        expect(errors.windowedCountDefault).toBe('Default must be a lower rate than limit');
+        expect(errors.windowedCountLimit).toBe('Default must be a lower rate than limit');
+    });
+
+    it('requires sampling fields to be non-empty', () => {
+        const errors = validateApiLoggingForm({
+            ...VALID_STATE,
+            probabilisticDefault: '',
+            countLimit: '   ',
+            temporalDefault: '',
+        });
+
+        expect(errors.probabilisticDefault).toBe('Value is required');
+        expect(errors.countLimit).toBe('Value is required');
+        expect(errors.temporalDefault).toBe('Value is required');
+    });
+
+    it('enforces probabilistic bounds', () => {
+        expect(validateApiLoggingForm({ ...VALID_STATE, probabilisticDefault: '0.001' }).probabilisticDefault).toBe(
+            'Value should be at least 0.01',
+        );
+        expect(validateApiLoggingForm({ ...VALID_STATE, probabilisticLimit: '1.1' }).probabilisticLimit).toBe(
+            'Value should not be greater than 1',
+        );
+    });
+
+    it('rejects non-integer and sub-minimum count values', () => {
+        expect(validateApiLoggingForm({ ...VALID_STATE, countDefault: '12.5' }).countDefault).toBe('Value should be an integer');
+        expect(validateApiLoggingForm({ ...VALID_STATE, countLimit: '0' }).countLimit).toBe('Value should be at least 1');
+    });
+
+    it('rejects invalid temporal ISO-8601 values', () => {
+        expect(validateApiLoggingForm({ ...VALID_STATE, temporalDefault: 'P1Y' }).temporalDefault).toBe(
+            'Value should conform to ISO-8601 duration format',
+        );
+        expect(validateApiLoggingForm({ ...VALID_STATE, temporalLimit: 'not-a-duration' }).temporalLimit).toBe(
+            'Value should conform to ISO-8601 duration format',
+        );
+    });
+
+    it('rejects invalid max duration values', () => {
+        expect(validateApiLoggingForm({ ...VALID_STATE, maxDurationMillis: '1.5' }).maxDurationMillis).toBe(
+            'Max duration must be a number',
+        );
+        expect(validateApiLoggingForm({ ...VALID_STATE, maxDurationMillis: 'abc' }).maxDurationMillis).toBe(
+            'Max duration must be a number',
+        );
+    });
+
+    it('rejects malformed windowed count values', () => {
+        expect(validateApiLoggingForm({ ...VALID_STATE, windowedCountDefault: '2abc/PT1S' }).windowedCountDefault).toBe(
+            'The sampling value must follow this format: COUNT/DURATION, where COUNT > 0 and DURATION is in ISO-8601 format (e.g., 1/PT1S)',
+        );
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingValidators.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/apiLoggingValidators.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidIso8601Duration, parseIso8601DurationSeconds } from './iso8601Duration';
+import { WindowedCount, WindowedCountFormatError } from './windowedCount';
+
+export interface ApiLoggingFormState {
+    maxDurationMillis: string;
+    auditEnabled: boolean;
+    auditTrailEnabled: boolean;
+    userDisplayed: boolean;
+    probabilisticDefault: string;
+    probabilisticLimit: string;
+    countDefault: string;
+    countLimit: string;
+    temporalDefault: string;
+    temporalLimit: string;
+    windowedCountDefault: string;
+    windowedCountLimit: string;
+}
+
+export type ApiLoggingFieldKey = keyof ApiLoggingFormState;
+
+export type ApiLoggingFieldErrors = Partial<Record<ApiLoggingFieldKey, string>>;
+
+const PROBABILISTIC_MIN = 0.01;
+const PROBABILISTIC_MAX = 1;
+const COUNT_MIN = 1;
+const WINDOWED_COUNT_FORMAT_ERROR =
+    'The sampling value must follow this format: COUNT/DURATION, where COUNT > 0 and DURATION is in ISO-8601 format (e.g., 1/PT1S)';
+
+function requiredError(value: string): string | undefined {
+    return value.trim() === '' ? 'Value is required' : undefined;
+}
+
+function parseProbabilistic(value: string): number | null {
+    if (value.trim() === '') {
+        return null;
+    }
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseCount(value: string): { parsed: number | null; integerError?: string } {
+    if (value.trim() === '') {
+        return { parsed: null };
+    }
+    if (!/^\d+$/.test(value.trim())) {
+        return { parsed: null, integerError: 'Value should be an integer' };
+    }
+    return { parsed: Number(value) };
+}
+
+function validateProbabilisticField(value: string): string | undefined {
+    const required = requiredError(value);
+    if (required) {
+        return required;
+    }
+
+    const parsed = parseProbabilistic(value);
+    if (parsed === null) {
+        return 'Value should be a number';
+    }
+    if (parsed < PROBABILISTIC_MIN) {
+        return `Value should be at least ${PROBABILISTIC_MIN}`;
+    }
+    if (parsed > PROBABILISTIC_MAX) {
+        return `Value should not be greater than ${PROBABILISTIC_MAX}`;
+    }
+
+    return undefined;
+}
+
+function validateCountField(value: string): string | undefined {
+    const required = requiredError(value);
+    if (required) {
+        return required;
+    }
+
+    const { parsed, integerError } = parseCount(value);
+    if (integerError) {
+        return integerError;
+    }
+    if (parsed !== null && parsed < COUNT_MIN) {
+        return `Value should be at least ${COUNT_MIN}`;
+    }
+
+    return undefined;
+}
+
+function validateTemporalField(value: string): string | undefined {
+    const required = requiredError(value);
+    if (required) {
+        return required;
+    }
+    if (!isValidIso8601Duration(value)) {
+        return 'Value should conform to ISO-8601 duration format';
+    }
+    return undefined;
+}
+
+function validateWindowedCountField(value: string): string | undefined {
+    const required = requiredError(value);
+    if (required) {
+        return required;
+    }
+
+    try {
+        const parsed = WindowedCount.parse(value);
+        if (!parsed.isValid()) {
+            return WINDOWED_COUNT_FORMAT_ERROR;
+        }
+    } catch (error) {
+        if (error instanceof WindowedCountFormatError) {
+            return WINDOWED_COUNT_FORMAT_ERROR;
+        }
+        return WINDOWED_COUNT_FORMAT_ERROR;
+    }
+
+    return undefined;
+}
+
+function compareProbabilistic(defaultValue: string, limitValue: string): string | undefined {
+    const defaultParsed = parseProbabilistic(defaultValue);
+    const limitParsed = parseProbabilistic(limitValue);
+    if (defaultParsed !== null && limitParsed !== null && defaultParsed > limitParsed) {
+        return 'Default should be lower than Limit';
+    }
+    return undefined;
+}
+
+function compareCount(defaultValue: string, limitValue: string): string | undefined {
+    const defaultParsed = parseCount(defaultValue).parsed;
+    const limitParsed = parseCount(limitValue).parsed;
+    if (defaultParsed !== null && limitParsed !== null && defaultParsed < limitParsed) {
+        return 'Default should be greater than Limit';
+    }
+    return undefined;
+}
+
+function compareTemporal(defaultValue: string, limitValue: string): string | undefined {
+    const defaultSeconds = parseIso8601DurationSeconds(defaultValue);
+    const limitSeconds = parseIso8601DurationSeconds(limitValue);
+    if (defaultSeconds !== null && limitSeconds !== null && defaultSeconds < limitSeconds) {
+        return 'Default should be greater than Limit';
+    }
+    return undefined;
+}
+
+function compareWindowedCount(defaultValue: string, limitValue: string): string | undefined {
+    try {
+        const defaultWindowed = WindowedCount.parse(defaultValue);
+        const limitWindowed = WindowedCount.parse(limitValue);
+        if (defaultWindowed.rate() > limitWindowed.rate()) {
+            return 'Default must be a lower rate than limit';
+        }
+    } catch (error) {
+        if (!(error instanceof WindowedCountFormatError)) {
+            return 'Default must be a lower rate than limit';
+        }
+    }
+    return undefined;
+}
+
+export function validateApiLoggingForm(state: ApiLoggingFormState): ApiLoggingFieldErrors {
+    const errors: ApiLoggingFieldErrors = {};
+
+    if (state.maxDurationMillis.trim() !== '' && !/^-?\d+$/.test(state.maxDurationMillis.trim())) {
+        errors.maxDurationMillis = 'Max duration must be a number';
+    }
+
+    const probabilisticDefaultError = validateProbabilisticField(state.probabilisticDefault);
+    const probabilisticLimitError = validateProbabilisticField(state.probabilisticLimit);
+    const probabilisticCompareError = compareProbabilistic(state.probabilisticDefault, state.probabilisticLimit);
+
+    if (probabilisticDefaultError) {
+        errors.probabilisticDefault = probabilisticDefaultError;
+    } else if (probabilisticCompareError) {
+        errors.probabilisticDefault = probabilisticCompareError;
+    }
+
+    if (probabilisticLimitError) {
+        errors.probabilisticLimit = probabilisticLimitError;
+    } else if (probabilisticCompareError) {
+        errors.probabilisticLimit = probabilisticCompareError;
+    }
+
+    const countDefaultError = validateCountField(state.countDefault);
+    const countLimitError = validateCountField(state.countLimit);
+    const countCompareError = compareCount(state.countDefault, state.countLimit);
+
+    if (countDefaultError) {
+        errors.countDefault = countDefaultError;
+    } else if (countCompareError) {
+        errors.countDefault = countCompareError;
+    }
+
+    if (countLimitError) {
+        errors.countLimit = countLimitError;
+    } else if (countCompareError) {
+        errors.countLimit = countCompareError;
+    }
+
+    const temporalDefaultError = validateTemporalField(state.temporalDefault);
+    const temporalLimitError = validateTemporalField(state.temporalLimit);
+    const temporalCompareError = compareTemporal(state.temporalDefault, state.temporalLimit);
+
+    if (temporalDefaultError) {
+        errors.temporalDefault = temporalDefaultError;
+    } else if (temporalCompareError) {
+        errors.temporalDefault = temporalCompareError;
+    }
+
+    if (temporalLimitError) {
+        errors.temporalLimit = temporalLimitError;
+    } else if (temporalCompareError) {
+        errors.temporalLimit = temporalCompareError;
+    }
+
+    const windowedDefaultError = validateWindowedCountField(state.windowedCountDefault);
+    const windowedLimitError = validateWindowedCountField(state.windowedCountLimit);
+    const windowedCompareError = compareWindowedCount(state.windowedCountDefault, state.windowedCountLimit);
+
+    if (windowedDefaultError) {
+        errors.windowedCountDefault = windowedDefaultError;
+    } else if (windowedCompareError) {
+        errors.windowedCountDefault = windowedCompareError;
+    }
+
+    if (windowedLimitError) {
+        errors.windowedCountLimit = windowedLimitError;
+    } else if (windowedCompareError) {
+        errors.windowedCountLimit = windowedCompareError;
+    }
+
+    return errors;
+}
+
+export function isApiLoggingFormValid(state: ApiLoggingFormState): boolean {
+    return Object.keys(validateApiLoggingForm(state)).length === 0;
+}
+
+export function toApiLoggingSettingsPayload(state: ApiLoggingFormState) {
+    return {
+        maxDurationMillis: state.maxDurationMillis.trim() === '' ? 0 : Number(state.maxDurationMillis),
+        audit: {
+            enabled: state.auditEnabled,
+            trail: {
+                enabled: state.auditTrailEnabled,
+            },
+        },
+        user: {
+            displayed: state.userDisplayed,
+        },
+        messageSampling: {
+            probabilistic: {
+                default: Number(state.probabilisticDefault),
+                limit: Number(state.probabilisticLimit),
+            },
+            count: {
+                default: Number(state.countDefault),
+                limit: Number(state.countLimit),
+            },
+            temporal: {
+                default: state.temporalDefault.trim(),
+                limit: state.temporalLimit.trim(),
+            },
+            windowedCount: {
+                default: state.windowedCountDefault.trim(),
+                limit: state.windowedCountLimit.trim(),
+            },
+        },
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/iso8601Duration.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/iso8601Duration.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidIso8601Duration, parseIso8601DurationSeconds } from './iso8601Duration';
+
+describe('iso8601Duration', () => {
+    it('parses second-based durations', () => {
+        expect(parseIso8601DurationSeconds('PT1S')).toBe(1);
+        expect(parseIso8601DurationSeconds('PT5S')).toBe(5);
+        expect(parseIso8601DurationSeconds('PT15S')).toBe(15);
+    });
+
+    it('parses minute-based durations', () => {
+        expect(parseIso8601DurationSeconds('PT1M')).toBe(60);
+    });
+
+    it('parses day-based durations', () => {
+        expect(parseIso8601DurationSeconds('P1D')).toBe(86_400);
+    });
+
+    it('rejects invalid or sub-second durations', () => {
+        expect(parseIso8601DurationSeconds('')).toBeNull();
+        expect(parseIso8601DurationSeconds('PT0.5S')).toBeNull();
+        expect(parseIso8601DurationSeconds('not-a-duration')).toBeNull();
+        expect(isValidIso8601Duration('PT0S')).toBe(false);
+    });
+
+    it('rejects year, month, and week durations unsupported by java.time.Duration', () => {
+        expect(parseIso8601DurationSeconds('P1Y')).toBeNull();
+        expect(parseIso8601DurationSeconds('P1M')).toBeNull();
+        expect(parseIso8601DurationSeconds('P1W')).toBeNull();
+        expect(isValidIso8601Duration('P1Y')).toBe(false);
+        expect(isValidIso8601Duration('P1M')).toBe(false);
+        expect(isValidIso8601Duration('P1W')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/iso8601Duration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/iso8601Duration.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Matches java.time.Duration.parse grammar: P[nD]T[nH][nM][n.nS] — no years, months, or weeks. */
+const ISO8601_DURATION = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+
+function toNumber(value: string | undefined): number {
+    return value ? Number(value) : 0;
+}
+
+/** Parses ISO-8601 durations used by API logging sampling (e.g. PT1S). Returns null when invalid or shorter than one second. */
+export function parseIso8601DurationSeconds(value: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const match = ISO8601_DURATION.exec(trimmed);
+    if (!match) {
+        return null;
+    }
+
+    const days = toNumber(match[1]);
+    const hours = toNumber(match[2]);
+    const minutes = toNumber(match[3]);
+    const seconds = toNumber(match[4]);
+
+    if (days + hours + minutes + seconds === 0) {
+        return null;
+    }
+
+    const totalSeconds = seconds + minutes * 60 + hours * 3600 + days * 86_400;
+    if (totalSeconds < 1) {
+        return null;
+    }
+
+    return totalSeconds;
+}
+
+export function isValidIso8601Duration(value: string): boolean {
+    return parseIso8601DurationSeconds(value) !== null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/windowedCount.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/windowedCount.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WindowedCount, WindowedCountFormatError } from './windowedCount';
+
+describe('WindowedCount', () => {
+    it('parses count/duration values', () => {
+        const parsed = WindowedCount.parse('2/PT15S');
+        expect(parsed.count).toBe(2);
+        expect(parsed.windowSeconds).toBe(15);
+        expect(parsed.rate()).toBeCloseTo(2 / 15);
+    });
+
+    it('rejects invalid formats', () => {
+        expect(() => WindowedCount.parse('invalid')).toThrow(WindowedCountFormatError);
+        expect(() => WindowedCount.parse('0/PT1S')).toThrow(WindowedCountFormatError);
+    });
+
+    it('rejects partial integer counts', () => {
+        expect(() => WindowedCount.parse('2abc/PT1S')).toThrow(WindowedCountFormatError);
+        expect(() => WindowedCount.parse('2.5/PT1S')).toThrow(WindowedCountFormatError);
+    });
+
+    it('returns zero rate when the window duration is zero', () => {
+        expect(new WindowedCount(5, 0).rate()).toBe(0);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/windowedCount.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/api-logging/utils/windowedCount.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseIso8601DurationSeconds } from './iso8601Duration';
+
+export class WindowedCountFormatError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'WindowedCountFormatError';
+    }
+}
+
+export class WindowedCount {
+    constructor(
+        readonly count: number,
+        readonly windowSeconds: number,
+    ) {}
+
+    rate(): number {
+        if (this.windowSeconds === 0) {
+            return 0;
+        }
+        return this.count / this.windowSeconds;
+    }
+
+    static parse(format: string): WindowedCount {
+        const parts = format.split('/');
+        if (parts.length !== 2) {
+            throw new WindowedCountFormatError('Invalid format: must be in count/duration format');
+        }
+
+        const countPart = (parts[0] ?? '').trim();
+        if (!/^\d+$/.test(countPart)) {
+            throw new WindowedCountFormatError('Invalid format: count must be a positive integer');
+        }
+
+        const count = Number(countPart);
+        const windowSeconds = parseIso8601DurationSeconds(parts[1] ?? '');
+
+        if (count <= 0 || windowSeconds === null) {
+            throw new WindowedCountFormatError('Invalid format: count must be a number and duration must be valid');
+        }
+
+        return new WindowedCount(count, windowSeconds);
+    }
+
+    isValid(): boolean {
+        return this.count > 0 && this.windowSeconds > 0;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/types/consoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/types/consoleSettings.ts
@@ -85,6 +85,27 @@ export interface ConsoleSettingsAuthentication {
     oauth2?: ConsoleSettingsClientId;
 }
 
+export interface ConsoleSettingsLoggingSamplingPair<T> {
+    default?: T;
+    limit?: T;
+}
+
+export interface ConsoleSettingsLogging {
+    maxDurationMillis?: number;
+    audit?: DisableableFeature & {
+        trail?: DisableableFeature;
+    };
+    user?: {
+        displayed?: boolean;
+    };
+    messageSampling?: {
+        probabilistic?: ConsoleSettingsLoggingSamplingPair<number>;
+        count?: ConsoleSettingsLoggingSamplingPair<number>;
+        temporal?: ConsoleSettingsLoggingSamplingPair<string>;
+        windowedCount?: ConsoleSettingsLoggingSamplingPair<string>;
+    };
+}
+
 /**
  * Org console settings from GET/POST `/organizations/{orgId}/settings`.
  * Extra backend fields are preserved via index signature so a section save cannot drop them.
@@ -95,6 +116,7 @@ export interface ConsoleSettings {
     cors?: ConsoleSettingsCors;
     scheduler?: ConsoleSettingsScheduler;
     management?: ConsoleSettingsManagement;
+    logging?: ConsoleSettingsLogging;
     trialInstance?: DisableableFeature;
     authentication?: ConsoleSettingsAuthentication;
     [key: string]: unknown;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildConsoleSettingsSavePayload.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildConsoleSettingsSavePayload.spec.ts
@@ -100,4 +100,18 @@ describe('buildConsoleSettingsSavePayload', () => {
 
         expect(payload.email).toEqual(CURRENT.email);
     });
+
+    it('overlays only logging', () => {
+        const payload = buildConsoleSettingsSavePayload(CURRENT, 'logging', {
+            logging: {
+                maxDurationMillis: 15000,
+                audit: { enabled: true, trail: { enabled: false } },
+            },
+        });
+
+        expect(payload.logging?.maxDurationMillis).toBe(15000);
+        expect(payload.logging?.audit?.trail?.enabled).toBe(false);
+        expect(payload.cors).toEqual(CURRENT.cors);
+        expect(payload.email).toEqual(CURRENT.email);
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildConsoleSettingsSavePayload.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/organization-settings/utils/buildConsoleSettingsSavePayload.ts
@@ -16,7 +16,7 @@
 
 import { PASSWORD_SENTINEL, type ConsoleSettings, type ConsoleSettingsEmail } from '../types/consoleSettings';
 
-export type ConsoleSettingsSection = 'management' | 'cors' | 'email';
+export type ConsoleSettingsSection = 'management' | 'cors' | 'email' | 'logging';
 
 function mergeEmail(current: ConsoleSettingsEmail | undefined, overlay: ConsoleSettingsEmail | undefined): ConsoleSettingsEmail {
     const password = overlay?.password === PASSWORD_SENTINEL || !overlay?.password ? current?.password : overlay?.password;
@@ -37,7 +37,7 @@ function mergeEmail(current: ConsoleSettingsEmail | undefined, overlay: ConsoleS
 export function buildConsoleSettingsSavePayload(
     current: ConsoleSettings,
     section: ConsoleSettingsSection,
-    overlay: Pick<ConsoleSettings, 'management' | 'scheduler' | 'cors' | 'email'>,
+    overlay: Pick<ConsoleSettings, 'management' | 'scheduler' | 'cors' | 'email' | 'logging'>,
 ): ConsoleSettings {
     const trialHidesEmail = Boolean(current.trialInstance?.enabled);
 
@@ -56,5 +56,6 @@ export function buildConsoleSettingsSavePayload(
         scheduler: section === 'management' ? { ...current.scheduler, ...overlay.scheduler } : current.scheduler,
         cors: section === 'cors' ? { ...current.cors, ...overlay.cors } : current.cors,
         email: section === 'email' && !trialHidesEmail ? mergeEmail(current.email, overlay.email) : current.email,
+        logging: section === 'logging' ? { ...current.logging, ...overlay.logging } : current.logging,
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApiLoggingSettingsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApiLoggingSettingsPage.spec.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { ApiLoggingSettingsPage } from './ApiLoggingSettingsPage';
+import { useOrgConsoleSettings } from '../features/organization-settings/hooks/useOrgConsoleSettings';
+import { useSaveOrgConsoleSettings } from '../features/organization-settings/hooks/useSaveOrgConsoleSettings';
+import type { ConsoleSettings } from '../features/organization-settings/types/consoleSettings';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../features/organization-settings/hooks/useOrgConsoleSettings', () => ({
+    useOrgConsoleSettings: jest.fn(),
+}));
+
+jest.mock('../features/organization-settings/hooks/useSaveOrgConsoleSettings', () => ({
+    useSaveOrgConsoleSettings: jest.fn(),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseOrgConsoleSettings = jest.mocked(useOrgConsoleSettings);
+const mockUseSaveOrgConsoleSettings = jest.mocked(useSaveOrgConsoleSettings);
+
+const SETTINGS: ConsoleSettings = {
+    cors: { allowOrigin: ['https://console.example.com'] },
+    email: { enabled: false },
+    logging: {
+        maxDurationMillis: 15000,
+        audit: { enabled: true, trail: { enabled: true } },
+        user: { displayed: true },
+        messageSampling: {
+            probabilistic: { default: 0.25, limit: 0.5 },
+            count: { default: 200, limit: 20 },
+            temporal: { default: 'PT5S', limit: 'PT1S' },
+            windowedCount: { default: '1/PT10S', limit: '1/PT1S' },
+        },
+    },
+};
+
+function renderPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return render(<ApiLoggingSettingsPage />, { wrapper: Wrapper });
+}
+
+describe('ApiLoggingSettingsPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseOrgConsoleSettings.mockReturnValue({
+            data: SETTINGS,
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useOrgConsoleSettings>);
+        mockUseSaveOrgConsoleSettings.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as unknown as ReturnType<typeof useSaveOrgConsoleSettings>);
+    });
+
+    it('renders API logging fields from settings', () => {
+        renderPage();
+
+        expect(screen.getByRole('heading', { name: 'API Logging' })).not.toBeNull();
+        expect((screen.getByLabelText('Max Duration (in ms)') as HTMLInputElement).value).toBe('15000');
+        expect((screen.getByLabelText('Probabilistic default') as HTMLInputElement).value).toBe('0.25');
+        expect((screen.getByLabelText('Temporal default') as HTMLInputElement).value).toBe('PT5S');
+    });
+
+    it('posts logging without wiping cors or email', () => {
+        const mutate = jest.fn();
+        mockUseSaveOrgConsoleSettings.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useSaveOrgConsoleSettings>);
+        renderPage();
+
+        fireEvent.change(screen.getByLabelText('Max Duration (in ms)'), { target: { value: '20000' } });
+        fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        expect(mutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cors: SETTINGS.cors,
+                email: SETTINGS.email,
+                logging: expect.objectContaining({
+                    maxDurationMillis: 20000,
+                }),
+            }),
+            expect.any(Object),
+        );
+    });
+
+    it('discards unsaved changes and hides the action bar', () => {
+        renderPage();
+
+        fireEvent.change(screen.getByLabelText('Max Duration (in ms)'), { target: { value: '20000' } });
+        expect(screen.getByRole('button', { name: /Save changes/i })).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /Discard/i }));
+
+        expect((screen.getByLabelText('Max Duration (in ms)') as HTMLInputElement).value).toBe('15000');
+        expect(screen.queryByRole('button', { name: /Save changes/i })).toBeNull();
+    });
+
+    it('keeps Save disabled when sampling validation fails', () => {
+        const mutate = jest.fn();
+        mockUseSaveOrgConsoleSettings.mockReturnValue({
+            mutate,
+            isPending: false,
+        } as unknown as ReturnType<typeof useSaveOrgConsoleSettings>);
+        renderPage();
+
+        fireEvent.change(screen.getByLabelText('Probabilistic default'), { target: { value: '0.6' } });
+        fireEvent.change(screen.getByLabelText('Probabilistic limit'), { target: { value: '0.5' } });
+
+        expect(screen.getByRole('button', { name: /Save changes/i })).toHaveProperty('disabled', true);
+        fireEvent.click(screen.getByRole('button', { name: /Save changes/i }));
+        expect(mutate).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApiLoggingSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApiLoggingSettingsPage.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { ApiLoggingSection } from '../features/api-logging/components/ApiLoggingSection';
+import { buildApiLoggingFormState, getApiLoggingReadonlyState } from '../features/api-logging/utils/apiLoggingFormState';
+import {
+    isApiLoggingFormValid,
+    toApiLoggingSettingsPayload,
+    validateApiLoggingForm,
+    type ApiLoggingFormState,
+} from '../features/api-logging/utils/apiLoggingValidators';
+import { OrgSettingsFormShell } from '../features/organization-settings/components/OrgSettingsFormShell';
+import { useOrgConsoleSettings } from '../features/organization-settings/hooks/useOrgConsoleSettings';
+import { useSaveOrgConsoleSettings } from '../features/organization-settings/hooks/useSaveOrgConsoleSettings';
+import { buildConsoleSettingsSavePayload } from '../features/organization-settings/utils/buildConsoleSettingsSavePayload';
+
+function formStatesEqual(left: ApiLoggingFormState, right: ApiLoggingFormState): boolean {
+    return (Object.keys(left) as (keyof ApiLoggingFormState)[]).every(key => left[key] === right[key]);
+}
+
+export function ApiLoggingSettingsPage() {
+    const canEdit = useHasPermission({ anyOf: ['organization-settings-u'] });
+    const { data: settings, isLoading, isError } = useOrgConsoleSettings();
+    const saveMutation = useSaveOrgConsoleSettings();
+
+    const [localState, setLocalState] = useState<ApiLoggingFormState>(() => buildApiLoggingFormState(settings));
+    const [savedState, setSavedState] = useState<ApiLoggingFormState>(() => buildApiLoggingFormState(settings));
+
+    const isDirty = !formStatesEqual(localState, savedState);
+    const isDirtyRef = useRef(isDirty);
+    isDirtyRef.current = isDirty;
+
+    useEffect(() => {
+        if (!settings) {
+            return;
+        }
+        const next = buildApiLoggingFormState(settings);
+        setSavedState(next);
+        if (!isDirtyRef.current) {
+            setLocalState(next);
+        }
+    }, [settings]);
+
+    const readonly = useMemo(() => getApiLoggingReadonlyState(settings), [settings]);
+    const fieldErrors = useMemo(() => validateApiLoggingForm(localState), [localState]);
+    const isValid = isApiLoggingFormValid(localState);
+
+    function handleSave() {
+        if (!settings) {
+            return;
+        }
+        if (!isDirty) {
+            return;
+        }
+        if (!isValid) {
+            return;
+        }
+        if (saveMutation.isPending) {
+            return;
+        }
+
+        const payload = buildConsoleSettingsSavePayload(settings, 'logging', {
+            logging: toApiLoggingSettingsPayload(localState),
+        });
+        saveMutation.mutate(payload, { onSuccess: () => setSavedState(localState) });
+    }
+
+    return (
+        <OrgSettingsFormShell
+            title="API Logging"
+            description="Cap how long APIs may log full payloads, audit who reads those logs, and set the default sampling for message APIs."
+            canEdit={canEdit}
+            isDirty={isDirty}
+            isValid={isValid}
+            isSaving={saveMutation.isPending}
+            isLoading={isLoading}
+            isError={isError}
+            onSave={handleSave}
+            onDiscard={() => setLocalState(savedState)}
+        >
+            <ApiLoggingSection value={localState} errors={fieldErrors} disabled={!canEdit} readonly={readonly} onChange={setLocalState} />
+        </OrgSettingsFormShell>
+    );
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-217


## Summary

Adds **API Logging** settings to the Gamma Platform module, matching the **Gamma Baby** UI/UX and reusing the same **organization console settings** backend as Classic Console.

- New route: `/environments/{env}/platform/api-logging`
- Nav: **Environment → System & Security**, between **SMTP** and **Security Plan Types**
- Permissions: view requires `organization-settings-r`; edit requires `organization-settings-u`
- Backend: `GET/POST /management/organizations/{orgId}/settings` (same `logging` payload as Classic Console)

## What changed

### UI
- **`ApiLoggingSettingsPage`** — page shell with load/save/discard, permission-aware read-only mode
- **`ApiLoggingSection`** — form sections:
  - **Duration** — max duration (ms)
  - **Audit** — consultation audit + audit trail toggles
  - **User** — display end user toggle (OAuth2/JWT)
  - **Message Sampling** — Probabilistic, Count, Temporal, Windowed count (default + limit each)
- Reuses **`OrgSettingsFormShell`** and org-settings hooks (`useOrgConsoleSettings`, `useSaveOrgConsoleSettings`)


### Tests (unit)
- `apiLoggingValidators.spec.ts` — valid state + all four sampling validation rules
- `iso8601Duration.spec.ts`, `windowedCount.spec.ts`
- `ApiLoggingSettingsPage.spec.tsx` — render from settings, save/discard on dirty
- `buildConsoleSettingsSavePayload.spec.ts` — logging section in save payload
- `navigation.spec.ts` — nav order updated

## Test plan

### Manual — browser (Gamma Console @ `localhost:4200`)

| # | Scenario | Notes |
|---|----------|-------|
| 1 | Navigation & page load | Nav under Environment → System & Security; all sections visible |
| 2 | Load from backend | Settings loaded from org settings API (values match backend) |
| 3–6 | Edit & save (duration, audit, user, sampling) | Implemented; recommend quick save/reload smoke test before merge |
| 7–10 | Validation errors block save | Probabilistic, count, temporal, windowed count (covered by unit tests) |
| 11 | Discard changes | Same shell as other org-settings pages |
| 12 | Read-only (no `organization-settings-u`) | No built-in user with read-only org settings in local env; code uses `canEdit` + disabled fields + permission banner via `OrgSettingsFormShell` |
| 13 | No access (no `organization-settings-r`) | As **`api1`**: API Logging hidden from nav; direct URL redirects to `/platform/applications` |
| 14 | Classic Console parity | Classic Console not running locally; structural parity confirmed vs **Gamma Baby** (`localhost:5173`) and Classic Console source — same fields, sections, and org settings API |

https://github.com/user-attachments/assets/9f255424-4651-45b6-9bac-113c1aad4b39
