### PR TITLE
fix(ci): install a gh CLI that has `auth setup-git`, and pin it

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -109,12 +109,19 @@ const yarn = {
   version: '4.1.1',
 };
 
+// The gh CLI the github-cli orb installs. The orb's own default is `latest`, which would let the
+// release lanes change under us from one run to the next; and 1.0.5 pinned 1.9.2, which predates
+// `gh auth setup-git` altogether.
+const githubCli = {
+  version: '2.100.0',
+};
+
 const orbs = {
   aikido: '1.0.3',
   artifactory: '1.0.1',
   awsCli: '5.1.2',
   awsS3: '4.1.0',
-  github: '1.0.5',
+  github: '2.7.2',
   gravitee: 'dev:4.5.0',
   helm: '3.0.0',
   keeper: '0.7.1',
@@ -187,6 +194,7 @@ export const config = {
   cache,
   components,
   executor,
+  githubCli,
   helm,
   jobContext,
   maven,

--- a/.circleci/ci/src/jobs/helm/job-release-helm.ts
+++ b/.circleci/ci/src/jobs/helm/job-release-helm.ts
@@ -53,7 +53,7 @@ export class ReleaseHelmJob {
         command: `git config --global user.name "\${GIT_USER_NAME}"
 git config --global user.email "\${GIT_USER_EMAIL}"`,
       }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.github.commands['setup'], { version: config.githubCli.version }),
       new reusable.ReusedCommand(orbs.helm.commands['install_helm_client'], { version: config.helm.defaultVersion }),
     ];
 

--- a/.circleci/ci/src/jobs/job-pin-core.ts
+++ b/.circleci/ci/src/jobs/job-pin-core.ts
@@ -54,7 +54,7 @@ export class PinCoreJob {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',
       }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.github.commands['setup'], { version: config.githubCli.version }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.gitUserName,
         'var-name': 'GIT_USER_NAME',

--- a/.circleci/ci/src/jobs/job-prepare-core-release.ts
+++ b/.circleci/ci/src/jobs/job-prepare-core-release.ts
@@ -40,7 +40,7 @@ export class PrepareCoreReleaseJob {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',
       }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.github.commands['setup'], { version: config.githubCli.version }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.gitUserName,
         'var-name': 'GIT_USER_NAME',

--- a/.circleci/ci/src/jobs/job-publish-pr-env-urls.ts
+++ b/.circleci/ci/src/jobs/job-publish-pr-env-urls.ts
@@ -37,7 +37,7 @@ export class PublishPrEnvUrlsJob {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',
       }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.github.commands['setup'], { version: config.githubCli.version }),
       new commands.Run({
         name: 'Edit Pull Request Description',
         command: `# First check there is an associated pull request, otherwise just stop the job here

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -50,7 +50,7 @@ export class ReleaseCommitAndPrepareNextVersionJob {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',
       }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new reusable.ReusedCommand(orbs.github.commands['setup'], { version: config.githubCli.version }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.gitUserName,
         'var-name': 'GIT_USER_NAME',

--- a/.circleci/ci/src/jobs/job-release-notes-apim.ts
+++ b/.circleci/ci/src/jobs/job-release-notes-apim.ts
@@ -59,7 +59,7 @@ export class ReleaseNotesApimJob {
         command: `git config --global user.name "\${GIT_USER_NAME}"
 git config --global user.email "\${GIT_USER_EMAIL}"`,
       }),
-      new reusable.ReusedCommand(github.commands['setup']),
+      new reusable.ReusedCommand(github.commands['setup'], { version: config.githubCli.version }),
       new reusable.ReusedCommand(installYarnCmd),
       new commands.Run({
         name: 'Install dependencies',

--- a/.circleci/ci/src/orbs/github.ts
+++ b/.circleci/ci/src/orbs/github.ts
@@ -20,6 +20,6 @@ export const github = new orb.OrbImport('gh', 'circleci', 'github-cli', config.o
   jobs: {},
   executors: {},
   commands: {
-    setup: new parameters.CustomParametersList(),
+    setup: new parameters.CustomParametersList([new parameters.CustomParameter('version', 'string')]),
   },
 });

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -201,7 +201,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -302,4 +303,4 @@ workflows:
                 - /^core_(\d+\.\d+\.\d+(-[a-z]+\.\d+)?)$/
 orbs:
   keeper: gravitee-io/keeper@0.7.1
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -712,7 +712,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -834,7 +835,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -936,7 +938,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - cmd-install-yarn
       - run:
           name: Install dependencies
@@ -1428,6 +1431,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   helm: circleci/helm@3.0.0
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -712,7 +712,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -836,7 +837,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -988,7 +990,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - cmd-install-yarn
       - run:
           name: Install dependencies
@@ -1392,5 +1395,5 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -713,7 +713,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -835,7 +836,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -981,7 +983,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - cmd-install-yarn
       - run:
           name: Install dependencies
@@ -1473,6 +1476,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   helm: circleci/helm@3.0.0
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -712,7 +712,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -836,7 +837,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -982,7 +984,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - cmd-install-yarn
       - run:
           name: Install dependencies
@@ -1474,6 +1477,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   helm: circleci/helm@3.0.0
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -712,7 +712,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -836,7 +837,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -982,7 +984,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - cmd-install-yarn
       - run:
           name: Install dependencies
@@ -1474,6 +1477,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   helm: circleci/helm@3.0.0
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
@@ -34,7 +34,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -84,4 +85,4 @@ workflows:
           name: Tag the core release
 orbs:
   keeper: gravitee-io/keeper@0.7.1
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -483,7 +483,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - run:
           name: Edit Pull Request Description
           command: |-
@@ -660,5 +661,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -484,7 +484,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - run:
           name: Edit Pull Request Description
           command: |-
@@ -661,5 +662,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -483,7 +483,8 @@ jobs:
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - run:
           name: Edit Pull Request Description
           command: |-
@@ -660,5 +661,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -573,7 +573,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -929,5 +930,5 @@ orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   helm: circleci/helm@3.0.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -573,7 +573,8 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - gh/setup
+      - gh/setup:
+          version: 2.100.0
       - helm/install_helm_client:
           version: v3.12.3
       - run:
@@ -993,5 +994,5 @@ orbs:
   keeper: gravitee-io/keeper@0.7.1
   slack: circleci/slack@4.12.5
   helm: circleci/helm@3.0.0
-  gh: circleci/github-cli@1.0.5
+  gh: circleci/github-cli@2.7.2
   aikido: gravitee-io/aikido@1.0.3


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-393

## Description

`gh auth setup-git` does not exist in the gh CLI the `circleci/github-cli` orb installs at `1.0.5` — that orb pins **gh 1.9.2**, and the command arrived in gh 2.0.0. Every job that moves the git remote to HTTPS before pushing therefore dies immediately:

```
unknown command "setup-git" for "gh auth"
Available commands: login, logout, refresh, status
```

**Three lanes are affected, and none of them had ever run**, which is why nothing went red until now:

| Job | Lane | Introduced |
| --- | --- | --- |
| `job-release-commit-and-prepare-next-version` | `full_release` — the product release | `5a8395eeed`, 2026-09-08 |
| `job-prepare-core-release` | the core release lane | `db3e8ab108`, 2026-09-08 |
| `job-pin-core` | the pull request that advances the pin | `226a3cf4c8`, 2026-09-09 |

**Nothing in production is broken.** `4.12.x` and `4.11.x` do not carry the HTTPS remote step, so no release that has actually run was affected. The first release from master's lineage — right after the next code freeze — would have hit it, on all three lanes at once.

### The change

- **The orb goes to `2.7.2`.** Its `setup` command keeps the same interface: `token` still defaults to `GITHUB_TOKEN`, which is what the Keeper step exports. `3.0.0` only adds GitHub App authentication, which nothing here needs.
- **The gh version is pinned.** From `2.x` the orb's own `version` defaults to `latest`, which would let a release lane install a different gh from one run to the next. All **six** `gh/setup` call sites now pass `config.githubCli.version` explicitly — the same habit as every other pinned version in this repo.

`gh auth setup-git` is kept rather than worked around: it reads the token from the credential helper, so it stays out of `.git/config` and out of any command that prints the remote.

## Additional context

Found by rehearsing the core release lane with `--dry-run`, which is exactly what the rehearsal is for — it reached the job and stopped one step before the push: [job 2065706](https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/95443/workflows/990d81e9-1baf-4646-9d93-a02573dbdc41/jobs/2065706).

Verification: `npx tsc --noEmit` clean, **218/218 tests**, `npm run lint` green, and `circleci config validate` green on all **36** fixtures (12 of which are regenerated here).

Worth a look from a reviewer: `job-publish-pr-env-urls` is the only one of the six that runs today, so it is the one place where the bump changes something already in service. Its `gh pr view --json` / `gh pr edit --body` are unchanged between gh 1.x and 2.x, and this PR's own pipeline exercises that job.
