### PR TITLE
feat(distribution): add the Guardian Agent Studio

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
@@ -1576,6 +1576,112 @@
                 </dependency>
 
 
+                <!-- Agent entrypoints -->
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-a2a</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-ag-ui</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-guardian</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-http</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-openresponses</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-playground</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-slack</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.entrypoints</groupId>
+                    <artifactId>gravitee-agent-entrypoint-web-ai-assistant</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
                 <!-- Endpoints -->
                 <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>
@@ -1773,6 +1879,73 @@
                     </exclusions>
                 </dependency>
 
+                <!-- Agent endpoints: the responses endpoint, and the tools an agent calls out through -->
+                <dependency>
+                    <groupId>com.graviteesource.agent.endpoints</groupId>
+                    <artifactId>gravitee-agent-endpoint-responses</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.tools</groupId>
+                    <artifactId>gravitee-agent-tool-http</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.tools</groupId>
+                    <artifactId>gravitee-agent-tool-mcp</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.tools</groupId>
+                    <artifactId>gravitee-agent-tool-mcp-studio-inline</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.tools</groupId>
+                    <artifactId>gravitee-agent-tool-sandbox</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
                 <!-- Gamma -->
                 <dependency>
                     <groupId>com.graviteesource.gamma.module</groupId>
@@ -1939,6 +2112,112 @@
                     <groupId>com.graviteesource.resource</groupId>
                     <artifactId>gravitee-resource-schema-registry-embedded</artifactId>
                     <version>${gravitee-resource-schema-registry-embedded.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <!-- Agent resources: channels, sandboxes, skills and stores -->
+                <dependency>
+                    <groupId>com.graviteesource.agent.channels</groupId>
+                    <artifactId>gravitee-agent-channel-slack</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.channels</groupId>
+                    <artifactId>gravitee-agent-channel-webhook</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.sandboxes</groupId>
+                    <artifactId>gravitee-agent-sandbox-docker</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.sandboxes</groupId>
+                    <artifactId>gravitee-agent-sandbox-e2b</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.sandboxes</groupId>
+                    <artifactId>gravitee-agent-sandbox-local</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.skills</groupId>
+                    <artifactId>gravitee-agent-skill-inline</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.stores</groupId>
+                    <artifactId>gravitee-agent-store-inmemory</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.agent.stores</groupId>
+                    <artifactId>gravitee-agent-store-redis</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>
@@ -2424,6 +2703,21 @@
                     <groupId>com.graviteesource.reactor</groupId>
                     <artifactId>gravitee-reactor-edge</artifactId>
                     <version>${gravitee-reactor-edge.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <!-- Agent reactor -->
+                <dependency>
+                    <groupId>com.graviteesource.reactor</groupId>
+                    <artifactId>gravitee-reactor-agent</artifactId>
+                    <version>${gravitee-reactor-agent.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>

--- a/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-standalone/pom.xml
@@ -1949,6 +1949,19 @@
                 <!-- Gamma -->
                 <dependency>
                     <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-act</artifactId>
+                    <version>${gravitee-gamma-module-act.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
                     <artifactId>gravitee-gamma-module-aim</artifactId>
                     <version>${gravitee-gamma-module-aim.version}</version>
                     <type>zip</type>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -279,6 +279,9 @@
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>
 
+    <!-- Agent plugins, all released together from gravitee-reactor-agent -->
+    <gravitee-reactor-agent.version>1.0.0-agent-gateway-SNAPSHOT</gravitee-reactor-agent.version>
+
     <!-- Authz plugins -->
     <gravitee-service-authz-pdp.version>2.1.1</gravitee-service-authz-pdp.version>
     <gravitee-policy-authz-pep.version>1.4.0</gravitee-policy-authz-pep.version>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -274,6 +274,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
+    <gravitee-gamma-module-act.version>1.0.0-guardian-agent-SNAPSHOT</gravitee-gamma-module-act.version>
     <gravitee-gamma-module-aim.version>4.3.0-beta.23</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.icons.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.icons.ts
@@ -22,6 +22,7 @@ import {
     GioEventApiManagementIcon,
     GioHomeIcon,
     GioPlatformIcon,
+    GioSecureIcon,
 } from '@gravitee/graphene-core/icons';
 import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
@@ -32,6 +33,7 @@ import type { LucideIcon } from '@gravitee/graphene-core/icons';
 export const HOME_ICON = GioHomeIcon;
 
 export const MODULE_ICONS: Record<string, LucideIcon> = {
+    act: GioSecureIcon,
     aim: GioAgentManagementIcon,
     apim: GioApiManagementIcon,
     platform: GioPlatformIcon,


### PR DESCRIPTION
Adds the agent plugins and the act gamma module to the distribution, so it ships the Guardian Agent Studio for the demo.

Also gives the module its own icon in the console switcher, instead of the generic globe.