### PR TITLE
fix(rest-api): accept performance target rules scoped to api types absent from the subject

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainService.java
@@ -38,6 +38,10 @@ import lombok.RequiredArgsConstructor;
  * Checks a target against the analytics definition and against the APIs of its subject, so that every rule can be
  * evaluated from gateway telemetry: the metric, measure and filters exist for the API types the rule covers, the
  * threshold fits the metric's unit, and the subject only lists v4 APIs of the target's environment.
+ *
+ * <p>A rule may name API types the subject does not hold yet. Its metric is still checked against those types, but
+ * the subject is not required to contain them: a subject grows and shrinks as its dependencies change, and such a
+ * rule is simply NOT_EVALUABLE until an API of that type joins it.
  */
 @DomainService
 @RequiredArgsConstructor
@@ -114,11 +118,9 @@ public class ValidatePerformanceTargetDomainService {
     }
 
     private void validateRule(PerformanceTarget.Rule rule, Set<ApiType> subjectApiTypes) {
-        for (var apiType : rule.apiTypes()) {
-            if (!subjectApiTypes.contains(apiType)) {
-                throw new InvalidPerformanceTargetException("API type %s is not part of the subject".formatted(apiType));
-            }
-        }
+        // A rule scoped to API types the subject does not hold right now is accepted: the metric is checked against
+        // the rule's own types, and the evaluator reports it NOT_EVALUABLE until the subject grows an API of that
+        // type. A subject changes as its dependencies come and go, so a scope must not pin it.
         var ruleApiTypes = rule.apiTypes().isEmpty() ? subjectApiTypes : rule.apiTypes();
 
         var metric = analyticsDefinition

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/domain_service/ValidatePerformanceTargetDomainServiceTest.java
@@ -117,17 +117,51 @@ class ValidatePerformanceTargetDomainServiceTest {
     }
 
     @Test
-    void should_reject_rule_api_types_that_are_not_in_the_subject() {
+    void should_accept_rule_api_types_that_are_not_in_the_subject_yet() {
+        // A subject grows and shrinks as its dependencies change; a rule scoped to a type the subject does not hold
+        // right now is NOT_EVALUABLE at evaluation time, not a reason to refuse the whole target.
         var rule = aRule(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 5)
             .toBuilder()
             .apiTypes(Set.of(ApiType.LLM_PROXY))
             .build();
         var target = aTarget(List.of(A2A_API), rule);
 
+        assertThatCode(() -> service.validate(target)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_still_reject_a_metric_unavailable_for_the_rule_api_types_even_when_they_are_absent_from_the_subject() {
+        var rule = aRule(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, MetricSpec.Measure.AVG, 0.01)
+            .toBuilder()
+            .apiTypes(Set.of(ApiType.A2A_PROXY))
+            .build();
+        var target = aTarget(List.of(LLM_API), rule);
+
         assertThatThrownBy(() -> service.validate(target))
             .isInstanceOf(InvalidPerformanceTargetException.class)
-            .hasMessageContaining("LLM_PROXY")
-            .hasMessageContaining("subject");
+            .hasMessageContaining("LLM_PROMPT_TOKEN_TOTAL_COST")
+            .hasMessageContaining("A2A_PROXY");
+    }
+
+    @Test
+    void should_accept_scoped_rules_on_a_subject_without_api_ids() {
+        // The shape a catalog agent is seeded with before any API is attributed to it.
+        var latency = aRule(MetricSpec.Name.HTTP_GATEWAY_RESPONSE_TIME, MetricSpec.Measure.P95, 4500)
+            .toBuilder()
+            .apiTypes(Set.of(ApiType.A2A_PROXY))
+            .build();
+        var errors = aRule(MetricSpec.Name.HTTP_ERROR_RATE, MetricSpec.Measure.PERCENTAGE, 5);
+        var cost = aRule(MetricSpec.Name.LLM_PROMPT_TOKEN_TOTAL_COST, MetricSpec.Measure.AVG, 0.06)
+            .toBuilder()
+            .apiTypes(Set.of(ApiType.LLM_PROXY))
+            .build();
+        var tokens = aRule(MetricSpec.Name.LLM_PROMPT_TOTAL_TOKEN, MetricSpec.Measure.AVG, 4000)
+            .toBuilder()
+            .apiTypes(Set.of(ApiType.LLM_PROXY))
+            .build();
+        var target = aTarget(List.of(), latency, errors, cost, tokens);
+
+        assertThatCode(() -> service.validate(target)).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Jira: [AIAM-516](https://gravitee.atlassian.net/browse/AIAM-516) — epic [AIAM-436](https://gravitee.atlassian.net/browse/AIAM-436).

## What

`ValidatePerformanceTargetDomainService` no longer rejects a rule whose `apiTypes` name a type the subject does not hold. The metric and filters are still validated against the rule's own types; the subject just is not required to contain them. Such a rule evaluates `NOT_EVALUABLE` until an API of that type joins the subject, which is already the evaluator's behaviour (`PerformanceTarget.apiIdsFor` → no ids → no samples).

## Why

A catalog agent's target is seeded before any API is attributed to it, with rules scoped to `A2A_PROXY` and `LLM_PROXY`, and its subject grows and shrinks as the agent's dependencies change. The AIAM-516 acceptance criteria ("adding an LLM proxy makes cost metrics available on the existing target", "removing the only API results in NOT_EVALUABLE") need the rules to survive those changes; the previous check made both the seed and the shrink a 400.

## Tests

- `should_reject_rule_api_types_that_are_not_in_the_subject` → `should_accept_rule_api_types_that_are_not_in_the_subject_yet`
- new: a metric unavailable for the rule's own types is still rejected even when those types are absent from the subject
- new: the four agent default rules are accepted on a subject without API ids
- `ValidatePerformanceTargetDomainServiceTest`, `PerformanceTargetEvaluatorImplTest`, `PerformanceTargetTest` green (24 / 22 / 17).

Consumer: gravitee-gamma-module-aim [PR #803](https://github.com/gravitee-io/gravitee-gamma-module-aim/pull/803) "performance targets on the catalog agent".

[AIAM-516]: https://gravitee.atlassian.net/browse/AIAM-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIAM-436]: https://gravitee.atlassian.net/browse/AIAM-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ