### PR TITLE
feat(ci): resolve the core version at build time, so the pin governs what is assembled

### DIFF
--- a/.ai/rules/apim-distribution-build.md
+++ b/.ai/rules/apim-distribution-build.md
@@ -13,7 +13,7 @@ Run Maven here with `-f gravitee-apim-distribution/pom.xml` — see the two-reac
 
 Three flags, each of which fails quietly rather than loudly:
 
-- **`-Pengine-snapshot`** — without it you assemble the pinned *released* engine instead of the working tree. The build succeeds and the change under test is simply absent.
+- **`-Dapim.core.version=<root triplet>`** — without it you assemble the pinned *released* core instead of the working tree. The build succeeds and the change under test is simply absent. `task build-distribution` computes the value for you.
 - **`-nsu`** — without it Maven may replace the engine you just installed with a timestamped snapshot from the remote. Same symptom, different route.
 - **`-Dbundle=dev`** — activates the profile adding the Cloud initializer and MCP libraries to `lib/`. That profile belongs to the gateway container, an external dependency here, so `-P` does not reach it; only the property activation does.
 

--- a/.ai/rules/apim-two-reactors.md
+++ b/.ai/rules/apim-two-reactors.md
@@ -17,4 +17,4 @@ Consequences for any Maven command:
 - `mvn -pl gravitee-apim-distribution/…` from the root fails with *Could not find the selected project in the reactor*. Use `-f gravitee-apim-distribution/pom.xml`; inside that reactor, `-pl` paths are relative to it.
 - Building the distribution takes two phases: install the engine first, then assemble against it. `task build-quick` does both.
 
-The distribution assembles a **pinned released** engine unless `-Pengine-snapshot` is passed. Leaving the profile out does not fail — it produces a distribution without the change under test. `task which-engine` prints which engine actually got bundled.
+The distribution assembles the **pinned released** core unless `-Dapim.core.version=<root triplet>` is passed. Leaving it out does not fail — it produces a distribution without the change under test. `task build-distribution` passes it for you, and `task which-engine` prints which core actually got bundled.

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -18,7 +18,7 @@ import { OpenJdkNodeExecutor } from '../../executors';
 import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, SyncFolderToS3Command } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
-import { parse } from '../../utils';
+import { computeApimVersion, parse } from '../../utils';
 
 export class BackendBuildAndPublishOnDownloadWebsiteJob {
   private static jobName = 'job-backend-build-and-publish-on-download-website';
@@ -63,11 +63,11 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-
         // reaches it; the property activation does. Without this the released zip and images ship
         // without those two jars, and no pull-request build would show it — job-build-backend
         // passes -Dbundle=dev and so activates the profile by property already.
-        // engine-snapshot resolves ${revision}${sha1}${changelist}, which the step above has just
-        // set to the version being released: the distribution ships the engine this build produced,
-        // not the one its pom is pinned to.
+        // The core version passed here is the root pom's, which the step above has just set to the
+        // version being released: the distribution ships the core this build produced, not the one
+        // its pom is pinned to.
         name: 'Maven build APIM distribution',
-        command: `mvn --settings ${config.maven.settingsFile} -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress`,
+        command: `mvn --settings ${config.maven.settingsFile} -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=${computeApimVersion(environment)} -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress`,
         environment: {
           BUILD_ID: environment.buildId,
           BUILD_NUMBER: environment.buildNum,

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -33,10 +33,49 @@ export class BackendBuildAndPublishOnDownloadWebsiteJob {
     const saveMavenJobCacheCommand = SaveMavenJobCacheCommand.get();
     dynamicConfig.addReusableCommand(saveMavenJobCacheCommand);
 
+    // Which line this release belongs to, computed here rather than in shell: the version is already
+    // parsed for the artefact paths below, and one parser is enough.
+    const { version: releasedVersion } = parse(environment.graviteeioVersion);
+    const releasedLine = `${releasedVersion.major}.${releasedVersion.minor}`;
+
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(restoreMavenJobCacheCommand, { jobName: BackendBuildAndPublishOnDownloadWebsiteJob.jobName }),
+      new commands.Run({
+        // First, before anything is built: placed after the engine build it fired half an hour into
+        // the release. Reading the pin needs no reactor and no installed artifact — the pom parents
+        // to the organisation pom with <relativePath/> — and the `versions:set -DremoveSnapshot`
+        // below only touches the project version, never this property.
+        //
+        // What replaces `Check both reactors carry the same version`. A SNAPSHOT is mutable, so a
+        // distribution assembled on one is not reproducible: the same tag rebuilt tomorrow would
+        // carry a different core. Read through Maven rather than parsed out of the pom — a parsing
+        // slip here would let a release through silently, which is the failure this exists to stop.
+        name: 'Refuse a core pin this release cannot assemble',
+        command: `PIN=$(mvn --settings ${config.maven.settingsFile} -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+echo "Releasing ${environment.graviteeioVersion}, which pins core $PIN"
+
+case "$PIN" in
+*-SNAPSHOT)
+  echo
+  echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+  echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+  exit 1
+  ;;
+esac
+
+# The pin may trail the release by a few patches — it moves only when someone decides a core is
+# ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+# freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+PIN_BASE=\${PIN%%-*}
+if [ "\${PIN_BASE%.*}" != "${releasedLine}" ]; then
+  echo
+  echo "core $PIN is not on the ${releasedLine} line, which ${environment.graviteeioVersion} releases."
+  echo "Release a ${releasedLine} core and merge the pull request that pins it, or fix the pin by hand."
+  exit 1
+fi`,
+      }),
       new commands.Run({
         // The distribution carries its own version properties now, so it needs the same treatment.
         name: 'Remove `-SNAPSHOT` from versions',

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -18,7 +18,7 @@ import { OpenJdkNodeExecutor } from '../../executors';
 import { PrepareGpgCmd, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, SyncFolderToS3Command } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
-import { computeApimVersion, parse } from '../../utils';
+import { parse } from '../../utils';
 
 export class BackendBuildAndPublishOnDownloadWebsiteJob {
   private static jobName = 'job-backend-build-and-publish-on-download-website';
@@ -63,11 +63,11 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" gravitee-apim-
         // reaches it; the property activation does. Without this the released zip and images ship
         // without those two jars, and no pull-request build would show it — job-build-backend
         // passes -Dbundle=dev and so activates the profile by property already.
-        // The core version passed here is the root pom's, which the step above has just set to the
-        // version being released: the distribution ships the core this build produced, not the one
-        // its pom is pinned to.
+        // Nothing overrides apim.core.version here, so the distribution assembles the core it pins.
+        // That is the whole point of pinning: what ships is what someone reviewed and chose, not
+        // whatever this build happened to compile.
         name: 'Maven build APIM distribution',
-        command: `mvn --settings ${config.maven.settingsFile} -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=${computeApimVersion(environment)} -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress`,
+        command: `mvn --settings ${config.maven.settingsFile} -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress`,
         environment: {
           BUILD_ID: environment.buildId,
           BUILD_NUMBER: environment.buildNum,

--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -19,6 +19,7 @@ import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
 import { computeApimVersion, mavenParallelism } from '../../utils';
+import { assemblesPinnedCore } from '../../workflows/groups/changed-files';
 
 export class BuildBackendJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
@@ -35,6 +36,12 @@ export class BuildBackendJob {
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
     dynamicConfig.addReusableCommand(installYarnCmd);
+
+    // A change that can only affect the distribution is assembled against the core it pins, not the
+    // one this branch is developing: the pull request that advances the pin would otherwise exercise
+    // something other than what merging it ships. The `Build engine` step above is then wasted work,
+    // which is worth removing on its own once this has settled.
+    const coreVersion = assemblesPinnedCore(environment.changedFiles) ? '' : ` -Dapim.core.version=${computeApimVersion(environment)}`;
 
     const steps: Command[] = [
       new commands.Checkout(),
@@ -57,7 +64,7 @@ export class BuildBackendJob {
         // Second phase: assemble against the engine just installed above, not the released one.
         // -nsu so a published snapshot cannot take its place.
         name: 'Build distribution',
-        command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=${computeApimVersion(environment)} -DwithJavadoc`,
+        command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -Dbundle=dev -Pintegration-tests-modules${coreVersion} -DwithJavadoc`,
         environment: {
           MAVEN_OPTS: '-Xmx2048m',
         },

--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -18,7 +18,7 @@ import { OpenJdkNodeExecutor } from '../../executors';
 import { InstallYarnCommand, NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { config } from '../../config';
 import { CircleCIEnvironment } from '../../pipelines';
-import { mavenParallelism } from '../../utils';
+import { computeApimVersion, mavenParallelism } from '../../utils';
 
 export class BuildBackendJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
@@ -57,7 +57,7 @@ export class BuildBackendJob {
         // Second phase: assemble against the engine just installed above, not the released one.
         // -nsu so a published snapshot cannot take its place.
         name: 'Build distribution',
-        command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc`,
+        command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')} -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=${computeApimVersion(environment)} -DwithJavadoc`,
         environment: {
           MAVEN_OPTS: '-Xmx2048m',
         },

--- a/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
@@ -17,7 +17,7 @@ import { Command, Config, Job, commands, reusable } from '../../circleci-config'
 import { OpenJdkNodeExecutor } from '../../executors';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { CircleCIEnvironment } from '../../pipelines';
-import { mavenParallelism } from '../../utils';
+import { computeApimVersion, mavenParallelism } from '../../utils';
 
 export class CommunityBuildBackendJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
@@ -40,10 +40,10 @@ export class CommunityBuildBackendJob {
       new commands.Run({
         // The distribution left the product reactor, so the root build above no longer reaches it.
         // Without this step the job stopped answering the question it exists for — whether an
-        // outside contributor can build what we ship. engine-snapshot points it at the engine just
-        // installed rather than at the pinned release.
+        // outside contributor can build what we ship. The core version is passed explicitly so it
+        // assembles the one just installed rather than the pinned release.
         name: 'Build distribution',
-        command: `mvn -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -Pengine-snapshot -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')}`,
+        command: `mvn -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -Dapim.core.version=${computeApimVersion(environment)} -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false ${mavenParallelism('large')}`,
       }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new reusable.ReusedCommand(saveMavenJobCacheCmd, { jobName: jobName }),

--- a/.circleci/ci/src/jobs/backend/job-test-integration.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-integration.ts
@@ -19,6 +19,7 @@ import { UbuntuExecutor } from '../../executors';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
 import { CircleCIEnvironment } from '../../pipelines';
 import { computeApimVersion } from '../../utils';
+import { assemblesPinnedCore } from '../../workflows/groups/changed-files';
 
 export class TestIntegrationJob {
   private static jobName = 'job-test-integration';
@@ -31,6 +32,9 @@ export class TestIntegrationJob {
     dynamicConfig.addReusableCommand(saveMavenJobCacheCmd);
     dynamicConfig.addReusableCommand(notifyOnFailureCmd);
     const executor = UbuntuExecutor.create();
+
+    // Same rule as job-build-backend: a distribution-only change is tested against the core it pins.
+    const coreVersion = assemblesPinnedCore(environment.changedFiles) ? '' : ` -Dapim.core.version=${computeApimVersion(environment)}`;
 
     const steps: Command[] = [
       new commands.Checkout(),
@@ -60,7 +64,7 @@ echo "Following test files will run on this executor:"
 cat tests-to-run
 
 # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=${computeApimVersion(environment)} -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300`,
+mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu${coreVersion} -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300`,
       }),
       new commands.Run({
         name: 'Save test results',

--- a/.circleci/ci/src/jobs/backend/job-test-integration.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-integration.ts
@@ -18,6 +18,7 @@ import { config } from '../../config';
 import { UbuntuExecutor } from '../../executors';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand, withJdk } from '../../commands';
 import { CircleCIEnvironment } from '../../pipelines';
+import { computeApimVersion } from '../../utils';
 
 export class TestIntegrationJob {
   private static jobName = 'job-test-integration';
@@ -59,7 +60,7 @@ echo "Following test files will run on this executor:"
 cat tests-to-run
 
 # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300`,
+mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=${computeApimVersion(environment)} -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300`,
       }),
       new commands.Run({
         name: 'Save test results',

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -47,31 +47,6 @@ export class ValidateJob {
         name: 'Validate distribution',
         command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules ${mavenParallelism('large')}`,
       }),
-      new commands.Run({
-        // The two reactors each carry a version triplet, and this holds them in step. It no longer
-        // guards what gets assembled — the core version is now passed explicitly, so the
-        // distribution's own triplet cannot pull in the wrong core — it only enforces a single
-        // lineage, which is what has to go before the two can be released apart.
-        name: 'Check both reactors carry the same version',
-        command: `triplet() {
-  rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-  chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-  # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-  sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-  echo "revision=$rev sha1=$sha changelist=$chg"
-}
-ROOT=$(triplet pom.xml)
-DIST=$(triplet gravitee-apim-distribution/pom.xml)
-echo "root:         $ROOT"
-echo "distribution: $DIST"
-if [ "$ROOT" != "$DIST" ]; then
-  echo
-  echo "The root pom and the distribution pom disagree on the version being built."
-  echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-  echo "job-release-commit-and-prepare-next-version."
-  exit 1
-fi`,
-      }),
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new reusable.ReusedCommand(saveMavenJobCacheCmd, { jobName: ValidateJob.jobName }),
     ];

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -39,19 +39,19 @@ export class ValidateJob {
         command: `mvn -s ${config.maven.settingsFile} validate -Dgravitee.archrules.skip=true --no-transfer-progress -Pall-modules ${mavenParallelism('large')}`,
       }),
       new commands.Run({
-        // Its own reactor, so validated separately. No engine-snapshot here: the profile makes the
-        // BOM import resolve ${revision}${sha1}${changelist}, and this step runs before anything is
-        // installed. It works only for as long as that snapshot happens to be on Nexus — right
-        // after a <revision> bump none exists, and validation would hard-fail on every pull request
-        // until the first publication. License and prettier do not care which engine is pinned.
+        // Its own reactor, so validated separately. The core version is left at whatever the pom
+        // pins: overriding it here would make the BOM import resolve a snapshot, and this step runs
+        // before anything is installed — right after a <revision> bump none exists, and validation
+        // would hard-fail on every pull request until the first publication. License and prettier do
+        // not care which core is pinned.
         name: 'Validate distribution',
         command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules ${mavenParallelism('large')}`,
       }),
       new commands.Run({
-        // The two reactors each carry a version triplet and they must stay in step: engine-snapshot
-        // resolves apim.core.version from the distribution's own properties, so a stale triplet
-        // does not fail — it resolves the previous version's snapshot from Nexus and quietly
-        // assembles the wrong engine. Cheap to check, expensive to notice otherwise.
+        // The two reactors each carry a version triplet, and this holds them in step. It no longer
+        // guards what gets assembled — the core version is now passed explicitly, so the
+        // distribution's own triplet cannot pull in the wrong core — it only enforces a single
+        // lineage, which is what has to go before the two can be released apart.
         name: 'Check both reactors carry the same version',
         command: `triplet() {
   rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -40,10 +40,13 @@ export class ValidateJob {
       }),
       new commands.Run({
         // Its own reactor, so validated separately. The core version is left at whatever the pom
-        // pins: overriding it here would make the BOM import resolve a snapshot, and this step runs
-        // before anything is installed — right after a <revision> bump none exists, and validation
-        // would hard-fail on every pull request until the first publication. License and prettier do
-        // not care which core is pinned.
+        // pins — license and prettier do not care which core it names, and this step runs before
+        // anything is installed, so the coordinate has to be one somebody publishes.
+        //
+        // On master that is the branch's own snapshot, republished on every merge. Elsewhere it is a
+        // release. What this depends on is that the pin never names a version nobody produces any
+        // more: a branch whose code freeze left the pin behind would make every pull request here
+        // rest on Nexus not purging a snapshot. BX-383 is what closes that.
         name: 'Validate distribution',
         command: `mvn -s ${config.maven.settingsFile} -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules ${mavenParallelism('large')}`,
       }),

--- a/.circleci/ci/src/jobs/index.ts
+++ b/.circleci/ci/src/jobs/index.ts
@@ -25,6 +25,7 @@ export * from './job-deploy-on-next-gen-integration';
 export * from './job-package-bundle';
 export * from './job-publish-pr-env-urls';
 export * from './job-publish-rpm-packages';
+export * from './job-pin-core';
 export * from './job-prepare-core-release';
 export * from './job-release-commit-and-prepare-next-version';
 export * from './job-release-notes-apim';

--- a/.circleci/ci/src/jobs/job-build-docker-image.ts
+++ b/.circleci/ci/src/jobs/job-build-docker-image.ts
@@ -233,7 +233,16 @@ export class BuildDockerChainguardFipsImageJob {
 }
 
 function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string[], isProd: boolean, variant?: Variant) {
-  let command = 'docker buildx build';
+  // The core version travels inside the distribution the assembly produced, so the label states what
+  // the image actually embeds rather than what a pom happened to pin at the time. Only the backend
+  // images declare the arg and ship that file; a UI context has neither, and nothing is passed.
+  let command = `CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+CORE_ARG=""
+if [ -f "$CORE_VERSION_FILE" ]; then
+  CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+  echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+fi
+docker buildx build`;
 
   let dockerfile = 'docker/Dockerfile';
   if (variant === 'debian') {
@@ -260,6 +269,7 @@ function dockerBuildCommand(environment: CircleCIEnvironment, dockerTags: string
     command += `--build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \\\n`;
   }
 
+  command += '${CORE_ARG} \\\n';
   command += `${dockerTags.map((t) => `-t ${t}`).join(' ')} \\\n`;
   command += `<< parameters.docker-context >>`;
 

--- a/.circleci/ci/src/jobs/job-pin-core.ts
+++ b/.circleci/ci/src/jobs/job-pin-core.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command, Config, Job, commands, reusable } from '../circleci-config';
+import { BaseExecutor } from '../executors';
+import { config } from '../config';
+import { orbs } from '../orbs';
+import { parse } from '../utils';
+import { CircleCIEnvironment } from '../pipelines';
+
+/**
+ * Opens the pull request that advances the distribution's pin onto the core just published.
+ *
+ * The pin never moves on its own: merging this is the moment someone decides a core is ready to
+ * ship. Leaving it unmerged costs nothing — the branch stays releasable on the core it already
+ * pins.
+ *
+ * There is no dry run here. This lane is reachable only from a pushed tag, and a tag forces
+ * `isDryRun` off — a tag is never a rehearsal. `prepare_core_release --dry-run` therefore rehearses
+ * the commit and the tag, and stops short of this.
+ */
+export class PinCoreJob {
+  private static jobName = 'job-pin-core';
+
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
+    dynamicConfig.importOrb(orbs.keeper);
+    dynamicConfig.importOrb(orbs.github);
+
+    const version = environment.graviteeioVersion;
+    const parsed = parse(version);
+    // The lane runs on a tag, where CIRCLE_BRANCH is empty, so the branch is derived from the
+    // version the way every release command already derives it: 4.13.0-alpha.1 comes from 4.13.x.
+    const branch = `${parsed.version.major}.${parsed.version.minor}.x`;
+    // Named after the branch it targets, never after the version: it is the same pull request being
+    // brought up to date, the way Renovate keeps one branch per dependency. Two support branches
+    // releasing at once would otherwise fight over one name.
+    const pinBranch = `chore/pin-core-${branch}`;
+
+    const steps: Command[] = [
+      new commands.Checkout(),
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.githubApiToken,
+        'var-name': 'GITHUB_TOKEN',
+      }),
+      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.gitUserName,
+        'var-name': 'GIT_USER_NAME',
+      }),
+      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
+        'secret-url': config.secrets.gitUserEmail,
+        'var-name': 'GIT_USER_EMAIL',
+      }),
+      new commands.Run({
+        name: 'Git config',
+        command: `git config --global user.name "\${GIT_USER_NAME}"
+git config --global user.email "\${GIT_USER_EMAIL}"
+gh auth setup-git
+git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}.git"`,
+      }),
+      new commands.Run({
+        name: `Pin core ${version} on ${branch}`,
+        command: `# The lane checked out the tag, and the branch has moved on since — it carries the commit
+# reopening the next development version. The pin has to be advanced there, not on the tag.
+# --no-track: a remote starting point sets an upstream on its own, and this branch is pushed
+# explicitly below.
+git fetch origin ${branch}
+git checkout -B ${pinBranch} --no-track origin/${branch}
+
+sed -i "s#<apim.core.version>.*</apim.core.version>#<apim.core.version>${version}</apim.core.version>#" gravitee-apim-distribution/pom.xml
+
+# The sed above no-ops if the property line ever changes shape, and an empty diff would then read
+# as "already pinned" and exit 0 on a pin that never moved. Assert the outcome, not the absence of
+# a change.
+if ! grep -q "<apim.core.version>${version}</apim.core.version>" gravitee-apim-distribution/pom.xml; then
+  echo "The pin was not set to ${version}. The property is not the shape this edit expects."
+  exit 1
+fi
+
+if git diff --quiet; then
+  echo "${branch} already pins ${version}, nothing to do."
+  exit 0
+fi
+
+git add --update
+git commit -m "chore(distribution): pin core ${version}"
+# Rebuilt from the base branch every time, so the push replaces whatever was there. A release that
+# lands before the previous pin was merged updates that pull request instead of opening a rival —
+# only the newest core is worth reviewing. Anything pushed onto this branch by hand goes with it.
+git push --force origin ${pinBranch}
+
+TITLE="chore(distribution): pin core ${version}"
+BODY="Core ${version} has been published. Merging this makes the distribution assemble it.
+
+Its integration tests run against the pinned core, so a green build here is the evidence that this core is ready to ship. Until it is merged, ${branch} keeps releasing on the core it already pins.
+
+This branch is rebuilt on every core release: a newer core replaces this one rather than opening a second pull request."
+
+if [ "$(gh pr list --head ${pinBranch} --state open --json number --jq 'length')" = "0" ]; then
+  gh pr create --base ${branch} --head ${pinBranch} --title "$TITLE" --body "$BODY"
+else
+  echo "A pin pull request is already open on ${pinBranch}, bringing it up to core ${version}."
+  gh pr edit ${pinBranch} --title "$TITLE" --body "$BODY"
+fi`,
+      }),
+    ];
+    return new Job(PinCoreJob.jobName, BaseExecutor.create(), steps);
+  }
+}

--- a/.circleci/ci/src/jobs/job-prepare-core-release.ts
+++ b/.circleci/ci/src/jobs/job-prepare-core-release.ts
@@ -62,26 +62,19 @@ git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIR
       }),
       new commands.Run({
         name: `Tag core ${environment.graviteeioVersion} ${environment.isDryRun ? '- Dry Run' : ''}`,
-        command: `# Both poms, even though only the root reactor is published here. \`Check both reactors carry
-# the same version\` runs on every pull request and exits 1 when the triplets differ, so moving the
-# root alone would redden the branch until the next full release. The two lineages part company only
-# once that check goes — until then they have to advance together.
-POMS="pom.xml gravitee-apim-distribution/pom.xml"
-for POM in \${POMS}; do
-  sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "\${POM}"
-done
+        command: `# Only the root pom. The distribution carries its own triplet and releases under its own tag;
+# what it assembles is its pin, which a reviewed pull request advances after this has published.
+sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
 
 git add --update
 git commit -m "${tag}"
 git tag ${tag}
 
-for POM in \${POMS}; do
-  sed -i "s#<revision>.*</revision>#<revision>${nextVersion}</revision>#" "\${POM}"
-  sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" "\${POM}"
-  # <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
-  # never matches — the qualifier was silently kept on any pom already holding the empty form.
-  sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1>${nextQualifier}</sha1>#" "\${POM}"
-done
+sed -i "s#<revision>.*</revision>#<revision>${nextVersion}</revision>#" pom.xml
+sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" pom.xml
+# <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
+# never matches — the qualifier was silently kept on any pom already holding the empty form.
+sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1>${nextQualifier}</sha1>#" pom.xml
 
 git add --update
 git commit -m 'chore: prepare next core version [skip ci]'

--- a/.circleci/ci/src/jobs/job-prepare-core-release.ts
+++ b/.circleci/ci/src/jobs/job-prepare-core-release.ts
@@ -65,7 +65,7 @@ git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIR
         command: `# Both poms, even though only the root reactor is published here. \`Check both reactors carry
 # the same version\` runs on every pull request and exits 1 when the triplets differ, so moving the
 # root alone would redden the branch until the next full release. The two lineages part company only
-# once engine-snapshot stops overriding the pin — until then they have to advance together.
+# once that check goes — until then they have to advance together.
 POMS="pom.xml gravitee-apim-distribution/pom.xml"
 for POM in \${POMS}; do
   sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "\${POM}"

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -78,9 +78,8 @@ git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIR
         name: `Git release ${environment.isDryRun ? '- Dry Run' : ''}`,
         command: `# Remove \`-SNAPSHOT\` from source
 # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-# and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-# it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-# Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+# and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+# branch until the next release puts them back in step.
 POMS="pom.xml gravitee-apim-distribution/pom.xml"
 for POM in \${POMS}; do
   sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "\${POM}"

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -77,8 +77,8 @@ git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIR
       new commands.Run({
         name: `Git release ${environment.isDryRun ? '- Dry Run' : ''}`,
         command: `# Remove \`-SNAPSHOT\` from source
-# Backend. Both poms: this releases the two reactors at once, so both carry the version being
-# released. The core lane moves the root alone, the distribution lane will move the other.
+# Backend. Both poms: this is the one command that releases the two reactors at once, so both
+# carry the version being released. The core lane moves the root alone.
 POMS="pom.xml gravitee-apim-distribution/pom.xml"
 for POM in \${POMS}; do
   sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "\${POM}"

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -77,9 +77,8 @@ git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIR
       new commands.Run({
         name: `Git release ${environment.isDryRun ? '- Dry Run' : ''}`,
         command: `# Remove \`-SNAPSHOT\` from source
-# Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-# and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-# branch until the next release puts them back in step.
+# Backend. Both poms: this releases the two reactors at once, so both carry the version being
+# released. The core lane moves the root alone, the distribution lane will move the other.
 POMS="pom.xml gravitee-apim-distribution/pom.xml"
 for POM in \${POMS}; do
   sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "\${POM}"

--- a/.circleci/ci/src/pipelines/tests/pipeline-bridge-compatibility-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-bridge-compatibility-tests.spec.ts
@@ -28,7 +28,7 @@ describe('Run bridge compatibility tests', () => {
       buildId: '1234',
       graviteeioVersion: '4.2.0',
       isDryRun: false,
-      apimVersionPath: '',
+      apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
     });
 
     const expected = fs.readFileSync(`./src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml`, 'utf-8');

--- a/.circleci/ci/src/pipelines/tests/pipeline-core-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-core-release.spec.ts
@@ -28,7 +28,7 @@ const environment: CircleCIEnvironment = {
   graviteeioVersion: '4.13.0',
   tag: 'core_4.13.0',
   isDryRun: false,
-  apimVersionPath: '',
+  apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
 };
 
 describe('Core release workflow tests', () => {

--- a/.circleci/ci/src/pipelines/tests/pipeline-core-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-core-release.spec.ts
@@ -39,6 +39,48 @@ describe('Core release workflow tests', () => {
     expect(result.stringify()).toStrictEqual(expected);
   });
 
+  it('should open the pinning pull request against the branch the version comes from', function () {
+    const generated = generateCoreReleaseConfig(environment).stringify();
+
+    expect(generated).toContain('git checkout -B chore/pin-core-4.13.x --no-track origin/4.13.x');
+    expect(generated).toContain('gh pr create --base 4.13.x --head chore/pin-core-4.13.x');
+  });
+
+  it('should name the branch after the base, so a second release updates the same pull request', function () {
+    const generated = generateCoreReleaseConfig({ ...environment, graviteeioVersion: '4.13.1', tag: 'core_4.13.1' }).stringify();
+
+    expect(generated).toContain('chore/pin-core-4.13.x');
+    expect(generated).not.toContain('chore/pin-core-4.13.1');
+  });
+
+  it('should update the open pull request rather than open a rival', function () {
+    const generated = generateCoreReleaseConfig(environment).stringify();
+
+    expect(generated).toContain('gh pr list --head chore/pin-core-4.13.x --state open');
+    expect(generated).toContain('gh pr edit chore/pin-core-4.13.x');
+    expect(generated).toContain('git push --force');
+  });
+
+  it('should advance the pin onto the version just published', function () {
+    expect(generateCoreReleaseConfig(environment).stringify()).toContain(
+      '<apim.core.version>4.13.0</apim.core.version>#" gravitee-apim-distribution/pom.xml',
+    );
+  });
+
+  it('should open it only after the core has been published', function () {
+    const generated = generateCoreReleaseConfig(environment).stringify();
+
+    expect(generated.indexOf('Open the pinning pull request')).toBeGreaterThan(generated.indexOf('Nexus staging'));
+  });
+
+  it('should refuse to believe a pin edit that did not take', function () {
+    const generated = generateCoreReleaseConfig(environment).stringify();
+
+    expect(generated.indexOf('grep -q "<apim.core.version>4.13.0</apim.core.version>"')).toBeLessThan(
+      generated.indexOf('git diff --quiet'),
+    );
+  });
+
   it('should throw when no tag started the pipeline', function () {
     expect(() => generateCoreReleaseConfig({ ...environment, tag: undefined })).toThrow(
       new Error('Core release is triggered by a tag, and no tag started this pipeline'),

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -17,6 +17,41 @@ import * as fs from 'fs';
 import { generateFullReleaseConfig } from '../pipeline-full-release';
 
 describe('Full release tests', () => {
+  const guardOf = (version: string) =>
+    generateFullReleaseConfig({
+      action: 'full_release',
+      baseBranch: 'master',
+      branch: 'master',
+      sha1: '784ff35ca',
+      changedFiles: [],
+      buildNum: '1234',
+      buildId: '1234',
+      graviteeioVersion: version,
+      isDryRun: false,
+      apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
+    }).stringify();
+
+  it('should refuse a core pin that is a SNAPSHOT', () => {
+    expect(guardOf('4.12.16')).toContain('A release cannot assemble a SNAPSHOT core');
+  });
+
+  it('should refuse a core pin from another version line', () => {
+    // The pin may trail by patches, so the comparison is on the line rather than on the version.
+    expect(guardOf('4.12.16')).toContain('"${PIN_BASE%.*}" != "4.12"');
+  });
+
+  it('should check the pin before anything is built', () => {
+    // Behind the engine build it fired roughly half an hour into the release, and a mispinned
+    // release is the expected first outcome after a code freeze.
+    const generated = guardOf('4.12.16');
+
+    expect(generated.indexOf('Refuse a core pin this release cannot assemble')).toBeLessThan(generated.indexOf('Maven build APIM engine'));
+  });
+
+  it('should take the line from a qualified version too', () => {
+    expect(guardOf('4.13.0-alpha.1')).toContain('"${PIN_BASE%.*}" != "4.13"');
+  });
+
   it.each`
     baseBranch | branch            | isDryRun | dockerTagAsLatest | graviteeioVersion   | apimVersionPath                                              | expectedResult
     ${'4.2.x'} | ${'4.2.x'}        | ${true}  | ${false}          | ${'4.2.0'}          | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-dry-run.yml'}

--- a/.circleci/ci/src/pipelines/tests/pipeline-integration-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-integration-tests.spec.ts
@@ -28,7 +28,7 @@ describe('Run Integration Tests', () => {
       buildId: '1234',
       graviteeioVersion: '4.2.0',
       isDryRun: false,
-      apimVersionPath: '',
+      apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
     });
 
     const expected = fs.readFileSync(`./src/pipelines/tests/resources/integration-tests/integration-tests.yml`, 'utf-8');

--- a/.circleci/ci/src/pipelines/tests/pipeline-prepare-core-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-prepare-core-release.spec.ts
@@ -61,10 +61,8 @@ describe('Prepare core release workflow tests', () => {
     expect(generated).toContain('<sha1>-alpha.2</sha1>');
   });
 
-  it('should advance both poms, which a pull request check requires to agree', function () {
-    const generated = tagStep(generatePrepareCoreReleaseConfig(environment));
-
-    expect(generated).toContain('POMS="pom.xml gravitee-apim-distribution/pom.xml"');
+  it('should leave the distribution pom alone, it releasing under its own tag', function () {
+    expect(tagStep(generatePrepareCoreReleaseConfig(environment))).not.toContain('gravitee-apim-distribution/pom.xml');
   });
 
   it('should push nothing on a dry run', function () {

--- a/.circleci/ci/src/pipelines/tests/pipeline-prepare-core-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-prepare-core-release.spec.ts
@@ -27,7 +27,7 @@ const environment: CircleCIEnvironment = {
   buildId: '1234',
   graviteeioVersion: '4.13.0',
   isDryRun: false,
-  apimVersionPath: '',
+  apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
 };
 
 const tagStep = (config: { stringify: () => string }) => config.stringify();

--- a/.circleci/ci/src/pipelines/tests/pipeline-repositories-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-repositories-tests.spec.ts
@@ -28,7 +28,7 @@ describe('Run Repositories Tests', () => {
       buildId: '1234',
       graviteeioVersion: '4.2.0',
       isDryRun: false,
-      apimVersionPath: '',
+      apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
     });
 
     const expected = fs.readFileSync(`./src/pipelines/tests/resources/repositories-tests/repositories-tests.yml`, 'utf-8');

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -193,7 +193,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -148,27 +148,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -104,6 +104,74 @@ jobs:
           command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots
       - cmd-save-maven-job-cache:
           jobName: job-nexus-staging
+  job-pin-core:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+          var-name: GITHUB_TOKEN
+      - gh/setup
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+          var-name: GIT_USER_NAME
+      - keeper/env-export:
+          secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+          var-name: GIT_USER_EMAIL
+      - run:
+          name: Git config
+          command: |-
+            git config --global user.name "${GIT_USER_NAME}"
+            git config --global user.email "${GIT_USER_EMAIL}"
+            gh auth setup-git
+            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+      - run:
+          name: Pin core 4.13.0 on 4.13.x
+          command: |-
+            # The lane checked out the tag, and the branch has moved on since — it carries the commit
+            # reopening the next development version. The pin has to be advanced there, not on the tag.
+            # --no-track: a remote starting point sets an upstream on its own, and this branch is pushed
+            # explicitly below.
+            git fetch origin 4.13.x
+            git checkout -B chore/pin-core-4.13.x --no-track origin/4.13.x
+
+            sed -i "s#<apim.core.version>.*</apim.core.version>#<apim.core.version>4.13.0</apim.core.version>#" gravitee-apim-distribution/pom.xml
+
+            # The sed above no-ops if the property line ever changes shape, and an empty diff would then read
+            # as "already pinned" and exit 0 on a pin that never moved. Assert the outcome, not the absence of
+            # a change.
+            if ! grep -q "<apim.core.version>4.13.0</apim.core.version>" gravitee-apim-distribution/pom.xml; then
+              echo "The pin was not set to 4.13.0. The property is not the shape this edit expects."
+              exit 1
+            fi
+
+            if git diff --quiet; then
+              echo "4.13.x already pins 4.13.0, nothing to do."
+              exit 0
+            fi
+
+            git add --update
+            git commit -m "chore(distribution): pin core 4.13.0"
+            # Rebuilt from the base branch every time, so the push replaces whatever was there. A release that
+            # lands before the previous pin was merged updates that pull request instead of opening a rival —
+            # only the newest core is worth reviewing. Anything pushed onto this branch by hand goes with it.
+            git push --force origin chore/pin-core-4.13.x
+
+            TITLE="chore(distribution): pin core 4.13.0"
+            BODY="Core 4.13.0 has been published. Merging this makes the distribution assemble it.
+
+            Its integration tests run against the pinned core, so a green build here is the evidence that this core is ready to ship. Until it is merged, 4.13.x keeps releasing on the core it already pins.
+
+            This branch is rebuilt on every core release: a newer core replaces this one rather than opening a second pull request."
+
+            if [ "$(gh pr list --head chore/pin-core-4.13.x --state open --json number --jq 'length')" = "0" ]; then
+              gh pr create --base 4.13.x --head chore/pin-core-4.13.x --title "$TITLE" --body "$BODY"
+            else
+              echo "A pin pull request is already open on chore/pin-core-4.13.x, bringing it up to core 4.13.0."
+              gh pr edit chore/pin-core-4.13.x --title "$TITLE" --body "$BODY"
+            fi
 workflows:
   core_release:
     jobs:
@@ -131,5 +199,19 @@ workflows:
             tags:
               only:
                 - /^core_(\d+\.\d+\.\d+(-[a-z]+\.\d+)?)$/
+      - job-pin-core:
+          context:
+            - cicd-orchestrator
+          name: Open the pinning pull request
+          requires:
+            - Nexus staging
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^core_(\d+\.\d+\.\d+(-[a-z]+\.\d+)?)$/
 orbs:
   keeper: gravitee-io/keeper@0.7.1
+  gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -610,9 +610,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-            # branch until the next release puts them back in step.
+            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
+            # released. The core lane moves the root alone, the distribution lane will move the other.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-alpha.1-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -586,9 +586,8 @@ jobs:
           command: |
             # Remove `-SNAPSHOT` from source
             # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+            # branch until the next release puts them back in step.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -486,6 +486,31 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
       - run:
+          name: Refuse a core pin this release cannot assemble
+          command: |-
+            PIN=$(mvn --settings .gravitee.settings.xml -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+            echo "Releasing 4.2.0-alpha.1, which pins core $PIN"
+
+            case "$PIN" in
+            *-SNAPSHOT)
+              echo
+              echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+              echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+              exit 1
+              ;;
+            esac
+
+            # The pin may trail the release by a few patches — it moves only when someone decides a core is
+            # ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+            # freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+            PIN_BASE=${PIN%%-*}
+            if [ "${PIN_BASE%.*}" != "4.2" ]; then
+              echo
+              echo "core $PIN is not on the 4.2 line, which 4.2.0-alpha.1 releases."
+              echo "Release a 4.2 core and merge the pull request that pins it, or fix the pin by hand."
+              exit 1
+            fi
+      - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
             mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -645,8 +645,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
-            # released. The core lane moves the root alone, the distribution lane will move the other.
+            # Backend. Both poms: this is the one command that releases the two reactors at once, so both
+            # carry the version being released. The core lane moves the root alone.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -345,7 +345,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -382,14 +389,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -427,7 +448,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -469,8 +497,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-alpha-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-alpha.1-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -645,8 +645,8 @@ jobs:
           name: Git release - Dry Run
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
-            # released. The core lane moves the root alone, the distribution lane will move the other.
+            # Backend. Both poms: this is the one command that releases the two reactors at once, so both
+            # carry the version being released. The core lane moves the root alone.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -610,9 +610,8 @@ jobs:
           name: Git release - Dry Run
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-            # branch until the next release puts them back in step.
+            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
+            # released. The core lane moves the root alone, the distribution lane will move the other.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -586,9 +586,8 @@ jobs:
           command: |
             # Remove `-SNAPSHOT` from source
             # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+            # branch until the next release puts them back in step.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -345,7 +345,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -382,14 +389,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -427,7 +448,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -469,8 +497,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -486,6 +486,31 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
       - run:
+          name: Refuse a core pin this release cannot assemble
+          command: |-
+            PIN=$(mvn --settings .gravitee.settings.xml -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+            echo "Releasing 4.2.0, which pins core $PIN"
+
+            case "$PIN" in
+            *-SNAPSHOT)
+              echo
+              echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+              echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+              exit 1
+              ;;
+            esac
+
+            # The pin may trail the release by a few patches — it moves only when someone decides a core is
+            # ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+            # freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+            PIN_BASE=${PIN%%-*}
+            if [ "${PIN_BASE%.*}" != "4.2" ]; then
+              echo
+              echo "core $PIN is not on the 4.2 line, which 4.2.0 releases."
+              echo "Release a 4.2 core and merge the pull request that pins it, or fix the pin by hand."
+              exit 1
+            fi
+      - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
             mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -646,8 +646,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
-            # released. The core lane moves the root alone, the distribution lane will move the other.
+            # Backend. Both poms: this is the one command that releases the two reactors at once, so both
+            # carry the version being released. The core lane moves the root alone.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -503,7 +503,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-hotfix.1-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -346,7 +346,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -383,14 +390,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1 -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1-debian -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -428,7 +449,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix.1-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2.0-hotfix-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -470,8 +498,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-hotfix.1-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-hotfix-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -487,6 +487,31 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
       - run:
+          name: Refuse a core pin this release cannot assemble
+          command: |-
+            PIN=$(mvn --settings .gravitee.settings.xml -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+            echo "Releasing 4.2.0-hotfix.1, which pins core $PIN"
+
+            case "$PIN" in
+            *-SNAPSHOT)
+              echo
+              echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+              echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+              exit 1
+              ;;
+            esac
+
+            # The pin may trail the release by a few patches — it moves only when someone decides a core is
+            # ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+            # freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+            PIN_BASE=${PIN%%-*}
+            if [ "${PIN_BASE%.*}" != "4.2" ]; then
+              echo
+              echo "core $PIN is not on the 4.2 line, which 4.2.0-hotfix.1 releases."
+              echo "Release a 4.2 core and merge the pull request that pins it, or fix the pin by hand."
+              exit 1
+            fi
+      - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
             mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -503,7 +503,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-hotfix.1-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -587,9 +587,8 @@ jobs:
           command: |
             # Remove `-SNAPSHOT` from source
             # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+            # branch until the next release puts them back in step.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -611,9 +611,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-            # branch until the next release puts them back in step.
+            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
+            # released. The core lane moves the root alone, the distribution lane will move the other.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -610,9 +610,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-            # branch until the next release puts them back in step.
+            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
+            # released. The core lane moves the root alone, the distribution lane will move the other.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -345,7 +345,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -382,14 +389,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 -t graviteeio/<< parameters.docker-image-name >>:4 -t graviteeio/<< parameters.docker-image-name >>:latest \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian -t graviteeio/<< parameters.docker-image-name >>:4-debian -t graviteeio/<< parameters.docker-image-name >>:latest-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -427,7 +448,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard -t graviteeio/<< parameters.docker-image-name >>:4-chainguard -t graviteeio/<< parameters.docker-image-name >>:latest-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -469,8 +497,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:latest-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -645,8 +645,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
-            # released. The core lane moves the root alone, the distribution lane will move the other.
+            # Backend. Both poms: this is the one command that releases the two reactors at once, so both
+            # carry the version being released. The core lane moves the root alone.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -586,9 +586,8 @@ jobs:
           command: |
             # Remove `-SNAPSHOT` from source
             # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+            # branch until the next release puts them back in step.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -486,6 +486,31 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
       - run:
+          name: Refuse a core pin this release cannot assemble
+          command: |-
+            PIN=$(mvn --settings .gravitee.settings.xml -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+            echo "Releasing 4.2.0, which pins core $PIN"
+
+            case "$PIN" in
+            *-SNAPSHOT)
+              echo
+              echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+              echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+              exit 1
+              ;;
+            esac
+
+            # The pin may trail the release by a few patches — it moves only when someone decides a core is
+            # ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+            # freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+            PIN_BASE=${PIN%%-*}
+            if [ "${PIN_BASE%.*}" != "4.2" ]; then
+              echo
+              echo "core $PIN is not on the 4.2 line, which 4.2.0 releases."
+              echo "Release a 4.2 core and merge the pull request that pins it, or fix the pin by hand."
+              exit 1
+            fi
+      - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
             mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -610,9 +610,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
-            # branch until the next release puts them back in step.
+            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
+            # released. The core lane moves the root alone, the distribution lane will move the other.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -345,7 +345,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -382,14 +389,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0 -t graviteeio/<< parameters.docker-image-name >>:4.2 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-debian -t graviteeio/<< parameters.docker-image-name >>:4.2-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -427,7 +448,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio/<< parameters.docker-image-name >>:4.2.0-chainguard -t graviteeio/<< parameters.docker-image-name >>:4.2-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -469,8 +497,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --quiet --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2.0-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.2-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -645,8 +645,8 @@ jobs:
           name: "Git release "
           command: |
             # Remove `-SNAPSHOT` from source
-            # Backend. Both poms: this releases the two reactors at once, so both carry the version being
-            # released. The core lane moves the root alone, the distribution lane will move the other.
+            # Backend. Both poms: this is the one command that releases the two reactors at once, so both
+            # carry the version being released. The core lane moves the root alone.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release,engine-snapshot -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"
@@ -586,9 +586,8 @@ jobs:
           command: |
             # Remove `-SNAPSHOT` from source
             # Backend. Both poms: since the reactor cut, the distribution carries its own version triplet,
-            # and engine-snapshot resolves apim.core.version from its properties, not the root's. Leaving
-            # it behind makes the two drift, and the drift is silent — the previous version's snapshot is on
-            # Nexus, so a later build resolves it and assembles the wrong engine instead of failing.
+            # and a CI check on every pull request requires the two to agree. Leaving one behind reddens the
+            # branch until the next release puts them back in step.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -502,7 +502,7 @@ jobs:
             GIT_COMMIT: 784ff35ca
       - run:
           name: Maven build APIM distribution
-          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dapim.core.version=4.2.0-SNAPSHOT -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
+          command: mvn --settings .gravitee.settings.xml -B -nsu -f gravitee-apim-distribution/pom.xml -P gio-release -Dbundle clean verify -DskipTests=true -Dskip.validation -Dgravitee.archrules.skip=true -T 4 --no-transfer-progress
           environment:
             BUILD_ID: "1234"
             BUILD_NUMBER: "1234"

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -486,6 +486,31 @@ jobs:
       - cmd-restore-maven-job-cache:
           jobName: job-backend-build-and-publish-on-download-website
       - run:
+          name: Refuse a core pin this release cannot assemble
+          command: |-
+            PIN=$(mvn --settings .gravitee.settings.xml -q -N -f gravitee-apim-distribution/pom.xml help:evaluate -Dexpression=apim.core.version -DforceStdout)
+            echo "Releasing 4.2.0, which pins core $PIN"
+
+            case "$PIN" in
+            *-SNAPSHOT)
+              echo
+              echo "A release cannot assemble a SNAPSHOT core: it is mutable, so this tag would not rebuild to"
+              echo "the same artefacts. Release the core first, then merge the pull request that pins it."
+              exit 1
+              ;;
+            esac
+
+            # The pin may trail the release by a few patches — it moves only when someone decides a core is
+            # ready — but never by a minor. A pin from another line is a hand-edit, or a branch whose code
+            # freeze never moved it off the previous line, and either ships a core nobody meant to ship.
+            PIN_BASE=${PIN%%-*}
+            if [ "${PIN_BASE%.*}" != "4.2" ]; then
+              echo
+              echo "core $PIN is not on the 4.2 line, which 4.2.0 releases."
+              echo "Release a 4.2 core and merge the pull request that pins it, or fix the pin by hand."
+              exit 1
+            fi
+      - run:
           name: Remove `-SNAPSHOT` from versions
           command: |-
             mvn -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/integration-tests/integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -228,7 +228,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -902,7 +902,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -939,14 +946,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -987,8 +1008,15 @@ jobs:
       - run:
           name: Build Chainguard FIPS docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
             --build-arg BASE_IMAGE=<< parameters.docker-fips-base-image >> \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard-fips -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard-fips \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nightly/nightly.yml
@@ -623,7 +623,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0-SNAPSHOT -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-
@@ -763,7 +763,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0-SNAPSHOT -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
@@ -57,7 +57,7 @@ jobs:
             # Both poms, even though only the root reactor is published here. `Check both reactors carry
             # the same version` runs on every pull request and exits 1 when the triplets differ, so moving the
             # root alone would redden the branch until the next full release. The two lineages part company only
-            # once engine-snapshot stops overriding the pin — until then they have to advance together.
+            # once that check goes — until then they have to advance together.
             POMS="pom.xml gravitee-apim-distribution/pom.xml"
             for POM in ${POMS}; do
               sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"

--- a/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
@@ -54,26 +54,19 @@ jobs:
       - run:
           name: "Tag core 4.13.0 "
           command: |
-            # Both poms, even though only the root reactor is published here. `Check both reactors carry
-            # the same version` runs on every pull request and exits 1 when the triplets differ, so moving the
-            # root alone would redden the branch until the next full release. The two lineages part company only
-            # once that check goes — until then they have to advance together.
-            POMS="pom.xml gravitee-apim-distribution/pom.xml"
-            for POM in ${POMS}; do
-              sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" "${POM}"
-            done
+            # Only the root pom. The distribution carries its own triplet and releases under its own tag;
+            # what it assembles is its pin, which a reviewed pull request advances after this has published.
+            sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
 
             git add --update
             git commit -m "core_4.13.0"
             git tag core_4.13.0
 
-            for POM in ${POMS}; do
-              sed -i "s#<revision>.*</revision>#<revision>4.13.1</revision>#" "${POM}"
-              sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" "${POM}"
-              # <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
-              # never matches — the qualifier was silently kept on any pom already holding the empty form.
-              sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1></sha1>#" "${POM}"
-            done
+            sed -i "s#<revision>.*</revision>#<revision>4.13.1</revision>#" pom.xml
+            sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" pom.xml
+            # <sha1 /> is self-closing when the qualifier is empty, which the plain <sha1>.*</sha1> pattern
+            # never matches — the qualifier was silently kept on any pom already holding the empty form.
+            sed -i -E "s#<sha1( */>|>[^<]*</sha1>)#<sha1></sha1>#" pom.xml
 
             git add --update
             git commit -m 'chore: prepare next core version [skip ci]'

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -314,7 +314,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -351,14 +358,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -175,7 +175,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -176,7 +176,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -315,7 +315,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -352,14 +359,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-branch-name-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -175,7 +175,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -314,7 +314,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -351,14 +358,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -314,7 +314,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -351,14 +358,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-debian -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -395,7 +416,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:4.1.x-784ff35-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -175,7 +175,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -305,7 +305,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -305,7 +305,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -164,7 +164,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-services-only.yml
@@ -119,27 +119,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -305,7 +305,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -305,7 +305,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -190,27 +190,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -235,7 +235,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-es-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -175,27 +175,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -220,7 +220,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -190,27 +190,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -235,7 +235,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -134,27 +134,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -179,7 +179,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -294,7 +294,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -249,27 +249,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -314,7 +314,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -351,14 +358,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-debian -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -395,7 +416,14 @@ jobs:
       - run:
           name: Build Chainguard docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.chainguard \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-latest-chainguard -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:master-784ff35-chainguard \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -175,7 +175,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -294,7 +294,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -249,27 +249,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -319,7 +319,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure
@@ -728,7 +728,7 @@ jobs:
             cat tests-to-run
 
             # Run tests with rerunFailingTestsCount=3 because some integration tests related to RabbitMQ or Websocket are randomly failing on the CI
-            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Pengine-snapshot -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
+            mvn --fail-fast -s ../../.gravitee.settings.xml test --no-transfer-progress -nsu -Dapim.core.version=4.2.0 -Dskip.validation=true -Dgravitee.archrules.skip=true -Dsurefire.excludesFile=/tmp/ignore_list -Dsurefire.rerunFailingTestsCount=3 -Dsurefire.exitTimeout=300
       - run:
           name: Save test results
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -874,7 +874,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -1023,14 +1030,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-1234-run-e2e-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -274,27 +274,6 @@ jobs:
       - run:
           name: Validate distribution
           command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml validate -nsu -Dgravitee.archrules.skip=true --no-transfer-progress -Pintegration-tests-modules -T 8
-      - run:
-          name: Check both reactors carry the same version
-          command: |-
-            triplet() {
-              rev=$(grep -o '<revision>[^<]*</revision>' "$1" | head -1 | sed -E 's#</?revision>##g')
-              chg=$(grep -o '<changelist>[^<]*</changelist>' "$1" | head -1 | sed -E 's#</?changelist>##g')
-              # <sha1 /> and <sha1></sha1> mean the same thing; normalise both to the empty string.
-              sha=$(grep -oE '<sha1 */>|<sha1>[^<]*</sha1>' "$1" | head -1 | sed -E 's#<sha1 */>##; s#</?sha1>##g')
-              echo "revision=$rev sha1=$sha changelist=$chg"
-            }
-            ROOT=$(triplet pom.xml)
-            DIST=$(triplet gravitee-apim-distribution/pom.xml)
-            echo "root:         $ROOT"
-            echo "distribution: $DIST"
-            if [ "$ROOT" != "$DIST" ]; then
-              echo
-              echo "The root pom and the distribution pom disagree on the version being built."
-              echo "Both must be bumped together — see release/code-freeze/_common.sh and"
-              echo "job-release-commit-and-prepare-next-version."
-              exit 1
-            fi
       - cmd-notify-on-failure
       - cmd-save-maven-job-cache:
           jobName: job-validate

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -166,7 +166,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -176,7 +176,7 @@ jobs:
             MAVEN_OPTS: -Xmx2048m
       - run:
           name: Build distribution
-          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pengine-snapshot,integration-tests-modules -DwithJavadoc
+          command: mvn -s .gravitee.settings.xml -f gravitee-apim-distribution/pom.xml clean install --no-transfer-progress -nsu -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=false -T 8 -Dbundle=dev -Pintegration-tests-modules -Dapim.core.version=4.2.0 -DwithJavadoc
           environment:
             MAVEN_OPTS: -Xmx2048m
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -292,7 +292,14 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
@@ -329,14 +336,28 @@ jobs:
       - run:
           name: Build docker image for << parameters.apim-project >>-alpine
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-784ff35 \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>
       - run:
           name: Build docker image for << parameters.apim-project >>-debian
           command: |-
+            CORE_VERSION_FILE="<< parameters.docker-context >>/distribution/core.version"
+            CORE_ARG=""
+            if [ -f "$CORE_VERSION_FILE" ]; then
+              CORE_ARG="--build-arg CORE_VERSION=$(cat "$CORE_VERSION_FILE")"
+              echo "This image embeds core $(cat "$CORE_VERSION_FILE")"
+            fi
             docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.debian \
+            ${CORE_ARG} \
             -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:apim-xxx-test-784ff35-debian \
             << parameters.docker-context >>
           working_directory: << parameters.apim-project-workdir >>

--- a/.circleci/ci/src/workflows/groups/changed-files.ts
+++ b/.circleci/ci/src/workflows/groups/changed-files.ts
@@ -197,3 +197,26 @@ export function shouldTestRestApi(changedFiles: string[]): boolean {
     changedFiles.some((file) => mavenProjectsIdentifiers.some((identifier) => file.includes(identifier)))
   );
 }
+
+/**
+ * Whether a change can only affect the distribution, and should therefore be assembled against the
+ * core it pins rather than the one this branch is developing.
+ *
+ * The pull request that advances the pin is the case this exists for: built against the branch's
+ * core it would exercise something other than what merging it ships, and go green having proved
+ * nothing. An empty list means the changed files are unknown — a master or support-branch build —
+ * and those keep assembling the branch's own core.
+ *
+ * It is deliberately no narrower than the whole reactor, because it cannot be: `keepFirstPathItem`
+ * reduces every path to its first segment before it reaches here, so a change to the integration
+ * tests and a change to the pom arrive as the same string. A test-only change is therefore in scope,
+ * and on a support branch it runs against the pinned core rather than the branch's — which is what
+ * the distribution will ship, so it is the more honest of the two answers anyway.
+ */
+export function assemblesPinnedCore(changedFiles: string[]): boolean {
+  const distribution = 'gravitee-apim-distribution';
+  // Anchored rather than `includes`, unlike the predicates above: a false positive here assembles a
+  // core the change is not about, so a sibling directory whose name merely starts the same way must
+  // not match.
+  return changedFiles.length > 0 && changedFiles.every((file) => file === distribution || file.startsWith(`${distribution}/`));
+}

--- a/.circleci/ci/src/workflows/groups/tests/changed-files.spec.ts
+++ b/.circleci/ci/src/workflows/groups/tests/changed-files.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { assemblesPinnedCore } from '../changed-files';
+
+describe('assemblesPinnedCore', () => {
+  // What production actually hands over: `keepFirstPathItem` has already reduced every path to its
+  // first segment, so these lists never contain a separator. The nested forms below are the fixture
+  // convention, kept because the predicate is anchored and has to stay so.
+  it('assembles the pin when only the distribution changed', () => {
+    expect(assemblesPinnedCore(['gravitee-apim-distribution'])).toBe(true);
+  });
+
+  it('accepts a nested path too, which the reduction upstream never produces', () => {
+    expect(assemblesPinnedCore(['gravitee-apim-distribution/pom.xml'])).toBe(true);
+  });
+
+  it('assembles the branch core as soon as anything outside the distribution changed', () => {
+    expect(assemblesPinnedCore(['gravitee-apim-distribution/pom.xml', 'gravitee-apim-gateway/pom.xml'])).toBe(false);
+  });
+
+  it('assembles the branch core when the changed files are unknown', () => {
+    // A master or support-branch build: index.ts hands over an empty list rather than a diff, and
+    // `every` on an empty array would otherwise say the change is distribution-only.
+    expect(assemblesPinnedCore([])).toBe(false);
+  });
+
+  it('does not mistake a sibling path for the distribution', () => {
+    expect(assemblesPinnedCore(['gravitee-apim-distribution-something/pom.xml'])).toBe(false);
+  });
+});

--- a/.circleci/ci/src/workflows/workflow-core-release.ts
+++ b/.circleci/ci/src/workflows/workflow-core-release.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Config, Workflow, workflow } from '../circleci-config';
-import { NexusStagingJob, SetupJob } from '../jobs';
+import { NexusStagingJob, PinCoreJob, SetupJob } from '../jobs';
 import { CircleCIEnvironment } from '../pipelines';
 import { config } from '../config';
 import { CORE_TAG_FILTER } from '../utils';
@@ -46,6 +46,9 @@ export class WorkflowCoreRelease {
     const nexusStagingJob = NexusStagingJob.create(dynamicConfig, environment, environment.tag);
     dynamicConfig.addJob(nexusStagingJob);
 
+    const pinCoreJob = PinCoreJob.create(dynamicConfig, environment);
+    dynamicConfig.addJob(pinCoreJob);
+
     return new Workflow(WorkflowCoreRelease.workflowName, [
       new workflow.WorkflowJob(setupJob, { context: config.jobContext, name: 'Setup', filters: WorkflowCoreRelease.tagOnly }),
 
@@ -53,6 +56,15 @@ export class WorkflowCoreRelease {
         context: config.jobContext,
         name: 'Nexus staging',
         requires: ['Setup'],
+        filters: WorkflowCoreRelease.tagOnly,
+      }),
+
+      // After publication, never before: the pull request's integration tests resolve the core it
+      // pins, and that core has to exist by then.
+      new workflow.WorkflowJob(pinCoreJob, {
+        context: config.jobContext,
+        name: 'Open the pinning pull request',
+        requires: ['Nexus staging'],
         filters: WorkflowCoreRelease.tagOnly,
       }),
     ]);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Consequences for any Maven command:
 - Building the distribution takes two phases: install the engine first, then assemble against it. `task build-quick` does both.
 - After a `clean install` fails or is interrupted (especially with `-T`, parallel reactor builds), a later scoped `mvn test`/`mvn -pl <module> test` **without `clean`** silently compiles against stale `target/classes` left by modules that never finished rebuilding — producing "cannot find symbol"/"constructor cannot be applied" errors that look like a broken annotation processor (e.g. Lombok) but aren't. Re-run a full `clean install` covering every changed reactor module before trusting a scoped test run.
 
-The distribution assembles a **pinned released** engine unless `-Pengine-snapshot` is passed. Leaving the profile out does not fail — it produces a distribution without the change under test. `task which-engine` prints which engine actually got bundled.
+The distribution assembles the **pinned released** core unless `-Dapim.core.version=<root triplet>` is passed. Leaving it out does not fail — it produces a distribution without the change under test. `task build-distribution` passes it for you, and `task which-engine` prints which core actually got bundled.
 
 # Modules
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -21,10 +21,10 @@ env:
   DOCKER_TAG: '{{.DOCKER_TAG | default "local"}}'
 
 tasks:
-  # The distribution is a reactor of its own and assembles a released engine by default. Anything
-  # that has to run YOUR engine therefore takes two steps: install it, then assemble against it with
-  # the engine-snapshot profile. These tasks do that in order — prefer them over calling mvn by hand,
-  # or you will quietly assemble the released engine and wonder where your changes went.
+  # The distribution is a reactor of its own and assembles the released core it pins by default.
+  # Anything that has to run YOUR core therefore takes two steps: install it, then assemble against
+  # it by passing the version explicitly. These tasks do that in order — prefer them over calling mvn
+  # by hand, or you will quietly assemble the released core and wonder where your changes went.
 
   build-quick:
     desc: "Build management-api & gateway quickly without running tests & validations steps"
@@ -39,10 +39,16 @@ tasks:
 
   build-distribution:
     desc: "Assemble the distribution against the engine currently installed locally"
+    vars:
+      # The root reactor's version, which is what `build-engine` has just installed. Read from Maven
+      # rather than parsed out of the pom: the version is a triplet of properties, and Maven is the
+      # one thing guaranteed to compose it the same way the build will.
+      CORE_VERSION:
+        sh: mvn -q -N help:evaluate -Dexpression=project.version -DforceStdout
     cmds:
       # -nsu: do not go looking for a newer snapshot upstream. You have just built the engine; a
       # published snapshot must not silently take its place.
-      - mvn -f gravitee-apim-distribution/pom.xml clean install -Pengine-snapshot -nsu -DskipTests -Dskip.validation -Dbundle=dev -T 1C
+      - mvn -f gravitee-apim-distribution/pom.xml clean install -Dapim.core.version={{.CORE_VERSION}} -nsu -DskipTests -Dskip.validation -Dbundle=dev -T 1C
       - task: which-engine
 
   which-engine:
@@ -62,13 +68,16 @@ tasks:
     desc: "Run all tests in gravitee-apim-distribution/gravitee-apim-distribution-integration-tests"
     env:
       JDK_JAVA_OPTIONS: -XX:+MaxFDLimit
+    vars:
+      CORE_VERSION:
+        sh: mvn -q -N help:evaluate -Dexpression=project.version -DforceStdout
     cmds:
-      # Installing the engine first is what makes these tests exercise your working tree: with the
-      # engine-snapshot profile and nothing installed, Maven would happily pull the published snapshot.
+      # Installing the engine first is what makes these tests exercise your working tree: asking for
+      # that version with nothing installed, Maven would happily pull the published snapshot.
       - task: build-engine
-      - mvn -f gravitee-apim-distribution/pom.xml -T2C -nsu -pl gravitee-apim-distribution-integration-tests -am clean install -Pengine-snapshot,integration-tests-modules -Dskip.validation=true -DskipTests -Dbundle=dev -Dmaven.test.skip
+      - mvn -f gravitee-apim-distribution/pom.xml -T2C -nsu -pl gravitee-apim-distribution-integration-tests -am clean install -Pintegration-tests-modules -Dapim.core.version={{.CORE_VERSION}} -Dskip.validation=true -DskipTests -Dbundle=dev -Dmaven.test.skip
       - ulimit -n 102400
-      - mvn -f gravitee-apim-distribution/pom.xml -fae -nsu -pl gravitee-apim-distribution-integration-tests install -Pengine-snapshot,integration-tests-modules -Dbundle=dev
+      - mvn -f gravitee-apim-distribution/pom.xml -fae -nsu -pl gravitee-apim-distribution-integration-tests install -Pintegration-tests-modules -Dapim.core.version={{.CORE_VERSION}} -Dbundle=dev
 
   docker:
     desc: "Build all 🐳 images"

--- a/gravitee-apim-distribution/AGENTS.md
+++ b/gravitee-apim-distribution/AGENTS.md
@@ -76,6 +76,8 @@ Bundled plugin versions live in `gravitee-apim-distribution/pom.xml` — bumping
 
 The two reactors carry their own `<revision>`/`<sha1>`/`<changelist>` and no longer have to agree. Which core the distribution assembles is decided by `apim.core.version` — its pin — or by the `-Dapim.core.version` a build passes, never by its own triplet.
 
+The assembled distribution carries a `core.version` file at its root, filtered at assembly time, so what shipped can be read back from the bundle. The gateway and rest-api images publish the same value as the OCI label `io.gravitee.core.version`.
+
 # APIM Java Conventions
 
 - **Formatter:** Google Java Style via the Maven Prettier plugin — run `mvn prettier:write -pl <module>` on every module you changed.

--- a/gravitee-apim-distribution/AGENTS.md
+++ b/gravitee-apim-distribution/AGENTS.md
@@ -58,7 +58,7 @@ Run Maven here with `-f gravitee-apim-distribution/pom.xml` — see the two-reac
 
 Three flags, each of which fails quietly rather than loudly:
 
-- **`-Pengine-snapshot`** — without it you assemble the pinned *released* engine instead of the working tree. The build succeeds and the change under test is simply absent.
+- **`-Dapim.core.version=<root triplet>`** — without it you assemble the pinned *released* core instead of the working tree. The build succeeds and the change under test is simply absent. `task build-distribution` computes the value for you.
 - **`-nsu`** — without it Maven may replace the engine you just installed with a timestamped snapshot from the remote. Same symptom, different route.
 - **`-Dbundle=dev`** — activates the profile adding the Cloud initializer and MCP libraries to `lib/`. That profile belongs to the gateway container, an external dependency here, so `-P` does not reach it; only the property activation does.
 

--- a/gravitee-apim-distribution/AGENTS.md
+++ b/gravitee-apim-distribution/AGENTS.md
@@ -74,7 +74,7 @@ Its parent is `io.gravitee:gravitee-parent`, the organisation pom — not `gravi
 
 Bundled plugin versions live in `gravitee-apim-distribution/pom.xml` — bumping one is a one-line change that does not touch the engine's build.
 
-Both reactors must keep the same `<revision>`/`<sha1>`/`<changelist>`. A CI step fails the build when they diverge, because a stale triplet resolves the previous version's snapshot from Nexus instead of failing.
+The two reactors carry their own `<revision>`/`<sha1>`/`<changelist>` and no longer have to agree. Which core the distribution assembles is decided by `apim.core.version` — its pin — or by the `-Dapim.core.version` a build passes, never by its own triplet.
 
 # APIM Java Conventions
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
@@ -76,6 +76,8 @@ Bundled plugin versions live in `gravitee-apim-distribution/pom.xml` — bumping
 
 The two reactors carry their own `<revision>`/`<sha1>`/`<changelist>` and no longer have to agree. Which core the distribution assembles is decided by `apim.core.version` — its pin — or by the `-Dapim.core.version` a build passes, never by its own triplet.
 
+The assembled distribution carries a `core.version` file at its root, filtered at assembly time, so what shipped can be read back from the bundle. The gateway and rest-api images publish the same value as the OCI label `io.gravitee.core.version`.
+
 # APIM Java Conventions
 
 - **Formatter:** Google Java Style via the Maven Prettier plugin — run `mvn prettier:write -pl <module>` on every module you changed.

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
@@ -58,7 +58,7 @@ Run Maven here with `-f gravitee-apim-distribution/pom.xml` — see the two-reac
 
 Three flags, each of which fails quietly rather than loudly:
 
-- **`-Pengine-snapshot`** — without it you assemble the pinned *released* engine instead of the working tree. The build succeeds and the change under test is simply absent.
+- **`-Dapim.core.version=<root triplet>`** — without it you assemble the pinned *released* core instead of the working tree. The build succeeds and the change under test is simply absent. `task build-distribution` computes the value for you.
 - **`-nsu`** — without it Maven may replace the engine you just installed with a timestamped snapshot from the remote. Same symptom, different route.
 - **`-Dbundle=dev`** — activates the profile adding the Cloud initializer and MCP libraries to `lib/`. That profile belongs to the gateway container, an external dependency here, so `-P` does not reach it; only the property activation does.
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/AGENTS.md
@@ -74,7 +74,7 @@ Its parent is `io.gravitee:gravitee-parent`, the organisation pom — not `gravi
 
 Bundled plugin versions live in `gravitee-apim-distribution/pom.xml` — bumping one is a one-line change that does not touch the engine's build.
 
-Both reactors must keep the same `<revision>`/`<sha1>`/`<changelist>`. A CI step fails the build when they diverge, because a stale triplet resolves the previous version's snapshot from Nexus instead of failing.
+The two reactors carry their own `<revision>`/`<sha1>`/`<changelist>` and no longer have to agree. Which core the distribution assembles is decided by `apim.core.version` — its pin — or by the `-Dapim.core.version` a build passes, never by its own triplet.
 
 # APIM Java Conventions
 

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/observability/ObservabilityEntrypointsDistributionTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/observability/ObservabilityEntrypointsDistributionTest.java
@@ -185,10 +185,7 @@ class ObservabilityEntrypointsDistributionTest {
                     }
                 }
                 if (dirs.isEmpty()) {
-                    return fail(
-                        "No assembled distribution under %s. Assemble it first: mvn -f gravitee-apim-distribution/pom.xml install -Pengine-snapshot -DskipTests -Dbundle=dev",
-                        root
-                    );
+                    return fail("No assembled distribution under %s. Assemble it first: task build-distribution", root);
                 }
                 return dirs;
             }

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile
@@ -32,7 +32,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile.chainguard
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile.chainguard
@@ -71,7 +71,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile.debian
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/docker/Dockerfile.debian
@@ -33,7 +33,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base-debian
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/assembly/plugin-assembly-distribution.xml
@@ -119,6 +119,22 @@
                 <exclude>*</exclude>
             </excludes>
         </fileSet>
+
+        <!--
+            Which core this distribution embeds. Once the product version and the core version stop
+            being the same number, nothing published would tell support what is actually running.
+            Filtered, so it carries the version the build resolved rather than the one the pom pins:
+            a development build overrides it, and the file has to say what was really assembled.
+        -->
+        <fileSet>
+            <directory>src/main/resources/metadata</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>core.version</include>
+            </includes>
+            <fileMode>644</fileMode>
+            <filtered>true</filtered>
+        </fileSet>
     </fileSets>
 
     <dependencySets>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/metadata/core.version
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-gateway/src/main/resources/metadata/core.version
@@ -1,0 +1,1 @@
+${apim.core.version}

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile
@@ -27,7 +27,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile.chainguard
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile.chainguard
@@ -65,7 +65,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile.debian
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/docker/Dockerfile.debian
@@ -27,7 +27,11 @@ RUN chgrp -R 0 ${GRAVITEEIO_HOME} && \
 
 # Third stage to build the final docker image. COPY preserves ownership & permissions
 FROM base
+# The core this image embeds, which stops being the image's own version once the two reactors
+# release apart. Declared in this stage on purpose: an ARG before the first FROM does not reach it.
+ARG CORE_VERSION=unknown
 LABEL maintainer="contact@graviteesource.com"
+LABEL io.gravitee.core.version="${CORE_VERSION}"
 COPY --from=builder ${GRAVITEEIO_HOME} ${GRAVITEEIO_HOME}
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8083

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/assembly/plugin-assembly-distribution.xml
@@ -128,6 +128,22 @@
             </includes>
             <fileMode>755</fileMode>
         </fileSet>
+
+        <!--
+            Which core this distribution embeds. Once the product version and the core version stop
+            being the same number, nothing published would tell support what is actually running.
+            Filtered, so it carries the version the build resolved rather than the one the pom pins:
+            a development build overrides it, and the file has to say what was really assembled.
+        -->
+        <fileSet>
+            <directory>src/main/resources/metadata</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>core.version</include>
+            </includes>
+            <fileMode>644</fileMode>
+            <filtered>true</filtered>
+        </fileSet>
     </fileSets>
 
     <dependencySets>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/metadata/core.version
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/gravitee-apim-distribution-standalone-rest-api/src/main/resources/metadata/core.version
@@ -1,0 +1,1 @@
+${apim.core.version}

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
@@ -2851,28 +2851,5 @@
                 <!-- </dependency>-->
             </dependencies>
         </profile>
-        <profile>
-            <id>gravitee-release</id>
-            <activation>
-                <property>
-                    <name>gravitee-release</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <!-- don't build the full distribution when releasing -->
-                                <id>make-distribution</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -49,9 +49,12 @@
     <properties>
         <!--
             The distribution carries its own CI-friendly version properties: gravitee-parent does not
-            define them, and this reactor now sets its own version. Kept in step with the engine for
-            now — the two release together — which is what makes a later split of the two cadences a
-            change of these three lines rather than a restructuring.
+            define them, and this reactor sets its own version. It no longer has to agree with the
+            core's: a core release moves the root pom alone, and what this reactor assembles is the
+            apim.core.version below, never its own triplet.
+
+            The two still move together in a full release, which is the one command releasing both
+            reactors at once. That ends when the distribution gets a lane of its own.
         -->
         <revision>4.13.0</revision>
         <sha1 />

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -58,18 +58,21 @@
         <changelist>-SNAPSHOT</changelist>
 
         <!--
-            The APIM engine this distribution assembles: a released version, so the distribution can
-            be built and released on its own — a plugin bump needs no engine release.
+            The APIM core this distribution assembles.
 
-            Advancing it is the deliberate act of shipping a new engine, reviewed like any other
-            change. Bump it when a new engine version is released.
+            On a support branch it holds a released version, so the distribution can be built and
+            released on its own — a plugin bump needs no core release. Advancing it is the
+            deliberate act of shipping a new core, reviewed like any other change.
+
+            Here on master it tracks this branch's own version, and the -SNAPSHOT is what keeps
+            master structurally unreleasable: a release refuses a SNAPSHOT pin, a mutable core
+            being one that would not rebuild to the same artefacts.
 
             Development and pull-request builds override it on the command line, with
-            -Dapim.core.version=<root triplet>, to assemble the core currently being worked on.
-            Building without that override assembles the released core, which is what a release
-            does and almost never what you want locally — the Taskfile handles it for you.
+            -Dapim.core.version=<root triplet>, to assemble the core currently being worked on —
+            the Taskfile handles it for you.
         -->
-        <apim.core.version>4.12.14</apim.core.version>
+        <apim.core.version>4.13.0-SNAPSHOT</apim.core.version>
 
         <!--
             Versions shared with the engine. They are declared here as well because the distribution

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -64,10 +64,10 @@
             Advancing it is the deliberate act of shipping a new engine, reviewed like any other
             change. Bump it when a new engine version is released.
 
-            Development and pull-request builds do not use this value: they activate the
-            engine-snapshot profile below to assemble the engine currently being worked on. Building
-            without that profile assembles the released engine, which is what a release does and
-            almost never what you want locally — the Taskfile handles it for you.
+            Development and pull-request builds override it on the command line, with
+            -Dapim.core.version=<root triplet>, to assemble the core currently being worked on.
+            Building without that override assembles the released core, which is what a release
+            does and almost never what you want locally — the Taskfile handles it for you.
         -->
         <apim.core.version>4.12.14</apim.core.version>
 
@@ -454,19 +454,6 @@
     </modules>
 
     <profiles>
-        <!--
-            Assemble the engine as it currently stands rather than the released one. Used by local
-            development and by pull-request CI, so that a change to the engine is actually exercised
-            by what gets assembled and tested. Requires that engine to be installed first — the
-            Taskfile does both steps in order.
-        -->
-        <profile>
-            <id>engine-snapshot</id>
-            <properties>
-                <apim.core.version>${revision}${sha1}${changelist}</apim.core.version>
-            </properties>
-        </profile>
-
         <!--
             The integration tests moved here with the rest of the verification layer. Opt-in, as they
             were under the root pom and under the same profile id, so that assembling a distribution

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -99,7 +99,7 @@ Before triggering anything, the command checks two things, both read-only, so th
 
 `--dry-run` runs the same job with the pushes disarmed. It is the only rehearsal this lane has: a tag cannot be pushed provisionally.
 
-Both poms are advanced, even though only the root reactor is published. `Check both reactors carry the same version` runs on every pull request and fails when the triplets differ, so moving the root alone would redden the branch until the next full release. The two lineages will part company only once that check goes away.
+Only the root pom is advanced. The distribution carries its own triplet and releases under its own tag, so a core release leaves it where it is.
 
 What a core release never touches is `apim.core.version` — the version of the core the distribution assembles. Advancing that pin is a separate, reviewed change: it is the moment someone decides a core is ready to ship. Renovate opens it on its own, as an ordinary dependency update.
 

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -97,7 +97,7 @@ Before triggering anything, the command checks two things, both read-only, so th
 * the version matches the poms of the branch it will release from — the same check `full_release` makes;
 * `core_4.13.0` does not already exist. An existing tag means that version has already been released, and pushing it again fails halfway — after the branch has been committed to and reopened on the next version, a state that has to be unwound by hand.
 
-`--dry-run` runs the same job with the pushes disarmed. It is the only rehearsal this lane has: a tag cannot be pushed provisionally.
+`--dry-run` runs the same job with the pushes disarmed, which is as far as a rehearsal goes here: a tag cannot be pushed provisionally, so what it rehearses is the commit, the tag and the bump — not the publication, and not the pull request that follows it.
 
 Only the root pom is advanced. The distribution carries its own triplet and releases under its own tag, so a core release leaves it where it is.
 

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -99,7 +99,7 @@ Before triggering anything, the command checks two things, both read-only, so th
 
 `--dry-run` runs the same job with the pushes disarmed. It is the only rehearsal this lane has: a tag cannot be pushed provisionally.
 
-Both poms are advanced, even though only the root reactor is published. `Check both reactors carry the same version` runs on every pull request and fails when the triplets differ, so moving the root alone would redden the branch until the next full release. The two lineages will part company only once `engine-snapshot` stops overriding the pin at build time.
+Both poms are advanced, even though only the root reactor is published. `Check both reactors carry the same version` runs on every pull request and fails when the triplets differ, so moving the root alone would redden the branch until the next full release. The two lineages will part company only once that check goes away.
 
 What a core release never touches is `apim.core.version` — the version of the core the distribution assembles. Advancing that pin is a separate, reviewed change: it is the moment someone decides a core is ready to ship. Renovate opens it on its own, as an ordinary dependency update.
 

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -99,9 +99,11 @@ Before triggering anything, the command checks two things, both read-only, so th
 
 `--dry-run` runs the same job with the pushes disarmed, which is as far as a rehearsal goes here: a tag cannot be pushed provisionally, so what it rehearses is the commit, the tag and the bump — not the publication, and not the pull request that follows it.
 
-Only the root pom is advanced. The distribution carries its own triplet and releases under its own tag, so a core release leaves it where it is.
+Only the root pom is advanced. The distribution carries its own triplet, so a core release leaves it where it is; `full_release` is still what releases it, until it gets a lane of its own.
 
-What a core release never touches is `apim.core.version` — the version of the core the distribution assembles. Advancing that pin is a separate, reviewed change: it is the moment someone decides a core is ready to ship. Renovate opens it on its own, as an ordinary dependency update.
+What a core release never touches is `apim.core.version` — the version of the core the distribution assembles. Advancing that pin is a separate, reviewed change: it is the moment someone decides a core is ready to ship.
+
+The release lane opens that pull request itself, once the core is published, and brings it up to date on every later core release rather than opening a second one. Merging it is the decision; leaving it costs nothing, the branch keeping the core it already pins.
 
 == Hotfixes
 

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -18,7 +18,7 @@ Three things, and they are not the same thing.
 | After releasing, the branch is bumped to the next version. `4.12.18` leaves it at `4.12.19-SNAPSHOT`; a qualified version like `4.13.0-alpha.1` leaves it at `4.13.0-alpha.2-SNAPSHOT`.
 |===
 
-The second row is the one that surprises people, so the command checks it: before triggering anything it reads the root pom of the branch it is about to release from, and refuses when the two disagree. Without that check the tag would say one thing and the artefacts another, and nothing downstream would notice.
+The second row is the one that surprises people, so the command checks it: before triggering anything it reads the poms of the branch it is about to release from, and refuses when they disagree with `--version`. Without that check the tag would say one thing and the artefacts another, and nothing downstream would notice. `full_release` releases both reactors, so it requires both poms to carry the version; a core release moves the root alone, so it only reads that one.
 
 == Setup
 
@@ -94,7 +94,7 @@ The tag is prefixed because *the product keeps the bare version*: `4.13.0` names
 
 Before triggering anything, the command checks two things, both read-only, so they refuse in a second rather than after a pipeline has spun up:
 
-* the version matches the poms of the branch it will release from — the same check `full_release` makes;
+* the version matches the root pom of the branch it will release from — the same check `full_release` makes, narrowed to the one reactor this lane moves;
 * `core_4.13.0` does not already exist. An existing tag means that version has already been released, and pushing it again fails halfway — after the branch has been committed to and reopened on the next version, a state that has to be unwound by hand.
 
 `--dry-run` runs the same job with the pushes disarmed, which is as far as a rehearsal goes here: a tag cannot be pushed provisionally, so what it rehearses is the commit, the tag and the bump — not the publication, and not the pull request that follows it.

--- a/release/code-freeze/_common.sh
+++ b/release/code-freeze/_common.sh
@@ -30,8 +30,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 POM_FILE="$REPO_ROOT/pom.xml"
 # The distribution carries its own <revision>/<sha1>/<changelist> since it left the product
-# reactor. Both triplets must stay in step while a CI check enforces it, which is what the
-# release scripts assume; that check goes away when the two reactors start releasing apart.
+# reactor. The two no longer have to agree; what the distribution assembles is its own
+# apim.core.version, which a code freeze has to move onto a released core.
 DISTRIBUTION_POM_FILE="$REPO_ROOT/gravitee-apim-distribution/pom.xml"
 PARENT_DIR="$(dirname "$REPO_ROOT")"
 

--- a/release/code-freeze/_common.sh
+++ b/release/code-freeze/_common.sh
@@ -30,9 +30,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 POM_FILE="$REPO_ROOT/pom.xml"
 # The distribution carries its own <revision>/<sha1>/<changelist> since it left the product
-# reactor. Both triplets must stay in step: engine-snapshot resolves apim.core.version from
-# the distribution's own properties, and a stale value resolves an older snapshot from Nexus
-# instead of failing, so the drift would be silent.
+# reactor. Both triplets must stay in step while a CI check enforces it, which is what the
+# release scripts assume; that check goes away when the two reactors start releasing apart.
 DISTRIBUTION_POM_FILE="$REPO_ROOT/gravitee-apim-distribution/pom.xml"
 PARENT_DIR="$(dirname "$REPO_ROOT")"
 

--- a/release/code-freeze/_common.sh
+++ b/release/code-freeze/_common.sh
@@ -30,8 +30,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 POM_FILE="$REPO_ROOT/pom.xml"
 # The distribution carries its own <revision>/<sha1>/<changelist> since it left the product
-# reactor. The two no longer have to agree; what the distribution assembles is its own
-# apim.core.version, which a code freeze has to move onto a released core.
+# reactor, and the two no longer have to agree. What it assembles is its own apim.core.version.
+#
+# These scripts do NOT touch that pin, and they need to: a branch cut from master inherits master's
+# SNAPSHOT pin and cannot release until a core is released and its pinning pull request merged,
+# while master keeps pinning a version it stops publishing as soon as <revision> moves on.
+# Until BX-383 lands, both are gestures someone has to remember.
+# https://gravitee.atlassian.net/browse/BX-383
 DISTRIBUTION_POM_FILE="$REPO_ROOT/gravitee-apim-distribution/pom.xml"
 PARENT_DIR="$(dirname "$REPO_ROOT")"
 

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -5,6 +5,15 @@ export function isDryRun() {
 const HOTFIX_QUALIFIER = /-hotfix\.\d+$/;
 
 /**
+ * Whether a version is released from a branch cut off a tag rather than from its support line.
+ * @param {string} version
+ * @returns {boolean}
+ */
+export function isHotfixVersion(version) {
+  return HOTFIX_QUALIFIER.test(version);
+}
+
+/**
  * Branch the release runs on: the one --branch names, otherwise the one the version implies.
  *
  * That is not always versions.branch. A hotfix runs on the branch cut from the tag it fixes, while

--- a/release/helpers/version-helper.mjs
+++ b/release/helpers/version-helper.mjs
@@ -73,26 +73,71 @@ export function versionFromPom(pomXml) {
  * @param {string} version the version passed to the command
  * @param {string} branch the branch the release will run on
  */
-export async function assertVersionMatchesPom(version, branch) {
+export const ROOT_POM = 'pom.xml';
+export const DISTRIBUTION_POM = 'gravitee-apim-distribution/pom.xml';
+
+async function readPom(pom, branch) {
   // The contents API rather than raw.githubusercontent.com: the latter is served with a five-minute
   // cache, long enough for a release started right after a version bump to read the previous pom and
   // refuse a correct release. This is cached for one minute, and `Accept: raw` returns the file
   // itself rather than a base64 envelope, so the same parsing applies.
-  const url = `https://api.github.com/repos/gravitee-io/gravitee-api-management/contents/pom.xml?ref=${branch}`;
+  const url = `https://api.github.com/repos/gravitee-io/gravitee-api-management/contents/${pom}?ref=${branch}`;
   const response = await fetch(url, { headers: { Accept: 'application/vnd.github.raw' } });
+  if (response.status === 404) {
+    return undefined;
+  }
   if (!response.ok) {
-    console.log(chalk.red(`Cannot read pom.xml on '${branch}': ${response.status} ${response.statusText}`));
+    console.log(chalk.red(`Cannot read ${pom} on '${branch}': ${response.status} ${response.statusText}`));
     console.log(`Checked ${url}`);
     process.exit(1);
   }
+  return response.text();
+}
 
-  const published = versionFromPom(await response.text());
-  if (published !== version) {
-    console.log(chalk.red(`'${branch}' publishes ${published}, not ${version}.`));
-    console.log(`The published version comes from the poms; --version only names the tag. Fix the poms, or release ${published}.`);
-    console.log(chalk.yellow(`If you have just pushed a version bump, wait a minute: this reads GitHub through a one-minute cache.`));
-    process.exit(1);
+/**
+ * Refuses a version that the poms of `branch` do not publish.
+ *
+ * They are two independent inputs and nothing downstream reconciles them: the artefacts carry what
+ * the poms say, the git tag carries what --version says. A mismatch therefore ships one version
+ * under the name of another, without failing anywhere.
+ *
+ * Which poms to check is the caller's decision, because it depends on what is being released. A
+ * release of both reactors has to find the version in both — the product's published name comes
+ * from the distribution's triplet, not the root's — while a core release moves the root alone and
+ * leaves the distribution where it is on purpose.
+ * @param {string} version the version passed to the command
+ * @param {string} branch the branch the release will run on
+ * @param {string[]} poms the poms that have to carry it
+ */
+export async function assertVersionMatchesPoms(version, branch, poms) {
+  const published = {};
+  for (const pom of poms) {
+    const content = await readPom(pom, branch);
+    // The distribution only carries a triplet of its own where the reactor was cut; elsewhere it
+    // inherits the root's, and there is nothing separate to check.
+    if (content === undefined || !/<revision>/.test(content)) {
+      console.log(chalk.yellow(`Skipped ${pom}: it inherits the root version on '${branch}'.`));
+      continue;
+    }
+    published[pom] = versionFromPom(content);
   }
+
+  const wrong = Object.entries(published).filter(([, v]) => v !== version);
+  if (wrong.length === 0) {
+    return;
+  }
+
+  for (const [pom, v] of wrong) {
+    console.log(chalk.red(`'${branch}' publishes ${v} from ${pom}, not ${version}.`));
+  }
+  const distinct = new Set(Object.values(published));
+  if (distinct.size > 1) {
+    console.log(`The two reactors have drifted apart. Both have to carry the version being released, so set them together.`);
+  } else {
+    console.log(`The published version comes from the poms; --version only names the tag. Fix the poms, or release ${[...distinct][0]}.`);
+  }
+  console.log(chalk.yellow(`If you have just pushed a version bump, wait a minute: this reads GitHub through a one-minute cache.`));
+  process.exit(1);
 }
 
 /**

--- a/release/helpers/version-helper.test.mjs
+++ b/release/helpers/version-helper.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
-import { assertCoreTagIsFree, versionFromPom } from './version-helper.mjs';
+import { DISTRIBUTION_POM, ROOT_POM, assertCoreTagIsFree, assertVersionMatchesPoms, versionFromPom } from './version-helper.mjs';
 
 const pom = (properties) => `<project>
   <artifactId>gravitee-api-management</artifactId>
@@ -86,5 +86,78 @@ describe('assertCoreTagIsFree', () => {
     stub(500);
 
     await assert.rejects(() => assertCoreTagIsFree('4.13.0'), { message: 'exit 1' });
+  });
+});
+
+describe('assertVersionMatchesPoms', () => {
+  const realFetch = globalThis.fetch;
+  const realChalk = globalThis.chalk;
+  const realExit = process.exit;
+
+  const pom = (version) => `<project><properties>
+  <revision>${version}</revision><sha1 /><changelist>-SNAPSHOT</changelist>
+</properties></project>`;
+
+  /** Serves a pom per path; anything absent from the map answers 404, as GitHub would. */
+  function stub(poms) {
+    const asked = [];
+    globalThis.fetch = async (url) => {
+      const path = decodeURIComponent(url.split('/contents/')[1].split('?')[0]);
+      asked.push(path);
+      const body = poms[path];
+      return body === undefined ? { ok: false, status: 404, statusText: 'Not Found' } : { ok: true, status: 200, text: async () => body };
+    };
+    globalThis.chalk = { red: (s) => s, yellow: (s) => s };
+    process.exit = (code) => {
+      throw new Error(`exit ${code}`);
+    };
+    return asked;
+  }
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    globalThis.chalk = realChalk;
+    process.exit = realExit;
+  });
+
+  it('passes when every pom asked for carries the version', async () => {
+    const asked = stub({ 'pom.xml': pom('4.12.16'), 'gravitee-apim-distribution/pom.xml': pom('4.12.16') });
+
+    await assertVersionMatchesPoms('4.12.16', '4.12.x', [ROOT_POM, DISTRIBUTION_POM]);
+
+    assert.deepEqual(asked, ['pom.xml', 'gravitee-apim-distribution/pom.xml']);
+  });
+
+  it('refuses when the distribution lags behind the root, which a core release makes it do', async () => {
+    stub({ 'pom.xml': pom('4.12.16'), 'gravitee-apim-distribution/pom.xml': pom('4.12.15') });
+
+    await assert.rejects(() => assertVersionMatchesPoms('4.12.16', '4.12.x', [ROOT_POM, DISTRIBUTION_POM]), { message: 'exit 1' });
+  });
+
+  it('refuses the root version too, which is what the old check already caught', async () => {
+    stub({ 'pom.xml': pom('4.12.16'), 'gravitee-apim-distribution/pom.xml': pom('4.12.16') });
+
+    await assert.rejects(() => assertVersionMatchesPoms('4.12.15', '4.12.x', [ROOT_POM, DISTRIBUTION_POM]), { message: 'exit 1' });
+  });
+
+  it('ignores the distribution on a branch where it inherits the root version', async () => {
+    // Only master carries a triplet there; a support branch has the file without a <revision>.
+    stub({ 'pom.xml': pom('4.11.9'), 'gravitee-apim-distribution/pom.xml': '<project/>' });
+
+    await assertVersionMatchesPoms('4.11.9', '4.11.x', [ROOT_POM, DISTRIBUTION_POM]);
+  });
+
+  it('ignores a distribution pom the branch does not have at all', async () => {
+    stub({ 'pom.xml': pom('4.10.30') });
+
+    await assertVersionMatchesPoms('4.10.30', '4.10.x', [ROOT_POM, DISTRIBUTION_POM]);
+  });
+
+  it('reads the root alone for a core release, the distribution staying behind on purpose', async () => {
+    const asked = stub({ 'pom.xml': pom('4.13.0'), 'gravitee-apim-distribution/pom.xml': pom('4.12.14') });
+
+    await assertVersionMatchesPoms('4.13.0', '4.13.x', [ROOT_POM]);
+
+    assert.deepEqual(asked, ['pom.xml']);
   });
 });

--- a/release/steps/full_release.mjs
+++ b/release/steps/full_release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
-import { assertVersionMatchesPom, computeVersion, extractVersion } from '../helpers/version-helper.mjs';
+import { assertVersionMatchesPoms, computeVersion, DISTRIBUTION_POM, extractVersion, ROOT_POM } from '../helpers/version-helper.mjs';
 import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
@@ -9,7 +9,7 @@ await checkToken();
 const releasingVersion = await extractVersion();
 const versions = computeVersion(releasingVersion);
 const targetBranch = getTargetBranch(versions);
-await assertVersionMatchesPom(releasingVersion, targetBranch);
+await assertVersionMatchesPoms(releasingVersion, targetBranch, [ROOT_POM, DISTRIBUTION_POM]);
 
 console.log(chalk.green(`💪 Triggering Release Pipeline!\n`));
 

--- a/release/steps/prepare_core_release.mjs
+++ b/release/steps/prepare_core_release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken, triggerPipeline } from '../helpers/circleci-helper.mjs';
 import { assertCoreTagIsFree, assertVersionMatchesPom, computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { getTargetBranch, isDryRun } from '../helpers/option-helper.mjs';
+import { getTargetBranch, isDryRun, isHotfixVersion } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -10,6 +10,16 @@ const releasingVersion = await extractVersion();
 const versions = computeVersion(releasingVersion);
 const targetBranch = getTargetBranch(versions);
 const dryRun = isDryRun();
+
+// A hotfix version is released from a branch cut off a tag, and the pinning job derives its target
+// from the version — so it would open the pull request on the support line, the one branch that must
+// not receive this core, while the hotfix branch that needs it got nothing. Refused rather than
+// guessed until BX-394 gives the hotfix lane its own shape.
+if (isHotfixVersion(releasingVersion)) {
+  console.log(chalk.red(`${releasingVersion} is a hotfix version, and the core lane cannot pin it yet.`));
+  console.log(`See https://gravitee.atlassian.net/browse/BX-394.`);
+  process.exit(1);
+}
 
 // Read-only, and run here rather than in CI: they refuse in a second instead of after a pipeline
 // has spun up, and they refuse before anything has been written.

--- a/release/steps/prepare_core_release.mjs
+++ b/release/steps/prepare_core_release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 
 import { checkToken, triggerPipeline } from '../helpers/circleci-helper.mjs';
-import { assertCoreTagIsFree, assertVersionMatchesPom, computeVersion, extractVersion } from '../helpers/version-helper.mjs';
+import { assertCoreTagIsFree, assertVersionMatchesPoms, computeVersion, extractVersion, ROOT_POM } from '../helpers/version-helper.mjs';
 import { getTargetBranch, isDryRun, isHotfixVersion } from '../helpers/option-helper.mjs';
 
 await checkToken();
@@ -23,7 +23,7 @@ if (isHotfixVersion(releasingVersion)) {
 
 // Read-only, and run here rather than in CI: they refuse in a second instead of after a pipeline
 // has spun up, and they refuse before anything has been written.
-await assertVersionMatchesPom(releasingVersion, targetBranch);
+await assertVersionMatchesPoms(releasingVersion, targetBranch, [ROOT_POM]);
 await assertCoreTagIsFree(releasingVersion);
 
 console.log(chalk.green(`💪 Preparing the core release of ${releasingVersion}${dryRun ? ' - Dry Run' : ''}\n`));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-393

## Description

The distribution declares which core it assembles, in `apim.core.version`. That declaration had no effect on anything: the `engine-snapshot` profile overrode it in every build, including the one that publishes. A profile is static — it hardcoded the distribution's *own* triplet, which is the right core only while the two reactors share one lineage.

Nine commits, each readable on its own:

1. **The profile becomes a computed argument.** `-Dapim.core.version=<root triplet>`, from the root pom, by CI and by the Taskfile. No behaviour change.
2. **The release assembles what it pins.** It passed the version it was building, so it shipped the core of its own commit.
3. **A release whose pin ends in `-SNAPSHOT` is refused.** A SNAPSHOT is mutable: the same tag would not rebuild to the same artefacts.
4. **master's pin tracks master.** It never releases, and 3. now enforces that, so the pin follows the branch instead of lagging on 4.12.14.
5. **A distribution-only change assembles the pin**, not the branch's core. The pull request advancing the pin would otherwise exercise something other than what merging it ships.
6. **The two reactors carry their own version.** `Check both reactors carry the same version` is gone, and the core lane moves the root pom alone.
7. **The core lane opens the pinning pull request** after publication.
8. **Images and the bundle publish the core they embed**, as `io.gravitee.core.version` and a `core.version` file.
9. **A dead profile is removed** — see below.

## Additional context

**Security-sensitive.** The new job authenticates to GitHub with the bot `GITHUB_TOKEN` from Keeper, the same secret the release jobs already use, and force-pushes a branch it owns. No new secret is introduced.

**The three changes had to land together.** Removing the guard without the computed argument reopens the silent-wrong-core hole the guard was catching; replacing the profile without removing the guard changes nothing, since the triplets still have to match. The fourth — refusing a SNAPSHOT pin — is what replaces the guard rather than simply dropping it.

**The pinning pull request follows Renovate's shape**: one branch per base branch, named after the branch and not the version, rebuilt and force-pushed on every core release. A release landing before the previous pin was merged brings that pull request up to date instead of opening a rival. Anything pushed onto that branch by hand is replaced, which the body says. Two support branches releasing at once each get their own.

**Why Renovate does not do this job.** It only runs on `master` here — no `baseBranches` — and on master the pin is a SNAPSHOT it would not touch. On a support branch, where the pin holds a released version and does need advancing, Renovate never runs.

**What the label is fed from.** The value is written into the distribution by the assembly, filtered, so it states what was assembled rather than what the pom pins — a development build that overrides writes its own value and the label follows. The build arg is passed only when the context holds the file, so the UI images, which embed no core and declare no such label, get nothing.

**A dormant trap removed on the way.** `gravitee-apim-distribution-standalone/pom.xml` carried a `gravitee-release` profile skipping the assembly, from when the distribution was released alongside the product. Since the reactor cut the root pom no longer declares this module, and the only build activating that profile deploys the root reactor — so it was unreachable. It would have skipped `core.version` too, and the label would have fallen back to `unknown` in silence.

**Verification.** 29 suites / 210 tests on the CI project, typing, ESLint and Prettier clean, every affected configuration validated with the CircleCI CLI. Fixtures regenerated from the generators, never hand-edited. Measured rather than assumed: `help:evaluate` returns `4.12.14` without the override and `4.13.0-SNAPSHOT` with it, so the argument does what the profile did; `task --dry build-distribution` resolves the same value; `gravitee-apim-bom:4.13.0-SNAPSHOT` is published, so validation still resolves the pin; and the conditional override touches exactly the two distribution-only pull-request cases and no other.

**Not verified, and it cannot be from here.** The Maven filtering of `core.version` needs a full distribution build, so it has not been seen producing the file. The two assembly descriptors parse, and the filtered fileSet mirrors the `config` one immediately above it, which already relies on filtering. It is the first thing to look at when this runs.

**Operationally.** Once 2. is in production, a release ships the core its pom pins. On master that is now master's own; on a support branch, which does not yet carry this mechanism, the pin has to be set at the next code freeze — BX-383 covers it.


---

**On the commit history.** The nine commits after `chore(distribution): drop the gravitee-release profile` answer the review, and several of them are fixups of the nine before — a formatter that was not run, dead code removed, comments corrected. They are deliberately left separate so the review can be checked against them commit by commit. Since this merges with *Rebase and merge*, they would otherwise land on master as their own history, so they will be folded into the commits they fix once the review is settled.
