### PR TITLE
refactor(rest-api): remove the orphaned two-arg UserService.register overload

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -66,8 +66,6 @@ public interface UserService {
 
     Page<UserEntity> search(ExecutionContext executionContext, UserCriteria criteria, Pageable pageable);
 
-    UserEntity register(ExecutionContext executionContext, NewExternalUserEntity newExternalUserEntity);
-
     UserEntity register(ExecutionContext executionContext, NewExternalUserEntity newExternalUserEntity, String confirmationPageUrl);
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -887,11 +887,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     }
 
     @Override
-    public UserEntity register(ExecutionContext executionContext, final NewExternalUserEntity newExternalUserEntity) {
-        return register(executionContext, newExternalUserEntity, null);
-    }
-
-    @Override
     public UserEntity register(
         ExecutionContext executionContext,
         final NewExternalUserEntity newExternalUserEntity,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceRegistrationApprovalTest.java
@@ -171,7 +171,7 @@ class UserServiceRegistrationApprovalTest {
     void should_not_send_the_registration_email_when_the_request_has_to_be_approved() throws TechnicalException {
         givenUserRegistrationEnabled(false);
 
-        userService.register(PORTAL_CONTEXT, newExternalUser());
+        userService.register(PORTAL_CONTEXT, newExternalUser(), null);
 
         verify(emailService, never()).sendAsyncEmailNotification(eq(PORTAL_CONTEXT), any());
         verify(notifierService).trigger(eq(PORTAL_CONTEXT), eq(PortalHook.USER_REGISTRATION_REQUEST), any());
@@ -181,7 +181,7 @@ class UserServiceRegistrationApprovalTest {
     void should_create_a_pending_user_when_the_request_has_to_be_approved() throws TechnicalException {
         givenUserRegistrationEnabled(false);
 
-        userService.register(PORTAL_CONTEXT, newExternalUser());
+        userService.register(PORTAL_CONTEXT, newExternalUser(), null);
 
         verify(userRepository).create(argThat(user -> user.getStatus() == UserStatus.PENDING));
     }
@@ -190,7 +190,7 @@ class UserServiceRegistrationApprovalTest {
     void should_send_the_registration_email_when_registrations_are_automatically_validated() throws TechnicalException {
         givenUserRegistrationEnabled(true);
 
-        userService.register(PORTAL_CONTEXT, newExternalUser());
+        userService.register(PORTAL_CONTEXT, newExternalUser(), null);
 
         assertThat(capturedEmails()).anyMatch(this::isRegistrationEmail);
         verify(notifierService).trigger(eq(PORTAL_CONTEXT), eq(PortalHook.USER_REGISTERED), any());


### PR DESCRIPTION
[FOUND-306](https://gravitee.atlassian.net/browse/FOUND-306)

Follow-up to [#19792](https://github.com/gravitee-io/gravitee-api-management/pull/19792), where this
was raised as a SHOULD and deliberately deferred rather than folded in.

## What changed

`UserService.register(ExecutionContext, NewExternalUserEntity)` is gone, along with its
implementation. The three test call sites now pass the `null` explicitly.

The overload was a one-line delegation to `register(ctx, entity, null)`. Its only production caller
was `UsersRegistrationResource.registerUser`, which moved to `registerWithTarget` in #19792 — after
which the signature was reachable only from `UserServiceRegistrationApprovalTest`. Re-verified by
grep on current master before deleting, not taken from the earlier PR.

## What did not change

The behaviour is untouched. The Portal's `UsersResource.java:95` calls the **three**-arg overload
with `registerUserInput.getConfirmationPageUrl()`, which is routinely null, so the null-confirmation
path stays live in production and stays covered by the same three tests. They assert exactly what
they asserted before; only the call site is one argument longer.

## Why it is its own PR

An API removal riding inside a feature PR is hard to find later if it breaks a consumer — nobody
greps a Gamma email-routing change for a deleted method. `@Deprecated` was considered and rejected
in review: a half-deprecation inside a feature PR carries the same discoverability problem for less
benefit. [The thread](https://github.com/gravitee-io/gravitee-api-management/pull/19792#discussion_r3965222872).

No deprecation cycle here either — the signature carries no behaviour of its own, so a caller who has
to add one argument is the entire migration.

## Verification

- `mvn test -Dtest='UserService*Test'` — **128 tests, 0 failures**, identical counts to master
- `mvn -f gravitee-apim-rest-api/pom.xml test-compile` — the whole reactor compiles, so nothing else
  in the monorepo referenced the removed signature
- Module is prettier-formatted

[FOUND-306]: https://gravitee.atlassian.net/browse/FOUND-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ