### PR TITLE
feat(ci): resolve Maven dependencies from the Azure Artifacts feed

### DIFF
--- a/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
+++ b/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
@@ -97,6 +97,8 @@ echo "export AZURE_ARTIFACTS_PAT='\${TOKEN}'" >> "$BASH_ENV"`,
         //
         // io.gravitee.canary:feed-canary:1.0.0 exists on the feed and nowhere else, so
         // resolving it proves the feed answered, and answered to this token.
+        //
+        // Scaffolding, to be removed with Artifactory: see the note on job-setup's Maven check.
         command: `CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \\
   -u "bot:\${AZURE_ARTIFACTS_PAT}" \\
   "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000

--- a/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
+++ b/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
@@ -73,12 +73,14 @@ BODY=$(printf '%s' "$RESPONSE" | sed '$d')
 
 if [ "$CODE" != "200" ]; then
   echo "Entra refused to issue a token (HTTP \${CODE:-no answer})." >&2
-  printf '%s' "$BODY" | sed -n 's/.*"error_description":"\\([^"]*\\)".*/  \\1/p' >&2
+  # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+  # lines below — losing the diagnostics this branch exists to print.
+  printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
   echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
   exit 1
 fi
 
-TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')
+TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
 if [ -z "$TOKEN" ]; then
   echo "Entra answered 200 with no access_token in the body." >&2
   exit 1
@@ -101,7 +103,7 @@ echo "export AZURE_ARTIFACTS_PAT='\${TOKEN}'" >> "$BASH_ENV"`,
         // Scaffolding, to be removed with Artifactory: see the note on job-setup's Maven check.
         command: `CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \\
   -u "bot:\${AZURE_ARTIFACTS_PAT}" \\
-  "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+  "${config.maven.azureFeedUrl}/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
 
 case "$CODE" in
   200) echo "The feed resolves the canary." ;;

--- a/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
+++ b/.circleci/ci/src/commands/cmd-azure-artifacts-token.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command, Config, ReusableCommand, commands, reusable } from '../circleci-config';
+import { orbs } from '../orbs';
+import { config } from '../config';
+
+/**
+ * Exposes an Azure Artifacts token in AZURE_ARTIFACTS_PAT, which the Maven settings read as
+ * ${env.AZURE_ARTIFACTS_PAT}.
+ *
+ * Gravitee.io Bot is an Entra service principal, and a service principal cannot hold a personal
+ * access token: it authenticates with a token obtained from its client secret, valid for one hour.
+ *
+ * Every job running Maven therefore asks for its own, rather than one being fetched once and
+ * carried through the workspace. A "rerun from failed" does not replay the job that fetched it —
+ * it reuses the workspace, and would start again with a dead token. Same for a workflow left
+ * waiting on a manual approval. Neither is exotic, and the symptom would be a 401 pointing at
+ * permissions when the token has merely expired.
+ *
+ * The credentials are the service principal's own, the ones job-deploy-on-azure signs in with
+ * to restart the AKS pods. They are not the container registry's — that one has its own login.
+ */
+export class AzureArtifactsTokenCommand {
+  private static commandName = 'cmd-azure-artifacts-token';
+
+  public static get(dynamicConfig: Config): ReusableCommand {
+    dynamicConfig.importOrb(orbs.keeper);
+
+    const steps: Command[] = [
+      new reusable.ReusedCommand(orbs.keeper.commands['install']),
+      new commands.Run({
+        name: 'Get an Azure Artifacts token',
+        // The credentials are read into shell variables rather than exported: they stay inside
+        // this step instead of living in the environment of every step that follows.
+        //
+        // 499b84ac-1321-427f-aa17-267ca6975798 is the application ID of Azure DevOps as a whole —
+        // Artifacts has none of its own, it is one of its services. A client_credentials flow can
+        // only ask for .default anyway; what the token may do comes from the roles granted to the
+        // service principal on the feed, not from the scope.
+        command: `CLIENT_ID=$(ksm secret notation ${config.secrets.azureApplicationId})
+CLIENT_SECRET=$(ksm secret notation ${config.secrets.azureApplicationSecret})
+TENANT=$(ksm secret notation ${config.secrets.azureTenant})
+
+# --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+# a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+#
+# The status is captured instead of being left to --fail. Steps run under \`bash -eo pipefail\`,
+# where a failing command substitution aborts the step on the spot — the diagnostics below would
+# never run, and the job would die without printing anything at all.
+RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \\
+  -w '\\n%{http_code}' -X POST \\
+  "https://login.microsoftonline.com/\${TENANT}/oauth2/v2.0/token" \\
+  --data-urlencode "client_id=\${CLIENT_ID}" \\
+  --data-urlencode "client_secret=\${CLIENT_SECRET}" \\
+  --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \\
+  --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+CODE=$(printf '%s' "$RESPONSE" | tail -1)
+BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+if [ "$CODE" != "200" ]; then
+  echo "Entra refused to issue a token (HTTP \${CODE:-no answer})." >&2
+  printf '%s' "$BODY" | sed -n 's/.*"error_description":"\\([^"]*\\)".*/  \\1/p' >&2
+  echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+  exit 1
+fi
+
+TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p')
+if [ -z "$TOKEN" ]; then
+  echo "Entra answered 200 with no access_token in the body." >&2
+  exit 1
+fi
+
+# The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+# base64url and dots, nothing the shell can expand — and it never came from Keeper.
+echo "export AZURE_ARTIFACTS_PAT='\${TOKEN}'" >> "$BASH_ENV"`,
+      }),
+      new commands.Run({
+        name: 'Check the feed answers',
+        // Without this, a feed that rejects the token is invisible: the settings declare
+        // Artifactory after the feed, so Maven falls back to it with a warning and the build
+        // stays green. The fallback is there for artifacts not yet on the feed, not to paper
+        // over an authentication failure.
+        //
+        // io.gravitee.canary:feed-canary:1.0.0 exists on the feed and nowhere else, so
+        // resolving it proves the feed answered, and answered to this token.
+        command: `CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \\
+  -u "bot:\${AZURE_ARTIFACTS_PAT}" \\
+  "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+case "$CODE" in
+  200) echo "The feed resolves the canary." ;;
+  401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+  403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+  404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+  # Everything else is the feed being unavailable rather than misconfigured, and that is what
+  # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+  # design was built around.
+  *)   echo "The feed answered HTTP \${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+esac`,
+      }),
+    ];
+
+    return new reusable.ReusableCommand(
+      AzureArtifactsTokenCommand.commandName,
+      steps,
+      undefined,
+      'Get a short-lived Azure Artifacts token',
+    );
+  }
+}

--- a/.circleci/ci/src/commands/index.ts
+++ b/.circleci/ci/src/commands/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './cmd-azure-artifacts-token';
 export * from './cmd-create-docker-context';
 export * from './cmd-docker-login';
 export * from './cmd-docker-logout';

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -102,6 +102,7 @@ const maven = {
   settingsFile: '.gravitee.settings.xml',
   // Pinned: an unpinned plugin coordinate makes Maven resolve maven-metadata.xml first.
   dependencyPluginVersion: '3.8.1',
+  azureFeedUrl: 'https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1',
 };
 
 const yarn = {

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -100,6 +100,8 @@ const jobContext = ['cicd-orchestrator'];
 
 const maven = {
   settingsFile: '.gravitee.settings.xml',
+  // Pinned: an unpinned plugin coordinate makes Maven resolve maven-metadata.xml first.
+  dependencyPluginVersion: '3.8.1',
 };
 
 const yarn = {

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -146,7 +146,7 @@ const secrets = {
   graviteeLicense: 'keeper://w8WBpALVCgYdxtV5pVrQsw/custom_field/base64',
   graviteePackageCloudToken: 'keeper://8CG6HxY5gYsl-85eJKuIoA/field/password',
   jiraToken: 'keeper://hfnQD5TEfxzwRXUKhJhM-A/field/password',
-  mavenSettings: 'keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml',
+  mavenSettings: 'keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure',
   slackAccessToken: 'keeper://ZOz4db245GNaETVwmPBk8w/field/password',
   sonarToken: 'keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password',
 };

--- a/.circleci/ci/src/jobs/backend/abstract-job-test.ts
+++ b/.circleci/ci/src/jobs/backend/abstract-job-test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 import { Command, Config, Executor, Job, JobOptionalProperties, commands, reusable } from '../../circleci-config';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  withJdk,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 
@@ -31,9 +37,11 @@ export abstract class AbstractTestJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     return new Job(
       jobName,
@@ -46,6 +54,7 @@ export abstract class AbstractTestJob {
         new commands.cache.Restore({
           keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
         }),
+        new reusable.ReusedCommand(azureArtifactsTokenCmd),
         ...testSteps,
         new commands.Run({
           name: 'Save test results',

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -48,10 +48,12 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
       new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         // The distribution carries its own version properties now, so it needs the same treatment.
+        // Both calls resolve versions-maven-plugin, so they take the shared settings like every
+        // other Maven invocation — without it they reach Maven Central directly.
         name: 'Remove `-SNAPSHOT` from versions',
-        command: `mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+        command: `mvn -B -s ${config.maven.settingsFile} versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
 sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+mvn -B -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
 sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml`,
       }),
       new reusable.ReusedCommand(prepareGpgCommand),

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -15,7 +15,13 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, SyncFolderToS3Command } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  PrepareGpgCmd,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  SyncFolderToS3Command,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { parse } from '../../utils';
@@ -25,7 +31,9 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment, publishOnDownloadWebsite: boolean): Job {
     const restoreMavenJobCacheCommand = RestoreMavenJobCacheCommand.get(environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCommand);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const prepareGpgCommand = PrepareGpgCmd.get(dynamicConfig);
     dynamicConfig.addReusableCommand(prepareGpgCommand);
@@ -37,6 +45,7 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCommand, { jobName: BackendBuildAndPublishOnDownloadWebsiteJob.jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         // The distribution carries its own version properties now, so it needs the same treatment.
         name: 'Remove `-SNAPSHOT` from versions',

--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -15,7 +15,13 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkNodeExecutor } from '../../executors';
-import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  InstallYarnCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+} from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -31,16 +37,19 @@ export class BuildBackendJob {
     // generate-resources). Without corepack the image's yarn 1 cannot read the berry lockfile
     // and resolves the whole workspace from the registry instead.
     const installYarnCmd = InstallYarnCommand.get();
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
     dynamicConfig.addReusableCommand(installYarnCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: jobName }),
       new reusable.ReusedCommand(installYarnCmd),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Build engine',
         command: `mvn -s ${config.maven.settingsFile} clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -P all-modules -DwithJavadoc`,

--- a/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
+++ b/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
@@ -17,7 +17,7 @@ import { Command, Config, Job, commands, reusable } from '../../circleci-config'
 import { config } from '../../config';
 import { OpenJdkNodeExecutor } from '../../executors';
 import { CircleCIEnvironment } from '../../pipelines';
-import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { keeper } from '../../orbs/keeper';
 
 export class NexusStagingJob {
@@ -30,6 +30,7 @@ export class NexusStagingJob {
     dynamicConfig.importOrb(keeper);
 
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
 
     const prepareGpgCmd = PrepareGpgCmd.get(dynamicConfig);
@@ -37,6 +38,7 @@ export class NexusStagingJob {
 
     const saveMavenCacheCmd = SaveMavenJobCacheCommand.get();
     dynamicConfig.addReusableCommand(saveMavenCacheCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
@@ -47,6 +49,7 @@ export class NexusStagingJob {
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: NexusStagingJob.jobName }),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(prepareGpgCmd),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Release on Nexus',
         command: `mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings ${config.maven.settingsFile} --update-snapshots`,

--- a/.circleci/ci/src/jobs/backend/job-publish.ts
+++ b/.circleci/ci/src/jobs/backend/job-publish.ts
@@ -15,7 +15,7 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { config } from '../../config';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { OpenJdkNodeExecutor } from '../../executors';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -27,14 +27,17 @@ export class PublishJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       target === 'nexus'
         ? new commands.Run({
             name: 'Maven Package and deploy to Nexus Snapshots',

--- a/.circleci/ci/src/jobs/backend/job-test-integration.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-integration.ts
@@ -16,7 +16,13 @@
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { config } from '../../config';
 import { UbuntuExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  withJdk,
+} from '../../commands';
 import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestIntegrationJob {
@@ -26,7 +32,9 @@ export class TestIntegrationJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
     const executor = UbuntuExecutor.create();
@@ -36,6 +44,7 @@ export class TestIntegrationJob {
       ...withJdk(dynamicConfig, executor),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: TestIntegrationJob.jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.cache.Restore({
         keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
       }),

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -15,7 +15,7 @@
  */
 import { Command, Config, Job, commands, reusable } from '../../circleci-config';
 import { OpenJdkExecutor } from '../../executors';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { AzureArtifactsTokenCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { mavenParallelism } from '../../utils';
@@ -26,14 +26,17 @@ export class ValidateJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName: ValidateJob.jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.Run({
         name: 'Validate project',
         command: `mvn -s ${config.maven.settingsFile} validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules ${mavenParallelism('large')}`,

--- a/.circleci/ci/src/jobs/job-setup.ts
+++ b/.circleci/ci/src/jobs/job-setup.ts
@@ -16,11 +16,15 @@
 import { Command, Config, Job, commands, reusable } from '../circleci-config';
 import { orbs } from '../orbs';
 import { config } from '../config';
-import { BaseExecutor } from '../executors';
+import { OpenJdkExecutor } from '../executors';
+import { AzureArtifactsTokenCommand } from '../commands';
 
 export class SetupJob {
   public static create(dynamicConfig: Config): Job {
     dynamicConfig.importOrb(orbs.keeper);
+
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
     const steps: Command[] = [
       new commands.Checkout(),
@@ -41,11 +45,45 @@ if ! grep -q '</settings>' ${config.maven.settingsFile}; then
   exit 1
 fi`,
       }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
+      new commands.Run({
+        name: 'Check Maven resolves from the feed',
+        // Once per pipeline, on the settings this job just wrote, rather than in every job that
+        // runs Maven: the wiring is the same for all of them, since they all attach this one file.
+        //
+        // dependency:get runs project-less, so its remote repositories come from the active
+        // profile in the settings — the part a raw HTTPS request never exercises: the <server> id
+        // matching the repository id, and ${env.AZURE_ARTIFACTS_PAT} actually being interpolated.
+        // A settings with a mismatched server id passes a curl check and falls back to Artifactory
+        // for good.
+        //
+        // The plugin GAV is pinned: an unpinned one resolves maven-metadata.xml first, a round
+        // trip that proves nothing.
+        //
+        // Scaffolding, to be removed with Artifactory. This check and the HTTPS one in
+        // cmd-azure-artifacts-token both exist because the settings declare Artifactory behind
+        // the feed, so a feed that answers 401 leaves the build green. Once Artifactory is off
+        // there is no fallback left to hide behind, a broken feed fails on its own, and the two
+        // checks — along with io.gravitee.canary:feed-canary itself — can go.
+        command: `if ! mvn -B -q -s ${config.maven.settingsFile} \\
+  org.apache.maven.plugins:maven-dependency-plugin:${config.maven.dependencyPluginVersion}:get \\
+  -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+  echo "Maven could not resolve the canary from the feed." >&2
+  echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+  echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+  # Single quotes: the shell would try to expand this one, and a dot is not a valid
+  # variable name — the message would come out as a bad substitution instead.
+  echo '\${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+  exit 1
+fi
+
+echo "Maven resolved io.gravitee.canary:feed-canary from the feed."`,
+      }),
       new commands.workspace.Persist({
         root: '.',
         paths: [config.maven.settingsFile],
       }),
     ];
-    return new Job('job-setup', BaseExecutor.create('small'), steps);
+    return new Job('job-setup', OpenJdkExecutor.create('small'), steps);
   }
 }

--- a/.circleci/ci/src/jobs/job-setup.ts
+++ b/.circleci/ci/src/jobs/job-setup.ts
@@ -24,12 +24,22 @@ export class SetupJob {
 
     const steps: Command[] = [
       new commands.Checkout(),
-      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-        'secret-url': config.secrets.mavenSettings,
-        'var-name': 'MAVEN_SETTINGS',
-      }),
+      new reusable.ReusedCommand(orbs.keeper.commands['install']),
       new commands.Run({
-        command: `echo $MAVEN_SETTINGS > ${config.maven.settingsFile} `,
+        name: 'Get the Maven settings',
+        // Written straight to its file, never through the environment. `env-export` puts the
+        // value in $BASH_ENV inside an unquoted heredoc, where the shell expands whatever looks
+        // like a variable: a settings.xml holding ${env.SOMETHING} — the syntax Maven uses to
+        // read a token — breaks the export and leaves the remaining lines to be run as commands,
+        // which prints the file, credentials included, in the job output.
+        command: `ksm secret notation ${config.secrets.mavenSettings} > ${config.maven.settingsFile}
+
+# An empty or truncated file would only surface later, in another job, as an unreadable
+# settings or a 401 blamed on the credentials.
+if ! grep -q '</settings>' ${config.maven.settingsFile}; then
+  echo "The Maven settings read from Keeper are empty or truncated." >&2
+  exit 1
+fi`,
       }),
       new commands.workspace.Persist({
         root: '.',

--- a/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 import { AnyParameterLiteral, Config, Executor, commands, parameters, reusable } from '../../circleci-config';
-import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
+import {
+  AzureArtifactsTokenCommand,
+  NotifyOnFailureCommand,
+  RestoreMavenJobCacheCommand,
+  SaveMavenJobCacheCommand,
+  withJdk,
+} from '../../commands';
 import { UbuntuExecutor } from '../../executors';
 import { CircleCIEnvironment } from '../../pipelines';
 import { config } from '../../config';
@@ -31,7 +37,9 @@ export abstract class AbstractTestContainerJob {
     const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig, environment);
+    const azureArtifactsTokenCmd = AzureArtifactsTokenCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
+    dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
 
@@ -40,6 +48,7 @@ export abstract class AbstractTestContainerJob {
       ...withJdk(dynamicConfig, executor),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCmd, { jobName }),
+      new reusable.ReusedCommand(azureArtifactsTokenCmd),
       new commands.cache.Restore({
         keys: [`${config.cache.prefix}-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}`],
       }),

--- a/.circleci/ci/src/pipelines/tests/azure-artifacts-token.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/azure-artifacts-token.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { parse } from 'yaml';
+import { generatePullRequestsConfig } from '../pipeline-pull-requests';
+import { generateRepositoriesTestsConfig } from '../pipeline-repositories-tests';
+import { generateIntegrationTestsConfig } from '../pipeline-integration-tests';
+import { config } from '../../config';
+
+/**
+ * The generated-config snapshots pin the current output, not the rule behind it.
+ * This encodes the rule: resolving with the shared settings.xml needs a token, because
+ * Gravitee.io Bot is a service principal and its token lives one hour, so each job fetches
+ * its own.
+ *
+ * Without this, a job added later resolves with AZURE_ARTIFACTS_PAT unset, takes a 401 on
+ * the feed and falls back to Artifactory — green, and blind to whether the feed serves
+ * anything. That is how the first version of this change shipped with five jobs missing it.
+ *
+ * Four pipelines are generated on purpose. The four *-test-container jobs appear in none of
+ * the pull-request configurations, and job-test-integration in only some of them: checking
+ * pull-requests alone would pass over an empty set, which is the same "reports success while
+ * checking nothing" failure the rule exists to prevent.
+ */
+describe('Azure Artifacts token', () => {
+  const TOKEN_COMMAND = 'cmd-azure-artifacts-token';
+
+  const baseEnvironment = {
+    baseBranch: 'master',
+    branch: 'master',
+    sha1: '784ff35ca',
+    buildNum: '1234',
+    buildId: '1234',
+    isDryRun: false,
+  };
+
+  type GeneratedJob = { steps?: unknown[] };
+
+  /** Every job of every pipeline that can run Maven, keyed by "<pipeline>/<job>". */
+  function generatedJobs(): Record<string, GeneratedJob> {
+    const pipelines = {
+      'pull-requests': generatePullRequestsConfig({
+        ...baseEnvironment,
+        action: 'pull_requests',
+        apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
+        changedFiles: ['pom.xml'],
+        graviteeioVersion: '',
+      }),
+      // A backend change, which is what brings in the job-test-* family: a root pom.xml
+      // change on master generates none of them.
+      'pull-requests-backend': generatePullRequestsConfig({
+        ...baseEnvironment,
+        action: 'pull_requests',
+        branch: 'APIM-1234-my-custom-branch',
+        apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
+        changedFiles: ['gravitee-apim-definition'],
+        graviteeioVersion: '',
+      }),
+      'repositories-tests': generateRepositoriesTestsConfig({
+        ...baseEnvironment,
+        action: 'repositories_tests',
+        apimVersionPath: '',
+        changedFiles: [],
+        graviteeioVersion: '4.2.0',
+      }),
+      'integration-tests': generateIntegrationTestsConfig({
+        ...baseEnvironment,
+        action: 'integration_tests',
+        apimVersionPath: '',
+        changedFiles: [],
+        graviteeioVersion: '4.2.0',
+      }),
+    };
+
+    const jobs: Record<string, GeneratedJob> = {};
+    for (const [pipeline, generated] of Object.entries(pipelines)) {
+      for (const [name, job] of Object.entries(parse(generated.stringify()).jobs ?? {})) {
+        jobs[`${pipeline}/${name}`] = job as GeneratedJob;
+      }
+    }
+    return jobs;
+  }
+
+  /** Flattens a job's steps into the shell it runs plus the reusable commands it invokes. */
+  function stepsOf(job: GeneratedJob): { commands: string[]; shell: string } {
+    const commands: string[] = [];
+    let shell = '';
+
+    for (const step of job.steps ?? []) {
+      if (typeof step === 'string') {
+        commands.push(step);
+        continue;
+      }
+      for (const [name, value] of Object.entries(step as Record<string, unknown>)) {
+        commands.push(name);
+        if (name === 'run') {
+          shell += typeof value === 'string' ? value : ((value as { command?: string })?.command ?? '');
+          shell += '\n';
+        }
+      }
+    }
+
+    return { commands, shell };
+  }
+
+  /** Maven reaching the network, as opposed to `mvn versions:set` and friends. */
+  function resolvesWithSharedSettings(shell: string): boolean {
+    return new RegExp(`\\bmvn\\b[^\\n]*${config.maven.settingsFile.replaceAll('.', '\\.')}`).test(shell);
+  }
+
+  it('fetches a token in every job resolving with the shared settings', () => {
+    const resolving = Object.entries(generatedJobs()).filter(([, job]) => resolvesWithSharedSettings(stepsOf(job).shell));
+
+    // Guards against the check passing over an empty set.
+    expect(resolving.length).toBeGreaterThan(15);
+
+    const missing = resolving.filter(([, job]) => !stepsOf(job).commands.includes(TOKEN_COMMAND)).map(([name]) => name);
+
+    expect(missing).toStrictEqual([]);
+  });
+
+  it('covers the jobs that only exist outside the pull-request pipelines', () => {
+    const names = Object.keys(generatedJobs());
+
+    // These are the ones the first version of this change missed; each lives in a pipeline
+    // the pull-request configurations never generate.
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'repositories-tests/job-jdbc-test-container',
+        'repositories-tests/job-mongo-test-container',
+        'repositories-tests/job-elastic-test-container',
+        'repositories-tests/job-redis-test-container',
+        'integration-tests/job-test-integration',
+      ]),
+    );
+  });
+
+  it('does not fetch a token in jobs that never resolve with the shared settings', () => {
+    const superfluous = Object.entries(generatedJobs())
+      .filter(([, job]) => {
+        const { commands, shell } = stepsOf(job);
+        return !resolvesWithSharedSettings(shell) && commands.includes(TOKEN_COMMAND);
+      })
+      .map(([name]) => name);
+
+    expect(superfluous).toStrictEqual([]);
+  });
+});

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -25,47 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C08H9K43WSV
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -127,6 +86,47 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C08H9K43WSV
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-yarn:
     steps:
       - run:
@@ -180,7 +180,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -196,6 +196,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -66,6 +66,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -127,7 +188,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -149,6 +210,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -190,6 +252,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -123,11 +123,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -76,11 +76,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -25,50 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-prepare-gpg:
-    steps:
-      - keeper/install
-      - run:
-          command: |-
-            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key > pub.key
-            gpg --import pub.key
-
-            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key > private.key
-            # Need --batch to be able to import private key
-            gpg --import --batch private.key
-    description: Prepare GPG command
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -130,10 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-prepare-gpg:
+    steps:
+      - keeper/install
+      - run:
+          command: |-
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_pub_key > pub.key
+            gpg --import pub.key
+
+            ksm secret notation keeper://riW92t8X4tk4ZmQc8-FZ4Q/custom_field/armor_format_private_key > private.key
+            # Need --batch to be able to import private key
+            gpg --import --batch private.key
+    description: Prepare GPG command
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -149,6 +149,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -69,6 +69,67 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-setup:
     docker:
@@ -80,7 +141,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -106,6 +167,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -196,11 +196,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -137,6 +137,67 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -200,7 +261,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -492,6 +553,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -843,6 +905,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -576,9 +576,9 @@ jobs:
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
-            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
       - cmd-prepare-gpg
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -25,6 +25,67 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -137,67 +198,6 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
-  cmd-azure-artifacts-token:
-    steps:
-      - keeper/install
-      - run:
-          name: Get an Azure Artifacts token
-          command: |-
-            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
-            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
-            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
-
-            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
-            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
-            #
-            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
-            # where a failing command substitution aborts the step on the spot — the diagnostics below would
-            # never run, and the job would die without printing anything at all.
-            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -w '\n%{http_code}' -X POST \
-              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
-              --data-urlencode "client_id=${CLIENT_ID}" \
-              --data-urlencode "client_secret=${CLIENT_SECRET}" \
-              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
-
-            CODE=$(printf '%s' "$RESPONSE" | tail -1)
-            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
-
-            if [ "$CODE" != "200" ]; then
-              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
-              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
-              exit 1
-            fi
-
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
-            if [ -z "$TOKEN" ]; then
-              echo "Entra answered 200 with no access_token in the body." >&2
-              exit 1
-            fi
-
-            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
-            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
-            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
-      - run:
-          name: Check the feed answers
-          command: |-
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -u "bot:${AZURE_ARTIFACTS_PAT}" \
-              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
-
-            case "$CODE" in
-              200) echo "The feed resolves the canary." ;;
-              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
-              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
-              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
-              # Everything else is the feed being unavailable rather than misconfigured, and that is what
-              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
-              # design was built around.
-              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
-            esac
-    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -253,7 +253,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -269,6 +269,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -196,11 +196,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -576,9 +576,9 @@ jobs:
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
-            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
       - cmd-prepare-gpg
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -137,6 +137,67 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -200,7 +261,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -492,6 +553,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -877,6 +939,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -25,6 +25,67 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -137,67 +198,6 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
-  cmd-azure-artifacts-token:
-    steps:
-      - keeper/install
-      - run:
-          name: Get an Azure Artifacts token
-          command: |-
-            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
-            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
-            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
-
-            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
-            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
-            #
-            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
-            # where a failing command substitution aborts the step on the spot — the diagnostics below would
-            # never run, and the job would die without printing anything at all.
-            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -w '\n%{http_code}' -X POST \
-              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
-              --data-urlencode "client_id=${CLIENT_ID}" \
-              --data-urlencode "client_secret=${CLIENT_SECRET}" \
-              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
-
-            CODE=$(printf '%s' "$RESPONSE" | tail -1)
-            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
-
-            if [ "$CODE" != "200" ]; then
-              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
-              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
-              exit 1
-            fi
-
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
-            if [ -z "$TOKEN" ]; then
-              echo "Entra answered 200 with no access_token in the body." >&2
-              exit 1
-            fi
-
-            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
-            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
-            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
-      - run:
-          name: Check the feed answers
-          command: |-
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -u "bot:${AZURE_ARTIFACTS_PAT}" \
-              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
-
-            case "$CODE" in
-              200) echo "The feed resolves the canary." ;;
-              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
-              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
-              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
-              # Everything else is the feed being unavailable rather than misconfigured, and that is what
-              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
-              # design was built around.
-              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
-            esac
-    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -253,7 +253,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -269,6 +269,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -577,9 +577,9 @@ jobs:
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
-            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
       - cmd-prepare-gpg
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -138,6 +138,67 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
             - gravitee-api-management-v15-<< parameters.jobName >>-4.2.x
     description: Restore Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -201,7 +262,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -493,6 +554,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -888,6 +950,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -25,6 +25,67 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -138,67 +199,6 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
             - gravitee-api-management-v15-<< parameters.jobName >>-4.2.x
     description: Restore Maven cache for a dedicated job
-  cmd-azure-artifacts-token:
-    steps:
-      - keeper/install
-      - run:
-          name: Get an Azure Artifacts token
-          command: |-
-            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
-            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
-            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
-
-            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
-            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
-            #
-            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
-            # where a failing command substitution aborts the step on the spot — the diagnostics below would
-            # never run, and the job would die without printing anything at all.
-            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -w '\n%{http_code}' -X POST \
-              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
-              --data-urlencode "client_id=${CLIENT_ID}" \
-              --data-urlencode "client_secret=${CLIENT_SECRET}" \
-              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
-
-            CODE=$(printf '%s' "$RESPONSE" | tail -1)
-            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
-
-            if [ "$CODE" != "200" ]; then
-              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
-              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
-              exit 1
-            fi
-
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
-            if [ -z "$TOKEN" ]; then
-              echo "Entra answered 200 with no access_token in the body." >&2
-              exit 1
-            fi
-
-            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
-            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
-            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
-      - run:
-          name: Check the feed answers
-          command: |-
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -u "bot:${AZURE_ARTIFACTS_PAT}" \
-              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
-
-            case "$CODE" in
-              200) echo "The feed resolves the canary." ;;
-              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
-              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
-              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
-              # Everything else is the feed being unavailable rather than misconfigured, and that is what
-              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
-              # design was built around.
-              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
-            esac
-    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -254,7 +254,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -270,6 +270,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -197,11 +197,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -137,6 +137,67 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -200,7 +261,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -492,6 +553,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -889,6 +951,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -196,11 +196,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -576,9 +576,9 @@ jobs:
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
-            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
       - cmd-prepare-gpg
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -25,6 +25,67 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -137,67 +198,6 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
-  cmd-azure-artifacts-token:
-    steps:
-      - keeper/install
-      - run:
-          name: Get an Azure Artifacts token
-          command: |-
-            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
-            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
-            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
-
-            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
-            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
-            #
-            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
-            # where a failing command substitution aborts the step on the spot — the diagnostics below would
-            # never run, and the job would die without printing anything at all.
-            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -w '\n%{http_code}' -X POST \
-              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
-              --data-urlencode "client_id=${CLIENT_ID}" \
-              --data-urlencode "client_secret=${CLIENT_SECRET}" \
-              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
-
-            CODE=$(printf '%s' "$RESPONSE" | tail -1)
-            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
-
-            if [ "$CODE" != "200" ]; then
-              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
-              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
-              exit 1
-            fi
-
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
-            if [ -z "$TOKEN" ]; then
-              echo "Entra answered 200 with no access_token in the body." >&2
-              exit 1
-            fi
-
-            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
-            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
-            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
-      - run:
-          name: Check the feed answers
-          command: |-
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -u "bot:${AZURE_ARTIFACTS_PAT}" \
-              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
-
-            case "$CODE" in
-              200) echo "The feed resolves the canary." ;;
-              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
-              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
-              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
-              # Everything else is the feed being unavailable rather than misconfigured, and that is what
-              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
-              # design was built around.
-              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
-            esac
-    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -253,7 +253,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -269,6 +269,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -137,6 +137,67 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -200,7 +261,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -492,6 +553,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
+      - cmd-azure-artifacts-token
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
@@ -889,6 +951,7 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-prepare-gpg
+      - cmd-azure-artifacts-token
       - run:
           name: Release on Nexus
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -196,11 +196,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -576,9 +576,9 @@ jobs:
       - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
-            mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-            mvn -B -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+            mvn -B -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-distribution/pom.xml
       - cmd-prepare-gpg
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -25,6 +25,67 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-yarn:
     steps:
       - run:
@@ -137,67 +198,6 @@ commands:
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
-  cmd-azure-artifacts-token:
-    steps:
-      - keeper/install
-      - run:
-          name: Get an Azure Artifacts token
-          command: |-
-            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
-            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
-            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
-
-            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
-            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
-            #
-            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
-            # where a failing command substitution aborts the step on the spot — the diagnostics below would
-            # never run, and the job would die without printing anything at all.
-            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -w '\n%{http_code}' -X POST \
-              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
-              --data-urlencode "client_id=${CLIENT_ID}" \
-              --data-urlencode "client_secret=${CLIENT_SECRET}" \
-              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
-              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
-
-            CODE=$(printf '%s' "$RESPONSE" | tail -1)
-            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
-
-            if [ "$CODE" != "200" ]; then
-              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
-              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
-              exit 1
-            fi
-
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
-            if [ -z "$TOKEN" ]; then
-              echo "Entra answered 200 with no access_token in the body." >&2
-              exit 1
-            fi
-
-            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
-            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
-            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
-      - run:
-          name: Check the feed answers
-          command: |-
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
-              -u "bot:${AZURE_ARTIFACTS_PAT}" \
-              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
-
-            case "$CODE" in
-              200) echo "The feed resolves the canary." ;;
-              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
-              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
-              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
-              # Everything else is the feed being unavailable rather than misconfigured, and that is what
-              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
-              # design was built around.
-              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
-            esac
-    description: Get a short-lived Azure Artifacts token
   cmd-prepare-gpg:
     steps:
       - keeper/install
@@ -253,7 +253,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -269,6 +269,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -136,11 +136,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -140,7 +201,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -163,6 +224,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -211,6 +273,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-test-integration
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -193,7 +193,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -209,6 +209,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -117,12 +117,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -733,11 +733,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -88,6 +88,67 @@ commands:
           key: gravitee-api-management-v15-workspace-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -314,6 +375,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -345,6 +407,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -378,6 +441,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -420,6 +484,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -453,6 +518,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -486,6 +552,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -519,6 +586,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -546,6 +614,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4
@@ -599,6 +668,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-test-integration
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -737,7 +807,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -760,6 +830,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -799,7 +799,7 @@ jobs:
           path: << parameters.apim-ui-project-workdir >>/coverage/junit.xml
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -815,6 +815,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -145,11 +145,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -202,7 +202,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -218,6 +218,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -149,7 +210,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -172,6 +233,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -25,55 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +86,55 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -203,7 +203,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -219,6 +219,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -74,6 +74,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -150,7 +211,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -173,6 +234,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -146,11 +146,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -145,11 +145,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -202,7 +202,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -218,6 +218,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -149,7 +210,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -172,6 +233,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -145,11 +145,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -202,7 +202,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -218,6 +218,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -149,7 +210,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -172,6 +233,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -417,6 +479,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-artifactory
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U -P gio-artifactory-snapshot
@@ -433,6 +496,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-nexus
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Nexus Snapshots
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -288,6 +351,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-test-integration
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -289,6 +352,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -360,6 +424,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -94,11 +94,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
 jobs:
   job-danger-js:
     docker:
@@ -151,7 +151,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -167,6 +167,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
 jobs:
   job-danger-js:
     docker:
@@ -98,7 +159,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -120,6 +181,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -161,6 +223,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -233,6 +296,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -288,6 +351,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-test-integration
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -222,7 +222,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -238,6 +238,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -169,7 +230,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -191,6 +252,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -232,6 +294,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -304,6 +367,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -373,6 +437,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -406,6 +471,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -448,6 +514,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -481,6 +548,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -514,6 +582,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -547,6 +616,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -574,6 +644,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -165,11 +165,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -291,6 +354,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -291,6 +354,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -362,6 +426,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -154,7 +215,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -176,6 +237,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -217,6 +279,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -291,6 +354,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -207,7 +207,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -223,6 +223,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -150,11 +150,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -222,7 +222,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -238,6 +238,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -169,7 +230,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -191,6 +252,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -232,6 +294,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -306,6 +369,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -386,6 +450,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -413,6 +478,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -165,11 +165,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -109,11 +109,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -61,12 +61,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -74,6 +74,67 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -113,7 +174,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -135,6 +196,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -176,6 +238,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -248,6 +311,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -32,48 +32,6 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +93,48 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -166,7 +166,7 @@ jobs:
           command: cd .circleci/danger && yarn install && yarn run danger
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -182,6 +182,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -224,11 +224,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -74,6 +74,67 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -228,7 +289,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -250,6 +311,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -291,6 +353,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -363,6 +426,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -432,6 +496,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -465,6 +530,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -507,6 +573,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -540,6 +607,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -573,6 +641,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -606,6 +675,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -633,6 +703,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -71,12 +71,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -42,38 +42,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +103,38 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -281,7 +281,7 @@ jobs:
       - cmd-notify-on-failure
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -297,6 +297,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -145,11 +145,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -202,7 +202,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -218,6 +218,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -149,7 +210,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -172,6 +233,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -417,6 +479,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-artifactory
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U -P gio-artifactory-snapshot
@@ -433,6 +496,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-publish-on-nexus
+      - cmd-azure-artifacts-token
       - run:
           name: Maven Package and deploy to Nexus Snapshots
           command: mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8 -s .gravitee.settings.xml -U

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -224,11 +224,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -74,6 +74,67 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -228,7 +289,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -250,6 +311,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -291,6 +353,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -363,6 +426,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -432,6 +496,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -465,6 +530,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -507,6 +573,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -540,6 +607,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -573,6 +641,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -606,6 +675,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -633,6 +703,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -71,12 +71,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -42,38 +42,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-4.0.x
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +103,38 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-4.0.x
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -281,7 +281,7 @@ jobs:
       - cmd-notify-on-failure
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -297,6 +297,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -74,6 +74,67 @@ commands:
             - ~/.m2
           when: always
     description: Save Maven cache for a dedicated job
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -253,7 +314,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -275,6 +336,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-validate
+      - cmd-azure-artifacts-token
       - run:
           name: Validate project
           command: mvn -s .gravitee.settings.xml validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules -T 8
@@ -316,6 +378,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -388,6 +451,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2
@@ -457,6 +521,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 8
@@ -490,6 +555,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-rest-api-classes-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -532,6 +598,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -565,6 +632,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run reporter tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dreporter-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -598,6 +666,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C
@@ -631,6 +700,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Kafka Explorer tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -pl gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer -Dskip.validation=true -Dgravitee.archrules.skip=true -nsu
@@ -658,6 +728,7 @@ jobs:
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+      - cmd-azure-artifacts-token
       - run:
           name: Run Gamma tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgamma-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -Dskip.ui.build=true -nsu -T 4
@@ -711,6 +782,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-test-integration
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -42,38 +42,6 @@ commands:
           branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +103,38 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -306,7 +306,7 @@ jobs:
       - cmd-notify-on-failure
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -322,6 +322,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -249,11 +249,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -71,12 +71,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -136,11 +136,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -73,6 +73,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -140,7 +201,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -163,6 +224,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc
@@ -223,6 +285,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-jdbc-test-container
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -259,6 +322,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-mongo-test-container
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -302,6 +366,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-elastic-test-container
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
@@ -338,6 +403,7 @@ jobs:
           at: .
       - cmd-restore-maven-job-cache:
           jobName: job-redis-test-container
+      - cmd-azure-artifacts-token
       - restore_cache:
           keys:
             - gravitee-api-management-v15-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -25,54 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C08HMNYPHA4
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -134,6 +86,54 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C08HMNYPHA4
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-install-jdk:
     steps:
       - restore_cache:
@@ -193,7 +193,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -209,6 +209,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -25,55 +25,6 @@ parameters:
     default: /home/circleci/project/pom.xml
     description: Path to pom.xml with APIM version
 commands:
-  cmd-restore-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - restore_cache:
-          keys:
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v15-<< parameters.jobName >>-master
-    description: Restore Maven cache for a dedicated job
-  cmd-save-maven-job-cache:
-    parameters:
-      jobName:
-        type: string
-        default: ""
-        description: The job name
-    steps:
-      - run:
-          name: Exclude all APIM artefacts from cache.
-          command: rm -rf ~/.m2/repository/io/gravitee/apim
-      - run:
-          name: Drop failed resolution markers from cache.
-          command: find ~/.m2 -name '*.lastUpdated' -delete
-      - save_cache:
-          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-          paths:
-            - ~/.m2
-          when: always
-    description: Save Maven cache for a dedicated job
-  cmd-notify-on-failure:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-          var-name: SLACK_ACCESS_TOKEN
-      - slack/notify:
-          channel: C02JENTV2AX
-          branch_pattern: master,[0-9]+\.[0-9]+\.x
-          event: fail
-          template: basic_fail_1
-  cmd-install-yarn:
-    steps:
-      - run:
-          name: Enable Corepack and Set Yarn Version
-          command: |-
-            corepack enable || sudo corepack enable
-                    yarn set version 4.1.1
   cmd-azure-artifacts-token:
     steps:
       - keeper/install
@@ -135,6 +86,55 @@ commands:
               *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
             esac
     description: Get a short-lived Azure Artifacts token
+  cmd-restore-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - restore_cache:
+          keys:
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v15-<< parameters.jobName >>-master
+    description: Restore Maven cache for a dedicated job
+  cmd-save-maven-job-cache:
+    parameters:
+      jobName:
+        type: string
+        default: ""
+        description: The job name
+    steps:
+      - run:
+          name: Exclude all APIM artefacts from cache.
+          command: rm -rf ~/.m2/repository/io/gravitee/apim
+      - run:
+          name: Drop failed resolution markers from cache.
+          command: find ~/.m2 -name '*.lastUpdated' -delete
+      - save_cache:
+          key: gravitee-api-management-v15-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+          when: always
+    description: Save Maven cache for a dedicated job
+  cmd-notify-on-failure:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+          var-name: SLACK_ACCESS_TOKEN
+      - slack/notify:
+          channel: C02JENTV2AX
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
+          event: fail
+          template: basic_fail_1
+  cmd-install-yarn:
+    steps:
+      - run:
+          name: Enable Corepack and Set Yarn Version
+          command: |-
+            corepack enable || sudo corepack enable
+                    yarn set version 4.1.1
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -203,7 +203,7 @@ commands:
 jobs:
   job-setup:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/openjdk:25.0.3
     resource_class: small
     steps:
       - checkout
@@ -219,6 +219,23 @@ jobs:
               echo "The Maven settings read from Keeper are empty or truncated." >&2
               exit 1
             fi
+      - cmd-azure-artifacts-token
+      - run:
+          name: Check Maven resolves from the feed
+          command: |-
+            if ! mvn -B -q -s .gravitee.settings.xml \
+              org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get \
+              -Dartifact=io.gravitee.canary:feed-canary:1.0.0:pom; then
+              echo "Maven could not resolve the canary from the feed." >&2
+              echo "The token itself was accepted over HTTPS a step earlier, so what is left is the" >&2
+              echo "settings wiring: a <server> id that does not match the repository id, or" >&2
+              # Single quotes: the shell would try to expand this one, and a dot is not a valid
+              # variable name — the message would come out as a bad substitution instead.
+              echo '${env.AZURE_ARTIFACTS_PAT} not being interpolated.' >&2
+              exit 1
+            fi
+
+            echo "Maven resolved io.gravitee.canary:feed-canary from the feed."
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -54,12 +54,14 @@ commands:
 
             if [ "$CODE" != "200" ]; then
               echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
-              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              # || true: a non-JSON body would make jq exit non-zero and, under pipefail, cut the two
+              # lines below — losing the diagnostics this branch exists to print.
+              printf '%s' "$BODY" | jq -r '.error_description // empty' >&2 || true
               echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
               exit 1
             fi
 
-            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            TOKEN=$(printf '%s' "$BODY" | jq -r '.access_token // empty') || TOKEN=''
             if [ -z "$TOKEN" ]; then
               echo "Entra answered 200 with no access_token in the body." >&2
               exit 1

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -74,6 +74,67 @@ commands:
           command: |-
             corepack enable || sudo corepack enable
                     yarn set version 4.1.1
+  cmd-azure-artifacts-token:
+    steps:
+      - keeper/install
+      - run:
+          name: Get an Azure Artifacts token
+          command: |-
+            CLIENT_ID=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/login)
+            CLIENT_SECRET=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/field/password)
+            TENANT=$(ksm secret notation keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant)
+
+            # --data-urlencode rather than -d, which sends its argument verbatim: a client secret holding
+            # a +, & or = is mangled by the form decoder on the other side. Entra secrets routinely do.
+            #
+            # The status is captured instead of being left to --fail. Steps run under `bash -eo pipefail`,
+            # where a failing command substitution aborts the step on the spot — the diagnostics below would
+            # never run, and the job would die without printing anything at all.
+            RESPONSE=$(curl -sS --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -w '\n%{http_code}' -X POST \
+              "https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token" \
+              --data-urlencode "client_id=${CLIENT_ID}" \
+              --data-urlencode "client_secret=${CLIENT_SECRET}" \
+              --data-urlencode "scope=499b84ac-1321-427f-aa17-267ca6975798/.default" \
+              --data-urlencode "grant_type=client_credentials") || RESPONSE=""
+
+            CODE=$(printf '%s' "$RESPONSE" | tail -1)
+            BODY=$(printf '%s' "$RESPONSE" | sed '$d')
+
+            if [ "$CODE" != "200" ]; then
+              echo "Entra refused to issue a token (HTTP ${CODE:-no answer})." >&2
+              printf '%s' "$BODY" | sed -n 's/.*"error_description":"\([^"]*\)".*/  \1/p' >&2
+              echo "Same secret as job-deploy-on-azure: if it expired, that job is failing too." >&2
+              exit 1
+            fi
+
+            TOKEN=$(printf '%s' "$BODY" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+            if [ -z "$TOKEN" ]; then
+              echo "Entra answered 200 with no access_token in the body." >&2
+              exit 1
+            fi
+
+            # The one value that has to reach the next steps, so it goes through BASH_ENV. It is a JWT —
+            # base64url and dots, nothing the shell can expand — and it never came from Keeper.
+            echo "export AZURE_ARTIFACTS_PAT='${TOKEN}'" >> "$BASH_ENV"
+      - run:
+          name: Check the feed answers
+          command: |-
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --retry 3 --retry-all-errors --retry-delay 5 --max-time 30 \
+              -u "bot:${AZURE_ARTIFACTS_PAT}" \
+              "https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1/io/gravitee/canary/feed-canary/1.0.0/feed-canary-1.0.0.pom") || CODE=000
+
+            case "$CODE" in
+              200) echo "The feed resolves the canary." ;;
+              401) echo "401 — the feed rejected the token." >&2; exit 1 ;;
+              403) echo "403 — Gravitee.io Bot has no role on the feed." >&2; exit 1 ;;
+              404) echo "404 — token accepted but the canary is gone; publish it again." >&2; exit 1 ;;
+              # Everything else is the feed being unavailable rather than misconfigured, and that is what
+              # the Artifactory fallback exists to absorb. Failing here would remove the resilience this
+              # design was built around.
+              *)   echo "The feed answered HTTP ${CODE}; carrying on, Maven falls back to Artifactory." >&2 ;;
+            esac
+    description: Get a short-lived Azure Artifacts token
   cmd-workspace-install:
     steps:
       - restore_cache:
@@ -150,7 +211,7 @@ jobs:
       - run:
           name: Get the Maven settings
           command: |-
-            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml_azure > .gravitee.settings.xml
 
             # An empty or truncated file would only surface later, in another job, as an unreadable
             # settings or a 401 blamed on the credentials.
@@ -173,6 +234,7 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-build
       - cmd-install-yarn
+      - cmd-azure-artifacts-token
       - run:
           name: Build engine
           command: mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -P all-modules -DwithJavadoc

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -146,11 +146,18 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml
-          var-name: MAVEN_SETTINGS
+      - keeper/install
       - run:
-          command: "echo $MAVEN_SETTINGS > .gravitee.settings.xml "
+          name: Get the Maven settings
+          command: |-
+            ksm secret notation keeper://7CgijuGiFDSLynRJt1Dm9w/custom_field/xml > .gravitee.settings.xml
+
+            # An empty or truncated file would only surface later, in another job, as an unreadable
+            # settings or a 401 blamed on the credentials.
+            if ! grep -q '</settings>' .gravitee.settings.xml; then
+              echo "The Maven settings read from Keeper are empty or truncated." >&2
+              exit 1
+            fi
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-293

## Description

Maven now resolves from the Azure Artifacts feed.

Publication is deliberately untouched: the deploy profiles still target Artifactory and Nexus, and this PR does not move them. Read first, write later.

Six commits, each readable on its own:

| | |
|---|---|
| `fix(ci): read the Maven settings straight from Keeper` | writes the file with `ksm secret notation` instead of `env-export` and an `echo` — stands alone, unrelated to the feed |
| `feat(ci): resolve Maven dependencies from the Azure Artifacts feed` | the switch itself: the `xml_azure` field, and a per-job Entra token |
| `feat(ci): check the feed through Maven, once per pipeline` | proves the settings are wired, not just that the token works |
| `test(ci): encode the rule that resolving with the shared settings needs a token` | the rule the snapshots cannot express |
| `refactor(ci): parse the Entra response with jq and lift the feed URL into config` | |
| `fix(ci): pass the shared settings to versions:set` | pre-existing; the only Maven calls in the pipelines running without `-s` |

## Additional context

**What the Keeper field changes.** The substantive part of the switch is a one-line field change, so here is what it points at. `xml_azure` is `xml` with three blocks added and nothing removed — Artifactory, Sonatype and the deploy profiles are untouched:

```xml
<server>
  <id>azure-artifacts-gravitee</id>
  <username>gravitee-bot</username>
  <password>${env.AZURE_ARTIFACTS_PAT}</password>
</server>
```

```xml
<repository>
  <id>azure-artifacts-gravitee</id>
  <url>https://pkgs.dev.azure.com/graviteeio/packages/_packaging/gravitee/maven/v1</url>
  <releases><enabled>true</enabled></releases>
  <snapshots><enabled>true</enabled></snapshots>
</repository>
```

The same block again as a `<pluginRepository>`, both in first position of their list. **The file declares no `<mirrors>` section at all** — so the feed is a repository Maven tries first, and Artifactory remains a real fallback behind it. That is what the rest of this description relies on.

**Why a token per job, rather than one fetched once and carried through the workspace.** Gravitee.io Bot is an Entra service principal, and a service principal cannot hold a personal access token — it authenticates through `client_credentials`, and what it gets back lives one hour. Fetching it once breaks on "rerun from failed": that rerun does not replay the job that fetched the token, it reuses the workspace and starts again with a dead one. A workflow left waiting on a manual approval has the same problem. Job durations were measured against that hour: over the last 183 builds across all branches, the longest job is 12.5 minutes and the longest Maven one is 9, so the margin is comfortable.

**The two checks, and why they are temporary.** Each job asks the feed for the canary over HTTPS, and `job-setup` resolves it once per pipeline through Maven. They test different things: the first that the token opens the feed, the second that the settings are wired — the `<server>` id matching the repository id, and `${env.AZURE_ARTIFACTS_PAT}` actually being interpolated, neither of which a raw request exercises. Both exist only because Artifactory sits behind the feed and absorbs a 401 in silence. Once Artifactory is switched off there is no fallback left to hide behind, a broken feed fails on its own, and both checks go along with the canary artifact. That is noted in the code.

**Coverage.** Nineteen jobs resolve with the shared settings and all nineteen fetch a token. Five of them — the four `*-test-container` families and `job-test-integration` — were missing it in the first version of this branch, and stayed green precisely because of the fallback. The fourth commit encodes the rule so it cannot happen again; it generates four pipelines rather than one, since the `*-test-container` jobs appear in no pull-request configuration and `job-test-integration` in only some of them.

**The two settings fields.** `xml` and `xml_azure` now have to be kept in step. That cost is known and accepted for the duration of the migration: `xml` keeps serving every repository still on an older orb, `xml_azure` serves this one, and they collapse back into a single field once every repository has moved.

**Security-sensitive**, per `AGENTS.md`: this change touches credentials and CI configuration.

## Verification

Locally: 203 tests, licence headers, prettier, and `circleci config validate` on the 36 generated configurations.

The pull-request pipeline does **not** cover everything: `repositories-tests` and `integration-tests`, where the five jobs above live, are triggered by the `gio_action` pipeline parameter and never run on a pull request. They will be launched by hand once this pipeline is green.
