### PR TITLE
fix(console): restore health-check alert rule for API scope

### DIFF
--- a/gravitee-apim-console-webui/src/entities/alerts/rule.metrics.spec.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/rule.metrics.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Rule } from './rule.metrics';
+
+import { Scope } from '../alert';
+
+describe('Rule', () => {
+  describe('findCategoriesByScope', () => {
+    const initialRules = Rule.RULES;
+
+    afterEach(() => {
+      Rule.RULES = initialRules;
+    });
+
+    it.each([false, true])('should include health-check rules for API scope when cloud is %s', cloudEnabled => {
+      expect(Rule.findCategoriesByScope(Scope.API, cloudEnabled)).toEqual(['API metrics', 'Health-check']);
+    });
+
+    it('should keep node categories first for environment scope', () => {
+      expect(Rule.findCategoriesByScope(Scope.ENVIRONMENT, false)).toEqual(['Node', 'API metrics', 'Health-check']);
+    });
+
+    it('should exclude node categories for environment scope in cloud', () => {
+      expect(Rule.findCategoriesByScope(Scope.ENVIRONMENT, true)).toEqual(['API metrics', 'Health-check']);
+    });
+
+    it.each([false, true])('should include application rules for application scope when cloud is %s', cloudEnabled => {
+      expect(Rule.findCategoriesByScope(Scope.APPLICATION, cloudEnabled)).toEqual(['Application']);
+    });
+
+    it('should only include categories with rules available for the scope', () => {
+      Rule.RULES = Rule.RULES.filter(rule => rule.category !== 'Health-check');
+
+      expect(Rule.findCategoriesByScope(Scope.API, false)).toEqual(['API metrics']);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/entities/alerts/rule.metrics.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/rule.metrics.ts
@@ -21,6 +21,13 @@ import { Metrics, Scope } from '../alert';
 
 type RuleCategory = 'API metrics' | 'Application' | 'Health-check' | 'Node';
 
+const RULE_CATEGORY_ORDER: Record<RuleCategory, number> = {
+  Node: 0,
+  'API metrics': 1,
+  'Health-check': 2,
+  Application: 3,
+};
+
 export class Rule {
   static API_METRICS_THRESHOLD: Rule = new Rule(
     'REQUEST',
@@ -169,17 +176,9 @@ export class Rule {
   }
 
   static findCategoriesByScope(scope: Scope, cloudEnabled: boolean): RuleCategory[] {
-    const baseCategories: Record<Scope, RuleCategory[]> = {
-      [Scope.ENVIRONMENT]: ['Node', 'API metrics', 'Health-check'],
-      [Scope.API]: ['API metrics'],
-      [Scope.APPLICATION]: ['Application'],
-    };
-    const categories = [...baseCategories[scope]];
-
-    if (scope === Scope.ENVIRONMENT && cloudEnabled) {
-      return categories.filter(c => c !== 'Node');
-    }
-    return categories;
+    return [...new Set(Rule.findByScope(scope, cloudEnabled).map(rule => rule.category))].sort(
+      (firstCategory, secondCategory) => RULE_CATEGORY_ORDER[firstCategory] - RULE_CATEGORY_ORDER[secondCategory],
+    );
   }
 
   constructor(source: string, type: string, description: string, scopes: Scope[], category: RuleCategory, metrics?: Metrics[]) {


### PR DESCRIPTION
## Issue

[APIM-15063](https://gravitee.atlassian.net/browse/APIM-15063)

## Description

The API health-check alert rule was defined for API scope but was not available in the Console alert creation form.

The `Health-check` category was missing from the categories returned for API-scoped alerts. As a result, the existing “Alert when the health status of an endpoint has changed” rule was filtered out of the rule selector.

This change restores the `Health-check` category for API scope.

## Changes

- Add `Health-check` to the alert categories available for API scope.
- Add a regression test covering both cloud-hosted and non-cloud-hosted configurations.

No backend or HTTP contract changes are required.


<img width="1812" height="1052" alt="Zrzut ekranu 2026-09-9 o 13 36 31" src="https://github.com/user-attachments/assets/928886f9-9819-4f42-b048-9d15c0fdccf5" />



[APIM-15063]: https://gravitee.atlassian.net/browse/APIM-15063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ