### PR TITLE
feat(portal): improve api vs agent wording.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
@@ -25,7 +25,7 @@
           <div class="m3-body-medium">{{ api.version }}</div>
         </div>
         @if (!!api.mcp) {
-          <mat-chip i18n="@@apiCardMcpEnabled" i18n-matTooltip matTooltip="MCP available for this API">
+          <mat-chip i18n="@@apiCardMcpEnabled" i18n-matTooltip matTooltip="MCP available">
             <img matChipAvatar alt="" [src]="'assets/images/mcp.svg'" />MCP</mat-chip
           >
         }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
@@ -23,8 +23,7 @@
       } @else {
         <div class="m3-body-large" i18n="@@apiDetailsNotAvailable">No details available</div>
         <div class="m3-body-medium" i18n="@@apiDetailsNotAvailableExplanation">
-          It seems that there is currently no details available for this API. If you’re seeking information, feel free to explore the
-          documentation available.
+          No details available yet. Check the documentation for more information.
         </div>
       }
     } @else {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-documentation/api-tab-documentation.component.html
@@ -30,5 +30,5 @@
     <app-api-documentation [apiId]="apiId" [pages]="pages" [pageId]="pageId" class="api-tab-documentation__page-content" />
   }
 } @else {
-  <div i18n="@@apiDocumentationEmpty" class="api-tab-documentation__empty">Documentation for this API is missing.</div>
+  <div i18n="@@apiDocumentationEmpty" class="api-tab-documentation__empty">No documentation available.</div>
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -126,9 +126,9 @@ export class SubscriptionsDetailsComponent implements OnInit {
 
   closeSubscription() {
     const dialogData: ConfirmDialogData = {
-      title: $localize`:@@titleCancelSubscriptionDialog:Close this subscription?`,
-      content: $localize`:@@contentCancelSubscriptionDialog:You will lose access to the API.`,
-      confirmLabel: $localize`:@@confirmCancelSubscriptionDialog:Yes, close`,
+      title: $localize`:@@titleCancelSubscriptionDialog:Cancel this subscription?`,
+      content: $localize`:@@contentCancelSubscriptionDialog:You will lose access.`,
+      confirmLabel: $localize`:@@confirmCancelSubscriptionDialog:Yes, cancel`,
       cancelLabel: $localize`:@@cancelCancelSubscriptionDialog:Cancel`,
     };
     this.dialog

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
@@ -32,7 +32,7 @@
       @if (subscriptionsStatus.value?.length) {
         <p i18n="@@noSubscriptionsFoundWithFilter">Try unchecking some of the chosen filters.</p>
       } @else {
-        <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
+        <p i18n="@@subscribeToApi">Subscribe and your subscription will show up here.</p>
       }
     </div>
   } @else {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.html
@@ -28,7 +28,7 @@
       <app-mcp-tool class="api-tab-tools__tool" [tool]="mcpTool.toolDefinition" />
     } @empty {
       <div class="next-gen-body" data-testid="api-tab-tools-empty-message" i18n="@@mcpToolsNotAvailableExplanation">
-        It seems that there are currently no tools available for this API.
+        No tools available.
       </div>
     }
   </div>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-tools/api-tab-tools.component.spec.ts
@@ -54,7 +54,7 @@ describe('ApiTabToolsComponent', () => {
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiTabToolsComponentHarness);
     const emptyMessage = await harness.getEmptyToolsMessageText();
     expect(emptyMessage).not.toBeNull();
-    expect(emptyMessage).toContain('It seems that there are currently no tools available for this API.');
+    expect(emptyMessage).toContain('No tools available.');
   });
 
   it('should show tools when available', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.html
@@ -58,8 +58,7 @@
                 (selectItem)="apiKeyMode.set('EXCLUSIVE')"
               >
                 <div i18n="@@subscribeToApiGeneratedApiKeyDescription" class="m3-body-medium">
-                  A new API Key will be generated for each new subscription of the chosen application, ensuring secure and unique access for
-                  every user.
+                  A new API Key will be generated for each new subscription, ensuring secure and unique access.
                 </div>
               </app-radio-card>
               <app-radio-card
@@ -70,7 +69,7 @@
                 (selectItem)="apiKeyMode.set('SHARED')"
               >
                 <div i18n="@@subscribeToApiSharedApiKeyDescription" class="m3-body-medium">
-                  The same API Key will be used for each new subscription, simplifying management across multiple APIs.
+                  The same API Key will be used for each new subscription, simplifying management across multiple subscriptions.
                 </div>
               </app-radio-card>
             </div>

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
@@ -21,7 +21,7 @@
       <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.PLAN_SELECTION)">
         <div class="next-gen-h5" i18n="@@subscribeChoosePlan">Choose a plan</div>
         <div class="next-gen-body" i18n="@@subscribeChoosePlanDescription">
-          A plan lets an application access an API. Once subscribed and approved, the application gets credentials to use it.
+          A plan sets your access level and usage limits. Once your request is approved, you get the credentials to start using it.
         </div>
       </app-subscribe-to-api-step-header>
       <mat-card-content>
@@ -42,8 +42,7 @@
       <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.APP_SELECTION)">
         <div class="next-gen-h5" i18n="@@subscribeChooseApplication">Choose an application</div>
         <div class="next-gen-body" i18n="@@subscribeChooseApplicationDescription">
-          An application represents a developer's project that interacts with the API. It acts as a means to manage access control to APIs
-          via subscriptions.
+          An application holds your credentials and keeps track of what you have subscribed to.
         </div>
       </app-subscribe-to-api-step-header>
       <mat-card-content>
@@ -74,8 +73,8 @@
       <app-subscribe-to-api-step-header [stepNumber]="stepNumberOf(SubscribeStep.REVIEW)">
         <div class="next-gen-h5" i18n="@@subscribeReview">Review</div>
         @if (currentPlan()?.security === 'KEY_LESS') {
-          <div class="next-gen-body" i18n="@@subscribeChooseApplicationDescription">
-            This plan does not need any subscription to consume the API.
+          <div class="next-gen-body" i18n="@@subscribeReviewKeylessDescription">
+            This plan does not need a subscription. You can start using it right away.
           </div>
         }
       </app-subscribe-to-api-step-header>

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog-item.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog-item.spec.ts
@@ -22,13 +22,13 @@ const plan = (overrides: Partial<Plan>): Plan =>
 describe('catalog item', () => {
   describe('isAgent', () => {
     it.each([
-      ['A2A_PROXY' as const, false, true],
-      ['MCP_PROXY' as const, false, true],
-      ['PROXY' as const, true, true],
-      ['PROXY' as const, false, false],
-      [undefined, false, false],
-    ])('reads %s / mcp=%s as agent=%s', (apiType, hasMcpServer, expected) => {
-      expect(isAgent(apiType, hasMcpServer)).toBe(expected);
+      ['A2A_PROXY' as const, true],
+      ['MCP_PROXY' as const, true],
+      ['LLM_PROXY' as const, true],
+      ['PROXY' as const, false],
+      [undefined, false],
+    ])('reads %s as agent=%s', (apiType, expected) => {
+      expect(isAgent(apiType)).toBe(expected);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog-item.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog-item.ts
@@ -16,17 +16,15 @@
 import type { LocalizeFn } from '@angular/localize/init';
 
 import { ApiCardAccess } from '../../components/api-card/api-card.component';
-import { ApiType } from '../../entities/api/api';
+import { ApiType, isAgentApi } from '../../entities/api/api';
 import { Plan } from '../../entities/plan/plan';
 
 declare const $localize: LocalizeFn;
 
 export type CatalogKind = 'agents' | 'apis';
 
-const AGENT_API_TYPES: ApiType[] = ['A2A_PROXY', 'MCP_PROXY', 'LLM_PROXY'];
-
-export function isAgent(apiType: ApiType | undefined, hasMcpServer: boolean): boolean {
-  return (!!apiType && AGENT_API_TYPES.includes(apiType)) || hasMcpServer;
+export function isAgent(apiType: ApiType | undefined): boolean {
+  return isAgentApi({ type: apiType });
 }
 
 const PROTOCOL_LABELS: Partial<Record<ApiType, string>> = {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="content">
   <div class="api-list__header" [appIsMobile]="'api-list__header--mobile'">
-    <div class="next-gen-h1" i18n="@@catalogTitle">Marketplace</div>
+    <div class="next-gen-h1" i18n="@@catalogTitle">Catalog</div>
   </div>
 
   <div class="api-list__search-row" [appIsMobile]="'api-list__search-row--mobile'">
@@ -94,7 +94,7 @@
                     [typeLabel]="item.isAgent ? agentTypeLabel : apiTypeLabel"
                     (cardSelect)="navigateToDocumentation(item)"
                     (documentationSelect)="navigateToDocumentation(item)"
-                    (subscribeSelect)="navigateToSubscribe(item.id)"
+                    (subscribeSelect)="navigateToSubscribe(item)"
                   />
                 }
               }
@@ -172,7 +172,7 @@
                 <th mat-header-cell *matHeaderCellDef></th>
                 <td mat-cell *matCellDef="let item" class="api-list__table__mcp-cell">
                   @if (item.type !== 'API_PRODUCT' && item.isEnabledMcpServer) {
-                    <app-badge i18n-label label="MCP" i18n-matTooltip matTooltip="MCP available for this API" />
+                    <app-badge i18n-label label="MCP" i18n-matTooltip matTooltip="MCP available" />
                   }
                 </td>
               </ng-container>

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -183,7 +183,7 @@ describe('CatalogComponent', () => {
 
     const apiCards = await harnessLoader.getAllHarnesses(ApiCardHarness);
 
-    expect(await Promise.all(apiCards.map(card => card.getTitle()))).toEqual(['Helpdesk Agent', 'MCP Server API']);
+    expect(await Promise.all(apiCards.map(card => card.getTitle()))).toEqual(['Helpdesk Agent']);
     expect(await apiCards[0].getType()).toBe('AGENT');
     expect(await harnessLoader.getAllHarnesses(ApiProductCardHarness)).toHaveLength(0);
   });
@@ -191,8 +191,8 @@ describe('CatalogComponent', () => {
   it('should take an item the backend calls an agent at its word', async () => {
     await init();
 
-    expect(await catalogHarness.getKindCounts()).toEqual(['2', '2']);
-    expect(await catalogHarness.getTally()).toBe('2 Agents');
+    expect(await catalogHarness.getKindCounts()).toEqual(['1', '3']);
+    expect(await catalogHarness.getTally()).toBe('1 Agent');
   });
 
   it('should render APIs and API Products together on the APIs side', async () => {
@@ -204,9 +204,10 @@ describe('CatalogComponent', () => {
     const apiCards = await harnessLoader.getAllHarnesses(ApiCardHarness);
     const productCards = await harnessLoader.getAllHarnesses(ApiProductCardHarness);
 
-    expect(apiCards).toHaveLength(1);
-    expect(await apiCards[0].getTitle()).toBe('Weather API');
+    expect(apiCards).toHaveLength(2);
+    expect(await Promise.all(apiCards.map(card => card.getTitle()))).toEqual(['MCP Server API', 'Weather API']);
     expect(await apiCards[0].getType()).toBe('API');
+    expect(await apiCards[1].getType()).toBe('API');
     expect(productCards).toHaveLength(1);
     expect(await productCards[0].getTitle()).toBe('AI Workspace');
     expect(await productCards[0].getApiCount()).toContain('2 APIS INCLUDED');
@@ -220,13 +221,17 @@ describe('CatalogComponent', () => {
     fixture.detectChanges();
 
     const rows = await catalogHarness.getAllRowsCellText();
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3);
     expect(rows[0]).toMatchObject({
       name: expect.stringContaining('AI Workspace'),
       labels: expect.stringContaining('Included APIs: 2'),
       version: '3.0',
     });
     expect(rows[1]).toMatchObject({
+      name: expect.stringContaining('MCP Server API'),
+      version: '2.0',
+    });
+    expect(rows[2]).toMatchObject({
       name: expect.stringContaining('Weather API'),
       labels: expect.stringContaining('# weather'),
       version: '1.0',
@@ -254,8 +259,8 @@ describe('CatalogComponent', () => {
 
     await (await harnessLoader.getAllHarnesses(ApiCardHarness))[0].select();
 
-    expect(navigate).toHaveBeenCalledWith(['/documentation', 'api-root-1'], {
-      queryParams: { selectedId: 'api-nav-1' },
+    expect(navigate).toHaveBeenCalledWith(['/documentation', 'api-root-2'], {
+      queryParams: { selectedId: 'api-nav-2' },
     });
   });
 
@@ -575,8 +580,8 @@ describe('CatalogComponent', () => {
       await init();
 
       expect(await catalogHarness.getKinds()).toEqual(['Agents', 'APIs']);
-      expect(await catalogHarness.getKindCounts()).toEqual(['2', '2']);
-      expect(await catalogHarness.getTally()).toBe('2 Agents');
+      expect(await catalogHarness.getKindCounts()).toEqual(['1', '3']);
+      expect(await catalogHarness.getTally()).toBe('1 Agent');
     });
 
     it('should put the chosen side in the URL', async () => {
@@ -603,8 +608,8 @@ describe('CatalogComponent', () => {
       flushPlans();
       fixture.detectChanges();
 
-      expect(await catalogHarness.getTally()).toBe('2 APIs');
-      expect(await (await harnessLoader.getAllHarnesses(ApiCardHarness))[0].getTitle()).toBe('Weather API');
+      expect(await catalogHarness.getTally()).toBe('3 APIs');
+      expect(await (await harnessLoader.getAllHarnesses(ApiCardHarness))[0].getTitle()).toBe('MCP Server API');
     });
 
     it('should switch sides without asking the server again', async () => {
@@ -613,14 +618,14 @@ describe('CatalogComponent', () => {
       await catalogHarness.selectKind('APIs');
       fixture.detectChanges();
 
-      expect(await harnessLoader.getAllHarnesses(ApiCardHarness)).toHaveLength(1);
-      expect(await catalogHarness.getTally()).toBe('2 APIs');
+      expect(await harnessLoader.getAllHarnesses(ApiCardHarness)).toHaveLength(2);
+      expect(await catalogHarness.getTally()).toBe('3 APIs');
       httpTestingController.expectNone(request => request.url === `${TESTING_BASE_URL}/portal-navigation-items/_search`);
 
       await catalogHarness.selectKind('Agents');
       fixture.detectChanges();
 
-      expect(await catalogHarness.getTally()).toBe('2 Agents');
+      expect(await catalogHarness.getTally()).toBe('1 Agent');
     });
 
     it('should read the access state off the plans and filter by it', async () => {
@@ -633,8 +638,10 @@ describe('CatalogComponent', () => {
       fixture.detectChanges();
 
       const cards = await harnessLoader.getAllHarnesses(ApiCardHarness);
-      expect(await cards[0].getAccess()).toBe('No key needed');
-      expect(await catalogHarness.getFilterValues('access')).toEqual(['No key needed 1']);
+      expect(await Promise.all(cards.map(card => card.getTitle()))).toEqual(['MCP Server API', 'Weather API']);
+      expect(await cards[0].getAccess()).toBe('Approval needed');
+      expect(await cards[1].getAccess()).toBe('No key needed');
+      expect(await catalogHarness.getFilterValues('access')).toEqual(['No key needed 1', 'Approval needed 1']);
 
       await catalogHarness.pickFilterValue('access', 'No key needed');
       fixture.detectChanges();
@@ -682,19 +689,21 @@ describe('CatalogComponent', () => {
       fixture.detectChanges();
 
       expect(await catalogHarness.hasClearFilters()).toBe(false);
-      expect(await harnessLoader.getAllHarnesses(ApiCardHarness)).toHaveLength(1);
+      expect(await harnessLoader.getAllHarnesses(ApiCardHarness)).toHaveLength(2);
     });
 
     it('should show the tools of an MCP server as its capabilities, and labels otherwise', async () => {
       stubOverflowLabelsLayout({ containerWidth: 500 });
       await init();
 
-      expect(await (await harnessLoader.getAllHarnesses(ApiCardHarness))[1].getCapabilities()).toEqual(['MCP Tool']);
+      expect(await (await harnessLoader.getAllHarnesses(ApiCardHarness))[0].getCapabilities()).toEqual(['helpdesk']);
 
       await catalogHarness.selectKind('APIs');
       fixture.detectChanges();
 
-      expect(await (await harnessLoader.getAllHarnesses(ApiCardHarness))[0].getCapabilities()).toEqual(['weather']);
+      const apiCards = await harnessLoader.getAllHarnesses(ApiCardHarness);
+      expect(await apiCards[0].getCapabilities()).toEqual(['MCP Tool']);
+      expect(await apiCards[1].getCapabilities()).toEqual(['weather']);
     });
 
     it('should say when the filters hide everything, instead of claiming the catalog is empty', async () => {
@@ -882,8 +891,12 @@ describe('CatalogComponent', () => {
       flushPlans({ 'api-2': [fakePlan({ security: 'API_KEY' })] });
       fixture.detectChanges();
 
+      await catalogHarness.selectKind('APIs');
+      fixture.detectChanges();
+
       const cards = await harnessLoader.getAllHarnesses(ApiCardHarness);
-      expect(await cards[1].getAccess()).toBe('Subscribed');
+      expect(await cards[0].getTitle()).toBe('MCP Server API');
+      expect(await cards[0].getAccess()).toBe('Subscribed');
     });
 
     it('should ask for its own subscriptions without listing every api in the url', async () => {
@@ -945,13 +958,32 @@ describe('CatalogComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should send the reader to the subscribe page of the catalog, not the root', async () => {
+  it('should send an agent card Subscribe to the documentation subscribe page', async () => {
     await init();
     const navigate = jest.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
 
-    fixture.componentInstance.navigateToSubscribe('api-2');
+    const card = (await harnessLoader.getAllHarnesses(ApiCardHarness))[0];
+    await card.toggleDetails();
+    await card.clickDetailAction('subscribe');
 
-    expect(navigate).toHaveBeenCalledWith(['api', 'api-2', 'subscribe'], { relativeTo: expect.anything() });
+    expect(navigate).toHaveBeenCalledWith(['/documentation', 'agent-root-1', 'api', 'agent-api-1', 'subscribe'], {
+      queryParams: { selectedId: 'agent-nav-1' },
+    });
+  });
+
+  it('should send an API card Subscribe to the documentation subscribe page', async () => {
+    await init();
+    await catalogHarness.selectKind('APIs');
+    fixture.detectChanges();
+    const navigate = jest.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+    const card = (await harnessLoader.getAllHarnesses(ApiCardHarness))[0];
+    await card.toggleDetails();
+    await card.clickDetailAction('subscribe');
+
+    expect(navigate).toHaveBeenCalledWith(['/documentation', 'api-root-2', 'api', 'api-2', 'subscribe'], {
+      queryParams: { selectedId: 'api-nav-2' },
+    });
   });
 
   function flushPlanRequestsAndReturnApiIds(): string[] {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -324,8 +324,10 @@ export class CatalogComponent {
     }
   }
 
-  navigateToSubscribe(apiId: string) {
-    this.router.navigate(['api', apiId, 'subscribe'], { relativeTo: this.route });
+  navigateToSubscribe(item: CatalogApiVM) {
+    this.router.navigate(['/documentation', item.rootId, 'api', item.id, 'subscribe'], {
+      queryParams: { selectedId: item.navItemId },
+    });
   }
 
   trackById(_index: number, item: CatalogCardVM) {
@@ -445,7 +447,7 @@ export class CatalogComponent {
               picture: item._links?.picture,
               isEnabledMcpServer: !!item.mcp,
               labels: item.labels,
-              isAgent: item.type === 'AGENT' || isAgent(item.apiType, !!item.mcp),
+              isAgent: item.type === 'AGENT' || isAgent(item.apiType),
               capabilities: skills.length ? skills.map(skill => skill.name) : (item.labels ?? []),
               skills,
               endpoint: item.entrypoints?.[0],

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/api-product-subscription-details/api-product-subscription-details.component.ts
@@ -273,7 +273,7 @@ export class ApiProductSubscriptionDetailsComponent {
           this.apiKeyRenewed.emit();
           this.apiKeyFeedback.set({
             type: 'success',
-            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
+            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to get access.`,
           });
         },
         error: () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.html
@@ -88,9 +88,7 @@
     <div class="subscriptions__empty-state">
       <span class="material-icons icon-with-background m3-headline-large" aria-hidden="true">search</span>
       <h2 class="m3-title-large" i18n="@@subscriptionsEmptyTitle">No subscriptions yet</h2>
-      <p i18n="@@subscriptionsEmptyDescription">
-        Browse the catalog to discover available APIs and API Products and subscribe with an application.
-      </p>
+      <p i18n="@@subscriptionsEmptyDescription">Browse the catalog to find something to subscribe to.</p>
     </div>
   }
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -311,7 +311,7 @@ export default class SubscriptionsComponent {
 
     switch (subscription.reference_type) {
       case 'API':
-        return $localize`:@@unavailableApiSubscriptionTarget:Unavailable API`;
+        return $localize`:@@unavailableApiSubscriptionTarget:Unavailable`;
       case 'API_PRODUCT':
         return $localize`:@@unavailableApiProductSubscriptionTarget:Unavailable API Product`;
       default:

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -105,6 +105,6 @@
     animate.leave="side-panel-leave"
     (closed)="chatOpen.set(false)"
   >
-    <app-agent-chat [agentName]="session.agentName" [applicationName]="session.applicationName" [target]="session.target" />
+    <app-agent-chat [agentName]="session.agentName" [target]="session.target" />
   </app-side-panel>
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -635,7 +635,7 @@ describe('DocumentationFolderComponent', () => {
   });
 
   describe('agent chat', () => {
-    const AGENT_ACCESS: AgentSubscriptionAccess = { apiKey: 'key-1', applicationName: 'My App' };
+    const AGENT_ACCESS: AgentSubscriptionAccess = { apiKey: 'key-1' };
 
     const realFetch = globalThis.fetch;
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -122,8 +122,7 @@ export class DocumentationFolderComponent {
   chatSession = computed(() => {
     const target = this.chatTarget();
     const agentName = this.api.error() ? null : this.api.value()?.name;
-    const applicationName = this.agentAccess.value()?.applicationName;
-    return target && agentName ? { target, agentName, applicationName: applicationName ?? '' } : null;
+    return target && agentName ? { target, agentName } : null;
   });
 
   hasBreadcrumbActions = computed(() => !!this.subscriptionTarget() || this.apiHasMcp() || !!this.chatTarget());

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
@@ -22,8 +22,8 @@
     class="documentation-subscribe__back-link internal-link"
   >
     <mat-icon>arrow_backward</mat-icon>
-    <span i18n="@@documentationSubscribeBack">Back to API</span>
+    <span i18n="@@documentationSubscribeBack">Back</span>
   </a>
-  <div class="next-gen-h3"><span i18n="@@documentationSubscribeCTA">Subscribe to the API:</span> {{ api().name }}</div>
+  <div class="next-gen-h3"><span i18n="@@documentationSubscribeCTA">Subscribe to:</span> {{ api().name }}</div>
   <app-subscribe-to-api [api]="api()" [cancelFn]="cancel" />
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.html
@@ -18,7 +18,6 @@
 <div class="agent-chat">
   <div class="agent-chat__header">
     <div class="next-gen-h5" i18n="@@agentChatTitle">Chat with {{ agentName() }}</div>
-    <div class="next-gen-small agent-chat__header__application" i18n="@@agentChatApplication">Calling as {{ applicationName() }}</div>
   </div>
 
   <div #log class="agent-chat__log" role="log" tabindex="0" i18n-aria-label="@@agentChatLogAria" aria-label="Conversation">

--- a/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.scss
@@ -13,10 +13,6 @@
     flex-direction: column;
     gap: 4px;
     padding-right: 40px;
-
-    &__application {
-      color: app-theme.$paragraph-color;
-    }
   }
 
   &__log {

--- a/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.spec.ts
@@ -57,17 +57,17 @@ describe('AgentChatComponent', () => {
 
     fixture = TestBed.createComponent(AgentChatComponent);
     fixture.componentRef.setInput('agentName', 'Incident Commander');
-    fixture.componentRef.setInput('applicationName', 'My App');
     fixture.componentRef.setInput('target', TARGET);
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AgentChatComponentHarness);
     fixture.detectChanges();
   });
 
-  it('names the agent and the application whose key is used', async () => {
+  it('names the agent without exposing the application', async () => {
     const header = await harness.getHeaderText();
 
     expect(header).toContain('Incident Commander');
-    expect(header).toContain('My App');
+    expect(header).not.toContain('My App');
+    expect(header).not.toContain('Calling as');
   });
 
   it('invites the viewer to start before anything has been said', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-chat/agent-chat.component.ts
@@ -35,7 +35,6 @@ export class AgentChatComponent {
   private readonly store = inject(AgentChatStore);
 
   agentName = input.required<string>();
-  applicationName = input.required<string>();
   target = input.required<ChatTarget>();
 
   protected readonly draft = new FormControl<string>('', { nonNullable: true });

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -20,7 +20,7 @@
     @if (subscription?.status === 'ACCEPTED' || planSecurity === 'KEY_LESS') {
       <mat-card-header>
         <div class="api-access__header-row">
-          <div class="next-gen-h5 api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">API access</div>
+          <div class="next-gen-h5 api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">Access</div>
           @if (planSecurity === 'API_KEY' && subscription?.status === 'ACCEPTED' && canManageApiKey) {
             <button
               mat-stroked-button
@@ -66,7 +66,7 @@
         } @else {
           @if (shouldShowApiAccessContent()) {
             <div class="api-access__copy-code-content__calling-api">
-              <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Calling the API</div>
+              <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Making requests</div>
               @if (entrypointUrlValues().length === 1) {
                 <app-copy-code id="base-url" title="Base URL" [text]="entrypointUrlValues()[0]" />
               } @else if (entrypointUrlValues().length > 1) {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -255,7 +255,7 @@ describe('ApiAccessComponent', () => {
           fixture.detectChanges();
 
           expect(apiKeyRenewedSpy).toHaveBeenCalled();
-          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
+          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to get access.');
           expect(getApiKeyFeedbackAttribute('aria-live')).toBe('polite');
           expect(getApiKeyFeedbackAttribute('role')).toBeNull();
         });
@@ -513,7 +513,7 @@ describe('ApiAccessComponent', () => {
           await revokeButton!.click();
           const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
           expect(await confirmDialog.getTitle()).toContain('Close this API key?');
-          expect(await confirmDialog.getContent()).toContain('Applications using it will no longer be able to access the API.');
+          expect(await confirmDialog.getContent()).toContain('Anything using it will no longer have access.');
           expect(await confirmDialog.getCancelText()).toContain('Cancel');
           expect(await confirmDialog.getConfirmText()).toContain('Yes, revoke');
 
@@ -866,7 +866,7 @@ describe('ApiAccessComponent', () => {
           fixture.detectChanges();
 
           expect(apiKeyRenewedSpy).toHaveBeenCalled();
-          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
+          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to get access.');
         });
 
         describe('Multiple Entrypoint URLs', () => {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -198,7 +198,7 @@ export class ApiAccessComponent {
 
     const dialogData: ConfirmDialogData = {
       title: $localize`:@@apiKeyRevokeDialogTitle:Close this API key?`,
-      content: $localize`:@@apiKeyRevokeDialogContent:Applications using it will no longer be able to access the API.`,
+      content: $localize`:@@apiKeyRevokeDialogContent:Anything using it will no longer have access.`,
       confirmLabel: $localize`:@@apiKeyRevokeDialogConfirm:Yes, revoke`,
       cancelLabel: $localize`:@@apiKeyRevokeDialogCancel:Cancel`,
     };
@@ -266,7 +266,7 @@ export class ApiAccessComponent {
           this.apiKeyRevoked.emit();
           this.apiKeyFeedback.set({
             type: 'success',
-            message: $localize`:@@apiKeyRevokeSuccess:API key revoked successfully. Applications using it will no longer be able to access the API.`,
+            message: $localize`:@@apiKeyRevokeSuccess:API key revoked successfully. Anything using it will no longer have access.`,
           });
         },
         error: () => {
@@ -297,7 +297,7 @@ export class ApiAccessComponent {
           this.apiKeyRenewed.emit();
           this.apiKeyFeedback.set({
             type: 'success',
-            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
+            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to get access.`,
           });
         },
         error: () => {

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
@@ -43,7 +43,7 @@
       @if (content) {
         {{ content }}
       } @else {
-        <span i18n="@@apiDescriptionMissing">Description for this API is missing.</span>
+        <span i18n="@@apiDescriptionMissing">No description provided.</span>
       }
     </div>
   </mat-card-content>

--- a/gravitee-apim-portal-webui-next/src/components/category-card/category-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/category-card/category-card.component.html
@@ -30,6 +30,6 @@
     </div>
   </mat-card-content>
   <mat-card-actions class="app-card__actions">
-    <button i18n="@@categoryCardButton" mat-stroked-button color="primary" [routerLink]="['.', category().id]">View APIs</button>
+    <button i18n="@@categoryCardButton" mat-stroked-button color="primary" [routerLink]="['.', category().id]">View all</button>
   </mat-card-actions>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="menu-items">
-  <app-nav-bar-button class="nav-button" i18n="@@catalog" [path]="['catalog']">Marketplace</app-nav-bar-button>
+  <app-nav-bar-button class="nav-button" i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
   @for (navigationItem of topBarNavigationItems(); track navigationItem.id) {
     @switch (navigationItem.type) {
       @case ('LINK') {

--- a/gravitee-apim-portal-webui-next/src/components/picture/picture.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/picture/picture.component.ts
@@ -22,7 +22,7 @@ import { toSvg } from 'jdenticon';
   template: `
     <img
       i18n-alt="@@apiPicture"
-      alt="API Picture"
+      alt="Picture"
       class="round"
       [src]="picture"
       [height]="size"

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
@@ -19,7 +19,7 @@
   <h1 class="next-gen-h3" i18n="@@subscriptionDetailsHeader">Subscription Details</h1>
   @if (subscription?.status === 'ACCEPTED' || subscription?.status === 'PAUSED') {
     <button mat-stroked-button color="warn" (click)="closeSubscription.emit()" data-testid="close-subscription-button">
-      <span class="next-gen-small-bold" i18n="@@subscriptionDetailsCloseSubscription">Close subscription</span>
+      <span class="next-gen-small-bold" i18n="@@subscriptionDetailsCloseSubscription">Cancel subscription</span>
     </button>
   }
 </div>
@@ -52,7 +52,7 @@
           <div class="subscription-info__content-row">
             <span class="next-gen-body">
               <span class="material-icons icon-small">api</span>
-              <span i18n="@@subscriptionDetailsHeaderApi">Subscribed API:</span>
+              <span i18n="@@subscriptionDetailsHeaderApi">Subscribed to:</span>
             </span>
             @if (api && api.id && documentationNavigationTarget) {
               <a
@@ -68,7 +68,7 @@
                 data-testid="subscription-api-label"
                 class="next-gen-body"
                 i18n-matTooltip="@@subscriptionApiUnpublishedTooltip"
-                matTooltip="The API has been unpublished from the Developer Portal"
+                matTooltip="No longer published in the Developer Portal"
                 matTooltipPosition="above"
                 >{{ resolvedApiName }}</span
               >
@@ -76,7 +76,7 @@
           </div>
         }
 
-        @if (application) {
+        @if (application && !isAgentApi(api)) {
           <div class="subscription-info__content-row">
             <span class="next-gen-body">
               <span class="material-icons icon-small">web_asset</span>

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
@@ -20,6 +20,9 @@ import { provideRouter } from '@angular/router';
 import { SubscriptionInfoComponent } from './subscription-info.component';
 import { SubscriptionInfoHarness } from './subscription-info.harness';
 import { Api } from '../../entities/api/api';
+import { fakeApi } from '../../entities/api/api.fixtures';
+import { Application } from '../../entities/application/application';
+import { fakeApplication } from '../../entities/application/application.fixture';
 import { Subscription } from '../../entities/subscription';
 import { ApiDocumentationNavigationTarget } from '../../services/portal-navigation-items.service';
 
@@ -33,6 +36,7 @@ describe('SubscriptionInfoComponent', () => {
     options?: {
       api?: Api;
       apiName?: string;
+      application?: Application;
       documentationNavigationTarget?: ApiDocumentationNavigationTarget;
     },
   ) => {
@@ -46,6 +50,7 @@ describe('SubscriptionInfoComponent', () => {
     component.subscription = subscription;
     component.api = options?.api;
     component.apiName = options?.apiName;
+    component.application = options?.application;
     component.documentationNavigationTarget = options?.documentationNavigationTarget;
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionInfoHarness);
     fixture.detectChanges();
@@ -136,6 +141,31 @@ describe('SubscriptionInfoComponent', () => {
       expect(getApiLink()).toBeTruthy();
       expect(getApiLink()?.textContent?.trim()).toStrictEqual('My API');
       expect(getApiLabel()).toBeNull();
+    });
+  });
+
+  describe('application row', () => {
+    const application = fakeApplication({ name: 'My App' });
+
+    it('shows the application for a regular API', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { api: fakeApi({ type: 'PROXY' }), application });
+
+      expect(fixture.nativeElement.textContent).toContain('Application:');
+      expect(fixture.nativeElement.textContent).toContain('My App');
+    });
+
+    it('shows the application for a PROXY API that has an MCP server', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { api: fakeApi({ type: 'PROXY', mcp: { mcpPath: '/mcp' } }), application });
+
+      expect(fixture.nativeElement.textContent).toContain('Application:');
+      expect(fixture.nativeElement.textContent).toContain('My App');
+    });
+
+    it('hides the application for an agent', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { api: fakeApi({ type: 'A2A_PROXY' }), application });
+
+      expect(fixture.nativeElement.textContent).not.toContain('Application:');
+      expect(fixture.nativeElement.textContent).not.toContain('My App');
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
@@ -19,7 +19,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 
-import { Api } from '../../entities/api/api';
+import { Api, isAgentApi } from '../../entities/api/api';
 import { Application } from '../../entities/application/application';
 import { getPlanSecurityTypeLabel, PlanSecurityEnum, PlanUsageConfiguration, PlanValidationEnum } from '../../entities/plan/plan';
 import { Subscription, SubscriptionConsumerStatusEnum } from '../../entities/subscription';
@@ -96,6 +96,7 @@ export class SubscriptionInfoComponent implements OnInit {
   public authentication: string = '';
 
   protected readonly SubscriptionConsumerStatusEnum = SubscriptionConsumerStatusEnum;
+  protected readonly isAgentApi = isAgentApi;
 
   ngOnInit() {
     this.authentication = getPlanSecurityTypeLabel(this.planSecurity);

--- a/gravitee-apim-portal-webui-next/src/entities/api/api.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiType, isAgentApi } from './api';
+import { fakeApi } from './api.fixtures';
+
+describe('isAgentApi', () => {
+  it.each([
+    ['A2A_PROXY' as const, true],
+    ['MCP_PROXY' as const, true],
+    ['LLM_PROXY' as const, true],
+    ['PROXY' as const, false],
+    ['NATIVE' as const, false],
+    [undefined, false],
+  ])('reads type %s as agent=%s', (type: ApiType | undefined, expected) => {
+    expect(isAgentApi({ type })).toBe(expected);
+  });
+
+  it('does not treat a PROXY with an MCP server as an agent', () => {
+    expect(isAgentApi(fakeApi({ type: 'PROXY', mcp: { mcpPath: '/mcp' } }))).toBe(false);
+  });
+
+  it('treats a missing api as not an agent', () => {
+    expect(isAgentApi(undefined)).toBe(false);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/entities/api/api.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.ts
@@ -77,3 +77,9 @@ export interface Api {
 }
 
 export type ApiType = 'NATIVE' | 'MESSAGE' | 'PROXY' | 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY';
+
+const AGENT_API_TYPES: ApiType[] = ['A2A_PROXY', 'MCP_PROXY', 'LLM_PROXY'];
+
+export function isAgentApi(api: Pick<Api, 'type'> | undefined): boolean {
+  return !!api?.type && AGENT_API_TYPES.includes(api.type);
+}

--- a/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.spec.ts
@@ -48,7 +48,7 @@ describe('AgentSubscriptionService', () => {
     subscriptionService.get.mockReturnValue(of(accepted('sub-1', [aKey('key-1', 'My App')])));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toEqual({ apiKey: 'key-1', applicationName: 'My App' });
+      expect(access).toEqual({ apiKey: 'key-1' });
       done();
     });
   });
@@ -68,7 +68,7 @@ describe('AgentSubscriptionService', () => {
     );
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toEqual({ apiKey: 'key-2', applicationName: 'Live App' });
+      expect(access).toEqual({ apiKey: 'key-2' });
       done();
     });
   });

--- a/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.ts
@@ -21,7 +21,6 @@ import { isActiveApiKey, Subscription } from '../entities/subscription';
 
 export interface AgentSubscriptionAccess {
   apiKey: string;
-  applicationName: string;
 }
 
 const MAX_CANDIDATES = 10;
@@ -37,7 +36,7 @@ export class AgentSubscriptionService {
       map(response => response.data ?? []),
       // Only get() returns the keys, so each candidate needs its own call; they go out together
       // rather than one after another, and the first usable one in listing order wins so the
-      // application named in the panel stays the same between visits.
+      // same key is used between visits.
       switchMap(candidates =>
         candidates.length
           ? forkJoin(candidates.map(candidate => this.subscriptionService.get(candidate.id).pipe(catchError(() => of(null)))))
@@ -55,7 +54,6 @@ export class AgentSubscriptionService {
     }
     return {
       apiKey: usableKey.key,
-      applicationName: usableKey.application?.name ?? '',
     };
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-595

### Description

The developer portal assumed every catalog item was an API that an application consumes. That reads poorly for agents, and it also leaked the application concept to non technical consumers.

This change uses one set of neutral strings for APIs and agents and hides the application on agent surfaces. API Key still names the credential.

### Changes

#### Neutral wording on the consumer journey

Subscribe, review, details tabs, catalog cards, and the subscriptions list drop API- and application-centric sentences. Examples include Subscribe to, A plan sets your access level, Subscribed to, Access, and Making requests. Empty states, MCP tooltips, picture alt text, and the close/cancel subscription dialog follow the same tone. The catalog nav label and page title are Catalog instead of Marketplace. The keyless review description gets its own i18n id so it no longer collides with the application-step text.

#### Hide application identity for agents

Subscription details omit the Application row when the subject is an agent. Agent chat no longer shows Calling as. The unused application name is dropped from the chat input, documentation folder wiring, and agent subscription access payload.

#### Who counts as an agent

isAgentApi lives on the API entity and looks only at type (A2A_PROXY, MCP_PROXY, LLM_PROXY). Catalog isAgent delegates to it. PROXY plus MCP is not an agent, so those items stay on the APIs side of the catalog and still show the application on a subscription.

#### Fix catalog redirecrion

When subscribing directly from the catalog as opposed to the agent page, the subscription flow would open on a legacy route. The correct route is now used for redirection.