### PR TITLE
feat(gamma-console): show a sign-up entry point on the login page when registration is enabled

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.spec.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AppRoutes } from './AppRoutes';
+import { TEST_MANAGEMENT_BASE } from '../testing/factories';
+import { seedBootstrap, trackHandler } from '../testing/helpers';
+
+function renderAt(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <AppRoutes />
+        </MemoryRouter>,
+    );
+}
+
+describe('AppRoutes', () => {
+    describe('/sign-up', () => {
+        it('should send a hand-typed sign-up URL to login when registration is disabled', async () => {
+            seedBootstrap({ registrationEnabled: false });
+            const customUserFields = trackHandler('get', `${TEST_MANAGEMENT_BASE}/configuration/custom-user-fields`, []);
+
+            renderAt('/sign-up');
+
+            expect(await screen.findByRole('button', { name: 'Sign in' })).toBeTruthy();
+            expect(screen.queryByRole('button', { name: 'Request account' })).toBeNull();
+            // Every anonymous load renders the loading route table, then the main one. Without a
+            // guard in either, the sign-up page mounts on the way to /login and this request fires.
+            expect(customUserFields.callCount).toBe(0);
+        });
+
+        it('should render the sign-up page when registration is enabled', async () => {
+            seedBootstrap({ registrationEnabled: true });
+
+            renderAt('/sign-up');
+
+            expect(await screen.findByRole('button', { name: 'Request account' })).toBeTruthy();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
@@ -15,7 +15,7 @@
  */
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { LoginPage, ProtectedRoute, PublicOnlyRoute, ResetPasswordPage, SignUpPage } from '../features/auth';
+import { LoginPage, ProtectedRoute, PublicOnlyRoute, RegistrationEnabledRoute, ResetPasswordPage, SignUpPage } from '../features/auth';
 import { EnvironmentGuard, RootRedirect } from '../features/environment';
 import { type GammaModule, RemoteModuleRoute, useGammaModules } from '../features/modules';
 import { HomePage } from '../pages/home';
@@ -33,7 +33,9 @@ export function AppRoutes() {
                 <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
                 <Route element={<PublicOnlyRoute />}>
                     <Route path="/login" element={<LoginPage />} />
-                    <Route path="/sign-up" element={<SignUpPage />} />
+                    <Route element={<RegistrationEnabledRoute />}>
+                        <Route path="/sign-up" element={<SignUpPage />} />
+                    </Route>
                 </Route>
                 <Route element={<ProtectedRoute />}>
                     <Route path="/environments/:envHrid" element={<ShellLayout modules={[]} />}>
@@ -53,7 +55,9 @@ export function AppRoutes() {
             <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
             <Route element={<PublicOnlyRoute />}>
                 <Route path="/login" element={<LoginPage />} />
-                <Route path="/sign-up" element={<SignUpPage />} />
+                <Route element={<RegistrationEnabledRoute />}>
+                    <Route path="/sign-up" element={<SignUpPage />} />
+                </Route>
             </Route>
             <Route element={<ProtectedRoute />}>
                 <Route path="/environments/:envHrid" element={<ShellLayout modules={modules} />}>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.selectors.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.selectors.ts
@@ -22,3 +22,4 @@ export const useLogin = () => useAuthStore(s => s.login);
 export const useLogout = () => useAuthStore(s => s.logout);
 export const useIdentityProviders = () => useBootstrapStore(s => s.config?.identityProviders ?? []);
 export const useLocalLoginEnabled = () => useBootstrapStore(s => s.config?.localLoginEnabled ?? true);
+export const useRegistrationEnabled = () => useBootstrapStore(s => s.config?.registrationEnabled ?? false);

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.spec.tsx
@@ -70,10 +70,11 @@ function seedWithProviders(providers: SocialIdentityProvider[], localLoginEnable
     });
 }
 
-function stubLoginMethods(providers: SocialIdentityProvider[] = [], localLoginEnabled = true) {
+function stubLoginMethods(providers: SocialIdentityProvider[] = [], localLoginEnabled = true, registrationEnabled = false) {
     respondWith('get', `${TEST_MANAGEMENT_BASE}/social-identities`, providers);
     respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, {
         authentication: { localLogin: { enabled: localLoginEnabled } },
+        management: { userCreation: { enabled: registrationEnabled } },
         reCaptcha: { enabled: false },
     });
 }
@@ -346,6 +347,45 @@ describe('LoginPage', () => {
 
             expect(loginWithProviderSpy).toHaveBeenCalledWith('google-idp', '/dashboard');
             loginWithProviderSpy.mockRestore();
+        });
+    });
+
+    describe('sign-up entry point', () => {
+        it('should link to sign-up when registration is enabled', async () => {
+            stubLoginMethods([], true, true);
+            renderLoginPage();
+
+            const link = await screen.findByRole('link', { name: 'Request an account' });
+            expect(link.getAttribute('href')).toBe('/sign-up');
+        });
+
+        it('should render nothing about sign-up when registration is disabled', async () => {
+            stubLoginMethods([], true, false);
+            renderLoginPage();
+
+            await screen.findByLabelText('Username');
+            // Not a disabled control and not an explanation: either would advertise a
+            // capability the operator turned off.
+            expect(screen.queryByRole('link', { name: 'Request an account' })).toBeNull();
+            expect(screen.queryByText(/account/i)).toBeNull();
+        });
+
+        it('should not offer sign-up when local login is disabled', async () => {
+            stubLoginMethods([googleProvider], false, true);
+            renderLoginPage();
+
+            await screen.findByText('Google');
+            // Sign-up creates a local account, which nothing on this page could then sign in with.
+            expect(screen.queryByRole('link', { name: 'Request an account' })).toBeNull();
+        });
+
+        it('should place sign-up after the identity providers', async () => {
+            stubLoginMethods([googleProvider], true, true);
+            renderLoginPage();
+
+            const signUp = await screen.findByRole('link', { name: 'Request an account' });
+            const provider = screen.getByRole('button', { name: 'Continue with Google' });
+            expect(provider.compareDocumentPosition(signUp) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/LoginPage.tsx
@@ -26,10 +26,10 @@ import {
     Spinner,
 } from '@gravitee/graphene-core';
 import { useEffect, useState, type SubmitEvent } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
-import { useIdentityProviders, useLocalLoginEnabled, useLogin } from '../auth.selectors';
+import { useIdentityProviders, useLocalLoginEnabled, useLogin, useRegistrationEnabled } from '../auth.selectors';
 import { useAuthStore } from '../auth.store';
 import type { SocialIdentityProvider } from '../auth.types';
 import { AuthPageShell } from './AuthPageShell';
@@ -56,6 +56,7 @@ export function LoginPage() {
     const [searchParams] = useSearchParams();
     const identityProviders = useIdentityProviders();
     const localLoginEnabled = useLocalLoginEnabled();
+    const registrationEnabled = useRegistrationEnabled();
     const refreshLoginMethods = useBootstrapStore(s => s.refreshLoginMethods);
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
@@ -95,7 +96,23 @@ export function LoginPage() {
     const description = loginCardDescription(noLoginMethod, localLoginEnabled);
 
     return (
-        <AuthPageShell title="Sign in" description={description}>
+        <AuthPageShell
+            title="Sign in"
+            description={description}
+            // The footer trails the identity providers: sign-up is the least frequent action here.
+            // It is absent, not disabled, unless both registration and local login are on: sign-up
+            // creates a local account, so without local login it would lead to one nobody can use.
+            footer={
+                registrationEnabled && localLoginEnabled ? (
+                    <>
+                        {"Don't have an account?"}{' '}
+                        <Link to="/sign-up" className="text-primary underline-offset-4 hover:underline">
+                            Request an account
+                        </Link>
+                    </>
+                ) : undefined
+            }
+        >
             {displayError ? (
                 <Alert variant="destructive" role="alert" className="mb-4">
                     <AlertTitle>{error ? 'Could not sign in' : 'Sign-in unavailable'}</AlertTitle>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/RegistrationEnabledRoute.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/RegistrationEnabledRoute.spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { RegistrationEnabledRoute } from './RegistrationEnabledRoute';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
+import { seedBootstrap } from '../../../testing/helpers';
+
+function renderSignUpRoute() {
+    return render(
+        <MemoryRouter initialEntries={['/sign-up']}>
+            <Routes>
+                <Route element={<RegistrationEnabledRoute />}>
+                    <Route path="/sign-up" element={<div>Sign-up Page</div>} />
+                </Route>
+                <Route path="/login" element={<div>Login Page</div>} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('RegistrationEnabledRoute', () => {
+    it('should render the sign-up page when registration is enabled', () => {
+        seedBootstrap({ registrationEnabled: true });
+
+        renderSignUpRoute();
+
+        expect(screen.getByText('Sign-up Page')).toBeTruthy();
+    });
+
+    it('should redirect to login when registration is disabled', () => {
+        seedBootstrap({ registrationEnabled: false });
+
+        renderSignUpRoute();
+
+        expect(screen.getByText('Login Page')).toBeTruthy();
+        expect(screen.queryByText('Sign-up Page')).toBeNull();
+    });
+
+    it('should redirect to login when the registration setting is unresolved', () => {
+        useBootstrapStore.setState({ config: null });
+
+        renderSignUpRoute();
+
+        expect(screen.getByText('Login Page')).toBeTruthy();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/RegistrationEnabledRoute.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/RegistrationEnabledRoute.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useRegistrationEnabled } from '../auth.selectors';
+
+/**
+ * Guards the sign-up request page only. The activation route must stay outside it: someone
+ * holding a valid token deserves the server's explanation, which comes from finalization,
+ * not a silent bounce to a login page that says nothing.
+ */
+export function RegistrationEnabledRoute() {
+    const registrationEnabled = useRegistrationEnabled();
+
+    if (!registrationEnabled) {
+        return <Navigate to="/login" replace />;
+    }
+
+    return <Outlet />;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
@@ -20,7 +20,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { SignUpPage } from './SignUpPage';
 import { TEST_MANAGEMENT_BASE } from '../../../testing/factories';
-import { respondWith, trackHandler } from '../../../testing/helpers';
+import { respondWith, seedBootstrap, trackHandler } from '../../../testing/helpers';
 import { server } from '../../../testing/server';
 import type { CustomUserField } from '../services/registration.service';
 
@@ -321,6 +321,34 @@ describe('SignUpPage', () => {
 
             await screen.findByText('Check your email');
             expect(screen.queryByRole('button', { name: /resend|send again/i })).toBeNull();
+        });
+
+        it('points to the spam folder when requests are validated automatically', async () => {
+            const user = userEvent.setup();
+            seedBootstrap({ automaticValidationEnabled: true });
+            trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            expect(await screen.findByText(/check your spam folder/)).toBeTruthy();
+            expect(screen.queryByText(/administrator/)).toBeNull();
+        });
+
+        it('says an administrator approves the request first when requests are not validated automatically', async () => {
+            const user = userEvent.setup();
+            seedBootstrap({ automaticValidationEnabled: false });
+            trackHandler('post', REGISTRATION_URL, {});
+            renderSignUpPage();
+
+            await fillIdentity(user);
+            await waitFor(() => expect(submitButton().disabled).toBe(false));
+            await user.click(submitButton());
+
+            expect(await screen.findByText(/An administrator reviews each request/)).toBeTruthy();
+            expect(screen.queryByText(/spam folder/)).toBeNull();
         });
 
         it('is identical for an address that already has an account', async () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
@@ -37,6 +37,7 @@ import { useEffect, useState, type SubmitEvent } from 'react';
 import { Link } from 'react-router-dom';
 
 import { AuthPageShell } from './AuthPageShell';
+import { useBootstrapStore } from '../../../shared/config/bootstrap.store';
 import { fetchCustomUserFields, submitRegistration, type CustomUserField } from '../services/registration.service';
 
 /**
@@ -80,6 +81,7 @@ export function SignUpPage() {
     const [formError, setFormError] = useState('');
     const [submitting, setSubmitting] = useState(false);
     const [sentTo, setSentTo] = useState<string | null>(null);
+    const automaticValidationEnabled = useBootstrapStore(s => s.config?.automaticValidationEnabled ?? false);
 
     useEffect(() => {
         let active = true;
@@ -167,12 +169,12 @@ export function SignUpPage() {
                         Your request has been sent. The activation link goes to{' '}
                         <span className="font-medium text-foreground">{sentTo}</span>.
                     </p>
-                    {/* Deliberately does not promise the email has already left. With
-                        `automaticValidation` off nothing is sent until an administrator
-                        approves, and this page cannot see that setting until FOUND-261 reads it. */}
+                    {/* With automatic validation off the server emails nothing until an
+                        administrator approves, so the page must not promise an email yet. */}
                     <p>
-                        If it has not arrived within a few minutes, check your spam folder — an administrator may need to approve the
-                        request first.
+                        {automaticValidationEnabled
+                            ? 'If it has not arrived within a few minutes, check your spam folder.'
+                            : 'An administrator reviews each request first. The link is sent once yours is approved.'}
                     </p>
                 </div>
                 {/* The only thing left to do here, so it is the page's control rather than muted

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useUser, useIsAuthenticated, useLogin, useLogout, useIdentityProviders, useLocalLoginEnabled } from './auth.selectors';
+export {
+    useUser,
+    useIsAuthenticated,
+    useLogin,
+    useLogout,
+    useIdentityProviders,
+    useLocalLoginEnabled,
+    useRegistrationEnabled,
+} from './auth.selectors';
 export { useAuthStore } from './auth.store';
 export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType } from './auth.types';
 export { LoginPage } from './components/LoginPage';
 export { ResetPasswordPage } from './components/ResetPasswordPage';
 export { SignUpPage } from './components/SignUpPage';
 export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
+export { RegistrationEnabledRoute } from './components/RegistrationEnabledRoute';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.spec.ts
@@ -115,6 +115,57 @@ describe('bootstrapStore', () => {
         expect(useBootstrapStore.getState().loginMethodsFetchedAt).toBeNull();
     });
 
+    it('should store the registration settings from console settings', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, {
+            authentication: { localLogin: { enabled: true } },
+            management: { userCreation: { enabled: true }, automaticValidation: { enabled: true } },
+            reCaptcha: { enabled: false },
+        });
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.registrationEnabled).toBe(true);
+        expect(useBootstrapStore.getState().config?.automaticValidationEnabled).toBe(true);
+    });
+
+    it('should treat missing registration settings as disabled', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { reCaptcha: { enabled: false } });
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.registrationEnabled).toBe(false);
+        expect(useBootstrapStore.getState().config?.automaticValidationEnabled).toBe(false);
+    });
+
+    it('should leave registration disabled when console fetch fails', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/console`, 500);
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.registrationEnabled).toBe(false);
+        expect(useBootstrapStore.getState().config?.automaticValidationEnabled).toBe(false);
+    });
+
+    it('should keep local login and registration off when the console body is unreadable', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, null);
+
+        await useBootstrapStore.getState().initialize();
+
+        expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+        expect(useBootstrapStore.getState().config?.registrationEnabled).toBe(false);
+        expect(useBootstrapStore.getState().loginMethodsFetchedAt).toBeNull();
+    });
+
+    it('should refresh the registration settings without a full reload', async () => {
+        await useBootstrapStore.getState().initialize();
+        useBootstrapStore.setState({ loginMethodsFetchedAt: 0 });
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, { management: { userCreation: { enabled: true } } });
+
+        await useBootstrapStore.getState().refreshLoginMethods();
+
+        expect(useBootstrapStore.getState().config?.registrationEnabled).toBe(true);
+    });
+
     it('should skip a refresh when login methods were just fetched', async () => {
         await useBootstrapStore.getState().initialize();
         const tracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/social-identities`, [GOOGLE_PROVIDER]);
@@ -150,6 +201,24 @@ describe('bootstrapStore', () => {
 
         expect(useBootstrapStore.getState().config?.identityProviders).toEqual([GOOGLE_PROVIDER]);
         expect(useBootstrapStore.getState().config?.localLoginEnabled).toBe(false);
+    });
+
+    it('should keep the previous console settings when a refresh body is unreadable', async () => {
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, {
+            authentication: { localLogin: { enabled: false } },
+            management: { userCreation: { enabled: true }, automaticValidation: { enabled: true } },
+        });
+        await useBootstrapStore.getState().initialize();
+        useBootstrapStore.setState({ loginMethodsFetchedAt: 0 });
+        respondWith('get', `${TEST_MANAGEMENT_BASE}/console`, null);
+
+        await useBootstrapStore.getState().refreshLoginMethods();
+
+        const { config, loginMethodsFetchedAt } = useBootstrapStore.getState();
+        expect(config?.localLoginEnabled).toBe(false);
+        expect(config?.registrationEnabled).toBe(true);
+        expect(config?.automaticValidationEnabled).toBe(true);
+        expect(loginMethodsFetchedAt).toBe(0);
     });
 
     it('should ignore an older refresh that finishes after a newer one', async () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/bootstrap.store.ts
@@ -25,6 +25,8 @@ export interface BootstrapConfig {
     organizationId: string;
     identityProviders: SocialIdentityProvider[];
     localLoginEnabled: boolean;
+    registrationEnabled: boolean;
+    automaticValidationEnabled: boolean;
 }
 
 interface BootstrapState {
@@ -49,11 +51,34 @@ function organizationManagementUrl(managementBaseURL: string, organizationId: st
     return `${sanitizeBaseURL(managementBaseURL)}/organizations/${organizationId}`;
 }
 
-function localLoginEnabledFrom(consoleJson: unknown): boolean {
+type ConsoleAccessSettings = Pick<BootstrapConfig, 'localLoginEnabled' | 'registrationEnabled' | 'automaticValidationEnabled'>;
+
+interface RegistrationConsoleSettings {
+    management?: {
+        userCreation?: { enabled?: boolean };
+        automaticValidation?: { enabled?: boolean };
+    };
+}
+
+/** Until `/console` has been read once, every way in that it controls stays shut. */
+const UNREAD_CONSOLE_ACCESS_SETTINGS: ConsoleAccessSettings = {
+    localLoginEnabled: false,
+    registrationEnabled: false,
+    automaticValidationEnabled: false,
+};
+
+/** A body that is not an object counts as unread, like a failed request, so it cannot reopen a gate. */
+function consoleAccessSettingsFrom(consoleJson: unknown): ConsoleAccessSettings | undefined {
     if (!consoleJson || typeof consoleJson !== 'object') {
-        return true;
+        return undefined;
     }
-    return isLocalLoginEnabled(consoleJson as LocalLoginConsoleSettings);
+    const { management } = consoleJson as RegistrationConsoleSettings;
+    // Unlike local login, registration defaults to off: only an explicit `true` opens sign-up.
+    return {
+        localLoginEnabled: isLocalLoginEnabled(consoleJson as LocalLoginConsoleSettings),
+        registrationEnabled: management?.userCreation?.enabled === true,
+        automaticValidationEnabled: management?.automaticValidation?.enabled === true,
+    };
 }
 
 async function fetchIdentityProviders(managementBaseURL: string, organizationId: string): Promise<SocialIdentityProvider[] | undefined> {
@@ -68,14 +93,14 @@ async function fetchIdentityProviders(managementBaseURL: string, organizationId:
     return undefined;
 }
 
-async function fetchLocalLoginEnabled(managementBaseURL: string, organizationId: string): Promise<boolean | undefined> {
+async function fetchConsoleAccessSettings(managementBaseURL: string, organizationId: string): Promise<ConsoleAccessSettings | undefined> {
     try {
         const consoleRes = await fetch(`${organizationManagementUrl(managementBaseURL, organizationId)}/console`);
         if (consoleRes.ok) {
-            return localLoginEnabledFrom(await consoleRes.json());
+            return consoleAccessSettingsFrom(await consoleRes.json());
         }
     } catch {
-        // Non-fatal: keep the previous value, or leave local login off until a successful read.
+        // Non-fatal: keep the previous values, or leave local login and registration off until a successful read.
     }
     return undefined;
 }
@@ -83,12 +108,12 @@ async function fetchLocalLoginEnabled(managementBaseURL: string, organizationId:
 async function loadLoginMethods(
     managementBaseURL: string,
     organizationId: string,
-): Promise<{ identityProviders: SocialIdentityProvider[] | undefined; localLoginEnabled: boolean | undefined }> {
-    const [identityProviders, localLoginEnabled] = await Promise.all([
+): Promise<{ identityProviders: SocialIdentityProvider[] | undefined; consoleSettings: ConsoleAccessSettings | undefined }> {
+    const [identityProviders, consoleSettings] = await Promise.all([
         fetchIdentityProviders(managementBaseURL, organizationId),
-        fetchLocalLoginEnabled(managementBaseURL, organizationId),
+        fetchConsoleAccessSettings(managementBaseURL, organizationId),
     ]);
-    return { identityProviders, localLoginEnabled };
+    return { identityProviders, consoleSettings };
 }
 
 function isLoginMethodsFresh(fetchedAt: number | null): boolean {
@@ -121,7 +146,7 @@ export const useBootstrapStore = create<BootstrapState>()(
                     const organizationId = bootstrap.organizationId as string;
                     const loginMethods = await loadLoginMethods(managementBaseURL, organizationId);
                     const loginMethodsFetchedAt =
-                        loginMethods.identityProviders !== undefined && loginMethods.localLoginEnabled !== undefined ? Date.now() : null;
+                        loginMethods.identityProviders !== undefined && loginMethods.consoleSettings !== undefined ? Date.now() : null;
 
                     set({
                         config: {
@@ -129,7 +154,7 @@ export const useBootstrapStore = create<BootstrapState>()(
                             gammaBaseURL: sanitizeBaseURL(bootstrap.gammaBaseURL),
                             organizationId,
                             identityProviders: loginMethods.identityProviders ?? [],
-                            localLoginEnabled: loginMethods.localLoginEnabled ?? false,
+                            ...(loginMethods.consoleSettings ?? UNREAD_CONSOLE_ACCESS_SETTINGS),
                         },
                         loginMethodsFetchedAt,
                         loading: false,
@@ -150,9 +175,9 @@ export const useBootstrapStore = create<BootstrapState>()(
                 }
 
                 const requestId = ++latestLoginMethodsRefreshId;
-                const [identityProviders, localLoginEnabled] = await Promise.all([
+                const [identityProviders, consoleSettings] = await Promise.all([
                     fetchIdentityProviders(config.managementBaseURL, config.organizationId),
-                    fetchLocalLoginEnabled(config.managementBaseURL, config.organizationId),
+                    fetchConsoleAccessSettings(config.managementBaseURL, config.organizationId),
                 ]);
                 if (requestId !== latestLoginMethodsRefreshId) {
                     return;
@@ -167,10 +192,12 @@ export const useBootstrapStore = create<BootstrapState>()(
                     config: {
                         ...current,
                         identityProviders: identityProviders ?? current.identityProviders,
-                        localLoginEnabled: localLoginEnabled ?? current.localLoginEnabled,
+                        localLoginEnabled: consoleSettings?.localLoginEnabled ?? current.localLoginEnabled,
+                        registrationEnabled: consoleSettings?.registrationEnabled ?? current.registrationEnabled,
+                        automaticValidationEnabled: consoleSettings?.automaticValidationEnabled ?? current.automaticValidationEnabled,
                     },
                     loginMethodsFetchedAt:
-                        identityProviders !== undefined && localLoginEnabled !== undefined ? Date.now() : get().loginMethodsFetchedAt,
+                        identityProviders !== undefined && consoleSettings !== undefined ? Date.now() : get().loginMethodsFetchedAt,
                 });
             },
         }),

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
@@ -23,6 +23,8 @@ export const TEST_CONFIG: BootstrapConfig = {
     gammaBaseURL: 'http://api.test/gamma',
     identityProviders: [],
     localLoginEnabled: true,
+    registrationEnabled: false,
+    automaticValidationEnabled: false,
 };
 
 export const TEST_MANAGEMENT_BASE = `${TEST_CONFIG.managementBaseURL}/organizations/${TEST_CONFIG.organizationId}`;


### PR DESCRIPTION
PR 4 of 7 for [FOUND-249](https://gravitee.atlassian.net/browse/FOUND-249). Story: [FOUND-261](https://gravitee.atlassian.net/browse/FOUND-261). **Stacked on #19839.** Retarget to `master` once that merges.

## ⚠️ Security-sensitive

This is the authentication entry gate. It fails closed: an absent or unreadable setting counts as off. The server still enforces `console.userCreation.enabled` on registration.

## Change

- **Bootstrap** reads `management.userCreation.enabled` and `management.automaticValidation.enabled` from the `/console` response it already fetches. No new request, no backend change. A body that isn't a usable object counts as unread, like a failed request: local login and registration stay off on first load, and a refresh keeps the last good values. Previously an unreadable body turned local login back on.
- **Login page** shows "Request an account" after the identity-provider buttons, only when **registration and local login are both on**. Otherwise nothing renders. This matches the classic Console, whose sign-up link sits inside the local-login form: sign-up creates a local account, so without local login the account couldn't be used.
- **`RegistrationEnabledRoute`** guards `/sign-up` only, in both route tables. With registration off, `/sign-up` redirects to `/login`. The activation route ([FOUND-263](https://gravitee.atlassian.net/browse/FOUND-263)) will sit outside the guard.
- **Sign-up sent state** reads `automaticValidationEnabled`. With it off, the page says an administrator reviews each request first, because the server emails nothing until approval. With it on, the page points to the spam folder.

## Notes

- Until this merges, `/sign-up` on `master` (from #19839) is reachable by URL with registration off. The server rejects the submit, but this should merge right after #19839.

## Verification

`nx test gamma-console`: 35 suites, 280 tests pass. Removing either route guard fails `AppRoutes.spec` (checked by mutation). `tsc`, eslint and prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FOUND-249]: https://gravitee.atlassian.net/browse/FOUND-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-261]: https://gravitee.atlassian.net/browse/FOUND-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-263]: https://gravitee.atlassian.net/browse/FOUND-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ