### PR TITLE
feat(gamma-console): request an account on Gamma, with configured user fields

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
@@ -15,7 +15,7 @@
  */
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { LoginPage, ProtectedRoute, PublicOnlyRoute, ResetPasswordPage } from '../features/auth';
+import { LoginPage, ProtectedRoute, PublicOnlyRoute, ResetPasswordPage, SignUpPage } from '../features/auth';
 import { EnvironmentGuard, RootRedirect } from '../features/environment';
 import { type GammaModule, RemoteModuleRoute, useGammaModules } from '../features/modules';
 import { HomePage } from '../pages/home';
@@ -33,6 +33,7 @@ export function AppRoutes() {
                 <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
                 <Route element={<PublicOnlyRoute />}>
                     <Route path="/login" element={<LoginPage />} />
+                    <Route path="/sign-up" element={<SignUpPage />} />
                 </Route>
                 <Route element={<ProtectedRoute />}>
                     <Route path="/environments/:envHrid" element={<ShellLayout modules={[]} />}>
@@ -52,6 +53,7 @@ export function AppRoutes() {
             <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
             <Route element={<PublicOnlyRoute />}>
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/sign-up" element={<SignUpPage />} />
             </Route>
             <Route element={<ProtectedRoute />}>
                 <Route path="/environments/:envHrid" element={<ShellLayout modules={modules} />}>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SignUpPage } from './SignUpPage';
+import { TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { respondWith, trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
+import type { CustomUserField } from '../services/registration.service';
+
+const REGISTRATION_URL = `${TEST_MANAGEMENT_BASE}/users/registration`;
+const CUSTOM_FIELDS_URL = `${TEST_MANAGEMENT_BASE}/configuration/custom-user-fields`;
+
+const JOB_TITLE: CustomUserField = { key: 'job_title', label: 'Job title', required: true };
+const TEAM: CustomUserField = { key: 'team', label: 'Team', values: ['Platform', 'Payments'], required: false };
+
+beforeAll(() => {
+    // Radix's Select drives pointer capture and scrolling, neither of which jsdom implements.
+    Element.prototype.hasPointerCapture = jest.fn();
+    Element.prototype.setPointerCapture = jest.fn();
+    Element.prototype.releasePointerCapture = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
+});
+
+function renderSignUpPage(customUserFields: CustomUserField[] = []) {
+    respondWith('get', CUSTOM_FIELDS_URL, customUserFields);
+    return render(
+        <MemoryRouter>
+            <SignUpPage />
+        </MemoryRouter>,
+    );
+}
+
+/** Waits out the custom-fields read, which submit is blocked on. */
+async function fillIdentity(user: ReturnType<typeof userEvent.setup>, email = 'ada@example.com') {
+    await user.type(await screen.findByLabelText(/First name/), 'Ada');
+    await user.type(screen.getByLabelText(/Last name/), 'Lovelace');
+    await user.type(screen.getByLabelText(/Email/), email);
+}
+
+function submitButton(): HTMLButtonElement {
+    return screen.getByRole('button', { name: 'Request account' }) as HTMLButtonElement;
+}
+
+describe('SignUpPage', () => {
+    describe('the identity form', () => {
+        it('sends what was typed and reports the request as sent', async () => {
+            const user = userEvent.setup();
+            const tracker = trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            await waitFor(() => expect(tracker.callCount).toBe(1));
+            expect(tracker.lastCall?.body).toEqual({ firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.com' });
+        });
+
+        it('rejects a malformed email in the field, before anything is sent', async () => {
+            const user = userEvent.setup();
+            const tracker = trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user, 'ada@example');
+            await user.tab();
+
+            expect(await screen.findByText('Enter a valid email address.')).toBeTruthy();
+            expect(submitButton().disabled).toBe(true);
+            expect(tracker.callCount).toBe(0);
+        });
+
+        it('holds the email to the rules the server applies, so the field and the server never disagree', async () => {
+            const user = userEvent.setup();
+            renderSignUpPage();
+
+            // A one-letter TLD: a loose shape check accepts it, `EmailValidator` does not.
+            await fillIdentity(user, 'ada@example.c');
+            await user.tab();
+
+            expect(await screen.findByText('Enter a valid email address.')).toBeTruthy();
+            expect(submitButton().disabled).toBe(true);
+        });
+
+        it('shows a pending submit and cannot be fired twice', async () => {
+            const user = userEvent.setup();
+            let resolveRequest: () => void = () => undefined;
+            const pending = new Promise<void>(resolve => {
+                resolveRequest = resolve;
+            });
+            let calls = 0;
+            server.use(
+                http.post(REGISTRATION_URL, async () => {
+                    calls += 1;
+                    await pending;
+                    return HttpResponse.json({});
+                }),
+            );
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            const pendingButton = await screen.findByRole('button', { name: /Sending request/ });
+            expect((pendingButton as HTMLButtonElement).disabled).toBe(true);
+            await user.click(pendingButton);
+
+            resolveRequest();
+            await screen.findByText('Check your email');
+            expect(calls).toBe(1);
+        });
+
+        it('renders a rejected email against the email field, not as a toast', async () => {
+            const user = userEvent.setup();
+            server.use(
+                http.post(REGISTRATION_URL, () =>
+                    HttpResponse.json(
+                        { message: 'Value [ada@example.com] is not a valid email.', http_status: 400, technicalCode: 'email.invalid' },
+                        { status: 400 },
+                    ),
+                ),
+            );
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            const emailError = await screen.findByText('Enter a valid email address.');
+            expect(screen.getByLabelText(/Email/).closest('[data-slot="field"]')?.contains(emailError)).toBe(true);
+            expect(screen.queryByText(/is not a valid email/)).toBeNull();
+        });
+
+        it('reports a rejection no field owns against the form, without the server wording', async () => {
+            const user = userEvent.setup();
+            server.use(
+                http.post(REGISTRATION_URL, () =>
+                    HttpResponse.json(
+                        { message: 'Gamma URL is not configured for organization: DEFAULT', http_status: 400 },
+                        { status: 400 },
+                    ),
+                ),
+            );
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            expect(await screen.findByText('Something went wrong while sending your request. Try again.')).toBeTruthy();
+            expect(screen.queryByText(/Gamma URL/)).toBeNull();
+            expect(screen.queryByText('Check your email')).toBeNull();
+        });
+    });
+
+    describe('the configured user fields', () => {
+        it('renders a fixed value list as a choice and everything else as free text', async () => {
+            const user = userEvent.setup();
+            renderSignUpPage([JOB_TITLE, TEAM]);
+
+            expect((await screen.findByLabelText(/Job title/)).tagName).toBe('INPUT');
+
+            const team = screen.getByRole('combobox', { name: /Team/ });
+            await user.click(team);
+            expect(screen.getByRole('option', { name: 'Platform' })).toBeTruthy();
+            expect(screen.getByRole('option', { name: 'Payments' })).toBeTruthy();
+        });
+
+        it('marks which fields are required, since a form can mix the two', async () => {
+            renderSignUpPage([JOB_TITLE, TEAM]);
+
+            const requiredLabel = await screen.findByText((_, element) => element?.getAttribute('for') === 'sign-up-field-job_title');
+            const optionalLabel = screen.getByText((_, element) => element?.getAttribute('for') === 'sign-up-field-team');
+
+            expect(requiredLabel.textContent).toBe('Job title*');
+            expect(optionalLabel.textContent).toBe('Team');
+        });
+
+        it('blocks submit until every required field is answered', async () => {
+            const user = userEvent.setup();
+            renderSignUpPage([JOB_TITLE, TEAM]);
+
+            await fillIdentity(user);
+            expect(submitButton().disabled).toBe(true);
+
+            await user.type(screen.getByLabelText(/Job title/), 'Analyst');
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+        });
+
+        it('sends the answers as customFields', async () => {
+            const user = userEvent.setup();
+            const tracker = trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage([JOB_TITLE, TEAM]);
+
+            await fillIdentity(user);
+            await user.type(screen.getByLabelText(/Job title/), 'Analyst');
+            await user.click(screen.getByRole('combobox', { name: /Team/ }));
+            await user.click(screen.getByRole('option', { name: 'Payments' }));
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            await waitFor(() => expect(tracker.callCount).toBe(1));
+            expect(tracker.lastCall?.body).toEqual({
+                firstname: 'Ada',
+                lastname: 'Lovelace',
+                email: 'ada@example.com',
+                customFields: { job_title: 'Analyst', team: 'Payments' },
+            });
+        });
+
+        it('leaves an unanswered optional field out of customFields', async () => {
+            const user = userEvent.setup();
+            const tracker = trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage([JOB_TITLE, TEAM]);
+
+            await fillIdentity(user);
+            await user.type(await screen.findByLabelText(/Job title/), 'Analyst');
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            await waitFor(() => expect(tracker.callCount).toBe(1));
+            expect(tracker.lastCall?.body).toEqual({
+                firstname: 'Ada',
+                lastname: 'Lovelace',
+                email: 'ada@example.com',
+                customFields: { job_title: 'Analyst' },
+            });
+        });
+
+        it('keeps the form short when no fields are configured', async () => {
+            renderSignUpPage([]);
+
+            await screen.findByLabelText(/First name/);
+            expect(screen.queryByText('Additional details')).toBeNull();
+        });
+
+        it('surfaces a failed fields read without blocking sign-up on identity alone', async () => {
+            const user = userEvent.setup();
+            const tracker = trackHandler('post', REGISTRATION_URL, {});
+            respondWith('get', CUSTOM_FIELDS_URL, { message: 'Service unavailable' }, 503);
+            render(
+                <MemoryRouter>
+                    <SignUpPage />
+                </MemoryRouter>,
+            );
+
+            expect(await screen.findByText("Couldn't load the additional questions")).toBeTruthy();
+            expect(screen.getByText('You can still request an account. Your administrator may ask for the rest later.')).toBeTruthy();
+            expect(screen.queryByText('Service unavailable')).toBeNull();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            await waitFor(() => expect(tracker.callCount).toBe(1));
+            expect(tracker.lastCall?.body).toEqual({ firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.com' });
+        });
+    });
+
+    describe('composition', () => {
+        it('offers sign in to someone who already has an account', async () => {
+            renderSignUpPage();
+
+            await screen.findByLabelText(/First name/);
+            expect(screen.getByText(/Already have an account\?/)).toBeTruthy();
+            expect(screen.getByRole('link', { name: 'Sign in' }).getAttribute('href')).toBe('/login');
+        });
+
+        it('groups identity and configured fields under their own headings', async () => {
+            renderSignUpPage([JOB_TITLE]);
+
+            await screen.findByLabelText(/Job title/);
+            expect(screen.getByText('Your details')).toBeTruthy();
+            expect(screen.getByText('Additional details')).toBeTruthy();
+        });
+    });
+
+    describe('the sent state', () => {
+        it('replaces the page, echoes the address back, and offers a route back to sign in', async () => {
+            const user = userEvent.setup();
+            trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            expect(await screen.findByText('Check your email')).toBeTruthy();
+            expect(screen.queryByLabelText(/First name/)).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Request account' })).toBeNull();
+            expect(screen.getByText('ada@example.com')).toBeTruthy();
+            expect(screen.getByRole('link', { name: 'Back to sign in' }).getAttribute('href')).toBe('/login');
+            expect(screen.queryByText(/Already have an account/)).toBeNull();
+        });
+
+        it('offers no resend, because the backend has no such endpoint', async () => {
+            const user = userEvent.setup();
+            trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            await screen.findByText('Check your email');
+            expect(screen.queryByRole('button', { name: /resend|send again/i })).toBeNull();
+        });
+
+        it('is identical for an address that already has an account', async () => {
+            const user = userEvent.setup();
+            // FOUND-303: an anonymous caller must not be able to tell the two apart.
+            server.use(
+                http.post(REGISTRATION_URL, () =>
+                    HttpResponse.json(
+                        {
+                            message: 'User cannot be created.',
+                            http_status: 400,
+                            technicalCode: 'user.invalid',
+                            parameters: { user: 'ada@example.com', source: 'gravitee' },
+                        },
+                        { status: 400 },
+                    ),
+                ),
+            );
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            expect(await screen.findByText('Check your email')).toBeTruthy();
+            expect(screen.getByText('ada@example.com')).toBeTruthy();
+            expect(screen.queryByText('User cannot be created.')).toBeNull();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Button,
+    Field,
+    FieldDescription,
+    FieldError,
+    FieldGroup,
+    FieldLabel,
+    FieldLegend,
+    FieldSet,
+    Input,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Spinner,
+} from '@gravitee/graphene-core';
+import { useEffect, useState, type SubmitEvent } from 'react';
+import { Link } from 'react-router-dom';
+
+import { AuthPageShell } from './AuthPageShell';
+import { fetchCustomUserFields, submitRegistration, type CustomUserField } from '../services/registration.service';
+
+/**
+ * The server's `EmailValidator` (OWASP pattern and length cap), copied rather than approximated: a
+ * looser check lets through addresses the server then rejects, a stricter one blocks addresses it
+ * would accept. Keep the two in step.
+ */
+const EMAIL_PATTERN = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+const EMAIL_MAX_LENGTH = 320;
+
+const INVALID_EMAIL = 'Enter a valid email address.';
+
+function fieldId(key: string): string {
+    return `sign-up-field-${key}`;
+}
+
+function isAnswered(value: string | undefined): boolean {
+    return Boolean(value?.trim());
+}
+
+/**
+ * Answers worth sending. An untouched optional field would otherwise be stored as an empty piece
+ * of user metadata, which reads to an administrator as an answer that was given and left blank.
+ */
+function answeredFields(answers: Record<string, string>): Record<string, string> {
+    return Object.fromEntries(Object.entries(answers).filter(([, value]) => isAnswered(value)));
+}
+
+export function SignUpPage() {
+    const [customUserFields, setCustomUserFields] = useState<CustomUserField[]>([]);
+    const [customUserFieldsLoading, setCustomUserFieldsLoading] = useState(true);
+    const [customUserFieldsFailed, setCustomUserFieldsFailed] = useState(false);
+
+    const [firstname, setFirstname] = useState('');
+    const [lastname, setLastname] = useState('');
+    const [email, setEmail] = useState('');
+    const [emailTouched, setEmailTouched] = useState(false);
+    const [answers, setAnswers] = useState<Record<string, string>>({});
+
+    const [emailRejected, setEmailRejected] = useState(false);
+    const [formError, setFormError] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [sentTo, setSentTo] = useState<string | null>(null);
+
+    useEffect(() => {
+        let active = true;
+        fetchCustomUserFields()
+            .then(fields => {
+                if (active) {
+                    setCustomUserFields(fields);
+                }
+            })
+            .catch(() => {
+                if (active) {
+                    setCustomUserFieldsFailed(true);
+                }
+            })
+            .finally(() => {
+                if (active) {
+                    setCustomUserFieldsLoading(false);
+                }
+            });
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const trimmedEmail = email.trim();
+    const emailValid = trimmedEmail.length <= EMAIL_MAX_LENGTH && EMAIL_PATTERN.test(trimmedEmail);
+    // The shape check waits for the field to be left: complaining at the first character tells
+    // everyone their address is wrong while they are still typing it.
+    const emailError = emailRejected || (emailTouched && email.length > 0 && !emailValid) ? INVALID_EMAIL : '';
+    const requiredFieldsAnswered = customUserFields.every(field => !field.required || isAnswered(answers[field.key]));
+    // The read has to finish first: submitting before it does would silently skip fields the
+    // administrator made mandatory. A read that failed leaves nothing to wait for.
+    const canSubmit =
+        isAnswered(firstname) && isAnswered(lastname) && emailValid && requiredFieldsAnswered && !customUserFieldsLoading && !submitting;
+
+    function answer(key: string, value: string) {
+        setAnswers(current => ({ ...current, [key]: value }));
+    }
+
+    async function handleSubmit(event: SubmitEvent) {
+        event.preventDefault();
+        if (!canSubmit) {
+            return;
+        }
+
+        setEmailRejected(false);
+        setFormError('');
+        setSubmitting(true);
+        const submittedEmail = email.trim();
+        try {
+            const result = await submitRegistration({
+                firstname: firstname.trim(),
+                lastname: lastname.trim(),
+                email: submittedEmail,
+                ...(customUserFields.length > 0 ? { customFields: answeredFields(answers) } : {}),
+            });
+
+            switch (result.outcome) {
+                case 'submitted':
+                    setSentTo(submittedEmail);
+                    break;
+                case 'email-rejected':
+                    setEmailRejected(true);
+                    break;
+                case 'rejected':
+                    setFormError(result.message);
+                    break;
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (sentTo) {
+        return (
+            <AuthPageShell title="Check your email">
+                {/* No resend control: the management API has no endpoint that could serve one, and a
+                    button that cannot work is worse than its absence. */}
+                {/* Unboxed: the whole page is the message, so an Alert here only framed the card's
+                    content a second time. */}
+                <div role="status" className="space-y-3 text-sm text-muted-foreground">
+                    {/* The address is echoed back so a typo is caught here, where the form can
+                        still be filled in again, rather than in an inbox nothing ever reaches. */}
+                    <p>
+                        Your request has been sent. The activation link goes to{' '}
+                        <span className="font-medium text-foreground">{sentTo}</span>.
+                    </p>
+                    {/* Deliberately does not promise the email has already left. With
+                        `automaticValidation` off nothing is sent until an administrator
+                        approves, and this page cannot see that setting until FOUND-261 reads it. */}
+                    <p>
+                        If it has not arrived within a few minutes, check your spam folder — an administrator may need to approve the
+                        request first.
+                    </p>
+                </div>
+                {/* The only thing left to do here, so it is the page's control rather than muted
+                    footer text -- and outline, because Solaris orange is for primary actions. */}
+                <Button asChild variant="outline" size="lg" className="mt-6 w-full">
+                    <Link to="/login">Back to sign in</Link>
+                </Button>
+            </AuthPageShell>
+        );
+    }
+
+    return (
+        <AuthPageShell
+            title="Request an account"
+            description="We'll email you a link to activate your account."
+            footer={
+                <>
+                    Already have an account?{' '}
+                    <Link to="/login" className="text-primary underline-offset-4 hover:underline">
+                        Sign in
+                    </Link>
+                </>
+            }
+        >
+            <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+                {customUserFieldsFailed ? (
+                    <Alert role="alert">
+                        <AlertTitle>{"Couldn't load the additional questions"}</AlertTitle>
+                        <AlertDescription>
+                            You can still request an account. Your administrator may ask for the rest later.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+
+                {formError ? (
+                    <Alert variant="destructive" role="alert">
+                        <AlertTitle>Could not send your request</AlertTitle>
+                        <AlertDescription>{formError}</AlertDescription>
+                    </Alert>
+                ) : null}
+
+                <FieldSet>
+                    <FieldLegend>Your details</FieldLegend>
+                    <FieldGroup>
+                        <Field orientation="vertical" className="gap-2">
+                            <FieldLabel htmlFor="sign-up-firstname" required>
+                                First name
+                            </FieldLabel>
+                            <Input
+                                id="sign-up-firstname"
+                                value={firstname}
+                                onChange={event => setFirstname(event.target.value)}
+                                required
+                                autoComplete="given-name"
+                                // eslint-disable-next-line jsx-a11y/no-autofocus
+                                autoFocus
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-2">
+                            <FieldLabel htmlFor="sign-up-lastname" required>
+                                Last name
+                            </FieldLabel>
+                            <Input
+                                id="sign-up-lastname"
+                                value={lastname}
+                                onChange={event => setLastname(event.target.value)}
+                                required
+                                autoComplete="family-name"
+                            />
+                        </Field>
+
+                        <Field orientation="vertical" className="gap-2" data-invalid={emailError ? true : undefined}>
+                            <FieldLabel htmlFor="sign-up-email" required>
+                                Email
+                            </FieldLabel>
+                            <Input
+                                id="sign-up-email"
+                                type="email"
+                                value={email}
+                                onChange={event => {
+                                    // A rejection describes the address that was sent, so editing it retires it.
+                                    setEmail(event.target.value);
+                                    setEmailRejected(false);
+                                }}
+                                onBlur={() => setEmailTouched(true)}
+                                required
+                                aria-invalid={emailError ? true : undefined}
+                                autoComplete="email"
+                            />
+                            <FieldError>{emailError || undefined}</FieldError>
+                        </Field>
+                    </FieldGroup>
+                </FieldSet>
+
+                {customUserFields.length > 0 ? (
+                    <FieldSet>
+                        <FieldLegend>Additional details</FieldLegend>
+                        {/* Names who is asking, so the extra questions read as a request from the
+                            organization rather than as an interrogation by the product. */}
+                        <FieldDescription>Your administrator asks everyone requesting an account for these.</FieldDescription>
+                        <FieldGroup>
+                            {customUserFields.map(field => (
+                                <CustomUserFieldControl
+                                    key={field.key}
+                                    field={field}
+                                    value={answers[field.key] ?? ''}
+                                    onChange={value => answer(field.key, value)}
+                                />
+                            ))}
+                        </FieldGroup>
+                    </FieldSet>
+                ) : null}
+
+                <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
+                    {submitting ? (
+                        <span className="inline-flex items-center justify-center gap-2">
+                            <Spinner className="size-4 shrink-0" aria-hidden />
+                            Sending request…
+                        </span>
+                    ) : (
+                        'Request account'
+                    )}
+                </Button>
+            </form>
+        </AuthPageShell>
+    );
+}
+
+/**
+ * One administrator-configured field. A fixed list of values is a choice and renders as one;
+ * anything else is free text, matching what the classic console offers for the same configuration.
+ */
+function CustomUserFieldControl({ field, value, onChange }: { field: CustomUserField; value: string; onChange: (value: string) => void }) {
+    const id = fieldId(field.key);
+    const hasChoices = (field.values?.length ?? 0) > 0;
+
+    return (
+        <Field orientation="vertical" className="gap-2">
+            <FieldLabel htmlFor={id} required={field.required}>
+                {field.label}
+            </FieldLabel>
+            {hasChoices ? (
+                <Select value={value || undefined} onValueChange={onChange} required={field.required}>
+                    <SelectTrigger id={id} className="w-full">
+                        <SelectValue placeholder={`Select ${field.label.toLowerCase()}`} />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {field.values?.map(option => (
+                            <SelectItem key={option} value={option}>
+                                {option}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            ) : (
+                <Input id={id} value={value} onChange={event => onChange(event.target.value)} required={field.required} />
+            )}
+        </Field>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
@@ -18,4 +18,5 @@ export { useAuthStore } from './auth.store';
 export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
 export { LoginPage } from './components/LoginPage';
 export { ResetPasswordPage } from './components/ResetPasswordPage';
+export { SignUpPage } from './components/SignUpPage';
 export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { resetReCaptchaConfigCacheForTests } from './recaptcha.service';
+import { fetchCustomUserFields, submitRegistration } from './registration.service';
+import { TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { respondWith, trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
+
+const REGISTRATION_URL = `${TEST_MANAGEMENT_BASE}/users/registration`;
+const CUSTOM_FIELDS_URL = `${TEST_MANAGEMENT_BASE}/configuration/custom-user-fields`;
+
+const IDENTITY = { firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.com' };
+
+/** Fails the registration request the way the management API's `ErrorEntity` does. */
+function rejectRegistration(body: { message: string; technicalCode?: string; parameters?: Record<string, string> }, status = 400) {
+    server.use(http.post(REGISTRATION_URL, () => HttpResponse.json({ ...body, http_status: status }, { status })));
+}
+
+beforeEach(() => {
+    resetReCaptchaConfigCacheForTests();
+});
+
+describe('fetchCustomUserFields', () => {
+    it('reads the fields an administrator configured', async () => {
+        respondWith('get', CUSTOM_FIELDS_URL, [
+            { key: 'job_title', label: 'Job title', required: true },
+            { key: 'team', label: 'Team', values: ['Platform', 'Payments'], required: false },
+        ]);
+
+        await expect(fetchCustomUserFields()).resolves.toEqual([
+            { key: 'job_title', label: 'Job title', required: true },
+            { key: 'team', label: 'Team', values: ['Platform', 'Payments'], required: false },
+        ]);
+    });
+
+    it('reports a failed read rather than pretending there are no fields', async () => {
+        respondWith('get', CUSTOM_FIELDS_URL, { message: 'Service unavailable' }, 503);
+
+        await expect(fetchCustomUserFields()).rejects.toThrow('Service unavailable');
+    });
+});
+
+describe('submitRegistration', () => {
+    it('posts the identity and the custom field values, targeting the Gamma activation page', async () => {
+        const tracker = trackHandler('post', REGISTRATION_URL, {});
+
+        await expect(submitRegistration({ ...IDENTITY, customFields: { job_title: 'Analyst' } })).resolves.toEqual({
+            outcome: 'submitted',
+        });
+
+        expect(tracker.callCount).toBe(1);
+        expect(tracker.lastCall?.body).toEqual({
+            firstname: 'Ada',
+            lastname: 'Lovelace',
+            email: 'ada@example.com',
+            customFields: { job_title: 'Analyst' },
+        });
+        expect(new URL(tracker.lastCall!.url).searchParams.get('registrationTarget')).toBe('gamma');
+    });
+
+    it('omits customFields when the administrator configured none', async () => {
+        const tracker = trackHandler('post', REGISTRATION_URL, {});
+
+        await submitRegistration(IDENTITY);
+
+        expect(tracker.lastCall?.body).toEqual({ firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.com' });
+    });
+
+    it('carries a reCAPTCHA token when reCAPTCHA is configured', async () => {
+        server.use(http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ reCaptcha: { enabled: true, siteKey: 'site' } })));
+        window.grecaptcha = {
+            ready: (callback: () => void) => callback(),
+            execute: () => Promise.resolve('recaptcha-token'),
+        };
+        // No script fetch: `loadReCaptchaScript` resolves on the element it finds already present.
+        const script = document.createElement('script');
+        script.id = 'gamma-recaptcha';
+        document.head.appendChild(script);
+
+        const tracker = trackHandler('post', REGISTRATION_URL, {});
+
+        await submitRegistration(IDENTITY);
+
+        expect(tracker.lastCall?.headers.get('X-Recaptcha-Token')).toBe('recaptcha-token');
+
+        script.remove();
+        delete window.grecaptcha;
+    });
+
+    it('sends no reCAPTCHA header when reCAPTCHA is off', async () => {
+        const tracker = trackHandler('post', REGISTRATION_URL, {});
+
+        await submitRegistration(IDENTITY);
+
+        expect(tracker.lastCall?.headers.get('X-Recaptcha-Token')).toBeNull();
+    });
+
+    it('attributes a rejected email to the email field, without the server wording', async () => {
+        rejectRegistration({ message: 'Value [ada] is not a valid email.', technicalCode: 'email.invalid' });
+
+        await expect(submitRegistration({ ...IDENTITY, email: 'ada' })).resolves.toEqual({ outcome: 'email-rejected' });
+    });
+
+    it('says sign-up is off when the organization has turned registration off', async () => {
+        rejectRegistration({ message: 'User registration service is unavailable.', technicalCode: 'user.registration.disabled' }, 503);
+
+        await expect(submitRegistration(IDENTITY)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Sign-up is turned off for this organization. Ask your administrator for an account.',
+        });
+    });
+
+    it('never relays the server wording of a rejection no field owns', async () => {
+        // A 400 that names the organization: the caller is anonymous, and nothing in it is written for them.
+        rejectRegistration({ message: 'Gamma URL is not configured for organization: DEFAULT' });
+
+        await expect(submitRegistration(IDENTITY)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while sending your request. Try again.',
+        });
+    });
+
+    it('never relays the server wording of a server failure', async () => {
+        rejectRegistration({ message: 'java.lang.NullPointerException', technicalCode: 'unexpected' }, 500);
+
+        await expect(submitRegistration(IDENTITY)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while sending your request. Try again.',
+        });
+    });
+
+    it('reports an unreachable server against the form', async () => {
+        server.use(http.post(REGISTRATION_URL, () => HttpResponse.error()));
+
+        await expect(submitRegistration(IDENTITY)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while sending your request. Try again.',
+        });
+    });
+
+    it('reports an already-registered address as submitted, so an anonymous caller learns nothing', async () => {
+        // FOUND-303: `user.invalid` on this endpoint means only that the address is already taken.
+        // Relaying it would hand an anonymous caller an account-existence oracle in plain language.
+        rejectRegistration({
+            message: 'User cannot be created.',
+            technicalCode: 'user.invalid',
+            parameters: { user: 'ada@example.com', source: 'gravitee' },
+        });
+
+        await expect(submitRegistration(IDENTITY)).resolves.toEqual({ outcome: 'submitted' });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getReCaptchaHeaderName, resolveReCaptchaToken } from './recaptcha.service';
+import { ApiError, managementApi } from '../../../shared/api/api-client';
+
+/** One field an administrator added to the sign-up form (`CustomUserFieldEntity`). */
+export interface CustomUserField {
+    readonly key: string;
+    readonly label: string;
+    /** Absent or empty for a free-text field; a fixed list makes the field a choice. */
+    readonly values?: readonly string[];
+    readonly required: boolean;
+}
+
+export interface RegistrationRequest {
+    readonly firstname: string;
+    readonly lastname: string;
+    readonly email: string;
+    readonly customFields?: Readonly<Record<string, string>>;
+}
+
+export type RegistrationResult =
+    /** Nothing more is owed to the caller: an activation email is on its way, or deliberately is not. */
+    | { readonly outcome: 'submitted' }
+    /** The server refused the address itself. */
+    | { readonly outcome: 'email-rejected' }
+    /** Refused for a reason no single input owns, worded for the reader. */
+    | { readonly outcome: 'rejected'; readonly message: string };
+
+/**
+ * Sends the activation link to the Gamma registration page rather than the classic console.
+ * Only this fixed keyword is accepted -- `UsersRegistrationResource` rejects a URL.
+ */
+const GAMMA_REGISTRATION_TARGET = 'gamma';
+
+const UNEXPECTED_FAILURE = 'Something went wrong while sending your request. Try again.';
+const REGISTRATION_OFF = 'Sign-up is turned off for this organization. Ask your administrator for an account.';
+
+const EMAIL_REJECTED_CODE = 'email.invalid';
+const REGISTRATION_DISABLED_CODE = 'user.registration.disabled';
+
+/**
+ * Whether a rejection tells the caller only that the address is already registered.
+ *
+ * `POST /users/registration` reaches `InvalidUserException.cannotBeCreated` on exactly one
+ * condition -- `userRepository.findBySource` already holds the address -- and its sibling
+ * `user.invalid` throw is behind a service-account branch registration never takes. Passing that
+ * through would give an anonymous caller an account-existence oracle in plain language, so the
+ * page reports the same outcome either way (FOUND-303). The server-side fix is that story's.
+ */
+function isAccountExistenceOracle(error: ApiError): boolean {
+    return error.technicalCode === 'user.invalid';
+}
+
+/**
+ * The server's text is never shown: the caller is anonymous, and what arrives is an exception's own
+ * message -- at worst naming the organization, as a missing Gamma URL does in a 400.
+ */
+function toResult(error: ApiError): RegistrationResult {
+    if (isAccountExistenceOracle(error)) {
+        return { outcome: 'submitted' };
+    }
+    if (error.technicalCode === EMAIL_REJECTED_CODE) {
+        return { outcome: 'email-rejected' };
+    }
+    if (error.technicalCode === REGISTRATION_DISABLED_CODE) {
+        return { outcome: 'rejected', message: REGISTRATION_OFF };
+    }
+    return { outcome: 'rejected', message: UNEXPECTED_FAILURE };
+}
+
+/** The fields an administrator added to the sign-up form. Anonymous; may legitimately be empty. */
+export async function fetchCustomUserFields(): Promise<CustomUserField[]> {
+    return managementApi.get<CustomUserField[]>('/configuration/custom-user-fields');
+}
+
+/**
+ * Requests an account. Every failure comes back as a {@link RegistrationResult} so the page can
+ * render it against the input that caused it -- the alternative is a toast the reader may miss.
+ */
+export async function submitRegistration(request: RegistrationRequest): Promise<RegistrationResult> {
+    try {
+        const reCaptchaToken = await resolveReCaptchaToken('register');
+        const extraHeaders: Record<string, string> = {};
+        if (reCaptchaToken) {
+            extraHeaders[getReCaptchaHeaderName()] = reCaptchaToken;
+        }
+
+        await managementApi.post<void>(
+            `/users/registration?registrationTarget=${GAMMA_REGISTRATION_TARGET}`,
+            {
+                firstname: request.firstname,
+                lastname: request.lastname,
+                email: request.email,
+                ...(request.customFields ? { customFields: request.customFields } : {}),
+            },
+            extraHeaders,
+        );
+        return { outcome: 'submitted' };
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return toResult(error);
+        }
+        if (process.env.NODE_ENV !== 'production') {
+            console.error('Registration request failed', error);
+        }
+        return { outcome: 'rejected', message: UNEXPECTED_FAILURE };
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/auth.handlers.ts
@@ -44,4 +44,5 @@ export const authHandlers = [
         }),
     ),
     http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ reCaptcha: { enabled: false } })),
+    http.get(`${TEST_MANAGEMENT_BASE}/configuration/custom-user-fields`, () => HttpResponse.json([])),
 ];


### PR DESCRIPTION
Closes [FOUND-262](https://gravitee.atlassian.net/browse/FOUND-262).

Adds an anonymous sign-up page at `/sign-up` in the Gamma control plane. It collects first name, last name, email and any custom user fields the administrator configured, posts to `POST /users/registration?registrationTarget=gamma`, and replaces the page with a "check your email" state.

## ⚠️ Security-sensitive

- Anonymous page posting user input to an existing, already `permitAll` endpoint. No backend changes.
- Account enumeration ([FOUND-303](https://gravitee.atlassian.net/browse/FOUND-303)): a `user.invalid` response — the address is already registered — shows the same sent state as a success, so the page does not reveal whether an account exists.
- A reCAPTCHA token is sent when reCAPTCHA is configured.

## Notes

- The server's wording is never shown to the anonymous visitor: a rejected address shows on the email field, registration switched off gets its own sentence, and anything else a generic one.
- Email is checked on blur with the same rule as the server's `EmailValidator`.
- `registrationTarget` stays until [FOUND-307](https://gravitee.atlassian.net/browse/FOUND-307), still an idea, makes Gamma the default.
- Out of scope: the login-page link and registration gate ([FOUND-261](https://gravitee.atlassian.net/browse/FOUND-261)), and the activation page ([FOUND-263](https://gravitee.atlassian.net/browse/FOUND-263)). Known gap: focus is not moved when the page swaps.
- Based on `master`: the ticket's base branch `feat/FOUND-249-signup-gating` does not exist.

## Screenshots

| Configured fields — mixed required and optional | Identity only — no fields configured | Invalid email, caught before submit |
| --- | --- | --- |
| <img width="300" alt="Form with configured fields" src="https://github.com/user-attachments/assets/a342e48f-8c2f-4ce4-9acd-3570792f726a" /> | <img width="300" alt="Form with identity fields only" src="https://github.com/user-attachments/assets/0f063e4e-7d06-4b52-8616-f99027b8d103" /> | <img width="300" alt="Invalid email inline error" src="https://github.com/user-attachments/assets/d5079d37-0e30-4ced-aab2-e9a7a833baa3" /> |

| Fields read failed — surfaced, not blocking | Server rejection, inline on its field | Pending — submit cannot be fired twice |
| --- | --- | --- |
| <img width="300" alt="Custom user fields could not be loaded" src="https://github.com/user-attachments/assets/42b42137-f348-4c59-ad02-bbc75abc0a7c" /> | <img width="300" alt="Server error shown against the job title field" src="https://github.com/user-attachments/assets/d28be630-ee3d-47ab-aee0-a6b132b878ac" /> | <img width="300" alt="Pending submit" src="https://github.com/user-attachments/assets/f05bc7a2-d50e-40af-9717-2d0ce6039fdd" /> |

| Sent — identical for an already-registered address |
| --- |
| <img width="300" alt="Check your email" src="https://github.com/user-attachments/assets/ba332383-0561-4ae2-ad4a-695b75dbf3da" /> |

Tests: 33 suites / 263 tests green; `tsc`, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FOUND-262]: https://gravitee.atlassian.net/browse/FOUND-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-303]: https://gravitee.atlassian.net/browse/FOUND-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-307]: https://gravitee.atlassian.net/browse/FOUND-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
