### PR TITLE
chore(distribution): bump gamma module AIM version to 4.3.0-beta.18

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -274,7 +274,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>4.3.0-beta.17</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.18</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-561

## Description

Bump the Gamma AIM module bundled in the distribution from `4.3.0-beta.17` to `4.3.0-beta.18`, the first `beta` release that carries the human-in-the-loop approvals (AIAM-423): the approval broker and its gateway surface (#756), human approval attached to MCP proxies (#759), the Approvals console with inbox, decisions, rules and insights (#760) and the JDBC persistence (#761) of gravitee-gamma-module-aim.

## Additional context

- Pairs with the `human-approval` gateway policy `1.0.0-beta.2` bundled by #19857: the policy reads `decision.decidedByName`, which this module version returns.
- The Management API needs `modules.aim.approvals.gatewaySecret` (`gravitee_modules_aim_approvals_gatewaySecret`) and the gateway `policies.human-approval.broker.{url,authorization,secret}` with `http.requestTimeout` above the policy hold window; the demo environment values are in gravitee-io/cloud-apim#322.
