### PR TITLE
feat(ci): resolve Maven dependencies from the Azure Artifacts feed

### DIFF
--- a/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
+++ b/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command, Config, ReusableCommand, commands, reusable } from '../circleci-config';
+import { orbs } from '../orbs';
+import { config } from '../config';
+
+/**
+ * Exposes an Azure Artifacts token in AZURE_ARTIFACTS_PAT, which the Maven settings read as
+ * ${env.AZURE_ARTIFACTS_PAT}.
+ *
+ * Gravitee.io Bot is an Entra service principal, and a service principal cannot hold a personal
+ * access token: it authenticates with a token obtained from its client secret, valid for one hour.
+ *
+ * Every job running Maven therefore asks for its own, rather than one being fetched once and
+ * carried through the workspace. A "rerun from failed" does not replay the job that fetched it —
+ * it reuses the workspace, and would start again with a dead token. Same for a workflow left
+ * waiting on a manual approval. Neither is exotic, and the symptom would be a 401 pointing at
+ * permissions when the token has merely expired.
+ *
+ * The credentials are the ones already used to push images to the container registry.
+ */
+export class AzureArtifactsTokenCommand {
+  private static commandName = 'cmd-azure-artifacts-token';
+
+  public static get(dynamicConfig: Config): ReusableCommand {
+    dynamicConfig.importOrb(orbs.keeper);
+
+    const steps: Command[] = [
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.azureApplicationId,
+        'var-name': 'AZURE_SP_CLIENT_ID',
+      }),
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.azureApplicationSecret,
+        'var-name': 'AZURE_SP_CLIENT_SECRET',
+      }),
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.azureTenant,
+        'var-name': 'AZURE_SP_TENANT',
+      }),
+      new commands.Run({
+        name: 'Get an Azure Artifacts token',
+        // 499b84ac-1321-427f-aa17-267ca6975798 is the Azure DevOps application ID; the token is
+        // requested for that audience, not for the feed URL.
+        command: `TOKEN=$(curl -sf -X POST \\
+  "https://login.microsoftonline.com/\${AZURE_SP_TENANT}/oauth2/v2.0/token" \\
+  -d "client_id=\${AZURE_SP_CLIENT_ID}" \\
+  -d "client_secret=\${AZURE_SP_CLIENT_SECRET}" \\
+  -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \\
+  -d "grant_type=client_credentials" \\
+  | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')
+
+if [ -z "$TOKEN" ]; then
+  echo "Could not obtain an Entra token for the service principal." >&2
+  echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+  exit 1
+fi
+
+# Through BASH_ENV so the value survives to the following steps, and never appears on a
+# command line or in a process listing.
+echo "export AZURE_ARTIFACTS_PAT='\${TOKEN}'" >> "$BASH_ENV"`,
+      }),
+      new commands.Run({
+        name: 'Check the feed answers',
+        // Without this, a feed that rejects the token is invisible: the settings declare
+        // Artifactory after the feed, so Maven falls back to it with a warning and the build
+        // stays green. The fallback is there for artifacts not yet on the feed, not to paper
+        // over an authentication failure.
+        //
+        // io.gravitee.canary:feed-canary:1.0.0 exists on the feed and nowhere else, so
+        // resolving it proves the feed answered, and answered to this token.
+        command: `CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \\
+  -u "bot:\${AZURE_ARTIFACTS_PAT}" \\
+  "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+case "$CODE" in
+  200) echo "The feed resolves the canary." ;;
+  401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+  403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+  404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+  *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+esac`,
+      }),
+    ];
+
+    return new reusable.ReusableCommand(
+      AzureArtifactsTokenCommand.commandName,
+      steps,
+      undefined,
+      'Get a short-lived Azure Artifacts token',
+    );
+  }
+}

--- a/.circleci/ci/src/commands/index.ts
+++ b/.circleci/ci/src/commands/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './cmd-azure-artifacts-token';
 export * from './cmd-create-docker-context';
 export * from './cmd-docker-login';
 export * from './cmd-docker-logout';

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -146,7 +146,7 @@ const secrets = {
   graviteeLicense: 'keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64',
   graviteePackageCloudToken: 'keeper://8CG6HxY5gYsl-85eJKuIoA/field/password',
   jiraToken: 'keeper://hfnQD5TEfxzwRXUKhJhM-A/field/password',
-  mavenSettings: 'keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml',
+  mavenSettings: 'keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure',
   slackAccessToken: 'keeper://ZOz4db245GNaETVwmPBk8w/field/password',
   sonarToken: 'keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password',
 };

--- a/.circleci/ci/src/jobs/backend/abstract-job-test.ts
+++ b/.circleci/ci/src/jobs/backend/abstract-job-test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 import { Command, Config, Executor, Job, JobOptionalProperties, commands, reusable } from '../../circleci-config';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  withJdk,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 
@@ -31,9 +37,11 @@ export abstract class AbstractTestJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     return new Job(
       jobName,
@@ -46,6 +54,7 @@ export abstract class AbstractTestJob {
         new commands.cache.Restore({
           keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
         }),
+        new reusable.ReusedCommand(azureArtifactsTokenCmd),
         ...testSteps,
         new commands.Run({
           name: 'Save test results',

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -15,7 +15,13 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, SyncFolderToS3Command } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  PrepareGpgCmd,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  SyncFolderToS3Command,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { parse } from '../../utils';
@@ -25,6 +31,7 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment, publishOnDownloadWebsite: boolean): Job {
     const restoreMavenJobCacheCommand = RestoreMavenJobCacheCommand.get(environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCommand);
 
     const prepareGpgCommand = PrepareGpgCmd.get(dynamicConfig);
@@ -37,6 +44,7 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCommand, { jobName: BackendBuildAndPublishOnDownloadWebsiteJob.jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         // The distribution carries its own version properties now, so it needs the same treatment.
         name: 'Remove `-SNAPSHOT` from versions',
@@ -79,6 +87,7 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-
     if (publishOnDownloadWebsite) {
       const syncFolderToS3Cmd = SyncFolderToS3Command.get(dynamicConfig, parse(environment.graviteeioVersion), environment.isDryRun);
       dynamicConfig.addReusableCommand(syncFolderToS3Cmd);
+      dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
       steps.push(
         /**

--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -15,7 +15,13 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  InstallYarnCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -31,16 +37,19 @@ export class BuildBackendJob {
     // generate-resources). Without corepack the image's yarn 1 cannot read the berry lockfile
     // and resolves the whole workspace from the registry instead.
     const installYarnCmd = InstallYarnCommand.get();
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
     dynamicConfig.addReusableCommand(installYarnCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
       new reusable.ReusedCommand(installYarnCmd),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Build engine',
         command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -P all-modules -DwithJavadoc`,

--- a/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
+++ b/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
@@ -17,7 +17,7 @@ import { Command, Config, Job, commands, reusable } from '../../circleci-config'
 import { config } from '../../config';
 import { OpenJdkNodeExecutor } from '../../executors';
 import { CircleCIEnvironment } from '../../pipelines';
-import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { keeper } from '../../orbs/keeper';
 
 export class NexusStagingJob {
@@ -30,6 +30,7 @@ export class NexusStagingJob {
     dynamicConfig.importOrb(keeper);
 
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
 
     const prepareGpgCmd = PrepareGpgCmd.get(dynamicConfig);
@@ -37,6 +38,7 @@ export class NexusStagingJob {
 
     const saveMavenCacheCmd = SaveMavenJobCacheCommand.get();
     dynamicConfig.addReusableCommand(saveMavenCacheCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
@@ -47,6 +49,7 @@ export class NexusStagingJob {
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: NexusStagingJob.jobName }),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(prepareGpgCmd),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Release on Nexus',
         command: `mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings ${config.maven.settingsFile} --update-snapshots`,

--- a/.circleci/ci/src/jobs/backend/job-publish.ts
+++ b/.circleci/ci/src/jobs/backend/job-publish.ts
@@ -15,7 +15,7 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { config } from '../../config';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { OpenJdkNodeExecutor } from '../../executors';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -27,14 +27,17 @@ export class PublishJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       target === 'nexus'
         ? new commands.Run({
             name: 'Maven Package and deploy to Nexus Snapshots',

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -15,7 +15,7 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -26,14 +26,17 @@ export class ValidateJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: ValidateJob.jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Validate project',
         command: `mvn -s ${config.maven.settingsFile} validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules ${mavenParallelism('large')}`,

--- a/.circleci/ci/src/jobs/job-setup.ts
+++ b/.circleci/ci/src/jobs/job-setup.ts
@@ -29,7 +29,9 @@ export class SetupJob {
         'var-name': 'MAVEN_SETTINGS',
       }),
       new commands.Run({
-        command: `echo $MAVEN_SETTINGS > ${config.maven.settingsFile} `,
+        // Quoted: without them the shell collapses the XML onto a single line. It stays valid,
+        // but becomes unreadable the day a build has to be debugged.
+        command: `echo "$MAVEN_SETTINGS" > ${config.maven.settingsFile}`,
       }),
       new commands.workspace.Persist({
         root: '.',

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -66,6 +66,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -124,7 +170,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -142,6 +188,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -183,6 +230,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -127,7 +127,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -80,7 +80,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -69,6 +69,52 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -77,7 +123,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -99,6 +145,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -189,6 +189,52 @@ commands:
           from: << parameters.folder-to-sync>>
           to: s3://gravitee-releases-downloads/pre-releases
     description: Sync folder content to Gravitee download website
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -197,7 +243,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -485,6 +531,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -836,6 +883,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -200,7 +200,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -189,6 +189,52 @@ commands:
           from: << parameters.folder-to-sync>>
           to: s3://gravitee-dry-releases-downloads
     description: Sync folder content to Gravitee download website
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -197,7 +243,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -485,6 +531,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -870,6 +917,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -200,7 +200,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -201,7 +201,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -190,6 +190,52 @@ commands:
           from: << parameters.folder-to-sync>>
           to: s3://gravitee-releases-downloads/pre-releases
     description: Sync folder content to Gravitee download website
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -198,7 +244,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -486,6 +532,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -881,6 +928,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -189,6 +189,52 @@ commands:
           from: << parameters.folder-to-sync>>
           to: s3://gravitee-releases-downloads
     description: Sync folder content to Gravitee download website
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -197,7 +243,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -485,6 +531,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -882,6 +929,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -200,7 +200,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -189,6 +189,52 @@ commands:
           from: << parameters.folder-to-sync>>
           to: s3://gravitee-releases-downloads
     description: Sync folder content to Gravitee download website
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -197,7 +243,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -485,6 +531,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -882,6 +929,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -200,7 +200,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -137,7 +183,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -156,6 +202,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -140,7 +140,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -88,6 +88,52 @@ commands:
           key: gravitee-api-management-v15-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -314,6 +360,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -345,6 +392,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -378,6 +426,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -420,6 +469,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -453,6 +503,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -486,6 +537,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -519,6 +571,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -546,6 +599,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4
@@ -734,7 +788,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -753,6 +807,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -737,7 +737,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -146,7 +192,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -165,6 +211,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -149,7 +149,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -150,7 +150,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -74,6 +74,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -147,7 +193,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -166,6 +212,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -146,7 +192,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -165,6 +211,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -149,7 +149,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -149,7 +149,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -146,7 +192,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -165,6 +211,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -410,6 +457,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-artifactory
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U -P gio-artifactory-snapshot
@@ -426,6 +474,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-nexus
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Nexus Snapshots
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -282,6 +330,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -353,6 +402,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -98,7 +98,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-danger-js:
     docker:
@@ -95,7 +141,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -113,6 +159,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -154,6 +201,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -226,6 +274,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -169,7 +169,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -166,7 +212,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -184,6 +230,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -225,6 +272,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -297,6 +345,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -366,6 +415,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -399,6 +449,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -441,6 +492,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -474,6 +526,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -507,6 +560,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -540,6 +594,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -567,6 +622,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -284,6 +332,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -284,6 +332,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -355,6 +404,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -154,7 +154,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -151,7 +197,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -169,6 +215,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -210,6 +257,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -284,6 +332,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -169,7 +169,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -166,7 +212,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -184,6 +230,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -225,6 +272,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -299,6 +347,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -379,6 +428,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -406,6 +456,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -113,7 +113,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -74,6 +74,52 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -110,7 +156,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -128,6 +174,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -169,6 +216,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -241,6 +289,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -74,6 +74,52 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -225,7 +271,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -243,6 +289,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -284,6 +331,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -356,6 +404,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -425,6 +474,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -458,6 +508,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -500,6 +551,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -533,6 +585,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -566,6 +619,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -599,6 +653,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -626,6 +681,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -228,7 +228,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -149,7 +149,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -146,7 +192,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -165,6 +211,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -410,6 +457,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-artifactory
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U -P gio-artifactory-snapshot
@@ -426,6 +474,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-nexus
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Nexus Snapshots
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -74,6 +74,52 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -225,7 +271,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -243,6 +289,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -284,6 +331,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -356,6 +404,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -425,6 +474,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -458,6 +508,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -500,6 +551,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -533,6 +585,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -566,6 +619,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -599,6 +653,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -626,6 +681,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -228,7 +228,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -253,7 +253,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -74,6 +74,52 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -250,7 +296,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -268,6 +314,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -309,6 +356,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -381,6 +429,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -450,6 +499,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -483,6 +533,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -525,6 +576,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -558,6 +610,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -591,6 +644,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -624,6 +678,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -651,6 +706,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -73,6 +73,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -137,7 +183,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -156,6 +202,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -140,7 +140,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -150,7 +150,7 @@ jobs:
           secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
           var-name: MAVEN_SETTINGS
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -74,6 +74,52 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
+          var-name: AZURE_SP_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
+          var-name: AZURE_SP_CLIENT_SECRET
+      - keeper/env-export:
+          secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
+          var-name: AZURE_SP_TENANT
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            TOKEN=$(curl -sf -X POST \
+              "https://login.microsoftonline.com/${AZURE_SP_TENANT}/oauth2/v2.0/token" \
+              -d "client_id=${AZURE_SP_CLIENT_ID}" \
+              -d "client_secret=${AZURE_SP_CLIENT_SECRET}" \
+              -d "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              -d "grant_type=client_credentials" \
+              | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$TOKEN" ]; then
+              echo "Could not obtain an Entra token for the service principal." >&2
+              echo "The client secret is the one used to push images: if it expired, those are failing too." >&2
+              exit 1
+            fi
+
+            # Through BASH_ENV so the value survives to the following steps, and never appears on a
+            # command line or in a process listing.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' -m 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom")
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              *)   echo "HTTP $CODE from the feed." >&2; exit 1 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -147,7 +193,7 @@ jobs:
     steps:
       - checkout
       - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
+          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure
           var-name: MAVEN_SETTINGS
       - run:
           command: echo "$MAVEN_SETTINGS" > .gravitee.settings.xml
@@ -166,6 +212,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-293

## Description

Maven now resolves from the Azure Artifacts feed.

Publication is deliberately untouched: the deploy profiles still target Artifactory and Nexus, and this PR does not move them. Read first, write later.

- The shared Maven settings come from a new Keeper field, `custom_field/xml_azure`, which declares the feed before Artifactory. Artifactory stays declared, so anything not on the feed yet still resolves.
- A new command, `cmd-azure-artifacts-token`, obtains a one-hour Entra token and exports it as `AZURE_ARTIFACTS_PAT`, which the settings read as `${env.AZURE_ARTIFACTS_PAT}`.
- Every job that runs Maven calls it: fourteen in total.

## Additional context

**Why a token per job, rather than one fetched once and carried through the workspace.**
Gravitee.io Bot is an Entra service principal, and a service principal cannot hold a personal access token — it authenticates through `client_credentials`, and what it gets back lives one hour. Fetching it once breaks on "rerun from failed": that rerun does not replay the job that fetched the token, it reuses the workspace and starts again with a dead one. A workflow left waiting on a manual approval has the same problem. Neither is exotic, and the symptom would be a 401 that reads like a permissions problem when the token has merely expired. The credentials are the ones already used to push images to the registry.

**Why the canary check.**
The settings declare the feed before Artifactory, so a feed that rejects the token is invisible: Maven warns, falls back, and the build stays green — we would never learn whether the feed is serving anything at all. `io.gravitee.canary:feed-canary:1.0.0` exists on the feed and nowhere else, so one request settles it. This keeps the fallback doing its real job, which is serving artifacts not yet on the feed, and stops it from covering an authentication failure.

**Coverage.**
`abstract-job-test` carries the call for the thirteen test jobs that extend it; `job-validate`, `job-build-backend`, `job-nexus-staging`, `job-publish` and the download-website job have it individually. No `context:` had to be added anywhere — across the 556 job declarations in the fixtures, every job that needs the Keeper secrets already has one, including the two workflows that arrived with the core release lane.

**The quoting fix** in the first commit is independent and reviewable on its own: unquoted, `echo $MAVEN_SETTINGS` collapses the XML onto a single line.

**Fixtures** were regenerated, never hand-edited.

Verified locally: 200 tests, licence headers, prettier, and `circleci config validate` on the 36 generated configurations.

Draft on purpose — this pipeline is the real test. Each of the fourteen jobs fetches its own token and resolves the canary before Maven starts, so a green run means the feed answered.
