### PR TITLE
chore(distribution): bump gamma module AIM version to 4.3.0-beta.23

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -274,7 +274,7 @@
     <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
     <!-- Gamma plugins -->
-    <gravitee-gamma-module-aim.version>4.3.0-beta.21</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.23</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
Bumps the bundled gravitee-gamma-module-aim from 4.3.0-beta.21 to 4.3.0-beta.23.

beta.23 ships performance targets on the catalog agent (gravitee-io/gravitee-gamma-module-aim#803, AIAM-515 / AIAM-516). It relies on #19841 so that a default rule scoped to an API type the agent does not hold yet is accepted instead of refused.