### PR TITLE
fix(deps): bump gravitee-expression-language to 4.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <gravitee-common-mcp.version>1.2.0</gravitee-common-mcp.version>
     <gravitee-connector-api.version>2.0.0</gravitee-connector-api.version>
     <gravitee-exchange.version>3.0.0</gravitee-exchange.version>
-    <gravitee-expression-language.version>4.4.0</gravitee-expression-language.version>
+    <gravitee-expression-language.version>4.4.1</gravitee-expression-language.version>
     <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
     <gravitee-gateway-api.version>6.3.0</gravitee-gateway-api.version>
     <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15008

1. `#jsonPath()` is backed by JsonPathFunction. Its static block calls `CacheProvider.setCache()` on the jayway json-path library.
2. `jayway` has one cache slot for the whole JVM. It can only be written once, and just reading it fills it.
3. JsonPathFunction loads lazily, on the first `#jsonPath `evaluation — not at boot.
4. So if any other component evaluates a `JsonPath` first, `setCache() `throws. The class is then permanently broken for the life of the JVM, and every later `#jsonPath` fails with `NoClassDefFoundError`. Only a restart clears it.

bump `gravitee-expression-language 4.4.0 → 4.4.1` and removes the two `Class.forName(JsonPathFunction.class) `workarounds 

## Description

Before Fix:
[before-fix.log](https://github.com/user-attachments/files/32088187/before-fix.log)

after fix:
[after-fix.log](https://github.com/user-attachments/files/32088213/after-fix.log)

