### PR TITLE
feat(portal): decrease agent usage terms template font.

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1554,7 +1554,7 @@ describe('PortalNavigationItemsComponent', () => {
       });
       fixture.detectChanges();
       flushPendingLinkedApiSearchRequests();
-      expectGetPageContent('agent-terms-content-1', '# Agent usage terms');
+      expectGetPageContent('agent-terms-content-1', '## Agent Usage Terms');
       await fixture.whenStable();
       fixture.detectChanges();
     });
@@ -1562,7 +1562,7 @@ describe('PortalNavigationItemsComponent', () => {
     it('should load agent terms and conditions into the GMD editor', async () => {
       const gmdEditor = await harness.getGmdEditor();
       expect(gmdEditor).toBeTruthy();
-      expect(await harness.getEditorContentText()).toBe('# Agent usage terms');
+      expect(await harness.getEditorContentText()).toBe('## Agent Usage Terms');
       expect(await harness.isSaveButtonDisabled()).toBe(true);
     });
 
@@ -1621,7 +1621,7 @@ describe('PortalNavigationItemsComponent', () => {
         }),
       );
       flushPendingLinkedApiSearchRequests();
-      expectGetPageContent('agent-terms-content-1', '# Agent usage terms');
+      expectGetPageContent('agent-terms-content-1', '## Agent Usage Terms');
       await fixture.whenStable();
       fixture.detectChanges();
 
@@ -3568,7 +3568,7 @@ describe('PortalNavigationItemsComponent', () => {
       );
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdAgents] }));
-      await expectGetPageContent(createdAgents[0].termsAndConditionsPageContentId, 'Agent terms');
+      await expectGetPageContent(createdAgents[0].termsAndConditionsPageContentId, '## Agent Usage Terms');
 
       expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdAgents[0].id } }));
     });

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
@@ -130,7 +130,7 @@ describe('PortalService', () => {
     const apiId = 'api-123';
     const mockTerms: PortalPageContent = {
       type: 'GRAVITEE_MARKDOWN',
-      content: '# Agent usage terms',
+      content: '## Agent Usage Terms',
     };
 
     service.getAgentTermsAndConditions(apiId).subscribe(terms => {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiTermsAndConditionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiTermsAndConditionsResourceTest.java
@@ -71,7 +71,7 @@ class ApiTermsAndConditionsResourceTest extends AbstractResourceTest {
         var contentId = PortalPageContentId.random();
         portalNavigationItemsQueryService.initWith(List.of(publishedAgent(API_ID, contentId)));
         portalPageContentQueryService.initWith(
-            List.of(new GraviteeMarkdownPageContent(contentId, "DEFAULT", ENV_ID, GraviteeMarkdown.of("# Agent usage terms")))
+            List.of(new GraviteeMarkdownPageContent(contentId, "DEFAULT", ENV_ID, GraviteeMarkdown.of("## Agent Usage Terms")))
         );
 
         Response response = target(API_ID + "/terms-and-conditions").request().get();
@@ -79,7 +79,7 @@ class ApiTermsAndConditionsResourceTest extends AbstractResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
         var result = response.readEntity(PortalPageContent.class);
         assertThat(result.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
-        assertThat(result.getContent()).isEqualTo("# Agent usage terms");
+        assertThat(result.getContent()).isEqualTo("## Agent Usage Terms");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/agent-terms-and-conditions-page-content.md
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/agent-terms-and-conditions-page-content.md
@@ -1,23 +1,23 @@
-# Agent Usage Terms
+## Agent Usage Terms
 
 These sample terms apply to use of this agent through the Gravitee Developer Portal. Replace this content with your own terms before publishing.
 
-## 1. Acceptance
+### 1. Acceptance
 
 By subscribing to this agent, you agree to these terms and to the usage limits of the plan you select.
 
-## 2. Permitted use
+### 2. Permitted use
 
 You may call this agent only through the Gravitee gateway, using credentials issued for your application.
 
-## 3. Data processing
+### 3. Data processing
 
 Requests and responses may be logged for operations, metering, and support. Do not send secrets or personal data unless the agent is designed to handle them.
 
-## 4. Rate limits and availability
+### 4. Rate limits and availability
 
 Plan quotas, rate limits, and availability apply as configured on the selected plan. Excess usage may be throttled or rejected.
 
-## 5. Changes
+### 5. Changes
 
 The publisher may update these terms. Continued use after an update constitutes acceptance of the revised terms.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetAgentTermsAndConditionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetAgentTermsAndConditionsUseCaseTest.java
@@ -75,7 +75,7 @@ class GetAgentTermsAndConditionsUseCaseTest {
     void should_return_terms_content_when_agent_is_public_and_content_is_present() {
         var contentId = PortalPageContentId.random();
         navQueryService.initWith(List.of(publishedAgent(API_ID, PortalVisibility.PUBLIC, contentId)));
-        var content = new GraviteeMarkdownPageContent(contentId, ORG_ID, ENV_ID, GraviteeMarkdown.of("# Agent terms"));
+        var content = new GraviteeMarkdownPageContent(contentId, ORG_ID, ENV_ID, GraviteeMarkdown.of("## Agent Usage Terms"));
         pageContentQueryService.initWith(List.of(content));
 
         var result = useCase.execute(new GetAgentTermsAndConditionsUseCase.Input(ENV_ID, API_ID, USER_ID));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-552

### Description

The default agent terms-and-conditions page used top-level markdown headings, so the title rendered as large as the surrounding page heading. This change demotes those headings by one level so the sample terms sit visually under the page title in the console editor and on the portal.

### Changes

#### Default terms template

The seeded agent terms markdown now starts at heading level two, and the numbered sections sit at heading level three.

#### Test fixtures

Console, portal, and REST API tests that used the previous heading string now use the updated title so they stay aligned with the template.
