### PR TITLE
chore(ci): let Renovate move the Helm node plugins with gravitee-node

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,41 @@
         "(^|/).circleci/config.yml$"
       ]
     },
+    // The Helm chart pins the Hazelcast node plugins by URL, and the federation deployment
+    // fixture repeats those URLs byte for byte. Both have to follow <gravitee-node.version>:
+    // a management API pod would otherwise download plugins built against a different node
+    // minor than the node it runs. Renovate only ever read the poms, so the chart was brought
+    // back in line by hand afterwards, inside Renovate's own branch. These managers make it
+    // read the chart as well.
+    //
+    // The zips are served by download.gravitee.io, which exposes no index to query, so the
+    // versions are resolved from the same artifacts on Maven Central; gravitee-node publishes
+    // its whole lineage in lockstep, so a version never exists on one side only. One manager
+    // per artifact: depNameTemplate is manager-wide, and folding both into a single regex
+    // would need a backreference, which RE2 does not support.
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^helm/values\\.yaml$/",
+                "/^helm/tests/api/deployment_federation_test\\.yaml$/"
+            ],
+            // Matches the download URL, and in the fixture the bare zip name wget removes first.
+            "matchStrings": ["gravitee-node-cache-plugin-hazelcast-(?<currentValue>\\d[^/\\s]*?)\\.zip"],
+            "depNameTemplate": "io.gravitee.node:gravitee-node-cache-plugin-hazelcast",
+            "datasourceTemplate": "maven"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^helm/values\\.yaml$/",
+                "/^helm/tests/api/deployment_federation_test\\.yaml$/"
+            ],
+            "matchStrings": ["gravitee-node-cluster-plugin-hazelcast-(?<currentValue>\\d[^/\\s]*?)\\.zip"],
+            "depNameTemplate": "io.gravitee.node:gravitee-node-cluster-plugin-hazelcast",
+            "datasourceTemplate": "maven"
+        }
+    ],
     "packageRules": [
         {
             // Group all angular related packages updates together
@@ -103,6 +138,17 @@
             "matchPackageNames": ["com.graviteesource{/,}**", "io.gravitee{/,}**"],
             "matchCurrentVersion": "/-beta\\./",
             "allowedVersions": "/-beta\\./"
+        },
+        {
+            // Keep the chart in the same pull request as the poms. Every io.gravitee.node
+            // artifact here resolves through the single <gravitee-node.version> property, so
+            // grouping the whole groupId gathers nothing that was not already moving together,
+            // and groupSlug preserves the branch Renovate already uses for that property,
+            // renovate/gravitee-node.version, rather than opening a second pull request.
+            "matchDatasources": ["maven"],
+            "matchPackageNames": ["io.gravitee.node{/,}**"],
+            "groupName": "gravitee-node.version",
+            "groupSlug": "gravitee-node.version"
         }
     ]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-391

## Description

`helm/values.yaml` pins the Hazelcast node cache and cluster plugins by URL, and `helm/tests/api/deployment_federation_test.yaml` repeats those URLs byte for byte. Both have to follow `<gravitee-node.version>`: with `api.federation.enabled`, the management API pulls those zips in an init container, so a stale URL means a pod running node 9.10 with plugins built against 9.9.

Nothing moved them automatically. Renovate read the poms only, and the chart was brought back in line by hand afterwards, inside Renovate's own branch — commit `8f2a9bb2` on [#19772](https://github.com/gravitee-io/gravitee-api-management/pull/19772). [#19806](https://github.com/gravitee-io/gravitee-api-management/pull/19806) is open right now in that same half-done state: both poms at 9.10.1, the chart still at 9.10.0.

Two custom managers make Renovate read the chart as well, and one package rule keeps the result in the pull request that already moves the poms rather than in a second one.

- Versions are resolved from the same artifacts on Maven Central. download.gravitee.io serves the zips but exposes no index to query, and gravitee-node publishes its whole lineage in lockstep, so a version never exists on one side only.
- `groupSlug` preserves the branch Renovate already uses for the Maven property, `renovate/gravitee-node.version`.
- One manager per artifact: `depNameTemplate` is manager-wide, and folding both into a single regex would need a backreference, which RE2 does not support.

Still manual afterwards: the `helm/CHANGELOG.md` entry, and the bump on the support branches — there is no `baseBranches` here, and every pull request Renovate opens on this repository targets `master`.

## Additional context

Verified before opening, against Renovate 44.71.0:

- `renovate-config-validator` passes. The `Config migration necessary` warning it prints is pre-existing — `packagePatterns`, `packageNames`, `updateTypes`, `circleci.fileMatch` — and the migration diff leaves the new block untouched.
- Extraction over a copy of the two chart files: manager `regex`, 6 dependencies. One per artifact in `values.yaml`, two per artifact in the fixture, where the `wget` and the `rm` preceding it both name the zip. Exactly the occurrences `8f2a9bb2` had to edit by hand.
- Lookup returns `9.10.1` as a `patch` for all six.
- With the package rule in place, the six resolve to a single `branchName`, `renovate/gravitee-node.version`. Without it they split off into `renovate/io.gravitee.node-gravitee-node-cache-plugin-hazelcast-9.x`, which is the second pull request this is meant to avoid.

Once merged, [#19806](https://github.com/gravitee-io/gravitee-api-management/pull/19806) will not pick this up on its own: the shared preset sets `rebaseWhen: conflicted`, so its rebase box has to be ticked.

BX-391 covers why Danger's `gravitee-node-version-consistency` never failed that pull request. This does not fix Danger; it removes what Danger had to catch.
