### PR TITLE
revert(ci): push the release lanes over SSH, as they always did

### DIFF
--- a/.circleci/ci/src/jobs/job-pin-core.ts
+++ b/.circleci/ci/src/jobs/job-pin-core.ts
@@ -50,6 +50,7 @@ export class PinCoreJob {
 
     const steps: Command[] = [
       new commands.Checkout(),
+      new commands.AddSSHKeys({ fingerprints: config.ssh.fingerprints }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',
@@ -64,11 +65,11 @@ export class PinCoreJob {
         'var-name': 'GIT_USER_EMAIL',
       }),
       new commands.Run({
+        // The token is for `gh` alone — it opens and updates the pull request below. Git pushes over
+        // the remote `checkout` left in place, which is SSH.
         name: 'Git config',
         command: `git config --global user.name "\${GIT_USER_NAME}"
-git config --global user.email "\${GIT_USER_EMAIL}"
-gh auth setup-git
-git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}.git"`,
+git config --global user.email "\${GIT_USER_EMAIL}"`,
       }),
       new commands.Run({
         name: `Pin core ${version} on ${branch}`,

--- a/.circleci/ci/src/jobs/job-prepare-core-release.ts
+++ b/.circleci/ci/src/jobs/job-prepare-core-release.ts
@@ -29,18 +29,13 @@ export class PrepareCoreReleaseJob {
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     dynamicConfig.importOrb(orbs.keeper);
-    dynamicConfig.importOrb(orbs.github);
 
     const { version: nextVersion, qualifier: nextQualifier } = nextDevelopmentVersion(environment.graviteeioVersion);
     const tag = `core_${environment.graviteeioVersion}`;
 
     const steps: Command[] = [
       new commands.Checkout(),
-      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-        'secret-url': config.secrets.githubApiToken,
-        'var-name': 'GITHUB_TOKEN',
-      }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new commands.AddSSHKeys({ fingerprints: config.ssh.fingerprints }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.gitUserName,
         'var-name': 'GIT_USER_NAME',
@@ -53,12 +48,6 @@ export class PrepareCoreReleaseJob {
         name: 'Git config',
         command: `git config --global user.name "\${GIT_USER_NAME}"
 git config --global user.email "\${GIT_USER_EMAIL}"`,
-      }),
-      new commands.Run({
-        // A push over the project SSH key produces no webhook, so the tag it carries starts nothing.
-        name: 'Push over HTTPS, so that pushing the tag triggers the release',
-        command: `gh auth setup-git
-git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}.git"`,
       }),
       new commands.Run({
         name: `Tag core ${environment.graviteeioVersion} ${environment.isDryRun ? '- Dry Run' : ''}`,

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -39,18 +39,13 @@ export class ReleaseCommitAndPrepareNextVersionJob {
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     dynamicConfig.importOrb(orbs.keeper);
-    dynamicConfig.importOrb(orbs.github);
 
     const { version: nextVersion, qualifier: nextQualifier } = nextDevelopmentVersion(environment.graviteeioVersion);
 
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
-      new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
-        'secret-url': config.secrets.githubApiToken,
-        'var-name': 'GITHUB_TOKEN',
-      }),
-      new reusable.ReusedCommand(orbs.github.commands['setup']),
+      new commands.AddSSHKeys({ fingerprints: config.ssh.fingerprints }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.gitUserName,
         'var-name': 'GIT_USER_NAME',
@@ -63,16 +58,6 @@ export class ReleaseCommitAndPrepareNextVersionJob {
         name: 'Git config',
         command: `git config --global user.name "\${GIT_USER_NAME}"
  git config --global user.email "\${GIT_USER_EMAIL}"`,
-      }),
-      new commands.Run({
-        // A push over the project SSH key produces no webhook, so the tag it carries starts nothing.
-        // The bot token does, which is what makes the tag a trigger rather than a label. The remote
-        // has to move to HTTPS for the credential helper to be consulted at all: \`checkout\` leaves
-        // it on SSH. \`gh auth setup-git\` reads the token from the helper, so it stays out of
-        // .git/config and out of any command that prints the remote.
-        name: 'Push over HTTPS, so that pushing a tag triggers a pipeline',
-        command: `gh auth setup-git
-git remote set-url origin "https://github.com/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}.git"`,
       }),
       new commands.Run({
         name: `Git release ${environment.isDryRun ? '- Dry Run' : ''}`,

--- a/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/core-release/core-release.yml
@@ -198,6 +198,9 @@ jobs:
     resource_class: medium
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN
@@ -213,8 +216,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: Pin core 4.13.0 on 4.13.x
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -709,10 +709,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -724,11 +723,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
              git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing a tag triggers a pipeline
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: "Git release "
           command: |
@@ -1428,6 +1422,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
   helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -709,10 +709,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -724,11 +723,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
              git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing a tag triggers a pipeline
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: Git release - Dry Run
           command: |
@@ -1392,5 +1386,5 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
   helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-hotfix.yml
@@ -710,10 +710,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -725,11 +724,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
              git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing a tag triggers a pipeline
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: "Git release "
           command: |
@@ -1473,6 +1467,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
   helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -709,10 +709,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -724,11 +723,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
              git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing a tag triggers a pipeline
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: "Git release "
           command: |
@@ -1474,6 +1468,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
   helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -709,10 +709,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -724,11 +723,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
              git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing a tag triggers a pipeline
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: "Git release "
           command: |
@@ -1474,6 +1468,6 @@ orbs:
   slack: circleci/slack@4.12.5
   aws-cli: circleci/aws-cli@5.1.2
   aws-s3: circleci/aws-s3@4.1.0
-  gh: circleci/github-cli@1.0.5
   helm: circleci/helm@3.0.0
+  gh: circleci/github-cli@1.0.5
   aikido: gravitee-io/aikido@1.0.3

--- a/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/prepare-core-release/prepare-core-release.yml
@@ -31,10 +31,9 @@ jobs:
     resource_class: medium
     steps:
       - checkout
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
-      - gh/setup
+      - add_ssh_keys:
+          fingerprints:
+            - ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c
       - keeper/env-export:
           secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
           var-name: GIT_USER_NAME
@@ -46,11 +45,6 @@ jobs:
           command: |-
             git config --global user.name "${GIT_USER_NAME}"
             git config --global user.email "${GIT_USER_EMAIL}"
-      - run:
-          name: Push over HTTPS, so that pushing the tag triggers the release
-          command: |-
-            gh auth setup-git
-            git remote set-url origin "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
       - run:
           name: "Tag core 4.13.0 "
           command: |
@@ -84,4 +78,3 @@ workflows:
           name: Tag the core release
 orbs:
   keeper: gravitee-io/keeper@0.7.1
-  gh: circleci/github-cli@1.0.5


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/BX-393

## Description

Three release jobs moved their git remote to HTTPS and pushed with a bot token, on this claim:

> A push over the project SSH key produces no webhook, so the tag it carries starts nothing.

**It is false.** A tag pushed from a CI job with the project SSH key does trigger a pipeline, and so does one pushed with the bot token — the identity does not decide. The move bought nothing, and it replaced a push path with years of runs behind it by one that had never executed.

This puts it back:

- `job-release-commit-and-prepare-next-version` (`full_release`), `job-prepare-core-release` and `job-pin-core` push with `add_ssh_keys` again, like every other job here that pushes.
- The HTTPS remote, the credential handling and the bot token used only for git go with it.
- `job-pin-core` keeps gh and the token: `gh pr create` and `gh pr edit` need them, its git push does not. No orb bump — the gh the orb already installs covers every gh command left in the repository.

**Nothing in production was affected.** `4.12.x` and `4.11.x` never carried the HTTPS step; it was on master only, and would have run for the first time at the next code freeze.

BX-313 and BX-314 both listed the claim among their measured facts, and are corrected.

## Additional context

`tsc --noEmit` clean, 218/218 tests, `npm run lint` green, `circleci config validate` green on all 36 fixtures — 7 regenerated rather than hand-edited. 32 insertions, 93 deletions.

Supersedes #19871.
