### PR TITLE
chore(distribution): bump human-approval policy to 1.0.0-beta.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -268,7 +268,7 @@
     <gravitee-policy-token-ratelimit.version>1.2.0-beta.1</gravitee-policy-token-ratelimit.version>
     <gravitee-policy-cost-ratelimit.version>1.2.0-beta.1</gravitee-policy-cost-ratelimit.version>
     <gravitee-policy-mcp-acl.version>2.0.0</gravitee-policy-mcp-acl.version>
-    <gravitee-policy-human-approval.version>1.0.0-beta.1</gravitee-policy-human-approval.version>
+    <gravitee-policy-human-approval.version>1.0.0-beta.2</gravitee-policy-human-approval.version>
     <gravitee-policy-pii-filtering.version>2.2.0</gravitee-policy-pii-filtering.version>
     <gravitee-policy-native-ipfiltering.version>1.0.1</gravitee-policy-native-ipfiltering.version>
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>


### PR DESCRIPTION
## Summary
Follow-up of #19838: the `human-approval` policy `1.0.0-beta.2` is out (gravitee-io-labs/gravitee-policy-human-approval#3, cut by semantic-release from `beta`). It names the reviewer by display name in the refusal sent to the agent, which the approvals console of the AIM module now provides (`decision.decidedByName`). Jira: [AIAM-561](https://gravitee.atlassian.net/browse/AIAM-561).

## Changes
- `gravitee-apim-distribution/pom.xml`: `gravitee-policy-human-approval.version` `1.0.0-beta.1` → `1.0.0-beta.2`.

## Test plan
- [ ] The distribution build resolves `com.graviteesource.policy:gravitee-policy-human-approval:zip:1.0.0-beta.2` from the release repository.
- [ ] On the `amp-demo` images, reject a held call from the console: the agent's error reads `Tool call rejected by <display name> (<reason>)`, not a user id.

Refs AIAM-561


[AIAM-561]: https://gravitee.atlassian.net/browse/AIAM-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ