### PR TITLE
feat(tracing): add the consuming application to the root span

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -371,15 +371,16 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
 
     private static JsonObject rootSpan(JsonObject json) {
         var data = json.getJsonArray("data");
-        assertThat(data).isNotEmpty();
-        return data
+        assertThat(data).as("traces").hasSize(1);
+        var serverSpans = data
             .getJsonObject(0)
             .getJsonArray("spans")
             .stream()
             .map(JsonObject.class::cast)
             .filter(span -> hasSpanKind(span, "server"))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("no span with kind=server"));
+            .toList();
+        assertThat(serverSpans).as("spans with kind=server").hasSize(1);
+        return serverSpans.get(0);
     }
 
     private static String spanTag(JsonObject span, String key) {
@@ -397,13 +398,6 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
     }
 
     private static boolean hasSpanKind(JsonObject span, String expectedKind) {
-        var tags = span.getJsonArray("tags");
-        if (tags == null) {
-            return false;
-        }
-        return tags
-            .stream()
-            .map(JsonObject.class::cast)
-            .anyMatch(tag -> "span.kind".equals(tag.getString("key")) && expectedKind.equals(tag.getString("value")));
+        return expectedKind.equals(spanTag(span, "span.kind"));
     }
 }

--- a/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -15,13 +15,24 @@
  */
 package io.gravitee.apim.integration.tests.tracing;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static io.gravitee.apim.integration.tests.messages.sse.SseAssertions.assertOnMessage;
 import static io.gravitee.apim.integration.tests.messages.sse.SseAssertions.assertRetry;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.APPLICATION_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
 import com.graviteesource.reactor.message.MessageApiReactorFactory;
@@ -41,6 +52,9 @@ import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
@@ -49,12 +63,16 @@ import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
@@ -72,6 +90,9 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
     private static final JaegerTestContainer container = new JaegerTestContainer();
 
     public static final String MESSAGE = "{ \"message\": \"hello\" }";
+
+    private static final String API_KEY_API_ID = "v4-proxy-api";
+    private static final String API_KEY_VALUE = "apiKeyValue";
 
     @AfterAll
     static void stop() {
@@ -113,8 +134,11 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
         analytics.setEnabled(true);
         analytics.setTracing(tracing);
 
-        if (api.getDefinition() instanceof Api) {
-            ((Api) api.getDefinition()).setAnalytics(analytics);
+        if (api.getDefinition() instanceof Api apiDefinition) {
+            apiDefinition.setAnalytics(analytics);
+            if (API_KEY_API_ID.equals(apiDefinition.getId())) {
+                configurePlans(apiDefinition, Set.of("api-key"));
+            }
         }
     }
 
@@ -122,6 +146,10 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
     public void configurePolicies(Map<String, PolicyPlugin> policies) {
         policies.put("latency", PolicyBuilder.build("latency", LatencyPolicy.class, LatencyPolicy.LatencyConfiguration.class));
         policies.put("message-flow-ready", PolicyBuilder.build("message-flow-ready", MessageFlowReadyPolicy.class));
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
     }
 
     @Test
@@ -177,6 +205,10 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 JsonObject body = response.bodyAsJsonObject();
                 assertData(body, expectedOperationNames);
                 assertExactlyOneSpanWithKind(body, "POST /test", "server");
+
+                var rootSpan = rootSpan(body);
+                assertThat(spanTag(rootSpan, "gravitee.application.id")).isEqualTo("1");
+                assertThat(spanTag(rootSpan, "gravitee.application.name")).isNull();
             });
     }
 
@@ -239,6 +271,64 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             });
     }
 
+    @Test
+    @DeployApi("/apis/plan/v4-proxy-api.json")
+    void should_trace_consuming_application_on_root_span(HttpClient httpClient) {
+        final ApiKey apiKey = new ApiKey();
+        apiKey.setApi(API_KEY_API_ID);
+        apiKey.setApplication(APPLICATION_ID);
+        apiKey.setSubscription("subscription-id");
+        apiKey.setPlan(PLAN_APIKEY_ID);
+        apiKey.setKey(API_KEY_VALUE);
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        when(
+            getBean(SubscriptionService.class).getByApiAndSecurityToken(
+                eq(API_KEY_API_ID),
+                argThat(
+                    securityToken ->
+                        securityToken.getTokenType().equals(API_KEY.name()) && securityToken.getTokenValue().equals(API_KEY_VALUE)
+                ),
+                eq(PLAN_APIKEY_ID)
+            )
+        ).thenReturn(Optional.of(createSubscription(API_KEY_API_ID, PLAN_APIKEY_ID, false)));
+
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, getApiPath(API_KEY_API_ID))
+            .flatMap(request -> {
+                request.putHeader("X-Gravitee-Api-Key", API_KEY_VALUE);
+                return request.rxSend();
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .awaitDone(30, SECONDS)
+            .assertComplete()
+            .assertNoErrors();
+
+        await()
+            .atMost(30, SECONDS)
+            .untilAsserted(() -> {
+                var client = container.client(vertx.getDelegate());
+                var response = client
+                    .get("/api/traces")
+                    .addQueryParam("service", "gio-apim-gateway")
+                    .addQueryParam("tags", "{\"gravitee.api.id\":\"" + API_KEY_API_ID + "\"}")
+                    .send()
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get();
+
+                assertThat(response.statusCode()).isEqualTo(200);
+                var rootSpan = rootSpan(response.bodyAsJsonObject());
+                assertThat(spanTag(rootSpan, "gravitee.application.id")).isEqualTo(APPLICATION_ID);
+                assertThat(spanTag(rootSpan, "gravitee.application.name")).isEqualTo("Application name");
+            });
+    }
+
     private static TestSubscriber<Buffer> startSseStream(HttpClient httpClient) {
         return httpClient
             .rxRequest(HttpMethod.GET, "/test")
@@ -277,6 +367,33 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .toList();
         assertThat(matchingSpans).as("spans with kind=%s", expectedKind).hasSize(1);
         assertThat(matchingSpans.get(0).getString("operationName")).as("entry span operation name").isEqualTo(expectedOperationName);
+    }
+
+    private static JsonObject rootSpan(JsonObject json) {
+        var data = json.getJsonArray("data");
+        assertThat(data).isNotEmpty();
+        return data
+            .getJsonObject(0)
+            .getJsonArray("spans")
+            .stream()
+            .map(JsonObject.class::cast)
+            .filter(span -> hasSpanKind(span, "server"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("no span with kind=server"));
+    }
+
+    private static String spanTag(JsonObject span, String key) {
+        var tags = span.getJsonArray("tags");
+        if (tags == null) {
+            return null;
+        }
+        return tags
+            .stream()
+            .map(JsonObject.class::cast)
+            .filter(tag -> key.equals(tag.getString("key")))
+            .map(tag -> tag.getString("value"))
+            .findFirst()
+            .orElse(null);
     }
 
     private static boolean hasSpanKind(JsonObject span, String expectedKind) {

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -198,7 +198,7 @@
     <!-- Gateway Only -->
     <gravitee-reporter-tcp.version>5.0.0</gravitee-reporter-tcp.version>
     <gravitee-reporter-cloud.version>4.0.0</gravitee-reporter-cloud.version>
-    <gravitee-reporter-otel.version>1.3.1</gravitee-reporter-otel.version>
+    <gravitee-reporter-otel.version>1.4.0</gravitee-reporter-otel.version>
     <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and
     gateway-services-ratelimit    -->
     <!--

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -26,6 +26,7 @@ import static io.gravitee.repository.management.model.Subscription.Status.ACCEPT
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.handlers.api.context.SubscriptionVariable;
@@ -48,6 +49,8 @@ public class SubscriptionProcessor implements Processor {
     public static final String ID = "processor-subscription";
     public static final String ATTR_API_PRODUCT = ExecutionContext.ATTR_PREFIX + "apiProduct";
     public static final String DEFAULT_CLIENT_IDENTIFIER_HEADER = "X-Gravitee-Client-Identifier";
+    public static final String SPAN_APPLICATION_ID_ATTR = "gravitee.application.id";
+    public static final String SPAN_APPLICATION_NAME_ATTR = "gravitee.application.name";
     static final String APPLICATION_ANONYMOUS = "1";
     static final String PLAN_ANONYMOUS = "1";
     static final String SUBSCRIPTION_CONTEXT_ATTRIBUTE = "subscription";
@@ -143,6 +146,9 @@ public class SubscriptionProcessor implements Processor {
                 ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
             }
             metrics.setApplicationName(subscription.getApplicationName());
+            final Tracer tracer = ctx.getTracer();
+            tracer.deferRootSpanAttribute(SPAN_APPLICATION_ID_ATTR, applicationId);
+            tracer.deferRootSpanAttribute(SPAN_APPLICATION_NAME_ATTR, subscription.getApplicationName());
             if (subscription.getApiProductId() != null) {
                 ctx.setAttribute(ATTR_API_PRODUCT, subscription.getApiProductId());
                 metrics.setApiProductId(subscription.getApiProductId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -121,7 +121,7 @@ public class SubscriptionProcessor implements Processor {
             final Metrics metrics = ctx.metrics();
             // Stores information about the resolved plan (according to the incoming request)
             metrics.setPlanId(planId);
-            metrics.setApplicationId(ctx.getAttribute(ATTR_APPLICATION));
+            metrics.setApplicationId(applicationId);
             metrics.setSubscriptionId(subscriptionId);
             metrics.setClientIdentifier(requestClientIdentifier);
             if (metrics.getLog() != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
@@ -23,12 +23,17 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.APPLICATION_ANONYMOUS;
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.PLAN_ANONYMOUS;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.SPAN_APPLICATION_ID_ATTR;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.SPAN_APPLICATION_NAME_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.el.TemplateVariableProvider;
@@ -36,8 +41,11 @@ import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.handlers.api.context.SubscriptionVariable;
 import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
+import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.core.MultiMap;
 import java.util.Collection;
@@ -204,6 +212,58 @@ class SubscriptionProcessorTest extends AbstractProcessorTest {
             cut.execute(spyCtx).test().assertComplete();
 
             assertThat(spyCtx.metrics().getApplicationName()).isNull();
+        }
+    }
+
+    @Nested
+    class RootSpan {
+
+        private static final String APPLICATION_NAME = "applicationName";
+
+        private Tracer tracer;
+        private Span rootSpan;
+
+        @BeforeEach
+        void initTracer() {
+            tracer = new Tracer(null, new NoOpTracer());
+            spyCtx.tracer(tracer);
+            rootSpan = mock(Span.class);
+            when(rootSpan.isRoot()).thenReturn(true);
+        }
+
+        @Test
+        void should_set_application_id_and_name_when_subscription_has_an_application_name() {
+            var subscription = new Subscription();
+            subscription.setApplicationName(APPLICATION_NAME);
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
+
+            cut.execute(spyCtx).test().assertComplete();
+            tracer.end(rootSpan);
+
+            verify(rootSpan).withAttribute(SPAN_APPLICATION_ID_ATTR, APPLICATION_ID);
+            verify(rootSpan).withAttribute(SPAN_APPLICATION_NAME_ATTR, APPLICATION_NAME);
+        }
+
+        @Test
+        void should_set_application_id_only_when_subscription_has_no_application_name() {
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, new Subscription());
+
+            cut.execute(spyCtx).test().assertComplete();
+            tracer.end(rootSpan);
+
+            verify(rootSpan).withAttribute(SPAN_APPLICATION_ID_ATTR, APPLICATION_ID);
+            verify(rootSpan, never()).withAttribute(eq(SPAN_APPLICATION_NAME_ATTR), any());
+        }
+
+        @Test
+        void should_set_anonymous_application_id_when_security_chain_is_skipped() {
+            spyCtx.setInternalAttribute(ATTR_INTERNAL_SECURITY_SKIP, true);
+            spyCtx.setAttribute(ATTR_APPLICATION, null);
+
+            cut.execute(spyCtx).test().assertComplete();
+            tracer.end(rootSpan);
+
+            verify(rootSpan).withAttribute(SPAN_APPLICATION_ID_ATTR, APPLICATION_ANONYMOUS);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessor.java
@@ -15,26 +15,21 @@
  */
 package io.gravitee.gateway.reactive.reactor.processor.tracing;
 
-import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
-
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook;
-import io.gravitee.node.api.opentelemetry.Span;
 import io.reactivex.rxjava3.core.Completable;
 
 /**
  * Enriches the root OTel span with Gravitee request identifiers once they are available.
  *
- * <p>The root span is created in {@code DefaultHttpRequestDispatcher.doOnSubscribe()} and stored
- * under {@code ATTR_INTERNAL_TRACING_ROOT_SPAN} before the pre-processor chain runs. At that point
- * {@code transactionId} has not yet been assigned by
- * {@link io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessor}.
- * This processor runs immediately after {@code TransactionPreProcessor}, so both
- * {@code gravitee.request.id} and {@code gravitee.transaction.id} are guaranteed to be set.
+ * <p>The attributes are deferred on the request-scoped {@link Tracer} and stamped when the root span
+ * closes, so this processor never needs a reference to the span itself. It runs immediately after
+ * {@link io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessor}, so
+ * {@code gravitee.transaction.id} is already assigned by the time it reads it.
  *
- * <p>This processor is only registered when OTel traces are enabled. When tracing is disabled the
- * root span is never stored in context, so this processor would be a no-op regardless.
+ * <p>This processor is only registered when OTel traces are enabled.
  *
  * @author GraviteeSource Team
  */
@@ -48,12 +43,10 @@ public class TracingPreProcessor implements Processor {
     @Override
     public Completable execute(final HttpExecutionContextInternal ctx) {
         return Completable.fromRunnable(() -> {
-            Span rootSpan = ctx.getInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN);
-            if (rootSpan != null && ctx.request() != null) {
-                rootSpan.withAttribute(AbstractTracingHook.SPAN_REQUEST_ID_ATTR, ctx.request().id());
-                if (ctx.request().transactionId() != null) {
-                    rootSpan.withAttribute(AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR, ctx.request().transactionId());
-                }
+            if (ctx.request() != null) {
+                final Tracer tracer = ctx.getTracer();
+                tracer.deferRootSpanAttribute(AbstractTracingHook.SPAN_REQUEST_ID_ATTR, ctx.request().id());
+                tracer.deferRootSpanAttribute(AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR, ctx.request().transactionId());
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessorTest.java
@@ -15,16 +15,19 @@
  */
 package io.gravitee.gateway.reactive.reactor.processor.tracing;
 
-import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_REQUEST_ID_ATTR;
 import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.reactor.processor.AbstractProcessorTest;
 import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,23 +37,25 @@ import org.junit.jupiter.api.Test;
 class TracingPreProcessorTest extends AbstractProcessorTest {
 
     private TracingPreProcessor processor;
+    private Tracer tracer;
     private Span rootSpan;
 
     @BeforeEach
     public void setUp() {
         processor = new TracingPreProcessor();
+        tracer = new Tracer(null, new NoOpTracer());
+        ctx.tracer(tracer);
         rootSpan = mock(Span.class);
+        when(rootSpan.isRoot()).thenReturn(true);
     }
 
     @Test
     void should_set_request_id_and_transaction_id_on_root_span() {
         when(mockRequest.id()).thenReturn("req-id");
         when(mockRequest.transactionId()).thenReturn("tx-id");
-        when(rootSpan.withAttribute(SPAN_REQUEST_ID_ATTR, "req-id")).thenReturn(rootSpan);
-        when(rootSpan.withAttribute(SPAN_TRANSACTION_ID_ATTR, "tx-id")).thenReturn(rootSpan);
-        ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN, rootSpan);
 
         processor.execute(ctx).test().assertComplete();
+        tracer.end(rootSpan);
 
         verify(rootSpan).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
         verify(rootSpan).withAttribute(SPAN_TRANSACTION_ID_ATTR, "tx-id");
@@ -60,19 +65,11 @@ class TracingPreProcessorTest extends AbstractProcessorTest {
     void should_set_only_request_id_when_transaction_id_is_null() {
         when(mockRequest.id()).thenReturn("req-id");
         when(mockRequest.transactionId()).thenReturn(null);
-        when(rootSpan.withAttribute(SPAN_REQUEST_ID_ATTR, "req-id")).thenReturn(rootSpan);
-        ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN, rootSpan);
 
         processor.execute(ctx).test().assertComplete();
+        tracer.end(rootSpan);
 
         verify(rootSpan).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
-        verify(rootSpan, never()).withAttribute(SPAN_TRANSACTION_ID_ATTR, null);
-    }
-
-    @Test
-    void should_do_nothing_when_no_root_span_in_context() {
-        processor.execute(ctx).test().assertComplete();
-
-        verify(rootSpan, never()).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
+        verify(rootSpan, never()).withAttribute(eq(SPAN_TRANSACTION_ID_ATTR), any());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <gravitee-exchange.version>3.0.0</gravitee-exchange.version>
     <gravitee-expression-language.version>4.4.1</gravitee-expression-language.version>
     <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-    <gravitee-gateway-api.version>6.3.0</gravitee-gateway-api.version>
+    <gravitee-gateway-api.version>6.4.0</gravitee-gateway-api.version>
     <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
     <gravitee-json-validation.version>3.0.2</gravitee-json-validation.version>
     <gravitee-kubernetes.version>4.0.0</gravitee-kubernetes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15014

## Description

Puts the consuming application on the gateway's OpenTelemetry output, so traces **and** logs can be filtered by application with the same query:

- `gravitee.application.id` — the resolved application, including the anonymous `1` fallback for keyless traffic.
- `gravitee.application.name` — omitted when the subscription carries none.

**Spans.** Both attributes are deferred from `SubscriptionProcessor` onto the root span. That is the first point in the chain where the application id and the resolved subscription are both available — it already feeds the same two values into `Metrics`. Covers HTTP v4 and v2-emulated APIs.

**Logs.** No gateway change was needed: `ReporterProcessor` already copies both onto the `Log` reportable. The mapping was missing in the OTel reporter plugin, added in gravitee-io/gravitee-reporter-otel#26 and picked up here by bumping `gravitee-reporter-otel` to `1.4.0`. All four HTTP log types (entrypoint/endpoint × request/response) carry them.

Dependency bumps in this PR:

- `gravitee-gateway-api` `6.3.0` → `6.4.0` (root `pom.xml`) — brings `Tracer#deferRootSpanAttribute` (gravitee-io/gravitee-gateway-api#364).
- `gravitee-reporter-otel` `1.3.1` → `1.4.0` (`gravitee-apim-distribution/pom.xml`) — brings the log attributes.

Out of scope:

- The V3 legacy path, TCP and native/Kafka — no `SubscriptionProcessor` (see the TODO in `TcpApiReactor`) and/or no root span.
- Per-message log records. `MessageLog` has no application field, so message APIs carry the application on their HTTP log records only; closing that needs a `gravitee-reporter-api` change first.

**Security-sensitive**: this changes tracing and logging output. The consuming application's id and name are now exported to whatever OTel collector the gateway is configured against.

## Additional context

Tests, both verified RED before the change and GREEN after:

- `SubscriptionProcessorTest.RootSpan` — three unit tests driving a real `Tracer` and asserting the attributes land on the root span at close.
- `OpenTelemetryTracingV4IntegrationTest` — end to end against a Jaeger container. The existing keyless test now asserts the anonymous id and the absence of a name tag; a new api-key test asserts both tags for a subscribed application. Run with:

  ```
  mvn -f gravitee-apim-distribution/pom.xml -Pengine-snapshot -Dintegration-tests-modules=true \
      -pl gravitee-apim-distribution-integration-tests test -Dtest=OpenTelemetryTracingV4IntegrationTest
  ```

The log half is covered by `OtelReporterTest` in the plugin repo (25/25), not here.

Verified locally: full root reactor `clean install` on 6.4.0 (137 modules, validation enabled), `handlers-api` 1025/1025, integration test 3/3, and the standalone gateway bundle resolving `gravitee-reporter-otel:zip:1.4.0`.

Unrelated pre-existing issue noticed, not addressed here: `prettier:check` on `gravitee-apim-distribution-integration-tests` flags 234 committed test resources (233 JSON + 1 YAML) as incorrectly formatted at `master`. No Java file is affected.
