### PR TITLE
feat(portal): add agent subscription preview.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
@@ -20,6 +20,7 @@ import { GraviteeMarkdownViewerHarness } from '@gravitee/gravitee-markdown';
 
 import { TreeComponentHarness } from './tree/tree.component.harness';
 import { AgentChatComponentHarness } from '../../../../components/agent-chat/agent-chat.harness';
+import { AgentSubscriptionsComponentHarness } from '../../../../components/agent-subscriptions/agent-subscriptions.harness';
 import { BreadcrumbSkeletonComponentHarness } from '../../../../components/breadcrumb-skeleton/breadcrumb-skeleton.component.harness';
 import { BreadcrumbsComponentHarness } from '../../../../components/breadcrumbs/breadcrumbs.component.harness';
 import { DocumentationSkeletonComponentHarness } from '../../../../components/documentation-skeleton/documentation-skeleton.component.harness';
@@ -47,8 +48,12 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
   private readonly getSubscribeMatButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="subscribe-button"]' }));
   private readonly getMcpMatButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="mcp-button"]' }));
   private readonly getChatMatButton = this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="chat-button"]' }));
+  private readonly getSubscriptionsMatButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="subscriptions-button"]' }),
+  );
   private readonly locateApiTabTools = this.locatorForOptional(ApiTabToolsComponentHarness);
   private readonly locateAgentChat = this.locatorForOptional(AgentChatComponentHarness);
+  private readonly locateAgentSubscriptions = this.locatorForOptional(AgentSubscriptionsComponentHarness);
   private readonly locateSidePanel = this.locatorForOptional(SidePanelComponentHarness);
 
   async getSidenavToggleButton(): Promise<SidenavToggleButtonComponentHarness | null> {
@@ -108,6 +113,14 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
 
   async getAgentChat(): Promise<AgentChatComponentHarness | null> {
     return this.locateAgentChat();
+  }
+
+  async getSubscriptionsButton(): Promise<MatButtonHarness | null> {
+    return this.getSubscriptionsMatButton();
+  }
+
+  async getAgentSubscriptions(): Promise<AgentSubscriptionsComponentHarness | null> {
+    return this.locateAgentSubscriptions();
   }
 
   async getSidePanel(): Promise<SidePanelComponentHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -24,13 +24,19 @@
         </button>
       }
       @if (subscriptionTarget()) {
-        <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
-          @if (currentUser()) {
-            <span i18n="@@subscribeToApiButton">Subscribe</span>
-          } @else {
-            <span i18n="@@signInToSubscribeButton">Sign in to subscribe</span>
-          }
-        </button>
+        @if (hasAgentSubscriptions()) {
+          <button mat-stroked-button type="button" (click)="subscriptionsOpen.set(true)" data-testid="subscriptions-button">
+            <span i18n="@@agentSubscriptionsButton">Subscription</span>
+          </button>
+        } @else {
+          <button mat-stroked-button (click)="onSubscribe()" [disabled]="!currentUser()" data-testid="subscribe-button">
+            @if (currentUser()) {
+              <span i18n="@@subscribeToApiButton">Subscribe</span>
+            } @else {
+              <span i18n="@@signInToSubscribeButton">Sign in to subscribe</span>
+            }
+          </button>
+        }
       }
       @if (chatTarget()) {
         <button mat-flat-button type="button" (click)="chatOpen.set(true)" data-testid="chat-button">
@@ -106,5 +112,22 @@
     (closed)="chatOpen.set(false)"
   >
     <app-agent-chat [agentName]="session.agentName" [target]="session.target" />
+  </app-side-panel>
+}
+
+@if (subscriptionsOpen() && hasAgentSubscriptions()) {
+  <app-side-panel
+    panelTestId="agent-subscriptions-drawer"
+    i18n-ariaLabel="@@agentSubscriptionsPanelAria"
+    ariaLabel="Agent subscriptions"
+    animate.leave="side-panel-leave"
+    (closed)="subscriptionsOpen.set(false)"
+  >
+    <app-agent-subscriptions
+      [agentName]="api.value()?.name ?? ''"
+      [entrypointUrls]="agentEntrypointUrls()"
+      [subscriptions]="agentSubscriptions()"
+      (newSubscription)="onNewSubscription()"
+    />
   </app-side-panel>
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -27,6 +27,7 @@ import { completed, respondingGateway } from '../../../../components/agent-chat/
 import { ApiType } from '../../../../entities/api/api';
 import { PortalNavigationItem } from '../../../../entities/portal-navigation/portal-navigation-item';
 import { fakePortalNavigationApiProduct } from '../../../../entities/portal-navigation/portal-navigation-item.fixture';
+import { fakeSubscription } from '../../../../entities/subscription';
 import { makeItem, MOCK_ITEMS } from '../../../../mocks/portal-navigation-item.mocks';
 import { AgentSubscriptionAccess, AgentSubscriptionService } from '../../../../services/agent-subscription.service';
 import { ApiService } from '../../../../services/api.service';
@@ -39,7 +40,7 @@ describe('DocumentationFolderComponent', () => {
   let harness: DocumentationFolderComponentHarness;
   let navigationServiceSpy: PortalNavigationItemsService;
   let apiServiceSpy: { details: jest.Mock };
-  let agentSubscriptionServiceSpy: { findForAgent: jest.Mock };
+  let agentSubscriptionServiceSpy: { findForAgent: jest.Mock; loadAccessContexts: jest.Mock };
   let routerSpy: jest.Mocked<Router>;
   let queryParamsSubject: BehaviorSubject<{ selectedId?: string }>;
 
@@ -48,6 +49,34 @@ describe('DocumentationFolderComponent', () => {
   const MOCK_CONTENT = 'MOCK_CONTENT';
 
   const gmdViewerContent = (content: string) => `<p>${content}</p>\n`;
+
+  const EMPTY_AGENT_ACCESS: AgentSubscriptionAccess = { subscriptions: [], chatCredentials: null };
+
+  const agentAccessWith = (
+    params: {
+      statuses?: Array<'ACCEPTED' | 'PENDING' | 'PAUSED'>;
+      chatCredentials?: AgentSubscriptionAccess['chatCredentials'];
+    } = {},
+  ): AgentSubscriptionAccess => {
+    const statuses = params.statuses ?? [];
+    const subscriptions = statuses.map((status, index) => ({
+      subscription: fakeSubscription({
+        id: `sub-${index + 1}`,
+        status,
+        keys: status === 'ACCEPTED' ? [{ id: 'key-1-id', key: 'key-1', application: { id: 'app-1', name: 'My App' } }] : [],
+      }),
+      planName: 'Gold',
+      planSecurity: 'API_KEY' as const,
+      applicationName: 'My App',
+    }));
+    const chatCredentials =
+      params.chatCredentials !== undefined
+        ? params.chatCredentials
+        : statuses.includes('ACCEPTED')
+          ? { apiKey: 'key-1', applicationName: 'My App' }
+          : null;
+    return { subscriptions, chatCredentials };
+  };
 
   const baseApiDetails = {
     name: 'API',
@@ -80,6 +109,9 @@ describe('DocumentationFolderComponent', () => {
         if (options?.queryParams) queryParamsSubject.next(options.queryParams);
         return Promise.resolve(true);
       }),
+      createUrlTree: jest.fn().mockReturnValue({}),
+      serializeUrl: jest.fn().mockReturnValue(''),
+      events: of(),
     } as unknown as jest.Mocked<Router>;
 
     navigationServiceSpy = {
@@ -99,7 +131,10 @@ describe('DocumentationFolderComponent', () => {
         }),
       ),
     };
-    agentSubscriptionServiceSpy = { findForAgent: jest.fn().mockReturnValue(of(params.agentAccess ?? null)) };
+    agentSubscriptionServiceSpy = {
+      findForAgent: jest.fn().mockReturnValue(of(params.agentAccess ?? EMPTY_AGENT_ACCESS)),
+      loadAccessContexts: jest.fn().mockReturnValue(of(new Map())),
+    };
 
     await TestBed.configureTestingModule({
       animationsEnabled: true,
@@ -635,7 +670,7 @@ describe('DocumentationFolderComponent', () => {
   });
 
   describe('agent chat', () => {
-    const AGENT_ACCESS: AgentSubscriptionAccess = { apiKey: 'key-1' };
+    const AGENT_ACCESS: AgentSubscriptionAccess = agentAccessWith({ statuses: ['ACCEPTED'] });
 
     const realFetch = globalThis.fetch;
 
@@ -780,6 +815,131 @@ describe('DocumentationFolderComponent', () => {
       await initAgentPage({ apiType: 'PROXY' });
 
       expect(agentSubscriptionServiceSpy.findForAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('agent subscriptions', () => {
+    const AGENT_ACCESS: AgentSubscriptionAccess = agentAccessWith({ statuses: ['ACCEPTED'] });
+
+    const initAgentPage = async (params: {
+      apiType?: ApiType;
+      agentAccess?: AgentSubscriptionAccess | null;
+      isAuthenticated?: boolean;
+      apiEntrypoints?: string[];
+    }) => {
+      const agentItem = makeItem('agent1', 'AGENT', 'Agent 1', 0, undefined);
+      const agentPage = makeItem('p-agent1', 'PAGE', 'Agent 1 Documentation', 0, 'agent1');
+      await init({ items: [agentItem, agentPage], queryParams: { selectedId: 'p-agent1' }, content: MOCK_CONTENT, ...params });
+      await settle();
+    };
+
+    const settle = async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const openSubscriptions = async () => {
+      await (await harness.getSubscriptionsButton())!.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    it('should replace Subscribe with the Subscription button once the viewer is subscribed', async () => {
+      await initAgentPage({ apiType: 'A2A_PROXY', agentAccess: AGENT_ACCESS });
+
+      expect(await harness.getSubscriptionsButton()).not.toBeNull();
+      expect(await harness.getSubscribeButton()).toBeNull();
+    });
+
+    it('should keep the Subscribe button for an agent the viewer is not subscribed to', async () => {
+      await initAgentPage({ apiType: 'A2A_PROXY' });
+
+      expect(await harness.getSubscribeButton()).not.toBeNull();
+      expect(await harness.getSubscriptionsButton()).toBeNull();
+    });
+
+    it('should open the subscriptions panel when the Subscription button is clicked', async () => {
+      await initAgentPage({ apiType: 'A2A_PROXY', agentAccess: AGENT_ACCESS });
+
+      expect(await harness.getAgentSubscriptions()).toBeNull();
+
+      await openSubscriptions();
+
+      expect(await harness.getAgentSubscriptions()).not.toBeNull();
+      expect(await (await harness.getSidePanel())!.getPanelTestId()).toBe('agent-subscriptions-drawer');
+    });
+
+    it('should list a pending subscription so the viewer does not subscribe twice', async () => {
+      await initAgentPage({ apiType: 'A2A_PROXY', agentAccess: agentAccessWith({ statuses: ['PENDING'] }) });
+
+      expect(await harness.getSubscriptionsButton()).not.toBeNull();
+      expect(await harness.getSubscribeButton()).toBeNull();
+
+      await openSubscriptions();
+
+      expect(await (await harness.getAgentSubscriptions())!.getHeaderTexts()).toEqual([
+        expect.objectContaining({ description: 'Gold - Pending' }),
+      ]);
+    });
+
+    it('should navigate to the subscribe flow from the panel', async () => {
+      await initAgentPage({ apiType: 'A2A_PROXY', agentAccess: AGENT_ACCESS });
+      await openSubscriptions();
+
+      await (await harness.getAgentSubscriptions())!.clickNewSubscription();
+      fixture.detectChanges();
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['api', 'api-agent1', 'subscribe'], {
+        relativeTo: expect.anything(),
+        queryParamsHandling: 'preserve',
+      });
+      expect(await harness.getAgentSubscriptions()).toBeNull();
+    });
+
+    it('should keep the Subscribe button for a non-agent api that has subscriptions', async () => {
+      const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
+      const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
+      await init({
+        items: [apiItem, apiPage],
+        queryParams: { selectedId: 'p-api1' },
+        content: MOCK_CONTENT,
+        apiType: 'PROXY',
+        agentAccess: AGENT_ACCESS,
+      });
+      await settle();
+
+      expect(await harness.getSubscribeButton()).not.toBeNull();
+      expect(await harness.getSubscriptionsButton()).toBeNull();
+    });
+
+    it('should close the subscriptions panel when the viewer navigates to another item', async () => {
+      const agentItem = makeItem('agent1', 'AGENT', 'Agent 1', 0, undefined);
+      const agentPage = makeItem('p-agent1', 'PAGE', 'Agent 1 Documentation', 0, 'agent1');
+      const otherAgent = makeItem('agent2', 'AGENT', 'Agent 2', 1, undefined);
+      const otherAgentPage = makeItem('p-agent2', 'PAGE', 'Agent 2 Documentation', 0, 'agent2');
+      await init({
+        items: [agentItem, agentPage, otherAgent, otherAgentPage],
+        queryParams: { selectedId: 'p-agent1' },
+        content: MOCK_CONTENT,
+        apiType: 'A2A_PROXY',
+        agentAccess: AGENT_ACCESS,
+      });
+      await settle();
+      await openSubscriptions();
+      expect(await harness.getAgentSubscriptions()).not.toBeNull();
+
+      queryParamsSubject.next({ selectedId: 'p-agent2' });
+      await settle();
+      expect(await harness.getAgentSubscriptions()).toBeNull();
+
+      queryParamsSubject.next({ selectedId: 'p-agent1' });
+      await settle();
+
+      expect(await harness.getAgentSubscriptions()).toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -22,18 +22,19 @@ import { catchError, debounceTime, finalize, map, merge, Observable, switchMap, 
 import { of } from 'rxjs/internal/observable/of';
 
 import { GraviteeMarkdownViewerModule } from '@gravitee/gravitee-markdown';
-import { Api } from 'src/entities/api/api';
 
 import { TreeComponent } from './tree/tree.component';
 import { isChattableAgent, resolveChatTarget } from '../../../../components/agent-chat/agent-chat-access';
 import { AgentChatComponent } from '../../../../components/agent-chat/agent-chat.component';
 import { AgentChatStore } from '../../../../components/agent-chat/agent-chat.store';
+import { AgentSubscriptionsComponent } from '../../../../components/agent-subscriptions/agent-subscriptions.component';
 import { Breadcrumb } from '../../../../components/breadcrumbs/breadcrumbs.component';
 import { DocumentationSkeletonComponent } from '../../../../components/documentation-skeleton/documentation-skeleton.component';
 import { NavigationItemContentViewerComponent } from '../../../../components/navigation-item-content-viewer/navigation-item-content-viewer.component';
 import { SidePanelComponent } from '../../../../components/side-panel/side-panel.component';
 import { SidenavLayoutComponent } from '../../../../components/sidenav-layout/sidenav-layout.component';
 import { SidenavSkeletonComponent } from '../../../../components/sidenav-skeleton/sidenav-skeleton.component';
+import { Api, isAgentApi } from '../../../../entities/api/api';
 import { PortalNavigationAgent, PortalNavigationItem } from '../../../../entities/portal-navigation/portal-navigation-item';
 import { PortalPageContent } from '../../../../entities/portal-navigation/portal-page-content';
 import { AgentSubscriptionAccess, AgentSubscriptionService } from '../../../../services/agent-subscription.service';
@@ -69,6 +70,7 @@ enum NavParamsChange {
     ApiTabToolsComponent,
     AgentDetailComponent,
     AgentChatComponent,
+    AgentSubscriptionsComponent,
   ],
   templateUrl: './documentation-folder.component.html',
   styleUrl: './documentation-folder.component.scss',
@@ -95,6 +97,7 @@ export class DocumentationFolderComponent {
   selectedAgent = signal<PortalNavigationAgent | null>(null);
   mcpDrawerOpen = signal(false);
   chatOpen = signal(false);
+  subscriptionsOpen = signal(false);
   subscriptionTarget = computed(() => this.documentationActionContext().subscriptionTarget);
   apiId = computed(() => this.documentationActionContext().apiId);
   api = rxResource<Api | null, string | null>({
@@ -112,13 +115,22 @@ export class DocumentationFolderComponent {
   // must still render its tree and breadcrumbs when the api call fails.
   private readonly agentApiId = computed(() => {
     const api = this.api.error() ? null : this.api.value();
+    return isAgentApi(api ?? undefined) && this.currentUser() ? (api?.id ?? null) : null;
+  });
+  private readonly chattableAgentId = computed(() => {
+    const api = this.api.error() ? null : this.api.value();
     return isChattableAgent(api) && this.currentUser() ? (api?.id ?? null) : null;
   });
   agentAccess = rxResource<AgentSubscriptionAccess | null, string | null>({
     params: this.agentApiId,
     stream: ({ params }) => (params ? this.agentSubscriptionService.findForAgent(params) : of(null)),
   });
-  chatTarget = computed(() => (this.api.error() ? null : resolveChatTarget(this.api.value(), this.agentAccess.value()?.apiKey)));
+  agentSubscriptions = computed(() => this.agentAccess.value()?.subscriptions ?? []);
+  hasAgentSubscriptions = computed(() => this.agentSubscriptions().length > 0);
+  agentEntrypointUrls = computed(() => (this.api.error() ? [] : (this.api.value()?.entrypoints ?? [])));
+  chatTarget = computed(() =>
+    this.api.error() ? null : resolveChatTarget(this.api.value(), this.agentAccess.value()?.chatCredentials?.apiKey),
+  );
   chatSession = computed(() => {
     const target = this.chatTarget();
     const agentName = this.api.error() ? null : this.api.value()?.name;
@@ -134,14 +146,20 @@ export class DocumentationFolderComponent {
     private readonly treeService: TreeService,
   ) {
     effect(() => {
-      const agentId = this.agentApiId();
-      if (!agentId) {
+      const chattableId = this.chattableAgentId();
+      if (!chattableId) {
         // Selecting another page clears the api context, and a panel left open would otherwise
         // reopen itself once the next agent resolves.
         this.chatOpen.set(false);
-        return;
+      } else {
+        this.chatStore.resetFor(chattableId);
       }
-      this.chatStore.resetFor(agentId);
+    });
+
+    effect(() => {
+      if (!this.agentApiId()) {
+        this.subscriptionsOpen.set(false);
+      }
     });
   }
 
@@ -160,6 +178,11 @@ export class DocumentationFolderComponent {
       relativeTo: this.activatedRoute,
       queryParamsHandling: 'preserve',
     });
+  }
+
+  onNewSubscription() {
+    this.subscriptionsOpen.set(false);
+    this.onSubscribe();
   }
 
   private loadFolderData(): Observable<FolderData | undefined> {

--- a/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="agent-access-card">
+  @if (showApplicationName() && applicationName()) {
+    <div class="next-gen-body" data-testid="application-name">{{ applicationName() }}</div>
+  }
+
+  @if (isAccepted()) {
+    @if (planSecurity() === 'API_KEY' && apiKey()) {
+      <app-copy-code id="api-key" class="next-gen-small" title="API Key" i18n-title="@@agentAccessCardApiKey" [text]="apiKey()" />
+    }
+    @if (planSecurity() === 'OAUTH2' || planSecurity() === 'JWT') {
+      <app-copy-code id="client-id" class="next-gen-small" title="Client ID" i18n-title="@@agentAccessCardClientId" [text]="clientId()" />
+      @if (clientSecret()) {
+        <app-copy-code
+          id="client-secret"
+          class="next-gen-small"
+          title="Client Secret"
+          i18n-title="@@agentAccessCardClientSecret"
+          [text]="clientSecret()"
+          mode="PASSWORD"
+        />
+      }
+    }
+    @if (entrypointUrl()) {
+      <app-copy-code id="base-url" class="next-gen-small" title="Base URL" i18n-title="@@agentAccessCardBaseUrl" [text]="entrypointUrl()" />
+    }
+    @if (curlCmd()) {
+      <app-copy-code id="command-line" class="next-gen-small" title="cURL" i18n-title="@@agentAccessCardCurl" [text]="curlCmd()" />
+    }
+  } @else {
+    @switch (subscription().status) {
+      @case ('PENDING') {
+        <div class="next-gen-h5" i18n="@@subscriptionDetailsPendingHeader">Subscription in progress</div>
+        <div class="next-gen-body" i18n="@@subscriptionDetailsPendingContent">
+          Your subscription request is being validated. Come back later.
+        </div>
+      }
+      @case ('PAUSED') {
+        <div class="next-gen-h5" i18n="@@subscriptionDetailsPasueddHeader">Subscription paused</div>
+      }
+    }
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.scss
@@ -1,0 +1,8 @@
+@use '../../scss/theme' as app-theme;
+
+.agent-access-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 25px 0 10px;
+}

--- a/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { provideRouter } from '@angular/router';
+
+import { AgentAccessCardComponent } from './agent-access-card.component';
+import { AgentAccessCardComponentHarness } from './agent-access-card.harness';
+import { PlanSecurityEnum } from '../../entities/plan/plan';
+import { fakeSubscription, Subscription } from '../../entities/subscription';
+import { AppTestingModule } from '../../testing/app-testing.module';
+
+describe('AgentAccessCardComponent', () => {
+  let fixture: ComponentFixture<AgentAccessCardComponent>;
+  let harness: AgentAccessCardComponentHarness;
+
+  const init = async (
+    params: Partial<{
+      planSecurity: PlanSecurityEnum;
+      subscription: Subscription;
+      applicationName: string;
+      showApplicationName: boolean;
+      entrypointUrl: string;
+      apiKey: string;
+      clientId: string;
+      clientSecret: string;
+      apiKeyHeader: string;
+    }> = {},
+  ) => {
+    await TestBed.configureTestingModule({
+      imports: [AgentAccessCardComponent, MatIconTestingModule, AppTestingModule],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AgentAccessCardComponent);
+    fixture.componentRef.setInput('planSecurity', params.planSecurity ?? 'API_KEY');
+    fixture.componentRef.setInput('subscription', params.subscription ?? fakeSubscription({ id: 'sub-1', status: 'ACCEPTED' }));
+    fixture.componentRef.setInput('applicationName', params.applicationName ?? 'My App');
+    fixture.componentRef.setInput('showApplicationName', params.showApplicationName ?? false);
+    fixture.componentRef.setInput('entrypointUrl', params.entrypointUrl ?? 'https://gw.test/agent');
+    fixture.componentRef.setInput('apiKey', params.apiKey ?? 'live-key-1');
+    fixture.componentRef.setInput('clientId', params.clientId ?? '');
+    fixture.componentRef.setInput('clientSecret', params.clientSecret ?? '');
+    fixture.componentRef.setInput('apiKeyHeader', params.apiKeyHeader ?? 'X-Gravitee-Api-Key');
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AgentAccessCardComponentHarness);
+    fixture.detectChanges();
+  };
+
+  it('shows the active API key, base URL and a cURL command that includes the key', async () => {
+    await init({ apiKey: 'live-key-1', entrypointUrl: 'https://gw.test/agent' });
+
+    expect(await harness.getApiKeyText()).toBe('live-key-1');
+    expect(await harness.getBaseUrlText()).toBe('https://gw.test/agent');
+    expect(await harness.getCurlText()).toBe('curl --header "X-Gravitee-Api-Key: live-key-1" https://gw.test/agent');
+  });
+
+  it('shows a pending status message and no credentials', async () => {
+    await init({
+      subscription: fakeSubscription({ id: 'sub-pending', status: 'PENDING' }),
+      apiKey: 'hidden-key',
+    });
+
+    const text = await harness.getHostText();
+    expect(text).toContain('Subscription in progress');
+    expect(await harness.getApiKeyText()).toBeNull();
+    expect(await harness.getCurlText()).toBeNull();
+    expect(text).not.toContain('hidden-key');
+  });
+
+  it('shows a paused status message and no credentials', async () => {
+    await init({
+      subscription: fakeSubscription({ id: 'sub-paused', status: 'PAUSED' }),
+      apiKey: 'hidden-key',
+    });
+
+    const text = await harness.getHostText();
+    expect(text).toContain('Subscription paused');
+    expect(await harness.getApiKeyText()).toBeNull();
+  });
+
+  it('hides the application name unless asked to show it', async () => {
+    await init({ applicationName: 'Ops App', showApplicationName: false });
+
+    expect(await harness.getApplicationNameText()).toBeNull();
+  });
+
+  it('shows the application name when asked', async () => {
+    await init({ applicationName: 'Ops App', showApplicationName: true });
+
+    expect(await harness.getApplicationNameText()).toBe('Ops App');
+  });
+
+  it('shows the client id of an OAUTH2 plan', async () => {
+    await init({
+      planSecurity: 'OAUTH2',
+      apiKey: '',
+      clientId: 'client-1',
+      clientSecret: 'secret-1',
+    });
+
+    expect(await harness.getApiKeyText()).toBeNull();
+    expect(await harness.getClientIdText()).toBe('client-1');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.component.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, input } from '@angular/core';
+
+import { PlanSecurityEnum } from '../../entities/plan/plan';
+import { Subscription } from '../../entities/subscription';
+import { formatCurlCommandLine } from '../api-access/api-access.utils';
+import { CopyCodeComponent } from '../copy-code/copy-code.component';
+
+@Component({
+  selector: 'app-agent-access-card',
+  imports: [CopyCodeComponent],
+  templateUrl: './agent-access-card.component.html',
+  styleUrl: './agent-access-card.component.scss',
+})
+export class AgentAccessCardComponent {
+  planSecurity = input.required<PlanSecurityEnum>();
+  subscription = input.required<Subscription>();
+  applicationName = input('');
+  showApplicationName = input(false);
+  entrypointUrl = input('');
+  apiKey = input('');
+  clientId = input('');
+  clientSecret = input('');
+  apiKeyHeader = input('');
+
+  protected readonly isAccepted = computed(() => this.subscription().status === 'ACCEPTED');
+  protected readonly curlCmd = computed(() =>
+    formatCurlCommandLine(this.entrypointUrl(), this.planSecurity(), this.apiKeyHeader(), this.apiKey()),
+  );
+}

--- a/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-access-card/agent-access-card.harness.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+import { CopyCodeHarness } from '../copy-code/copy-code.harness';
+
+export class AgentAccessCardComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-agent-access-card';
+
+  private readonly getApplicationName = this.locatorForOptional('[data-testid="application-name"]');
+  private readonly getApiKey = this.locatorForOptional(CopyCodeHarness.with({ selector: '#api-key' }));
+  private readonly getBaseUrl = this.locatorForOptional(CopyCodeHarness.with({ selector: '#base-url' }));
+  private readonly getCurl = this.locatorForOptional(CopyCodeHarness.with({ selector: '#command-line' }));
+  private readonly getClientId = this.locatorForOptional(CopyCodeHarness.with({ selector: '#client-id' }));
+  private readonly getClientSecret = this.locatorForOptional(CopyCodeHarness.with({ selector: '#client-secret' }));
+
+  async getHostText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  async getApplicationNameText(): Promise<string | null> {
+    const name = await this.getApplicationName();
+    return name ? name.text() : null;
+  }
+
+  async getApiKeyText(): Promise<string | null> {
+    const copyCode = await this.getApiKey();
+    return copyCode ? copyCode.getText() : null;
+  }
+
+  async getBaseUrlText(): Promise<string | null> {
+    const copyCode = await this.getBaseUrl();
+    return copyCode ? copyCode.getText() : null;
+  }
+
+  async getCurlText(): Promise<string | null> {
+    const copyCode = await this.getCurl();
+    return copyCode ? copyCode.getText() : null;
+  }
+
+  async getClientIdText(): Promise<string | null> {
+    const copyCode = await this.getClientId();
+    return copyCode ? copyCode.getText() : null;
+  }
+
+  async getClientSecretText(): Promise<string | null> {
+    const copyCode = await this.getClientSecret();
+    return copyCode ? copyCode.getText() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="agent-subscriptions">
+  <div class="agent-subscriptions__header">
+    <div class="next-gen-h5" i18n="@@agentSubscriptionsTitle">Active subscriptions</div>
+  </div>
+
+  <mat-accordion class="agent-subscriptions__list">
+    @for (row of rows(); track row.summary.subscription.id) {
+      <div class="agent-subscriptions__item">
+        <a
+          class="agent-subscriptions__details-link internal-link"
+          [routerLink]="['/dashboard', 'subscriptions', row.summary.subscription.id]"
+          data-testid="subscription-details-link"
+        >
+          <span i18n="@@agentSubscriptionsViewDetails">View full details</span>
+        </a>
+        <mat-expansion-panel class="mat-elevation-z0" [expanded]="$first">
+          <mat-expansion-panel-header>
+            <mat-panel-description class="next-gen-body">
+              {{ row.summary.planName }} - {{ row.summary.subscription.status | capitalizeFirst }}
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+
+          <app-agent-access-card
+            [planSecurity]="row.summary.planSecurity"
+            [subscription]="row.summary.subscription"
+            [applicationName]="row.summary.applicationName"
+            [showApplicationName]="showApplicationName()"
+            [entrypointUrl]="entrypointUrl()"
+            [apiKey]="row.apiKey"
+            [clientId]="row.context.clientId ?? ''"
+            [clientSecret]="row.context.clientSecret ?? ''"
+            [apiKeyHeader]="apiKeyHeader"
+          />
+        </mat-expansion-panel>
+      </div>
+    }
+  </mat-accordion>
+
+  <button mat-stroked-button type="button" data-testid="new-subscription-button" (click)="newSubscription.emit()">
+    <span i18n="@@agentSubscriptionsNew">New subscription</span>
+  </button>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.scss
@@ -1,0 +1,63 @@
+@use '@angular/material' as mat;
+@use '../../scss/theme' as app-theme;
+
+.agent-subscriptions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 520px;
+  max-width: 100%;
+
+  @include mat.expansion-overrides(
+    (
+      header-hover-state-layer-color: transparent,
+      header-focus-state-layer-color: transparent,
+      container-shape: app-theme.$container-shape,
+    )
+  );
+
+  &__header {
+    padding-right: 40px;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__item {
+    position: relative;
+  }
+
+  &__details-link {
+    position: absolute;
+    top: 0;
+    right: 48px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    height: var(--mat-expansion-header-collapsed-state-height, 48px);
+  }
+
+  &__item:has(mat-expansion-panel.mat-expanded) &__details-link {
+    height: var(--mat-expansion-header-expanded-state-height, 64px);
+  }
+
+  mat-expansion-panel {
+    border: app-theme.$border-width solid app-theme.$border-color;
+  }
+
+  mat-expansion-panel-header {
+    padding: 0 10px;
+    background-color: app-theme.$table-header-background-color;
+  }
+
+  mat-panel-description {
+    margin-right: 140px;
+  }
+
+  mat-expansion-panel.mat-expanded mat-expansion-panel-header {
+    border-bottom: app-theme.$border-width solid app-theme.$border-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { AgentSubscriptionsComponent } from './agent-subscriptions.component';
+import { AgentSubscriptionsComponentHarness } from './agent-subscriptions.harness';
+import { PlanSecurityEnum } from '../../entities/plan/plan';
+import { fakeSubscription } from '../../entities/subscription';
+import {
+  AgentSubscriptionAccessContext,
+  AgentSubscriptionService,
+  AgentSubscriptionSummary,
+} from '../../services/agent-subscription.service';
+import { ConfigService } from '../../services/config.service';
+import { AppTestingModule, ConfigServiceStub } from '../../testing/app-testing.module';
+
+describe('AgentSubscriptionsComponent', () => {
+  let fixture: ComponentFixture<AgentSubscriptionsComponent>;
+  let harness: AgentSubscriptionsComponentHarness;
+  let loadAccessContexts: jest.Mock;
+
+  const aSummary = (
+    opts: {
+      id?: string;
+      status?: 'ACCEPTED' | 'PENDING' | 'PAUSED';
+      applicationName?: string;
+      planName?: string;
+      planSecurity?: PlanSecurityEnum;
+      key?: string;
+    } = {},
+  ): AgentSubscriptionSummary => {
+    const key = opts.key ?? 'key-1';
+    return {
+      subscription: fakeSubscription({
+        id: opts.id ?? 'sub-1',
+        status: opts.status ?? 'ACCEPTED',
+        keys: opts.status && opts.status !== 'ACCEPTED' ? [] : [{ id: `${key}-id`, key, application: { id: 'app-1', name: 'My App' } }],
+      }),
+      planName: opts.planName ?? 'Gold',
+      planSecurity: opts.planSecurity ?? 'API_KEY',
+      applicationName: opts.applicationName ?? 'My App',
+    };
+  };
+
+  const init = async (
+    params: Partial<{
+      agentName: string;
+      entrypointUrls: string[];
+      subscriptions: AgentSubscriptionSummary[];
+      contexts: Map<string, AgentSubscriptionAccessContext>;
+    }> = {},
+  ) => {
+    loadAccessContexts = jest.fn().mockReturnValue(of(params.contexts ?? new Map()));
+    const config = new ConfigServiceStub();
+    config.configuration = { portal: { apikeyHeader: 'X-Gravitee-Api-Key' } };
+
+    await TestBed.configureTestingModule({
+      imports: [AgentSubscriptionsComponent, MatIconTestingModule, AppTestingModule],
+      providers: [
+        provideRouter([]),
+        { provide: AgentSubscriptionService, useValue: { loadAccessContexts } },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AgentSubscriptionsComponent);
+    fixture.componentRef.setInput('agentName', params.agentName ?? 'Incident Commander');
+    fixture.componentRef.setInput('entrypointUrls', params.entrypointUrls ?? ['https://gw.test/agent']);
+    fixture.componentRef.setInput('subscriptions', params.subscriptions ?? [aSummary()]);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AgentSubscriptionsComponentHarness);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
+
+  it('renders one accordion item per subscription, in listing order', async () => {
+    await init({
+      subscriptions: [aSummary({ id: 'sub-1', planName: 'Gold' }), aSummary({ id: 'sub-2', planName: 'Silver', key: 'key-2' })],
+    });
+
+    expect(await harness.getPanelCount()).toBe(2);
+    expect(await harness.getHeaderTexts()).toEqual([
+      expect.objectContaining({ description: 'Gold - Accepted' }),
+      expect.objectContaining({ description: 'Silver - Accepted' }),
+    ]);
+  });
+
+  it('shows the plan name and capitalized status in the header', async () => {
+    await init({
+      subscriptions: [aSummary({ planName: 'Gold', status: 'ACCEPTED' })],
+    });
+
+    expect(await harness.getHeaderTexts()).toEqual([expect.objectContaining({ description: 'Gold - Accepted' })]);
+  });
+
+  it('hides the application name when there is only one subscription', async () => {
+    await init({
+      subscriptions: [aSummary({ applicationName: 'Ops App' })],
+    });
+
+    expect(await harness.getApplicationNameAt(0)).toBeNull();
+  });
+
+  it('shows the application name when there are multiple subscriptions', async () => {
+    await init({
+      subscriptions: [
+        aSummary({ id: 'sub-1', applicationName: 'First App' }),
+        aSummary({ id: 'sub-2', applicationName: 'Second App', key: 'key-2' }),
+      ],
+    });
+
+    expect(await harness.getApplicationNameAt(0)).toBe('First App');
+    await harness.expandAt(1);
+    expect(await harness.getApplicationNameAt(1)).toBe('Second App');
+  });
+
+  it('shows the API key of an accepted subscription', async () => {
+    await init({
+      subscriptions: [aSummary({ status: 'ACCEPTED', key: 'live-key-1' })],
+    });
+
+    expect(await harness.getAccessTextAt(0)).toContain('live-key-1');
+  });
+
+  it('shows a pending message and no key for a pending subscription', async () => {
+    await init({
+      subscriptions: [aSummary({ id: 'sub-pending', status: 'PENDING', key: 'hidden-key' })],
+    });
+
+    const text = await harness.getAccessTextAt(0);
+    expect(text).toContain('Subscription in progress');
+    expect(text).not.toContain('hidden-key');
+  });
+
+  it('emits newSubscription when New subscription is clicked', async () => {
+    await init();
+    const newSubscription = jest.fn();
+    fixture.componentInstance.newSubscription.subscribe(newSubscription);
+
+    await harness.clickNewSubscription();
+
+    expect(newSubscription).toHaveBeenCalled();
+  });
+
+  it('renders the client id of an OAUTH2 plan from the loaded context', async () => {
+    const oauth = aSummary({ id: 'sub-oauth', planSecurity: 'OAUTH2' });
+    await init({
+      subscriptions: [oauth],
+      contexts: new Map([['sub-oauth', { clientId: 'client-1', clientSecret: 'secret-1' }]]),
+    });
+
+    expect(await harness.getClientIdAt(0)).toBe('client-1');
+  });
+
+  it('links to the full subscription details page', async () => {
+    await init({
+      subscriptions: [aSummary({ id: 'sub-42' })],
+    });
+
+    expect(await harness.getDetailsHrefAt(0)).toBe('/dashboard/subscriptions/sub-42');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.component.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input, output } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { RouterLink } from '@angular/router';
+
+import { isActiveApiKey } from '../../entities/subscription';
+import { CapitalizeFirstPipe } from '../../pipe/capitalize-first.pipe';
+import {
+  AgentSubscriptionAccessContext,
+  AgentSubscriptionService,
+  AgentSubscriptionSummary,
+} from '../../services/agent-subscription.service';
+import { ConfigService } from '../../services/config.service';
+import { AgentAccessCardComponent } from '../agent-access-card/agent-access-card.component';
+
+@Component({
+  selector: 'app-agent-subscriptions',
+  imports: [MatButtonModule, MatExpansionModule, RouterLink, AgentAccessCardComponent, CapitalizeFirstPipe],
+  templateUrl: './agent-subscriptions.component.html',
+  styleUrl: './agent-subscriptions.component.scss',
+})
+export class AgentSubscriptionsComponent {
+  private readonly agentSubscriptionService = inject(AgentSubscriptionService);
+  private readonly configService = inject(ConfigService);
+
+  agentName = input.required<string>();
+  entrypointUrls = input<string[]>([]);
+  subscriptions = input.required<AgentSubscriptionSummary[]>();
+
+  newSubscription = output<void>();
+
+  protected readonly apiKeyHeader = this.configService.configuration.portal?.apikeyHeader ?? '';
+
+  private readonly contexts = rxResource<Map<string, AgentSubscriptionAccessContext>, AgentSubscriptionSummary[]>({
+    params: () => this.subscriptions(),
+    stream: ({ params }) => this.agentSubscriptionService.loadAccessContexts(params),
+  });
+
+  protected readonly showApplicationName = computed(() => this.subscriptions().length > 1);
+  protected readonly entrypointUrl = computed(() => this.entrypointUrls()[0] ?? '');
+  protected readonly rows = computed(() => {
+    const contexts = this.contexts.value() ?? new Map();
+    return this.subscriptions().map(summary => {
+      const usableKey = (summary.subscription.keys ?? []).find(key => !!key.key && isActiveApiKey(key));
+      return {
+        summary,
+        context: contexts.get(summary.subscription.id) ?? {},
+        apiKey: usableKey?.key ?? '',
+      };
+    });
+  });
+}

--- a/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/agent-subscriptions/agent-subscriptions.harness.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
+
+import { AgentAccessCardComponentHarness } from '../agent-access-card/agent-access-card.harness';
+
+export class AgentSubscriptionsComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-agent-subscriptions';
+
+  private readonly getPanels = this.locatorForAll(MatExpansionPanelHarness);
+  private readonly getNewSubscriptionButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="new-subscription-button"]' }),
+  );
+  private readonly getDetailsLinks = this.locatorForAll('[data-testid="subscription-details-link"]');
+
+  async getPanelCount(): Promise<number> {
+    return (await this.getPanels()).length;
+  }
+
+  async getHeaderTexts(): Promise<{ title: string | null; description: string | null }[]> {
+    const panels = await this.getPanels();
+    return Promise.all(
+      panels.map(async panel => ({
+        title: await panel.getTitle(),
+        description: await panel.getDescription(),
+      })),
+    );
+  }
+
+  async expandAt(index: number): Promise<void> {
+    await (await this.panelAt(index)).expand();
+  }
+
+  async getAccessTextAt(index: number): Promise<string> {
+    return (await this.panelAt(index)).getTextContent();
+  }
+
+  async getApplicationNameAt(index: number): Promise<string | null> {
+    const card = await this.cardAt(index);
+    return card ? card.getApplicationNameText() : null;
+  }
+
+  async getClientIdAt(index: number): Promise<string | null> {
+    const card = await this.cardAt(index);
+    return card ? card.getClientIdText() : null;
+  }
+
+  async clickNewSubscription(): Promise<void> {
+    await (await this.getNewSubscriptionButton()).click();
+  }
+
+  async getDetailsHrefAt(index: number): Promise<string | null> {
+    const links = await this.getDetailsLinks();
+    const link = links[index];
+    if (!link) {
+      throw new Error(`No details link at index ${index}`);
+    }
+    return link.getAttribute('href');
+  }
+
+  private async cardAt(index: number): Promise<AgentAccessCardComponentHarness | null> {
+    return (await this.panelAt(index)).getHarnessOrNull(AgentAccessCardComponentHarness);
+  }
+
+  private async panelAt(index: number): Promise<MatExpansionPanelHarness> {
+    const panels = await this.getPanels();
+    const panel = panels[index];
+    if (!panel) {
+      throw new Error(`No subscription panel at index ${index}`);
+    }
+    return panel;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api/api.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.ts
@@ -78,7 +78,7 @@ export interface Api {
 
 export type ApiType = 'NATIVE' | 'MESSAGE' | 'PROXY' | 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY';
 
-const AGENT_API_TYPES: ApiType[] = ['A2A_PROXY', 'MCP_PROXY', 'LLM_PROXY'];
+const AGENT_API_TYPES: readonly ApiType[] = ['A2A_PROXY', 'MCP_PROXY', 'LLM_PROXY'];
 
 export function isAgentApi(api: Pick<Api, 'type'> | undefined): boolean {
   return !!api?.type && AGENT_API_TYPES.includes(api.type);

--- a/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.spec.ts
@@ -16,13 +16,17 @@
 import { TestBed } from '@angular/core/testing';
 import { of, Subject, throwError } from 'rxjs';
 
-import { AgentSubscriptionService } from './agent-subscription.service';
+import { AgentSubscriptionService, AgentSubscriptionSummary } from './agent-subscription.service';
+import { ApplicationService } from './application.service';
 import { SubscriptionService } from './subscription.service';
+import { fakeApplication } from '../entities/application/application.fixture';
+import { PlanSecurityEnum } from '../entities/plan/plan';
 import { fakeSubscription, fakeSubscriptionResponse, Subscription, SubscriptionDataKeys } from '../entities/subscription';
 
 describe('AgentSubscriptionService', () => {
   let service: AgentSubscriptionService;
   let subscriptionService: { list: jest.Mock; get: jest.Mock };
+  let applicationService: { get: jest.Mock };
 
   const aKey = (key: string, applicationName: string, revoked = false): SubscriptionDataKeys => ({
     id: `${key}-id`,
@@ -33,12 +37,31 @@ describe('AgentSubscriptionService', () => {
 
   const accepted = (id: string, keys: SubscriptionDataKeys[]): Subscription => fakeSubscription({ id, status: 'ACCEPTED', keys });
 
-  const listing = (subscriptions: Subscription[]) => of(fakeSubscriptionResponse({ data: subscriptions }));
+  const pending = (id: string): Subscription => fakeSubscription({ id, status: 'PENDING', keys: [] });
+
+  const listing = (subscriptions: Subscription[], metadata: Record<string, { name?: string; securityType?: PlanSecurityEnum }> = {}) =>
+    of(fakeSubscriptionResponse({ data: subscriptions, metadata }));
+
+  const aSummary = (opts: { id?: string; application?: string; planSecurity?: PlanSecurityEnum } = {}): AgentSubscriptionSummary => ({
+    subscription: fakeSubscription({
+      id: opts.id ?? 'sub-1',
+      application: opts.application ?? 'app-1',
+      status: 'ACCEPTED',
+    }),
+    planName: 'Gold',
+    planSecurity: opts.planSecurity ?? 'API_KEY',
+    applicationName: 'My App',
+  });
 
   beforeEach(() => {
     subscriptionService = { list: jest.fn(), get: jest.fn() };
+    applicationService = { get: jest.fn() };
     TestBed.configureTestingModule({
-      providers: [AgentSubscriptionService, { provide: SubscriptionService, useValue: subscriptionService }],
+      providers: [
+        AgentSubscriptionService,
+        { provide: SubscriptionService, useValue: subscriptionService },
+        { provide: ApplicationService, useValue: applicationService },
+      ],
     });
     service = TestBed.inject(AgentSubscriptionService);
   });
@@ -48,17 +71,61 @@ describe('AgentSubscriptionService', () => {
     subscriptionService.get.mockReturnValue(of(accepted('sub-1', [aKey('key-1', 'My App')])));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toEqual({ apiKey: 'key-1' });
+      expect(access.chatCredentials).toEqual({ apiKey: 'key-1', applicationName: 'My App' });
       done();
     });
   });
 
-  it('asks only for accepted subscriptions of that agent', () => {
+  it('asks for accepted, pending and paused subscriptions of that agent', () => {
     subscriptionService.list.mockReturnValue(listing([]));
 
     service.findForAgent('agent-1').subscribe();
 
-    expect(subscriptionService.list).toHaveBeenCalledWith(expect.objectContaining({ apiIds: ['agent-1'], statuses: ['ACCEPTED'] }));
+    expect(subscriptionService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ apiIds: ['agent-1'], statuses: ['ACCEPTED', 'PENDING', 'PAUSED'] }),
+    );
+  });
+
+  it('describes each subscription with its plan and application from the listing metadata', done => {
+    const sub = accepted('sub-1', []);
+    subscriptionService.list.mockReturnValue(
+      listing([sub], {
+        [sub.plan]: { name: 'Gold', securityType: 'API_KEY' },
+        [sub.application]: { name: 'Portal App' },
+      }),
+    );
+    subscriptionService.get.mockReturnValue(of(accepted('sub-1', [aKey('key-1', 'Key App')])));
+
+    service.findForAgent('agent-1').subscribe(access => {
+      expect(access.subscriptions).toEqual([
+        expect.objectContaining({
+          planName: 'Gold',
+          planSecurity: 'API_KEY',
+          applicationName: 'Portal App',
+        }),
+      ]);
+      done();
+    });
+  });
+
+  it('reads keys only for accepted subscriptions', () => {
+    subscriptionService.list.mockReturnValue(listing([pending('sub-pending'), accepted('sub-accepted', [])]));
+    subscriptionService.get.mockReturnValue(of(accepted('sub-accepted', [aKey('key-1', 'My App')])));
+
+    service.findForAgent('agent-1').subscribe();
+
+    expect(subscriptionService.get).toHaveBeenCalledTimes(1);
+    expect(subscriptionService.get).toHaveBeenCalledWith('sub-accepted');
+  });
+
+  it('ignores a pending subscription when choosing the chat key', done => {
+    subscriptionService.list.mockReturnValue(listing([pending('sub-pending'), accepted('sub-2', [])]));
+    subscriptionService.get.mockReturnValue(of(accepted('sub-2', [aKey('key-2', 'Live App')])));
+
+    service.findForAgent('agent-1').subscribe(access => {
+      expect(access.chatCredentials).toEqual({ apiKey: 'key-2', applicationName: 'Live App' });
+      done();
+    });
   });
 
   it('skips a subscription whose key is revoked and takes the next usable one', done => {
@@ -68,16 +135,16 @@ describe('AgentSubscriptionService', () => {
     );
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toEqual({ apiKey: 'key-2' });
+      expect(access.chatCredentials).toEqual({ apiKey: 'key-2', applicationName: 'Live App' });
       done();
     });
   });
 
-  it('returns nothing when the viewer has no subscription', done => {
+  it('returns an empty result when the viewer has no subscription', done => {
     subscriptionService.list.mockReturnValue(listing([]));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toBeNull();
+      expect(access).toEqual({ subscriptions: [], chatCredentials: null });
       done();
     });
   });
@@ -87,39 +154,71 @@ describe('AgentSubscriptionService', () => {
     subscriptionService.get.mockReturnValue(of(accepted('sub-1', [])));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toBeNull();
+      expect(access.chatCredentials).toBeNull();
+      expect(access.subscriptions).toHaveLength(1);
       done();
     });
   });
 
-  it('returns nothing when the listing fails', done => {
+  it('returns an empty result when the listing fails', done => {
     subscriptionService.list.mockReturnValue(throwError(() => new Error('boom')));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toBeNull();
+      expect(access).toEqual({ subscriptions: [], chatCredentials: null });
       done();
     });
   });
 
   it('asks for every candidate at once rather than one after another', done => {
     subscriptionService.list.mockReturnValue(listing([accepted('sub-1', []), accepted('sub-2', [])]));
-    const pending = new Subject<Subscription>();
-    subscriptionService.get.mockReturnValue(pending);
+    const pendingGets = new Subject<Subscription>();
+    subscriptionService.get.mockReturnValue(pendingGets);
 
     service.findForAgent('agent-1').subscribe();
 
     expect(subscriptionService.get).toHaveBeenCalledTimes(2);
-    pending.complete();
+    pendingGets.complete();
     done();
   });
 
-  it('returns nothing when reading the only subscription fails', done => {
+  it('keeps the subscription in the list when reading its keys fails', done => {
     subscriptionService.list.mockReturnValue(listing([accepted('sub-1', [])]));
     subscriptionService.get.mockReturnValue(throwError(() => new Error('boom')));
 
     service.findForAgent('agent-1').subscribe(access => {
-      expect(access).toBeNull();
+      expect(access.subscriptions).toEqual([expect.objectContaining({ subscription: expect.objectContaining({ id: 'sub-1' }) })]);
+      expect(access.chatCredentials).toBeNull();
       done();
+    });
+  });
+
+  describe('loadAccessContexts', () => {
+    it('fetches client credentials only for an OAUTH2 plan', done => {
+      applicationService.get.mockReturnValue(
+        of(fakeApplication({ settings: { oauth: { client_id: 'client-1', client_secret: 'secret-1' } } })),
+      );
+
+      const oauth = aSummary({ id: 'sub-oauth', planSecurity: 'OAUTH2' });
+      const apiKey = aSummary({ id: 'sub-key', planSecurity: 'API_KEY' });
+
+      service.loadAccessContexts([oauth, apiKey]).subscribe(contexts => {
+        expect(applicationService.get).toHaveBeenCalledTimes(1);
+        expect(applicationService.get).toHaveBeenCalledWith(oauth.subscription.application);
+        expect(contexts.get('sub-oauth')).toEqual({
+          clientId: 'client-1',
+          clientSecret: 'secret-1',
+        });
+        expect(contexts.get('sub-key')).toEqual({});
+        done();
+      });
+    });
+
+    it('issues no application call for an empty list', done => {
+      service.loadAccessContexts([]).subscribe(contexts => {
+        expect(contexts.size).toBe(0);
+        expect(applicationService.get).not.toHaveBeenCalled();
+        done();
+      });
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-subscription.service.ts
@@ -16,44 +16,140 @@
 import { inject, Injectable } from '@angular/core';
 import { catchError, forkJoin, map, Observable, of, switchMap } from 'rxjs';
 
+import { ApplicationService } from './application.service';
 import { SubscriptionService } from './subscription.service';
-import { isActiveApiKey, Subscription } from '../entities/subscription';
+import { Application } from '../entities/application/application';
+import { PlanSecurityEnum } from '../entities/plan/plan';
+import { isActiveApiKey, Subscription, SubscriptionMetadata } from '../entities/subscription';
+
+export interface AgentSubscriptionSummary {
+  subscription: Subscription;
+  planName: string;
+  planSecurity: PlanSecurityEnum;
+  applicationName: string;
+}
+
+export interface AgentChatCredentials {
+  apiKey: string;
+  applicationName: string;
+}
 
 export interface AgentSubscriptionAccess {
-  apiKey: string;
+  subscriptions: AgentSubscriptionSummary[];
+  chatCredentials: AgentChatCredentials | null;
+}
+
+export interface AgentSubscriptionAccessContext {
+  clientId?: string;
+  clientSecret?: string;
 }
 
 const MAX_CANDIDATES = 10;
+const EMPTY_ACCESS: AgentSubscriptionAccess = { subscriptions: [], chatCredentials: null };
 
 @Injectable({
   providedIn: 'root',
 })
 export class AgentSubscriptionService {
   private readonly subscriptionService = inject(SubscriptionService);
+  private readonly applicationService = inject(ApplicationService);
 
-  findForAgent(apiId: string): Observable<AgentSubscriptionAccess | null> {
-    return this.subscriptionService.list({ apiIds: [apiId], statuses: ['ACCEPTED'], size: MAX_CANDIDATES }).pipe(
-      map(response => response.data ?? []),
-      // Only get() returns the keys, so each candidate needs its own call; they go out together
-      // rather than one after another, and the first usable one in listing order wins so the
-      // same key is used between visits.
-      switchMap(candidates =>
-        candidates.length
-          ? forkJoin(candidates.map(candidate => this.subscriptionService.get(candidate.id).pipe(catchError(() => of(null)))))
-          : of([]),
-      ),
-      map(subscriptions => subscriptions.map(subscription => (subscription ? this.accessFrom(subscription) : null)).find(Boolean) ?? null),
-      catchError(() => of(null)),
+  findForAgent(apiId: string): Observable<AgentSubscriptionAccess> {
+    return this.subscriptionService.list({ apiIds: [apiId], statuses: ['ACCEPTED', 'PENDING', 'PAUSED'], size: MAX_CANDIDATES }).pipe(
+      switchMap(response => {
+        const listed = response.data ?? [];
+        const metadata = response.metadata ?? {};
+        const accepted = listed.filter(candidate => candidate.status === 'ACCEPTED');
+        // Only get() returns the keys, so each accepted candidate needs its own call; they go
+        // out together rather than one after another. Pending and paused rows stay in the
+        // listing so the panel can show them, but they never carry keys.
+        const details$ = accepted.length
+          ? forkJoin(accepted.map(candidate => this.subscriptionService.get(candidate.id).pipe(catchError(() => of(null)))))
+          : of([] as (Subscription | null)[]);
+
+        return details$.pipe(map(details => this.accessFrom(listed, metadata, accepted, details)));
+      }),
+      catchError(() => of(EMPTY_ACCESS)),
     );
   }
 
-  private accessFrom(subscription: Subscription): AgentSubscriptionAccess | null {
-    const usableKey = (subscription.keys ?? []).find(key => !!key.key && isActiveApiKey(key));
-    if (!usableKey?.key) {
-      return null;
+  loadAccessContexts(summaries: AgentSubscriptionSummary[]): Observable<Map<string, AgentSubscriptionAccessContext>> {
+    if (!summaries.length) {
+      return of(new Map());
     }
+
+    return forkJoin(summaries.map(summary => this.contextFor(summary))).pipe(
+      map(contexts => new Map(summaries.map((summary, index) => [summary.subscription.id, contexts[index]]))),
+    );
+  }
+
+  private accessFrom(
+    listed: Subscription[],
+    metadata: SubscriptionMetadata,
+    accepted: Subscription[],
+    details: (Subscription | null)[],
+  ): AgentSubscriptionAccess {
+    const detailsById = new Map(accepted.map((candidate, index) => [candidate.id, details[index]]));
+    const subscriptions = listed.map(listedSub => {
+      const detailed = detailsById.get(listedSub.id);
+      return {
+        subscription: detailed ?? listedSub,
+        planName: metadata[listedSub.plan]?.name ?? '',
+        planSecurity: metadata[listedSub.plan]?.securityType ?? 'KEY_LESS',
+        applicationName: metadata[listedSub.application]?.name ?? '',
+      };
+    });
+
     return {
-      apiKey: usableKey.key,
+      subscriptions,
+      chatCredentials: this.chatCredentialsFrom(subscriptions),
     };
+  }
+
+  private chatCredentialsFrom(summaries: AgentSubscriptionSummary[]): AgentChatCredentials | null {
+    for (const summary of summaries) {
+      if (summary.subscription.status !== 'ACCEPTED') {
+        continue;
+      }
+      const usableKey = (summary.subscription.keys ?? []).find(key => !!key.key && isActiveApiKey(key));
+      if (usableKey?.key) {
+        return {
+          apiKey: usableKey.key,
+          applicationName: usableKey.application?.name ?? '',
+        };
+      }
+    }
+    return null;
+  }
+
+  private contextFor(summary: AgentSubscriptionSummary): Observable<AgentSubscriptionAccessContext> {
+    if (!this.needsClientCredentials(summary.planSecurity)) {
+      return of({});
+    }
+
+    return this.applicationService.get(summary.subscription.application).pipe(
+      map(application => this.clientCredentialsFrom(application)),
+      catchError(() => of({})),
+    );
+  }
+
+  private needsClientCredentials(planSecurity: PlanSecurityEnum): boolean {
+    return planSecurity === 'OAUTH2' || planSecurity === 'JWT';
+  }
+
+  private clientCredentialsFrom(application: Application | undefined): Pick<AgentSubscriptionAccessContext, 'clientId' | 'clientSecret'> {
+    if (!application) {
+      return {};
+    }
+    if (application.settings.oauth) {
+      return {
+        clientId: application.settings.oauth.client_id,
+        clientSecret: application.settings.oauth.client_secret,
+      };
+    }
+    if (application.settings.app) {
+      return { clientId: application.settings.app.client_id };
+    }
+    return {};
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-446

### Description

On an agent documentation page, a signed-in viewer who already has a subscription no longer sees only Subscribe. That button becomes Subscription and opens a side panel that lists their accepted, pending, and paused subscriptions so they can copy credentials or see that a request is still in progress, instead of starting another one by mistake.

The panel shows plan name and status, API key or OAuth client credentials when the subscription is accepted, a link to the full subscription page, and a New subscription action that still goes to the existing subscribe flow. Non-agent APIs keep the original Subscribe button.

### Changes

#### Documentation page

The documentation folder toolbar swaps Subscribe for Subscription once the viewer has at least one agent subscription. Opening it shows the new side panel. The panel closes when they leave the agent, and New subscription closes it then navigates to the subscribe route. Chat still uses an accepted API key; the subscriptions lookup now covers pending and paused rows as well.

#### Agent subscriptions panel

A new accordion lists each subscription in listing order. Accepted rows show copyable access details (API key, base URL, cURL; client id and secret for OAuth or JWT). Pending and paused rows show a status message and hide credentials. The application name appears only when there is more than one subscription.

#### Subscription access lookup

findForAgent now returns the full list plus optional chat credentials, never null. Keys are fetched only for accepted subscriptions. Client credentials for OAuth and JWT plans are loaded on demand when the panel opens.
