### PR TITLE
test(ci): point the token spec at a pom, now that Build backend reads one

### DIFF
--- a/.circleci/ci/src/pipelines/tests/azure-artifacts-token.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/azure-artifacts-token.spec.ts
@@ -71,14 +71,14 @@ describe('Azure Artifacts token', () => {
       'repositories-tests': generateRepositoriesTestsConfig({
         ...baseEnvironment,
         action: 'repositories_tests',
-        apimVersionPath: '',
+        apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
         changedFiles: [],
         graviteeioVersion: '4.2.0',
       }),
       'integration-tests': generateIntegrationTestsConfig({
         ...baseEnvironment,
         action: 'integration_tests',
-        apimVersionPath: '',
+        apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
         changedFiles: [],
         graviteeioVersion: '4.2.0',
       }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-393

## Description

`master` is red, and because the suite runs inside `generate-config` — the setup job of every workflow — **no pipeline can be generated at all** until this lands.

Two pull requests, each green against a `master` that did not contain the other, merged 21 minutes apart:

- `feef5d9ee9` (17:11) added `azure-artifacts-token.spec.ts`, whose `repositories_tests` and `integration_tests` environments carry `apimVersionPath: ''`. Faithful at the time: `Build backend` did not read the pom.
- `32fba019bb`, merged at 17:32, made `Build backend` resolve the core version from the root pom — `-Dapim.core.version=${computeApimVersion(environment)}`. `computeApimVersion` throws on a path that does not exist.

Both pipelines include `Build backend`, so the spec now throws while building the fixture and three tests fail.

The fix is two lines: give those two environments the same fixture pom the pull-request entries already use. That is the right reading — the fixture described those pipelines accurately until the job gained a dependency on the pom, and it has to describe them again.

**The runtime is not affected.** In CI `apimVersionPath` comes from `APIM_VERSION_PATH ?? '/home/circleci/project/pom.xml'`, which always exists. Only the test fixture passed an empty string.

## Additional context

Reproduction, on `b77304df9f`:

```
cd .circleci/ci && npx jest
# Test Suites: 1 failed, 29 passed, 30 total
# Tests:       3 failed, 215 passed, 218 total
```

With this change: 218/218, and `npm run lint` green.

Seen while trying to rehearse the core release lane — the dry run never reached its own job, since `generate-config` fails first.
