### PR TITLE
fix(redis): reconnect when Sentinel leaves a READONLY replica

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepository.java
@@ -86,12 +86,12 @@ public class RedisDistributedEventRepository implements DistributedEventReposito
     // Per-attempt command timeout. Normal writes complete in milliseconds; this only fires for a command that
     // never resolves (half-open connection), so a permit can never be held indefinitely — the timeout is
     // retryable (see isRetryableWriteFailure) and bounds the hold.
-    // Caveat on the half-open case: a timeout does NOT currently invalidate the connection. notifyConnectionFailure
-    // gates on RedisClient#isRecoverableConnectionFailure, which does not recognise TimeoutException, and .timeout()
-    // emits on RxJava's computation scheduler (no Vert.x context) so the notification bails out regardless. The
-    // retries therefore re-hit the same stale connection, each timing out again, so the worst-case time a permit is
-    // held is ~66s (6 attempts × 10s + ~6s backoff), NOT ~6s. Still bounded, so the sync window is eventually
-    // replayed; making a timeout invalidate the connection (so the next attempt reconnects) is a possible follow-up.
+    // Caveat on the half-open case: a timeout does NOT invalidate the connection. notifyConnectionFailure
+    // skips TimeoutException by type, and .timeout() also emits on RxJava's computation scheduler (no Vert.x
+    // context) so the notification would bail even without that skip. The retries therefore re-hit the same
+    // stale connection, each timing out again, so the worst-case time a permit is held is ~66s
+    // (6 attempts × 10s + ~6s backoff), NOT ~6s. Still bounded, so the sync window is eventually replayed;
+    // making a timeout invalidate the connection (so the next attempt reconnects) is a possible follow-up.
     static final long WRITE_COMMAND_TIMEOUT_MS = 10_000;
 
     private final RedisClient redisClient;

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.redis.ratelimit;
 import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
 
 import io.gravitee.repository.exception.RedisNotConnectedException;
-import io.gravitee.repository.exception.RedisOperationTimeoutException;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.gravitee.repository.redis.vertx.RedisClient;
@@ -31,7 +30,6 @@ import io.vertx.rxjava3.SingleHelper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -82,7 +80,7 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
                         return redisAPI
                             .evalsha(scriptArgs)
                             .recover(t -> {
-                                if (!isNoScript(t)) {
+                                if (!RedisScriptSupport.isNoScript(t)) {
                                     return Future.failedFuture(t);
                                 }
                                 final String source = this.redisClient.scriptSource(SCRIPT_RATELIMIT_KEY);
@@ -109,15 +107,11 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
                                     });
                             })
                             .timeout(operationTimeout, TimeUnit.MILLISECONDS)
-                            .recover(this::mapTimeout);
+                            .recover(t -> RedisScriptSupport.mapTimeout(t, operationTimeout));
                     })
                     .onFailure(t -> {
                         logOperationFailure(t);
-                        // Timeouts are not connection failures; notifying would force unnecessary reconnects
-                        // (RxJava timeout previously sat outside this Vert.x chain and never notified).
-                        if (!(t instanceof RedisOperationTimeoutException)) {
-                            redisClient.notifyConnectionFailure(t);
-                        }
+                        redisClient.notifyConnectionFailure(t);
                     })
                     .onComplete(asyncResultHandler)
         ).map(response -> {
@@ -135,32 +129,6 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
 
             return newRate;
         });
-    }
-
-    private Future<Response> mapTimeout(Throwable t) {
-        if (t instanceof TimeoutException) {
-            return Future.failedFuture(new RedisOperationTimeoutException(operationTimeout));
-        }
-        return Future.failedFuture(t);
-    }
-
-    private static final String NOSCRIPT_PREFIX = "NOSCRIPT";
-
-    /**
-     * Returns true only when the error (or one of its causes) is a Redis {@code NOSCRIPT} reply.
-     * Matches the error-code prefix (Redis error replies start with the uppercase code), not a
-     * substring, so unrelated messages can't trigger a (non-idempotent) EVAL replay; walks the
-     * cause chain and is case-insensitive to survive wrapping.
-     */
-    private static boolean isNoScript(Throwable t) {
-        int depth = 0;
-        for (Throwable cause = t; cause != null && depth < 20; cause = cause.getCause(), depth++) {
-            String message = cause.getMessage();
-            if (message != null && message.stripLeading().regionMatches(true, 0, NOSCRIPT_PREFIX, 0, NOSCRIPT_PREFIX.length())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void logOperationFailure(Throwable t) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisScriptSupport.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisScriptSupport.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import io.vertx.core.Future;
+import io.vertx.redis.client.Response;
+import java.util.concurrent.TimeoutException;
+
+final class RedisScriptSupport {
+
+    private static final String NOSCRIPT_PREFIX = "NOSCRIPT";
+
+    private RedisScriptSupport() {}
+
+    static Future<Response> mapTimeout(Throwable t, int operationTimeout) {
+        if (t instanceof TimeoutException) {
+            return Future.failedFuture(new RedisOperationTimeoutException(operationTimeout));
+        }
+        return Future.failedFuture(t);
+    }
+
+    /**
+     * Returns true only when the error (or one of its causes) is a Redis {@code NOSCRIPT} reply.
+     * Matches the error-code prefix (Redis error replies start with the uppercase code), not a
+     * substring, so unrelated messages can't trigger a (non-idempotent) EVAL replay; walks the
+     * cause chain and is case-insensitive to survive wrapping.
+     */
+    static boolean isNoScript(Throwable t) {
+        int depth = 0;
+        for (Throwable cause = t; cause != null && depth < 20; cause = cause.getCause(), depth++) {
+            String message = cause.getMessage();
+            if (message != null && message.stripLeading().regionMatches(true, 0, NOSCRIPT_PREFIX, 0, NOSCRIPT_PREFIX.length())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.redis.ratelimit;
 import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_TOKEN_BUCKET_KEY;
 
 import io.gravitee.repository.exception.RedisNotConnectedException;
-import io.gravitee.repository.exception.RedisOperationTimeoutException;
 import io.gravitee.repository.ratelimit.api.TokenBucketCalculator;
 import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
 import io.gravitee.repository.ratelimit.api.TokenBucketRateLimitRepository;
@@ -47,8 +46,6 @@ import lombok.CustomLog;
 public class RedisTokenBucketRateLimitRepository implements TokenBucketRateLimitRepository<TokenBucket> {
 
     private static final String REDIS_KEY_PREFIX = "tokenbucket:";
-
-    private static final String NOSCRIPT_PREFIX = "NOSCRIPT";
 
     private final RedisClient redisClient;
     private final int operationTimeout;
@@ -99,7 +96,7 @@ public class RedisTokenBucketRateLimitRepository implements TokenBucketRateLimit
                                 )
                             )
                             .recover(t -> {
-                                if (!isNoScript(t)) {
+                                if (!RedisScriptSupport.isNoScript(t)) {
                                     return Future.failedFuture(t);
                                 }
                                 final String source = redisClient.scriptSource(SCRIPT_TOKEN_BUCKET_KEY);
@@ -135,20 +132,23 @@ public class RedisTokenBucketRateLimitRepository implements TokenBucketRateLimit
                                         return Future.failedFuture(evalError);
                                     });
                             })
+                            .timeout(operationTimeout, TimeUnit.MILLISECONDS)
+                            .recover(t -> RedisScriptSupport.mapTimeout(t, operationTimeout))
                     )
-                    .onFailure(this::logOperationFailure)
+                    .onFailure(t -> {
+                        logOperationFailure(t);
+                        redisClient.notifyConnectionFailure(t);
+                    })
                     .onComplete(asyncResultHandler)
-        )
-            .map(response -> {
-                boolean allowed = response.get(0).toLong() == 1L;
-                long newTokens = response.get(1).toLong();
-                return new TokenBucketConsumeResult(
-                    allowed,
-                    newTokens,
-                    TokenBucketCalculator.nextAvailableAtMillis(newTokens, refillRate, refillPeriodMillis, nowMillis)
-                );
-            })
-            .timeout(operationTimeout, TimeUnit.MILLISECONDS, Single.error(new RedisOperationTimeoutException(operationTimeout)));
+        ).map(response -> {
+            boolean allowed = response.get(0).toLong() == 1L;
+            long newTokens = response.get(1).toLong();
+            return new TokenBucketConsumeResult(
+                allowed,
+                newTokens,
+                TokenBucketCalculator.nextAvailableAtMillis(newTokens, refillRate, refillPeriodMillis, nowMillis)
+            );
+        });
     }
 
     // numkeys is "1": only the bucket key is a KEY, so all keys touched share one hash slot.
@@ -176,18 +176,6 @@ public class RedisTokenBucketRateLimitRepository implements TokenBucketRateLimit
             subscription == null ? "" : subscription,
             Long.toString(expireAt)
         );
-    }
-
-    // package-private for direct unit testing of the cause-chain matcher
-    static boolean isNoScript(Throwable t) {
-        int depth = 0;
-        for (Throwable cause = t; cause != null && depth < 20; cause = cause.getCause(), depth++) {
-            String message = cause.getMessage();
-            if (message != null && message.stripLeading().regionMatches(true, 0, NOSCRIPT_PREFIX, 0, NOSCRIPT_PREFIX.length())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void logOperationFailure(Throwable t) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.redis.vertx;
 
 import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
 import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
 import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -24,17 +25,21 @@ import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
 import java.io.InputStream;
 import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 
@@ -58,6 +63,7 @@ public class RedisClient {
     private final Map<String, String> scripts;
     private final Map<String, String> scriptsSource = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, LoopRedis> loops = new ConcurrentHashMap<>();
+    private final AtomicBoolean roleCheckSkippedLogged = new AtomicBoolean();
 
     public RedisClient(
         final Vertx vertx,
@@ -88,6 +94,11 @@ public class RedisClient {
         LoopRedis loop = resolveLoop();
         synchronized (loop.monitor) {
             if (loop.redisAPIFuture == null) {
+                // A failed ROLE/connect already scheduled backoff. Starting again at retry 0
+                // would reconnect as fast as callers arrive (rate-limit + dist-sync).
+                if (loop.reconnectPending.get()) {
+                    return Future.failedFuture("Redis reconnection is in progress");
+                }
                 startConnectLoop(loop, 0);
             }
             if (loop.redisAPIFuture == null) {
@@ -103,6 +114,11 @@ public class RedisClient {
      * fired yet, which was leaving {@code connected=true} and blocking automatic reconnection.
      */
     public void notifyConnectionFailure(final Throwable failure) {
+        // A command timeout is not a dead socket. Rate-limit uses RedisOperationTimeoutException;
+        // distributed sync uses Completable.timeout()'s TimeoutException.
+        if (isOperationTimeout(failure)) {
+            return;
+        }
         if (!isRecoverableConnectionFailure(failure)) {
             return;
         }
@@ -173,7 +189,10 @@ public class RedisClient {
                 conn.exceptionHandler(e -> handleConnectionLost(loop, connectionGeneration));
                 conn.endHandler(v -> handleConnectionLost(loop, connectionGeneration));
             })
-            .flatMap(redisConnection -> loadScripts(RedisAPI.api(redisConnection), loop))
+            .flatMap(redisConnection -> {
+                RedisAPI api = RedisAPI.api(redisConnection);
+                return requireWritableMaster(api).compose(writable -> loadScripts(writable, loop));
+            })
             .onSuccess(redisAPI -> {
                 if (connectionGeneration != loop.generation.get()) {
                     return;
@@ -187,7 +206,11 @@ public class RedisClient {
                 if (connectionGeneration != loop.generation.get()) {
                     return;
                 }
-                log.error("Unable to connect to Redis on event loop {}", currentLoopKey(), t);
+                if (isExpectedConnectFailure(t)) {
+                    log.warn("Unable to connect to Redis on event loop {}: {}", currentLoopKey(), t.getMessage());
+                } else {
+                    log.error("Unable to connect to Redis on event loop {}", currentLoopKey(), t);
+                }
                 scheduleReconnectAfterFailure(loop, retry);
             });
 
@@ -276,8 +299,12 @@ public class RedisClient {
             }
             final String message = current.getMessage();
             if (message != null) {
-                final String normalized = message.toLowerCase();
+                final String normalized = message.toLowerCase(Locale.ROOT).stripLeading();
+                // READONLY: TCP is healthy but the node is no longer writable (Sentinel demotion).
+                // Redis 7+ uses the READONLY code; Redis 6 wraps script writes as ERR ... -READONLY ...
                 if (
+                    normalized.startsWith("readonly") ||
+                    normalized.contains("-readonly ") ||
                     normalized.contains("connection is closed") ||
                     normalized.contains("connection lost") ||
                     normalized.contains("connection reset") ||
@@ -310,6 +337,104 @@ public class RedisClient {
                 throw new IllegalStateException("Unexpected error while reading lua script '" + scriptPath + "'", ex);
             }
         });
+    }
+
+    /**
+     * Sentinel can keep advertising a demoted node for tens of seconds. ROLE is only sent in
+     * Sentinel mode: the command is {@code @dangerous}, so a restricted ACL user would get
+     * {@code NOPERM} and never connect. Cluster has several writable masters; skip it there too.
+     * A successful non-{@code master} reply fails the connect so backoff can grow. If ROLE itself
+     * is unsupported (NOPERM, unknown command), skip the check rather than blocking connect forever.
+     * Other ROLE failures (closed connection mid-failover) fail the connect.
+     */
+    private Future<RedisAPI> requireWritableMaster(final RedisAPI redisAPI) {
+        return applySentinelRoleCheck(redisAPI, clientOptions.getSentinel() != null, this::logRoleCheckSkipped);
+    }
+
+    static Future<RedisAPI> applySentinelRoleCheck(
+        final RedisAPI redisAPI,
+        final boolean sentinelEnabled,
+        final Consumer<Throwable> onRoleCommandFailure
+    ) {
+        if (!sentinelEnabled) {
+            return Future.succeededFuture(redisAPI);
+        }
+        return redisAPI
+            .role()
+            .recover(t -> {
+                if (isRoleCommandUnsupported(t)) {
+                    onRoleCommandFailure.accept(t);
+                    return Future.succeededFuture((Response) null);
+                }
+                return Future.failedFuture(t);
+            })
+            .compose(response -> {
+                if (response == null) {
+                    return Future.succeededFuture(redisAPI);
+                }
+                final String role = roleName(response);
+                if (!"master".equalsIgnoreCase(role)) {
+                    return Future.failedFuture(
+                        new IllegalStateException("Redis node is not writable (ROLE=" + role + "); will retry with backoff")
+                    );
+                }
+                return Future.succeededFuture(redisAPI);
+            });
+    }
+
+    static boolean isExpectedConnectFailure(final Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            if (current instanceof IllegalStateException) {
+                final String message = current.getMessage();
+                if (message != null && message.contains("ROLE=")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    static boolean isRoleCommandUnsupported(final Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            final String message = current.getMessage();
+            if (message != null) {
+                final String normalized = message.toLowerCase(Locale.ROOT);
+                if (normalized.contains("noperm") || normalized.contains("unknown command")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean isOperationTimeout(final Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            if (current instanceof RedisOperationTimeoutException || current instanceof TimeoutException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private void logRoleCheckSkipped(final Throwable failure) {
+        if (roleCheckSkippedLogged.compareAndSet(false, true)) {
+            log.warn("Skipping Redis ROLE check: {}", failure.getMessage());
+        } else {
+            log.debug("Skipping Redis ROLE check: {}", failure.getMessage());
+        }
+    }
+
+    private static String roleName(Response response) {
+        if (response == null || response.size() < 1 || response.get(0) == null) {
+            return "unknown";
+        }
+        return response.get(0).toString();
     }
 
     private Future<RedisAPI> loadScripts(final RedisAPI redisAPI, final LoopRedis loop) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepositoryRetryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/distributedsync/RedisDistributedEventRepositoryRetryTest.java
@@ -54,6 +54,15 @@ class RedisDistributedEventRepositoryRetryTest {
     }
 
     @Test
+    void should_classify_readonly_as_retryable() {
+        assertThat(
+            RedisDistributedEventRepository.isRetryableWriteFailure(
+                new RuntimeException("READONLY You can't write against a read only replica.")
+            )
+        ).isTrue();
+    }
+
+    @Test
     void should_classify_timeout_reconnect_window_and_queue_saturation_as_retryable() {
         assertThat(RedisDistributedEventRepository.isRetryableWriteFailure(new TimeoutException())).isTrue();
         assertThat(

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepositoryTest.java
@@ -245,8 +245,8 @@ class RedisRateLimitRepositoryTest {
         assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
         assertThat(error.get()).isInstanceOf(RedisOperationTimeoutException.class);
         assertThat(error.get().getMessage()).contains(String.valueOf(OPERATION_TIMEOUT_MS));
-        // Timeouts must not look like connection failures (would force reconnect storms).
-        assertThat(connectionFailureNotifications.get()).isZero();
+        // Repo always notifies; RedisClient.notifyConnectionFailure swallows timeouts.
+        assertThat(connectionFailureNotifications.get()).isEqualTo(1);
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisScriptSupportTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisScriptSupportTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import io.vertx.core.Future;
+import io.vertx.redis.client.Response;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisScriptSupportTest {
+
+    @Test
+    void mapTimeout_wraps_timeout_exception_with_the_configured_delay() {
+        Future<Response> future = RedisScriptSupport.mapTimeout(new TimeoutException("timed out"), 50);
+
+        assertThat(future.failed()).isTrue();
+        assertThat(future.cause()).isInstanceOf(RedisOperationTimeoutException.class).hasMessage("Operation on Redis took more than 50ms");
+    }
+
+    @Test
+    void mapTimeout_passes_through_other_failures() {
+        RuntimeException original = new RuntimeException("READONLY You can't write against a read only replica.");
+
+        Future<Response> future = RedisScriptSupport.mapTimeout(original, 50);
+
+        assertThat(future.failed()).isTrue();
+        assertThat(future.cause()).isSameAs(original);
+    }
+
+    @Test
+    void isNoScript_matches_through_the_cause_chain_only() {
+        assertThat(RedisScriptSupport.isNoScript(new RuntimeException("NOSCRIPT No matching script"))).isTrue();
+        assertThat(RedisScriptSupport.isNoScript(new RuntimeException("wrapper", new IllegalStateException("NOSCRIPT x")))).isTrue();
+        assertThat(RedisScriptSupport.isNoScript(new RuntimeException("LOADING dataset"))).isFalse();
+        assertThat(RedisScriptSupport.isNoScript(new RuntimeException((String) null))).isFalse();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryFallbackTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryFallbackTest.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.redis.ratelimit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,8 +37,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Mock-based coverage of the token-bucket Redis repository's {@code NOSCRIPT -> EVAL} Redis-Cluster
- * fallback and the {@code isNoScript} cause-chain matcher — neither is exercised by the container test
- * (which only hits the EVALSHA happy path).
+ * fallback — not exercised by the container test (which only hits the EVALSHA happy path).
  *
  * @author GraviteeSource Team
  */
@@ -89,16 +89,28 @@ class RedisTokenBucketRateLimitRepositoryFallbackTest {
             repository.refillAndTryConsume("my-key", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("my-key")).blockingGet()
         ).hasMessageContaining("LOADING");
         verify(redisAPI, never()).eval(anyList());
+        verify(redisClient).notifyConnectionFailure(any());
     }
 
     @Test
-    void isNoScript_matches_through_the_cause_chain_only() {
-        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("NOSCRIPT No matching script"))).isTrue();
-        assertThat(
-            RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("wrapper", new IllegalStateException("NOSCRIPT x")))
-        ).isTrue();
-        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException("LOADING dataset"))).isFalse();
-        assertThat(RedisTokenBucketRateLimitRepository.isNoScript(new RuntimeException((String) null))).isFalse();
+    void notifies_connection_failure_on_readonly_without_falling_back_to_eval() {
+        RedisClient redisClient = mock(RedisClient.class);
+        RedisAPI redisAPI = mock(RedisAPI.class);
+
+        when(redisClient.isConnected()).thenReturn(true);
+        when(redisClient.scriptSha1("token-bucket")).thenReturn("the-sha");
+        when(redisClient.redisApi()).thenReturn(Future.succeededFuture(redisAPI));
+        when(redisAPI.evalsha(anyList())).thenReturn(
+            Future.failedFuture(new RuntimeException("READONLY You can't write against a read only replica."))
+        );
+
+        var repository = new RedisTokenBucketRateLimitRepository(redisClient, 2000);
+
+        assertThatThrownBy(() ->
+            repository.refillAndTryConsume("my-key", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("my-key")).blockingGet()
+        ).hasMessageContaining("READONLY");
+        verify(redisAPI, never()).eval(anyList());
+        verify(redisClient).notifyConnectionFailure(any());
     }
 
     private static Response consumeResponse(long allowed, long tokens) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryTimeoutTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisTokenBucketRateLimitRepositoryTimeoutTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import io.gravitee.repository.ratelimit.api.TokenBucketConsumeResult;
+import io.gravitee.repository.ratelimit.model.TokenBucket;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Token-bucket must time the Redis command on the Vert.x context, same as
+ * {@link RedisRateLimitRepository}: an RxJava timeout around the whole Single includes
+ * event-loop queue time and falsely fires {@link RedisOperationTimeoutException}.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisTokenBucketRateLimitRepositoryTimeoutTest {
+
+    private static final int OPERATION_TIMEOUT_MS = 50;
+
+    private Vertx vertx;
+    private AtomicBoolean connected;
+    private AtomicInteger connectionFailureNotifications;
+    private Function<List<String>, Future<Response>> evalshaHandler;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        connected = new AtomicBoolean(true);
+        connectionFailureNotifications = new AtomicInteger();
+        evalshaHandler = args -> Future.failedFuture("evalsha handler not configured");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        CountDownLatch closed = new CountDownLatch(1);
+        vertx.close().onComplete(ar -> closed.countDown());
+        assertThat(closed.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    @Timeout(5)
+    void does_not_timeout_when_redis_answered_while_event_loop_is_saturated() throws Exception {
+        Promise<Response> redisPromise = Promise.promise();
+        evalshaHandler = args -> redisPromise.future();
+
+        var repository = new RedisTokenBucketRateLimitRepository(stubRedisClient(), OPERATION_TIMEOUT_MS);
+        CountDownLatch subscribed = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<TokenBucketConsumeResult> result = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        vertx.runOnContext(v -> {
+            repository
+                .refillAndTryConsume("k", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("k"))
+                .subscribe(
+                    r -> {
+                        result.set(r);
+                        done.countDown();
+                    },
+                    t -> {
+                        error.set(t);
+                        done.countDown();
+                    }
+                );
+            subscribed.countDown();
+            try {
+                Thread.sleep(OPERATION_TIMEOUT_MS * 4L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertThat(subscribed.await(2, TimeUnit.SECONDS)).isTrue();
+        redisPromise.complete(consumeResponse(1L, 5L));
+
+        assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(error.get()).as("must not raise a false RedisOperationTimeoutException").isNull();
+        assertThat(result.get()).isNotNull();
+        assertThat(result.get().allowed()).isTrue();
+        assertThat(result.get().remainingTokens()).isEqualTo(5L);
+    }
+
+    @Test
+    @Timeout(5)
+    void times_out_when_redis_command_never_completes() throws Exception {
+        Promise<Response> redisPromise = Promise.promise();
+        evalshaHandler = args -> redisPromise.future();
+
+        var repository = new RedisTokenBucketRateLimitRepository(stubRedisClient(), OPERATION_TIMEOUT_MS);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        vertx.runOnContext(v ->
+            repository
+                .refillAndTryConsume("k", 1, 10, 1_000L, 20, 1_000L, () -> new TokenBucket("k"))
+                .subscribe(
+                    r -> done.countDown(),
+                    t -> {
+                        error.set(t);
+                        done.countDown();
+                    }
+                )
+        );
+
+        assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(error.get()).isInstanceOf(RedisOperationTimeoutException.class);
+        assertThat(connectionFailureNotifications.get()).isEqualTo(1);
+    }
+
+    private RedisClient stubRedisClient() {
+        RedisClientOptions options = RedisClientOptions.builder().host("127.0.0.1").port(1).connectTimeout(500).build();
+        return new RedisClient(vertx, new VertxRedisClientFactory(vertx), options, Map.of()) {
+            @Override
+            public boolean isConnected() {
+                return connected.get();
+            }
+
+            @Override
+            public Future<RedisAPI> redisApi() {
+                return Future.succeededFuture(redisApiProxy());
+            }
+
+            @Override
+            public String scriptSha1(final String key) {
+                return "the-sha";
+            }
+
+            @Override
+            public void notifyConnectionFailure(final Throwable failure) {
+                connectionFailureNotifications.incrementAndGet();
+            }
+        };
+    }
+
+    private RedisAPI redisApiProxy() {
+        return (RedisAPI) Proxy.newProxyInstance(
+            RedisAPI.class.getClassLoader(),
+            new Class<?>[] { RedisAPI.class },
+            (proxy, method, args) -> {
+                if ("evalsha".equals(method.getName()) && args != null && args.length == 1) {
+                    @SuppressWarnings("unchecked")
+                    List<String> command = (List<String>) args[0];
+                    return evalshaHandler.apply(command);
+                }
+                if ("toString".equals(method.getName())) {
+                    return "RedisAPI-stub";
+                }
+                throw new UnsupportedOperationException("Unexpected RedisAPI call: " + method.getName());
+            }
+        );
+    }
+
+    private static Response consumeResponse(long allowed, long tokens) {
+        List<Response> fields = List.of(longResponse(allowed), longResponse(tokens));
+        return new Response() {
+            @Override
+            public ResponseType type() {
+                return ResponseType.MULTI;
+            }
+
+            @Override
+            public String toString() {
+                return fields.toString();
+            }
+
+            @Override
+            public Response get(int index) {
+                return fields.get(index);
+            }
+
+            @Override
+            public int size() {
+                return fields.size();
+            }
+        };
+    }
+
+    private static Response longResponse(long value) {
+        return new Response() {
+            @Override
+            public ResponseType type() {
+                return ResponseType.NUMBER;
+            }
+
+            @Override
+            public String toString() {
+                return Long.toString(value);
+            }
+
+            @Override
+            public Long toLong() {
+                return value;
+            }
+        };
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientRecoverableFailureTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientRecoverableFailureTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
+import java.nio.channels.ClosedChannelException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards which Redis errors start a reconnect. READONLY means the TCP session is still up
+ * but the node is no longer writable (Sentinel demotion). That must reconnect so the next
+ * client asks Sentinel for the current master.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientRecoverableFailureTest {
+
+    @Test
+    void should_treat_readonly_as_recoverable() {
+        assertThat(
+            RedisClient.isRecoverableConnectionFailure(new RuntimeException("READONLY You can't write against a read only replica."))
+        ).isTrue();
+    }
+
+    @Test
+    void should_treat_a_wrapped_readonly_cause_as_recoverable() {
+        Throwable wrapped = new RuntimeException(
+            "Failed to run rate-limit script on Redis",
+            new RuntimeException("READONLY You can't write against a read only replica.")
+        );
+        assertThat(RedisClient.isRecoverableConnectionFailure(wrapped)).isTrue();
+    }
+
+    @Test
+    void should_treat_readonly_after_leading_whitespace_as_recoverable() {
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RuntimeException("  READONLY replica"))).isTrue();
+    }
+
+    @Test
+    void should_treat_redis_6_script_wrapped_readonly_as_recoverable() {
+        assertThat(
+            RedisClient.isRecoverableConnectionFailure(
+                new RuntimeException(
+                    "ERR Error running script (call to f_1e84a64d649a247ba53ce64b0be7bbedd64fe1b4): @user_script:12: @user_script: 12: -READONLY You can't write against a read only replica."
+                )
+            )
+        ).isTrue();
+    }
+
+    @Test
+    void should_not_treat_noscript_as_recoverable() {
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RuntimeException("NOSCRIPT No matching script"))).isFalse();
+    }
+
+    @Test
+    void should_not_treat_operation_timeout_as_recoverable() {
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RedisOperationTimeoutException(30_000))).isFalse();
+    }
+
+    @Test
+    void should_not_treat_generic_errors_as_recoverable() {
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RuntimeException("malformed payload"))).isFalse();
+        assertThat(RedisClient.isRecoverableConnectionFailure(new IllegalStateException())).isFalse();
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RuntimeException((String) null))).isFalse();
+    }
+
+    @Test
+    void should_still_treat_dropped_connections_as_recoverable() {
+        assertThat(RedisClient.isRecoverableConnectionFailure(new RuntimeException("Connection is closed"))).isTrue();
+        assertThat(RedisClient.isRecoverableConnectionFailure(new ClosedChannelException())).isTrue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientReplicaReconnectTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientReplicaReconnectTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPTS_RATELIMIT_LUA;
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
+import io.gravitee.plugin.configurations.redis.HostAndPort;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
+import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * After READONLY, reconnect must back off. {@code redisApi()} used to start a new connect
+ * at retry 0 whenever {@code redisAPIFuture} was null, which skipped that backoff.
+ * ROLE is Sentinel-only (it is {@code @dangerous}); ACL users without that category
+ * must still connect in standalone mode.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientReplicaReconnectTest {
+
+    private final Vertx vertx = Vertx.vertx();
+
+    private GenericContainer<?> redis;
+
+    @BeforeAll
+    void start_redis() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not available");
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+        redis.start();
+    }
+
+    @AfterAll
+    void stop_redis() {
+        if (redis != null) {
+            redis.stop();
+        }
+        vertx.close();
+    }
+
+    @Test
+    void should_not_start_a_new_connect_on_every_redisApi_call_while_backoff_pending() throws Exception {
+        GenericContainer<?> isolated = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+        isolated.start();
+        CountingRedisClientFactory factory = new CountingRedisClientFactory(vertx);
+        RedisClientOptions options = RedisClientOptions.builder()
+            .host(isolated.getHost())
+            .port(isolated.getFirstMappedPort())
+            .connectTimeout(500)
+            .build();
+        RedisClient client = new RedisClient(vertx, factory, options, Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA));
+        try {
+            await_connected(client);
+            isolated.stop();
+            TimeUnit.MILLISECONDS.sleep(200);
+
+            int before = factory.creates.get();
+            CountDownLatch done = new CountDownLatch(1);
+            long deadline = System.currentTimeMillis() + 400;
+            vertx.runOnContext(v -> hammer_redis_api(client, deadline, done));
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(factory.creates.get() - before)
+                .as("reconnects should follow backoff, not one connect per redisApi() call")
+                .isLessThan(12);
+        } finally {
+            if (isolated.isRunning()) {
+                isolated.stop();
+            }
+        }
+    }
+
+    private void hammer_redis_api(RedisClient redisClient, long deadline, CountDownLatch done) {
+        redisClient.redisApi();
+        if (System.currentTimeMillis() >= deadline) {
+            done.countDown();
+            return;
+        }
+        vertx.setTimer(10, id -> hammer_redis_api(redisClient, deadline, done));
+    }
+
+    @Test
+    void should_reconnect_after_replicaof_no_one() throws Exception {
+        RedisClient client = createClient();
+        await_connected(client);
+        await_connected_on_context(client);
+
+        replicaof("127.0.0.1", "1");
+        notify_connection_failure_on_context(client, new Exception("READONLY You can't write against a read only replica."));
+
+        replicaof("NO", "ONE");
+        await_connected_passive_on_context(client);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_connect_as_acl_user_without_dangerous_category() throws Exception {
+        var acl = redis.execInContainer("redis-cli", "ACL", "SETUSER", "limited", "on", "nopass", "~*", "&*", "+@all", "-@dangerous");
+        assertThat(acl.getExitCode()).as(acl.getStderr()).isZero();
+
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("ratelimit.redis.host", redis.getHost());
+        environment.setProperty("ratelimit.redis.port", redis.getFirstMappedPort().toString());
+        environment.setProperty("ratelimit.redis.username", "limited");
+        RedisClient client = new RedisConnectionFactory(
+            environment,
+            vertx,
+            "ratelimit",
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+        ).createRedisClient();
+
+        await_connected(client);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_connect_when_sentinel_live_role_is_master() throws Exception {
+        RedisClient client = new RedisClient(
+            vertx,
+            new StandaloneIgnoringSentinelFactory(vertx),
+            sentinelOptions(redis.getHost(), redis.getFirstMappedPort()),
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+        );
+        await_connected(client);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_fail_sentinel_connect_when_live_role_is_slave() throws Exception {
+        GenericContainer<?> replica = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+        replica.start();
+        try {
+            var replicaof = replica.execInContainer("redis-cli", "REPLICAOF", "127.0.0.1", "1");
+            assertThat(replicaof.getExitCode()).as(replicaof.getStderr()).isZero();
+
+            RedisClient client = new RedisClient(
+                vertx,
+                new StandaloneIgnoringSentinelFactory(vertx),
+                sentinelOptions(replica.getHost(), replica.getFirstMappedPort()),
+                Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+            );
+            TimeUnit.MILLISECONDS.sleep(1_500);
+            assertThat(client.isConnected()).as("ROLE on a replica must fail connect when Sentinel options are set").isFalse();
+        } finally {
+            replica.stop();
+        }
+    }
+
+    private static RedisClientOptions sentinelOptions(String host, int port) {
+        return RedisClientOptions.builder()
+            .host(host)
+            .port(port)
+            .connectTimeout(500)
+            .sentinel(
+                RedisSentinelOptions.builder()
+                    .masterId("mymaster")
+                    .nodes(List.of(HostAndPort.builder().host("127.0.0.1").port(26379).build()))
+                    .build()
+            )
+            .build();
+    }
+
+    private RedisClient createClient() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("ratelimit.redis.host", redis.getHost());
+        environment.setProperty("ratelimit.redis.port", redis.getFirstMappedPort().toString());
+        return new RedisConnectionFactory(
+            environment,
+            vertx,
+            "ratelimit",
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+        ).createRedisClient();
+    }
+
+    private void await_connected(RedisClient redisClient) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!redisClient.isConnected() && System.currentTimeMillis() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        assertThat(redisClient.isConnected()).isTrue();
+    }
+
+    private void await_connected_on_context(RedisClient redisClient) throws Exception {
+        poll_connected_on_context(redisClient, System.currentTimeMillis() + 30_000).get(35, TimeUnit.SECONDS);
+    }
+
+    private void await_connected_passive_on_context(RedisClient redisClient) throws Exception {
+        poll_connected_on_context(redisClient, System.currentTimeMillis() + 30_000).get(35, TimeUnit.SECONDS);
+    }
+
+    private CompletableFuture<Void> poll_connected_on_context(RedisClient redisClient, long deadline) {
+        CompletableFuture<Void> done = new CompletableFuture<>();
+        poll_connected_on_context(redisClient, deadline, done);
+        return done;
+    }
+
+    private void poll_connected_on_context(RedisClient redisClient, long deadline, CompletableFuture<Void> done) {
+        vertx.runOnContext(v -> {
+            if (redisClient.isConnected()) {
+                done.complete(null);
+                return;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                done.completeExceptionally(new AssertionError("Redis client did not reconnect in time"));
+                return;
+            }
+            vertx.setTimer(200, id -> poll_connected_on_context(redisClient, deadline, done));
+        });
+    }
+
+    private void notify_connection_failure_on_context(RedisClient redisClient, Exception failure) throws Exception {
+        CompletableFuture<Void> notified = new CompletableFuture<>();
+        vertx.runOnContext(v -> {
+            redisClient.notifyConnectionFailure(failure);
+            notified.complete(null);
+        });
+        notified.get(10, TimeUnit.SECONDS);
+    }
+
+    private void replicaof(String host, String port) throws Exception {
+        var result = redis.execInContainer("redis-cli", "REPLICAOF", host, port);
+        assertThat(result.getExitCode()).as(result.getStderr()).isZero();
+        assertThat(result.getStdout()).containsIgnoringCase("ok");
+    }
+
+    private String ping_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<String> ping = new CompletableFuture<>();
+        vertx.runOnContext(v ->
+            redisClient
+                .redisApi()
+                .compose(api -> api.ping(List.of()))
+                .onSuccess(response -> ping.complete(response.toString()))
+                .onFailure(ping::completeExceptionally)
+        );
+        return ping.get(10, TimeUnit.SECONDS);
+    }
+
+    private static final class CountingRedisClientFactory extends VertxRedisClientFactory {
+
+        private final AtomicInteger creates = new AtomicInteger();
+
+        private CountingRedisClientFactory(Vertx vertx) {
+            super(vertx);
+        }
+
+        @Override
+        public Redis createClient(RedisClientOptions options) {
+            creates.incrementAndGet();
+            return super.createClient(options);
+        }
+    }
+
+    /**
+     * Vert.x would talk Sentinel protocol if options carry sentinel nodes. Strip that so ROLE
+     * still runs (RedisClient keys off {@code getSentinel() != null}) against a live standalone.
+     */
+    private static final class StandaloneIgnoringSentinelFactory extends VertxRedisClientFactory {
+
+        private StandaloneIgnoringSentinelFactory(Vertx vertx) {
+            super(vertx);
+        }
+
+        @Override
+        public Redis createClient(RedisClientOptions options) {
+            return super.createClient(
+                RedisClientOptions.builder()
+                    .host(options.getHost())
+                    .port(options.getPort())
+                    .connectTimeout(options.getConnectTimeout())
+                    .build()
+            );
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientRoleCheckTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientRoleCheckTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientRoleCheckTest {
+
+    @Test
+    void should_skip_role_when_not_sentinel() {
+        RedisAPI api = mock(RedisAPI.class);
+
+        RedisAPI result = RedisClient.applySentinelRoleCheck(api, false, t -> {})
+            .toCompletionStage()
+            .toCompletableFuture()
+            .join();
+
+        assertThat(result).isSameAs(api);
+        verify(api, never()).role();
+    }
+
+    @Test
+    void should_accept_sentinel_master_role() {
+        RedisAPI api = mock(RedisAPI.class);
+        Response master = roleReply("master");
+        when(api.role()).thenReturn(Future.succeededFuture(master));
+
+        RedisAPI result = RedisClient.applySentinelRoleCheck(api, true, t -> {})
+            .toCompletionStage()
+            .toCompletableFuture()
+            .join();
+
+        assertThat(result).isSameAs(api);
+    }
+
+    @Test
+    void should_fail_sentinel_connect_when_role_is_slave() {
+        RedisAPI api = mock(RedisAPI.class);
+        Response slave = roleReply("slave");
+        when(api.role()).thenReturn(Future.succeededFuture(slave));
+
+        Future<RedisAPI> result = RedisClient.applySentinelRoleCheck(api, true, t -> {});
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause()).isInstanceOf(IllegalStateException.class).hasMessageContaining("ROLE=slave");
+        assertThat(RedisClient.isExpectedConnectFailure(result.cause())).isTrue();
+    }
+
+    @Test
+    void should_continue_when_sentinel_role_command_is_denied() {
+        RedisAPI api = mock(RedisAPI.class);
+        RuntimeException noperm = new RuntimeException("NOPERM this user has no permissions to run the 'role' command");
+        when(api.role()).thenReturn(Future.failedFuture(noperm));
+        AtomicReference<Throwable> skipped = new AtomicReference<>();
+
+        RedisAPI result = RedisClient.applySentinelRoleCheck(api, true, skipped::set).toCompletionStage().toCompletableFuture().join();
+
+        assertThat(result).isSameAs(api);
+        assertThat(skipped.get()).isSameAs(noperm);
+    }
+
+    @Test
+    void should_continue_when_sentinel_role_command_is_unknown() {
+        RedisAPI api = mock(RedisAPI.class);
+        RuntimeException unknown = new RuntimeException("ERR unknown command 'ROLE', with args beginning with: ");
+        when(api.role()).thenReturn(Future.failedFuture(unknown));
+        AtomicReference<Throwable> skipped = new AtomicReference<>();
+
+        RedisAPI result = RedisClient.applySentinelRoleCheck(api, true, skipped::set).toCompletionStage().toCompletableFuture().join();
+
+        assertThat(result).isSameAs(api);
+        assertThat(skipped.get()).isSameAs(unknown);
+    }
+
+    @Test
+    void should_fail_sentinel_connect_when_role_is_sentinel() {
+        RedisAPI api = mock(RedisAPI.class);
+        Response sentinel = roleReply("sentinel");
+        when(api.role()).thenReturn(Future.succeededFuture(sentinel));
+
+        Future<RedisAPI> result = RedisClient.applySentinelRoleCheck(api, true, t -> {});
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause()).isInstanceOf(IllegalStateException.class).hasMessageContaining("ROLE=sentinel");
+        assertThat(RedisClient.isExpectedConnectFailure(result.cause())).isTrue();
+    }
+
+    @Test
+    void should_treat_role_mismatch_as_expected_connect_failure() {
+        assertThat(
+            RedisClient.isExpectedConnectFailure(
+                new IllegalStateException("Redis node is not writable (ROLE=slave); will retry with backoff")
+            )
+        ).isTrue();
+        assertThat(RedisClient.isExpectedConnectFailure(new RuntimeException("Connection is closed"))).isFalse();
+    }
+
+    @Test
+    void should_fail_sentinel_connect_when_role_command_fails_for_connection() {
+        RedisAPI api = mock(RedisAPI.class);
+        RuntimeException closed = new RuntimeException("Connection is closed");
+        when(api.role()).thenReturn(Future.failedFuture(closed));
+        AtomicReference<Throwable> skipped = new AtomicReference<>();
+
+        Future<RedisAPI> result = RedisClient.applySentinelRoleCheck(api, true, skipped::set);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.cause()).isSameAs(closed);
+        assertThat(skipped.get()).isNull();
+    }
+
+    private static Response roleReply(String role) {
+        Response name = mock(Response.class);
+        when(name.toString()).thenReturn(role);
+        Response reply = mock(Response.class);
+        when(reply.size()).thenReturn(1);
+        when(reply.get(0)).thenReturn(name);
+        return reply;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -155,6 +156,18 @@ class RedisClientTest {
     }
 
     @Test
+    void should_reconnect_when_readonly_is_notified() throws Exception {
+        await_connected_on_context(client);
+
+        long idBefore = client_id_on_context(client);
+        notify_connection_failure_on_context(client, new Exception("READONLY You can't write against a read only replica."));
+        await_connected_passive_on_context(client);
+
+        assertThat(client_id_on_context(client)).isNotEqualTo(idBefore);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
     void should_ignore_non_connection_operation_failures() throws Exception {
         await_connected_on_context(client);
 
@@ -171,12 +184,29 @@ class RedisClientTest {
     void should_not_invalidate_on_operation_timeout() throws Exception {
         await_connected_on_context(client);
 
+        long idBefore = client_id_on_context(client);
         notify_connection_failure_on_context(client, new RedisOperationTimeoutException(30_000));
 
         CountDownLatch latch = new CountDownLatch(1);
         vertx.runOnContext(v -> vertx.setTimer(500, id -> latch.countDown()));
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
+        assertThat(client_id_on_context(client)).isEqualTo(idBefore);
+        assertThat(ping_on_context(client)).isEqualTo("PONG");
+    }
+
+    @Test
+    void should_not_invalidate_on_distributed_sync_timeout() throws Exception {
+        await_connected_on_context(client);
+
+        long idBefore = client_id_on_context(client);
+        notify_connection_failure_on_context(client, new TimeoutException("The source did not signal an event for 10000 milliseconds"));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.runOnContext(v -> vertx.setTimer(500, id -> latch.countDown()));
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(client_id_on_context(client)).isEqualTo(idBefore);
         assertThat(ping_on_context(client)).isEqualTo("PONG");
     }
 
@@ -257,6 +287,18 @@ class RedisClientTest {
                 .subscribe(result::complete, result::completeExceptionally)
         );
         return result.get(10, TimeUnit.SECONDS);
+    }
+
+    private long client_id_on_context(RedisClient redisClient) throws Exception {
+        CompletableFuture<Long> clientId = new CompletableFuture<>();
+        vertx.runOnContext(v ->
+            redisClient
+                .redisApi()
+                .compose(api -> api.client(List.of("ID")))
+                .onSuccess(response -> clientId.complete(response.toLong()))
+                .onFailure(clientId::completeExceptionally)
+        );
+        return clientId.get(10, TimeUnit.SECONDS);
     }
 
     private String ping_on_context(RedisClient redisClient) throws Exception {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14968

## Description

After a Redis Sentinel failover the gateway can keep a live connection to the demoted node. Writes fail with READONLY; rate-limit and distributed sync stop updating. Restart was the only fix.

READONLY is now treated as a recoverable connection failure, so the existing reconnect path re-queries Sentinel for the current master. Token-bucket rate-limit notifies on the same errors.

The first write after demotion can still fail. Recovery completes once Sentinel reports the new master. 
No restart.

Implementation idea : 

```mermaid
flowchart LR
  write[Redis write] --> readonly[READONLY]
  readonly --> notify[notifyConnectionFailure]
  notify --> pred{recoverable?}
  pred -->|before: no| stuck[Keep old socket]
  pred -->|after: yes| reconnect[New client]
  reconnect --> sentinel[Ask Sentinel]
  sentinel --> master[Connect to current master]
```


## Additional context

- Does not enable Vert.x autoFailover (needs gravitee-node / plugin-common-configurations).

- Vanilla SENTINEL FAILOVER already reconnects via CLIENT KILL. The stuck case is demotion that leaves TCP up (FAILOVER TO).

- Repro: Sentinel rate-limit Redis, warm an API with a rate-limit flow, run FAILOVER TO <replica> 6379, hit the API again. Before: READONLY forever, no Redis is now ready. After: brief READONLY, then reconnect and writes resume.

Video :

- Before :

https://github.com/user-attachments/assets/29c852d4-5c74-48de-b95d-50edfa1d79e0



- After : 

https://github.com/user-attachments/assets/5450a152-3db7-4158-b9f0-956f9474722f

---------
Pics :

- Before : 


<img width="1701" height="1005" alt="Screenshot 2026-09-10 at 8 42 02 PM" src="https://github.com/user-attachments/assets/a21d14d1-28ac-4ad0-bbdf-bbf24aa55db1" />

- After 

<img width="1701" height="1005" alt="Screenshot 2026-09-10 at 9 35 28 PM" src="https://github.com/user-attachments/assets/61cb91b7-2fcb-41c7-86ce-9ee30de3de44" />


