### PR TITLE
chore(distribution): bump gamma module AIM version to 4.3.0-beta.21

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -274,7 +274,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>4.3.0-beta.20</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.21</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-560

## Description

Bump the Gamma AIM module bundled in the distribution from `4.3.0-beta.20` to `4.3.0-beta.21`, which carries the fix for the Approvals navigation inside the Gamma host (gravitee-io/gravitee-gamma-module-aim#819): on the demo environment the Rules and Insights tabs, the back links of a record and the Insights actions were leaving the module for the host home page.

## Additional context

- Also in `4.3.0-beta.21` over `beta.20`: two compliance changes (`ship only the eu ai act`, `a framework passes or it does not`).
- The `human-approval` gateway policy `1.0.0-beta.2` bundled by #19857 and the module version pair as before; no configuration change.
