### PR TITLE
feat(portal): fix agent backlink from subscription details.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -55,7 +55,7 @@ describe('SubscriptionsDetailsComponent', () => {
   let httpTestingController: HttpTestingController;
   let harnessLoader: HarnessLoader;
   let rootLoader: HarnessLoader;
-  let searchNavigationItemsWithApisMock: jest.Mock;
+  let findDocumentationNavigationTargetMock: jest.Mock;
 
   const API_ID = 'testApiId';
   const CONFIGURATION_KAFKA_SASL_MECHANISMS = ['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'];
@@ -77,20 +77,10 @@ describe('SubscriptionsDetailsComponent', () => {
   }
 
   beforeEach(async () => {
-    searchNavigationItemsWithApisMock = jest.fn().mockReturnValue(
+    findDocumentationNavigationTargetMock = jest.fn().mockReturnValue(
       of({
-        data: [
-          {
-            id: API_ID,
-            name: 'API',
-            version: '1',
-            description: '',
-            rootId: 'root-id',
-            navItemId: 'nav-item-id',
-          },
-        ],
-        metadata: {},
-        links: {},
+        rootId: 'root-id',
+        navItemId: 'nav-item-id',
       }),
     );
 
@@ -104,8 +94,7 @@ describe('SubscriptionsDetailsComponent', () => {
         {
           provide: PortalNavigationItemsService,
           useValue: {
-            searchNavigationItemsWithApis: (page: number, query: string, size: number) =>
-              searchNavigationItemsWithApisMock(page, query, size),
+            findDocumentationNavigationTarget: (apiId: string, apiName?: string) => findDocumentationNavigationTargetMock(apiId, apiName),
           },
         },
       ],
@@ -678,7 +667,7 @@ describe('SubscriptionsDetailsComponent', () => {
 
   describe('when documentation is available but navigation target cannot be resolved', () => {
     beforeEach(() => {
-      searchNavigationItemsWithApisMock.mockReturnValue(of({ data: [], metadata: {}, links: {} }));
+      findDocumentationNavigationTargetMock.mockReturnValue(of(null));
       expectSubscriptionWithKeys(fakeSubscription({ status: 'ACCEPTED' }));
       expectGetApiPermissions();
       expectPlansList(fakePlansResponse());
@@ -691,6 +680,37 @@ describe('SubscriptionsDetailsComponent', () => {
 
       expect(fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]')).toBeNull();
       expect(fixture.nativeElement.querySelector('[data-testid="subscription-api-label"]')).not.toBeNull();
+    });
+  });
+
+  describe('when the subscribed API is an agent with a documentation target', () => {
+    const AGENT_NAME = 'Helpdesk Agent';
+    const AGENT_ROOT_ID = 'agent-root-id';
+    const AGENT_NAV_ITEM_ID = 'agent-nav-item-id';
+
+    beforeEach(() => {
+      findDocumentationNavigationTargetMock.mockReturnValue(
+        of({
+          rootId: AGENT_ROOT_ID,
+          navItemId: AGENT_NAV_ITEM_ID,
+        }),
+      );
+      expectSubscriptionWithKeys(fakeSubscription({ status: 'ACCEPTED' }));
+      expectGetApiPermissions();
+      expectPlansList(fakePlansResponse());
+      expectApplicationsList(fakeApplication());
+      expectGetApi(fakeApi({ id: API_ID, name: AGENT_NAME, entrypoints: ['https://gw/entrypoint'] }));
+    });
+
+    it('should link the agent name to its documentation page', async () => {
+      fixture.detectChanges();
+
+      expect(findDocumentationNavigationTargetMock).toHaveBeenCalledWith(API_ID, AGENT_NAME);
+      const apiLink = fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]');
+      expect(apiLink).not.toBeNull();
+      expect(apiLink.getAttribute('href')).toContain(`/documentation/${AGENT_ROOT_ID}`);
+      expect(apiLink.getAttribute('href')).toContain(`selectedId=${AGENT_NAV_ITEM_ID}`);
+      expect(apiLink.textContent?.trim()).toBe(AGENT_NAME);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -214,16 +214,21 @@ export class SubscriptionsDetailsComponent implements OnInit {
           application: this.applicationService.get(subscription.application),
           applicationPermissions: this.getApplicationPermissions$(subscription.application),
           hasDocumentationAccess: of(!!apiPermissions),
-          documentationNavigationTarget: apiPermissions
-            ? this.portalNavigationItemsService.searchNavigationItemsWithApis(1, this.apiId, 10).pipe(
-                map(res => {
-                  const item = res.data.find(i => i.id === this.apiId);
-                  return item ? { rootId: item.rootId, navItemId: item.navItemId } : null;
-                }),
-                catchError(() => of(null)),
-              )
-            : of(null),
         }),
+      ),
+      switchMap(({ subscription, apiPermissions, plan, api, application, applicationPermissions, hasDocumentationAccess }) =>
+        (apiPermissions ? this.portalNavigationItemsService.findDocumentationNavigationTarget(this.apiId, api?.name) : of(null)).pipe(
+          map(documentationNavigationTarget => ({
+            subscription,
+            apiPermissions,
+            plan,
+            api,
+            application,
+            applicationPermissions,
+            hasDocumentationAccess,
+            documentationNavigationTarget,
+          })),
+        ),
       ),
       map(
         ({

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -390,4 +390,92 @@ describe('PortalNavigationItemsService', () => {
     );
     req.flush(rawResponse);
   });
+
+  describe('findDocumentationNavigationTarget', () => {
+    const apiId = 'api-1';
+    const apiName = 'Helpdesk Agent';
+
+    it('should return the type=api search hit and skip the catalog', done => {
+      const api = fakeApi({ id: apiId, name: 'Weather API' });
+
+      service.findDocumentationNavigationTarget(apiId, apiName).subscribe(target => {
+        expect(target).toEqual({ rootId: 'root-1', navItemId: 'nav-1' });
+        done();
+      });
+
+      const apiSearch = httpMock.expectOne(
+        r =>
+          r.method === 'GET' &&
+          r.url === `${baseURL}/portal-navigation-items/_search` &&
+          r.params.get('type') === 'api' &&
+          r.params.get('query') === apiId &&
+          r.params.get('size') === '10',
+      );
+      apiSearch.flush({
+        data: [{ type: 'API' as const, apiId: api.id, id: 'nav-1', rootId: 'root-1' }],
+        apis: [api],
+      });
+    });
+
+    it('should fall back to an AGENT catalog item matching the api id when type=api search misses', done => {
+      const agentApi = fakeApi({ id: apiId, name: apiName });
+
+      service.findDocumentationNavigationTarget(apiId, apiName).subscribe(target => {
+        expect(target).toEqual({ rootId: 'agent-root-1', navItemId: 'agent-nav-1' });
+        done();
+      });
+
+      const apiSearch = httpMock.expectOne(
+        r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/_search` && r.params.get('type') === 'api',
+      );
+      apiSearch.flush({ data: [], apis: [] });
+
+      const catalogSearch = httpMock.expectOne(
+        r =>
+          r.method === 'GET' &&
+          r.url === `${baseURL}/portal-navigation-items/_search` &&
+          r.params.get('type') === 'catalog' &&
+          r.params.get('query') === apiName &&
+          r.params.get('size') === '10',
+      );
+      catalogSearch.flush({
+        data: [
+          {
+            type: 'AGENT' as const,
+            apiId: agentApi.id,
+            id: 'agent-nav-1',
+            rootId: 'agent-root-1',
+          },
+        ],
+        apis: [agentApi],
+      });
+    });
+
+    it('should return null when neither the type=api search nor the AGENT catalog fallback matches', done => {
+      service.findDocumentationNavigationTarget(apiId, apiName).subscribe(target => {
+        expect(target).toBeNull();
+        done();
+      });
+
+      httpMock
+        .expectOne(r => r.url === `${baseURL}/portal-navigation-items/_search` && r.params.get('type') === 'api')
+        .flush({
+          data: [],
+          apis: [],
+        });
+      httpMock
+        .expectOne(r => r.url === `${baseURL}/portal-navigation-items/_search` && r.params.get('type') === 'catalog')
+        .flush({
+          data: [
+            {
+              type: 'API' as const,
+              apiId: 'other-api',
+              id: 'other-nav',
+              rootId: 'other-root',
+            },
+          ],
+          apis: [fakeApi({ id: 'other-api', name: apiName })],
+        });
+    });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
@@ -110,6 +110,27 @@ export class PortalNavigationItemsService {
       .pipe(map(res => this.mapToCatalogSearchResponse(res)));
   }
 
+  findDocumentationNavigationTarget(apiId: string, apiName?: string): Observable<ApiDocumentationNavigationTarget | null> {
+    return this.searchNavigationItemsWithApis(1, apiId, 10).pipe(
+      switchMap(res => {
+        const item = res.data.find(i => i.id === apiId);
+        if (item) {
+          return of({ rootId: item.rootId, navItemId: item.navItemId });
+        }
+        if (!apiName) {
+          return of(null);
+        }
+        return this.searchCatalogItems(1, apiName, 10).pipe(
+          map(catalog => {
+            const agent = catalog.data.find(i => i.type === 'AGENT' && i.id === apiId);
+            return agent ? { rootId: agent.rootId, navItemId: agent.navItemId } : null;
+          }),
+        );
+      }),
+      catchError(() => of(null)),
+    );
+  }
+
   private mapToSearchResponse(res: PortalNavigationItemsSearchResponse): PortalNavigationApisSearchResponse {
     const navItems = res.data ?? [];
     const apis = res.apis ?? [];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-613

### Description

On Portal Next subscription details, the subscribed API name was a documentation link only when a type=api navigation search found a matching item. Published agents live in the catalog as AGENT items with a backing API id, so that search always missed and the name stayed a non-clickable label.

This change resolves the documentation target from the API search first, then falls back to a name-scoped catalog search for an AGENT item with the same backing API id. Opening dashboard subscription details for a published agent now links the name to its documentation page. Unpublished APIs and items with no matching nav entry still render as a label.
