### PR TITLE
ci: cap the maven heap in the community build job

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
@@ -43,6 +43,11 @@ export class CommunityBuildBackendJob {
       new commands.Run({
         name: 'Build project',
         command: `mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')}`,
+        environment: {
+          // Cap the maven JVM heap: its default is derived from the memory of the
+          // underlying CI host, not from the resource class of the job.
+          MAVEN_OPTS: '-Xmx2048m',
+        },
       }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new reusable.ReusedCommand(saveMavenJobCacheCmd, { jobName: jobName }),

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1066,6 +1066,8 @@ jobs:
       - run:
           name: Build project
           command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8
+          environment:
+            MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-community-build

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1066,6 +1066,8 @@ jobs:
       - run:
           name: Build project
           command: mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8
+          environment:
+            MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-community-build


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-392

## Description

`Check build as Community user` was OOM-killed on 4.12.x right after the corepack change landed (build [2060987](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/95201/workflows/6ca28425-2c8c-4c94-85fd-29ee67f0f657/jobs/2060987)):

```
success    Enable Corepack and Set Yarn Version
failed     Build project
...
[INFO] --- compiler:3.15.0:testCompile @ gravitee-apim-gateway-tests-sdk ---
Received "killed" signal
```

The corepack step itself succeeds and the build gets far past the yarn install — it dies during a javac run, killed by the container, not by a compilation error. The likely trigger is the corepack change itself: yarn 1 used to produce a partial tree from a re-resolution, while yarn 4 now materialises the workspace the lockfile actually pins, which is bigger. Same container, less headroom.

This job builds the whole reactor with `-T 8` and an unbounded JVM heap. `Build backend` on this branch already caps it, with a comment explaining why: the default heap is derived from the memory of the underlying CI host, not from the resource class of the job. This applies the same cap to the community job.

## Additional context

Checked locally in `.circleci/ci`: `npm run build`, `npm test` (11 suites, 72 tests) and `npm run lint` all pass. Two pipeline fixtures were regenerated and gain nothing but the `environment: MAVEN_OPTS: -Xmx2048m` block.

Worth knowing before merging: this job only runs on base-branch pipelines, never on a feature branch, so this pull request's own CI cannot exercise it. It will only be proven by the 4.12.x pipeline after merge — the same blind spot that let the OOM through in the first place.

If a rerun of 2060987 turns out green on its own, the failure was host colocation rather than headroom, and the cap is still worth keeping: it makes the job's memory budget explicit instead of dependent on which host it lands on.
