### PR TITLE
feat(gamma-console): activate a Gamma account and set a password

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
+++ b/gravitee-gamma/gamma-ui-shared/src/passwordPolicy/PasswordRequirements.tsx
@@ -37,10 +37,15 @@ interface PasswordRequirementsProps {
     readonly className?: string;
 }
 
+/*
+ * Only classes Graphene's pre-built `/styles` bundle emits: the consoles load that bundle instead of
+ * compiling their own, so any other utility renders as nothing. `graphene-check-classes` enforces it.
+ * The number of filled bars already tells "good" from "strong"; a paler green is not needed.
+ */
 const STRENGTH_BAR_CLASS: Record<ReturnType<typeof resolvePasswordStrengthLevel>, string> = {
     weak: 'bg-destructive',
     fair: 'bg-warning',
-    good: 'bg-success/70',
+    good: 'bg-success',
     strong: 'bg-success',
 };
 
@@ -75,60 +80,73 @@ export function PasswordRequirements({ policy, password = '', showStrengthMeter 
     const strengthLevel = refusedDespiteChecklist ? 'good' : resolvePasswordStrengthLevel(password, listedRules);
     const strengthLabel = resolvePasswordStrengthLabel(strengthLevel);
     const filledBars = showStrengthMeter ? STRENGTH_FILLED_BARS[strengthLevel] : 0;
+    const showsStrength = showStrengthMeter && Boolean(password) && listedRules.length > 0;
 
     return (
-        <div className={cn('space-y-3', className)}>
-            {showStrengthMeter && password && listedRules.length > 0 ? (
-                <div className="space-y-1">
-                    <div className="flex gap-1" aria-hidden>
-                        {Array.from({ length: 4 }, (_, index) => (
-                            <span
-                                key={index}
-                                className={cn(
-                                    'h-1.5 flex-1 rounded-full bg-muted',
-                                    index < filledBars && STRENGTH_BAR_CLASS[strengthLevel],
-                                )}
-                            />
-                        ))}
-                    </div>
-                    <p className={cn('text-sm font-medium', STRENGTH_TEXT_CLASS[strengthLevel])}>{strengthLabel}</p>
-                </div>
-            ) : null}
-
-            {/* Where the operator wrote a sentence of their own, it is the only guidance left. */}
-            {listedRules.length === 0 && policy.description ? <p className="text-sm text-muted-foreground">{policy.description}</p> : null}
-
-            {listedRules.length > 0 ? (
-                <div className="space-y-2">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requirements</p>
-                    <ul className="space-y-1.5">
-                        {listedRules.map(rule => {
-                            const satisfied = password ? evaluatePasswordPolicyRule(rule, password) : false;
-                            return (
-                                <li key={rule.id} className="flex items-start gap-2 text-sm">
-                                    {satisfied ? (
-                                        <CircleCheckIcon className="mt-0.5 size-4 shrink-0 text-success" aria-hidden />
-                                    ) : (
-                                        <span
-                                            className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border border-muted-foreground/40"
-                                            aria-hidden
-                                        />
+        <div className={className}>
+            <div className="space-y-3">
+                {showsStrength ? (
+                    <div className="space-y-1" aria-hidden>
+                        <div className="flex gap-1">
+                            {Array.from({ length: 4 }, (_, index) => (
+                                <span
+                                    key={index}
+                                    className={cn(
+                                        'h-1 flex-1 rounded-full bg-muted',
+                                        index < filledBars && STRENGTH_BAR_CLASS[strengthLevel],
                                     )}
-                                    <span className={cn(satisfied && password ? 'text-foreground' : 'text-muted-foreground')}>
-                                        {rule.label}
-                                    </span>
-                                </li>
-                            );
-                        })}
-                    </ul>
-                </div>
-            ) : null}
+                                />
+                            ))}
+                        </div>
+                        <p className={cn('text-sm font-medium', STRENGTH_TEXT_CLASS[strengthLevel])}>{strengthLabel}</p>
+                    </div>
+                ) : null}
 
-            {refusedDespiteChecklist ? (
-                <div className="space-y-1">
-                    <p className="text-sm text-destructive">{UNLISTED_REQUIREMENT}</p>
-                    {policy.description ? <p className="text-sm text-muted-foreground">{policy.description}</p> : null}
-                </div>
+                {/* Where the operator wrote a sentence of their own, it is the only guidance left. */}
+                {listedRules.length === 0 && policy.description ? (
+                    <p className="text-sm text-muted-foreground">{policy.description}</p>
+                ) : null}
+
+                {listedRules.length > 0 ? (
+                    <div className="space-y-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requirements</p>
+                        <ul className="space-y-2">
+                            {listedRules.map(rule => {
+                                const satisfied = password ? evaluatePasswordPolicyRule(rule, password) : false;
+                                return (
+                                    <li key={rule.id} className="flex items-start gap-2 text-sm">
+                                        {satisfied ? (
+                                            <CircleCheckIcon className="mt-0.5 size-4 shrink-0 text-success" aria-hidden />
+                                        ) : (
+                                            <span
+                                                className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border border-muted-foreground/40"
+                                                aria-hidden
+                                            />
+                                        )}
+                                        <span className={cn(satisfied && password ? 'text-foreground' : 'text-muted-foreground')}>
+                                            {rule.label}
+                                        </span>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </div>
+                ) : null}
+
+                {refusedDespiteChecklist ? (
+                    <div className="space-y-1">
+                        <p className="text-sm text-destructive">{UNLISTED_REQUIREMENT}</p>
+                        {policy.description ? <p className="text-sm text-muted-foreground">{policy.description}</p> : null}
+                    </div>
+                ) : null}
+            </div>
+            {/* The meter is only seen, so its verdict is spoken here. The region stays mounted, empty
+                until there is something to say: one that appears together with its first message is
+                usually not announced at all. Outside the spacing stack so the empty node adds no gap. */}
+            {showStrengthMeter ? (
+                <p aria-live="polite" className="sr-only">
+                    {showsStrength ? `Password strength: ${strengthLabel}` : ''}
+                </p>
             ) : null}
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.spec.tsx
@@ -51,4 +51,16 @@ describe('AppRoutes', () => {
             expect(await screen.findByRole('button', { name: 'Request account' })).toBeTruthy();
         });
     });
+
+    describe('/registration/:token', () => {
+        it('should reach the activation page while registration is disabled', async () => {
+            // The email predates the setting: someone holding the link still gets the page's answer.
+            seedBootstrap({ registrationEnabled: false });
+
+            renderAt('/registration/not-a-token');
+
+            expect(await screen.findByText('Activate your account')).toBeTruthy();
+            expect(screen.queryByRole('button', { name: 'Sign in' })).toBeNull();
+        });
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
@@ -15,7 +15,15 @@
  */
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { LoginPage, ProtectedRoute, PublicOnlyRoute, RegistrationEnabledRoute, ResetPasswordPage, SignUpPage } from '../features/auth';
+import {
+    ActivationPage,
+    LoginPage,
+    ProtectedRoute,
+    PublicOnlyRoute,
+    RegistrationEnabledRoute,
+    ResetPasswordPage,
+    SignUpPage,
+} from '../features/auth';
 import { EnvironmentGuard, RootRedirect } from '../features/environment';
 import { type GammaModule, RemoteModuleRoute, useGammaModules } from '../features/modules';
 import { HomePage } from '../pages/home';
@@ -31,6 +39,7 @@ export function AppRoutes() {
         return (
             <Routes>
                 <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+                <Route path="/registration/:token" element={<ActivationPage />} />
                 <Route element={<PublicOnlyRoute />}>
                     <Route path="/login" element={<LoginPage />} />
                     <Route element={<RegistrationEnabledRoute />}>
@@ -53,6 +62,9 @@ export function AppRoutes() {
     return (
         <Routes>
             <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+            {/* Outside every guard: the link is the only way in, whether or not someone is signed in or
+                registration is still on, and the server has the only explanation worth giving. */}
+            <Route path="/registration/:token" element={<ActivationPage />} />
             <Route element={<PublicOnlyRoute />}>
                 <Route path="/login" element={<LoginPage />} />
                 <Route element={<RegistrationEnabledRoute />}>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ActivationPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ActivationPage.spec.tsx
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ActivationPage } from './ActivationPage';
+import { TEST_MANAGEMENT_BASE } from '../../../testing/factories';
+import { seedBootstrap, trackHandler } from '../../../testing/helpers';
+import { server } from '../../../testing/server';
+
+const FINALIZE_URL = `${TEST_MANAGEMENT_BASE}/users/registration/finalize`;
+
+/** sub `user-1`, norm1 norm1 <norm1@gmail.com>, expiring far in the future. */
+const VALID_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6OTk5OTk5OTk5OTk5fQ.' +
+    'signature';
+
+/** The same claims, expired in 2001. */
+const EXPIRED_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+    'eyJzdWIiOiJ1c2VyLTEiLCJlbWFpbCI6Im5vcm0xQGdtYWlsLmNvbSIsImZpcnN0bmFtZSI6Im5vcm0xIiwibGFzdG5hbWUiOiJub3JtMSIsImV4cCI6MTAwMDAwMDAwMH0.' +
+    'signature';
+
+const PASSWORD = 'NewPassword1!a';
+
+function renderActivationPage(token = VALID_TOKEN) {
+    seedBootstrap();
+
+    return render(
+        <MemoryRouter initialEntries={[`/registration/${token}`]}>
+            <Routes>
+                <Route path="/registration/:token" element={<ActivationPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+function answerFinalize(body: { message: string; technicalCode: string }, status: number) {
+    server.use(http.post(FINALIZE_URL, () => HttpResponse.json({ ...body, http_status: status }, { status })));
+}
+
+async function submitPassword(password = PASSWORD, confirmation = password) {
+    const user = userEvent.setup();
+    await screen.findByText('At least 12 characters');
+    await user.type(screen.getByLabelText('Password'), password);
+    await user.type(screen.getByLabelText('Confirm password'), confirmation);
+    await user.click(screen.getByRole('button', { name: 'Activate account' }));
+    return user;
+}
+
+describe('ActivationPage', () => {
+    it('shows whose account this is as one line of context, not as fields', async () => {
+        renderActivationPage();
+
+        await screen.findByLabelText('Password');
+        expect(screen.getByText('norm1 norm1')).toBeTruthy();
+        expect(screen.getByText(/norm1@gmail\.com/)).toBeTruthy();
+        expect(screen.queryByLabelText('First name')).toBeNull();
+        expect(screen.queryByLabelText('Last name')).toBeNull();
+        expect(screen.queryByLabelText('Email')).toBeNull();
+    });
+
+    it('submits the token, the password and the identity the token carries, then offers sign-in', async () => {
+        const tracker = trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+        renderActivationPage();
+
+        await submitPassword();
+
+        await waitFor(() => expect(tracker.callCount).toBe(1));
+        expect(tracker.lastCall?.body).toEqual({ token: VALID_TOKEN, password: PASSWORD, firstname: 'norm1', lastname: 'norm1' });
+        expect((await screen.findByRole('status')).textContent).toContain('Your account is ready.');
+        expect(screen.getByRole('link', { name: 'Sign in' }).getAttribute('href')).toBe('/login');
+        expect(screen.queryByLabelText('Password')).toBeNull();
+        // The submit button went with the form; focus lands on the outcome rather than the body.
+        expect(document.activeElement?.textContent).toBe('Account activated');
+    });
+
+    it('says an administrator has to approve the account, and offers no sign-in that would fail', async () => {
+        answerFinalize(
+            {
+                message: 'The registration request is awaiting approval by an administrator.',
+                technicalCode: 'user.registration.pendingApproval',
+            },
+            409,
+        );
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('Waiting for approval')).toBeTruthy();
+        expect(screen.getByRole('status').textContent).toContain('An administrator needs to approve your account');
+        expect(screen.queryByRole('link', { name: 'Sign in' })).toBeNull();
+        expect(screen.getByRole('link', { name: 'Back to sign in' })).toBeTruthy();
+    });
+
+    it('treats an explicit PENDING status as awaiting approval', async () => {
+        trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'PENDING' });
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('Waiting for approval')).toBeTruthy();
+    });
+
+    it('points a link that was already used at sign-in', async () => {
+        answerFinalize({ message: 'User already finalized in organization DEFAULT.', technicalCode: 'user.finalized' }, 400);
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('Account already activated')).toBeTruthy();
+        expect(screen.getByRole('link', { name: 'Sign in' })).toBeTruthy();
+    });
+
+    it('replaces the form when the server says the link can no longer be used', async () => {
+        answerFinalize({ message: 'User [user-1] cannot be found.', technicalCode: 'user.notFound' }, 404);
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(
+            await screen.findByText("This activation link can't be used anymore. Ask your administrator to send a new one."),
+        ).toBeTruthy();
+        expect(screen.queryByLabelText('Password')).toBeNull();
+        // The server's wording names the account's internal id; the reader has no use for it.
+        expect(screen.queryByText(/user-1/)).toBeNull();
+        expect(document.activeElement?.textContent).toBe('Activate your account');
+    });
+
+    it('says activation is switched off, without calling the link dead, when registration is off', async () => {
+        answerFinalize({ message: 'User registration service is unavailable.', technicalCode: 'user.registration.disabled' }, 503);
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('Activation is turned off')).toBeTruthy();
+        expect(
+            screen.getByText('Account activation is turned off for now. Try this link again later, or contact your administrator.'),
+        ).toBeTruthy();
+        expect(screen.queryByText(/can't be used anymore/)).toBeNull();
+        expect(screen.queryByLabelText('Password')).toBeNull();
+    });
+
+    it('replaces the form when the link is not a token, leaving focus where the page starts', () => {
+        renderActivationPage('not-a-token');
+
+        expect(screen.getByText("This activation link isn't valid. Ask your administrator to send a new one.")).toBeTruthy();
+        expect(screen.queryByLabelText('Password')).toBeNull();
+        expect(document.activeElement).toBe(document.body);
+    });
+
+    it('replaces the form when the link has expired', () => {
+        renderActivationPage(EXPIRED_TOKEN);
+
+        expect(screen.getByText('This activation link has expired. Ask your administrator to send a new one.')).toBeTruthy();
+        expect(screen.queryByLabelText('Password')).toBeNull();
+    });
+
+    it('puts a refused password on the password field in its own words, and retires it once the password changes', async () => {
+        answerFinalize({ message: 'The password is not valid according to policy rules.', technicalCode: 'passwordFormat.invalid' }, 400);
+        renderActivationPage();
+
+        const user = await submitPassword();
+
+        const message = await screen.findByText("This password doesn't meet the password policy. Choose a different one.");
+        // As on sign-up, the server's wording never reaches an anonymous reader.
+        expect(screen.queryByText(/not valid according to policy rules/)).toBeNull();
+        const field = screen.getByLabelText('Password');
+        expect(field.getAttribute('aria-invalid')).toBe('true');
+        expect(field.getAttribute('aria-describedby')?.split(' ')).toContain(message.id);
+
+        await user.type(field, 'x');
+
+        expect(screen.queryByText("This password doesn't meet the password policy. Choose a different one.")).toBeNull();
+        expect(field.getAttribute('aria-invalid')).toBeNull();
+    });
+
+    it("reports a server failure above the form in the page's own words, keeping what was typed", async () => {
+        answerFinalize({ message: 'java.lang.IllegalStateException: JWT secret is mandatory', technicalCode: 'unexpected' }, 500);
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('Something went wrong while activating your account. Try again.')).toBeTruthy();
+        expect(screen.queryByText(/IllegalStateException/)).toBeNull();
+        expect((screen.getByLabelText('Password') as HTMLInputElement).value).toBe(PASSWORD);
+    });
+
+    it('keeps submit disabled while the two passwords differ', async () => {
+        const user = userEvent.setup();
+        renderActivationPage();
+
+        await screen.findByText('At least 12 characters');
+        await user.type(screen.getByLabelText('Password'), PASSWORD);
+        await user.type(screen.getByLabelText('Confirm password'), 'DifferentPassword1!a');
+
+        const mismatch = screen.getByText('Both passwords must match.');
+        expect(screen.getByLabelText('Confirm password').getAttribute('aria-describedby')).toBe(mismatch.id);
+        expect((screen.getByRole('button', { name: 'Activate account' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('describes the password field with its requirements', async () => {
+        renderActivationPage();
+
+        await screen.findByText('At least 12 characters');
+        const describedBy = screen.getByLabelText('Password').getAttribute('aria-describedby') ?? '';
+        const description = describedBy
+            .split(' ')
+            .map(id => document.getElementById(id)?.textContent ?? '')
+            .join(' ');
+        expect(description).toContain('At least 12 characters');
+    });
+
+    it('offers a password manager the address and two new-password fields', async () => {
+        const { container } = renderActivationPage();
+
+        await screen.findByLabelText('Password');
+        expect(container.querySelector<HTMLInputElement>('input[autocomplete="username"]')?.value).toBe('norm1@gmail.com');
+        expect(screen.getByLabelText('Password').getAttribute('autocomplete')).toBe('new-password');
+        expect(screen.getByLabelText('Confirm password').getAttribute('autocomplete')).toBe('new-password');
+    });
+
+    it('blocks submit when the password rules cannot be loaded', async () => {
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                HttpResponse.json({ message: 'Service unavailable' }, { status: 503 }),
+            ),
+        );
+        renderActivationPage();
+
+        expect(await screen.findByText("Couldn't load the password rules. Refresh the page to try again.")).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Activate account' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('keeps submit disabled, and says why, when the pattern refuses a password every listed rule accepts', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                // '\\d' defeats the parser, so only the length rule is derived from this pattern.
+                HttpResponse.json({
+                    description: '',
+                    pattern: '^(?=.*\\d).{8,}$',
+                    rules: [{ id: 'minLength', label: 'At least 8 characters', pattern: '^.{8,}$' }],
+                }),
+            ),
+        );
+        renderActivationPage();
+
+        await screen.findByText('At least 8 characters');
+        await user.type(screen.getByLabelText('Password'), 'abcdefghij');
+        await user.type(screen.getByLabelText('Confirm password'), 'abcdefghij');
+
+        expect(screen.getByText("This password doesn't meet the full policy yet. One of its requirements isn't listed here.")).toBeTruthy();
+        expect((screen.getByRole('button', { name: 'Activate account' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('leaves the verdict to the server for a pattern this browser cannot read', async () => {
+        const user = userEvent.setup();
+        const tracker = trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+        server.use(
+            http.get(`${TEST_MANAGEMENT_BASE}/configuration/password-policy`, () =>
+                // A possessive quantifier: valid for the server's Java engine, a syntax error in JavaScript.
+                HttpResponse.json({
+                    description: '',
+                    pattern: '^[a-z]++$',
+                    rules: [{ id: 'lowercase', label: 'Contains lowercase letter', pattern: '[a-z]' }],
+                }),
+            ),
+        );
+        renderActivationPage();
+
+        await screen.findByText('Contains lowercase letter');
+        await user.type(screen.getByLabelText('Password'), 'abcdefgh');
+        await user.type(screen.getByLabelText('Confirm password'), 'abcdefgh');
+        await user.click(screen.getByRole('button', { name: 'Activate account' }));
+
+        await waitFor(() => expect(tracker.callCount).toBe(1));
+    });
+});
+
+describe('ActivationPage, when the link expires while the page is open', () => {
+    /** Past VALID_TOKEN's `exp`, which is 999999999999 seconds. */
+    const AFTER_EXPIRY = 1_000_000_000_000_000;
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('says the link has expired instead of sending a request the server can only refuse', async () => {
+        const user = userEvent.setup();
+        const tracker = trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+        renderActivationPage();
+
+        await screen.findByText('At least 12 characters');
+        await user.type(screen.getByLabelText('Password'), PASSWORD);
+        await user.type(screen.getByLabelText('Confirm password'), PASSWORD);
+        jest.spyOn(Date, 'now').mockReturnValue(AFTER_EXPIRY);
+        await user.click(screen.getByRole('button', { name: 'Activate account' }));
+
+        expect(await screen.findByText('This activation link has expired. Ask your administrator to send a new one.')).toBeTruthy();
+        expect(tracker.callCount).toBe(0);
+        expect(screen.queryByLabelText('Password')).toBeNull();
+    });
+
+    it('reads a server failure as expiry when the link ran out in flight', async () => {
+        server.use(
+            http.post(FINALIZE_URL, () => {
+                jest.spyOn(Date, 'now').mockReturnValue(AFTER_EXPIRY);
+                return HttpResponse.json(
+                    { message: 'The Token has expired on 2026-09-01T00:00:00Z.', technicalCode: 'unexpected', http_status: 500 },
+                    { status: 500 },
+                );
+            }),
+        );
+        renderActivationPage();
+
+        await submitPassword();
+
+        expect(await screen.findByText('This activation link has expired. Ask your administrator to send a new one.')).toBeTruthy();
+        expect(screen.queryByText(/The Token has expired/)).toBeNull();
+        expect(document.activeElement?.textContent).toBe('Activate your account');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ActivationPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/ActivationPage.tsx
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Button,
+    Field,
+    FieldError,
+    FieldLabel,
+    PasswordInput,
+    Spinner,
+} from '@gravitee/graphene-core';
+import { useMemo, useState, type ReactNode, type SubmitEvent } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { AuthPageShell } from './AuthPageShell';
+import { PasswordRequirements, assessPassword } from '../../../shared/password-policy';
+import { usePasswordPolicy } from '../hooks/usePasswordPolicy';
+import { finalizeRegistration } from '../services/registration.service';
+import { isAuthTokenExpired, parseAuthToken, type AuthTokenClaims } from '../utils/authToken';
+
+const INVALID_LINK = "This activation link isn't valid. Ask your administrator to send a new one.";
+const EXPIRED_LINK = 'This activation link has expired. Ask your administrator to send a new one.';
+const UNUSABLE_LINK = "This activation link can't be used anymore. Ask your administrator to send a new one.";
+const REGISTRATION_OFF = 'Account activation is turned off for now. Try this link again later, or contact your administrator.';
+/** The page's own words: as on sign-up, the server's wording never reaches an anonymous reader. */
+const PASSWORD_REFUSED = "This password doesn't meet the password policy. Choose a different one.";
+
+const PASSWORD_ID = 'activation-password';
+const PASSWORD_REQUIREMENTS_ID = 'activation-password-requirements';
+const PASSWORD_ERROR_ID = 'activation-password-error';
+const CONFIRM_PASSWORD_ID = 'activation-confirm-password';
+const CONFIRM_PASSWORD_ERROR_ID = 'activation-confirm-password-error';
+
+/** Outcomes nothing typed into the form can change, so each replaces it. */
+type FinalOutcome = 'active' | 'pending-approval' | 'link-used' | 'link-unusable' | 'registration-off';
+
+function passwordsMatch(password: string, confirmPassword: string): boolean {
+    return password.length > 0 && password === confirmPassword;
+}
+
+/**
+ * Why an activation link cannot be used, or null when it can. Registration creates the account
+ * before the email leaves, so a genuine link always names it in its subject.
+ *
+ * The signature is not checked here -- only the server holds the secret -- and the server reports a
+ * forged or expired token as an unexpected failure, so these are the only checks that can tell the
+ * reader their link is the problem.
+ */
+function activationTokenError(token: string, claims: AuthTokenClaims | null): string | null {
+    if (!token || !claims) {
+        return INVALID_LINK;
+    }
+    if (isAuthTokenExpired(claims)) {
+        return EXPIRED_LINK;
+    }
+    if (!claims.sub) {
+        return INVALID_LINK;
+    }
+    return null;
+}
+
+function describedBy(...ids: (string | false)[]): string {
+    return ids.filter(Boolean).join(' ');
+}
+
+function ActivationShell({ description, focusTitle, children }: { description?: string; focusTitle?: boolean; children: ReactNode }) {
+    return (
+        <AuthPageShell
+            title="Activate your account"
+            description={description}
+            focusTitle={focusTitle}
+            footer={
+                <>
+                    Back to{' '}
+                    <Link to="/login" className="text-primary underline-offset-4 hover:underline">
+                        sign in
+                    </Link>
+                </>
+            }
+        >
+            {children}
+        </AuthPageShell>
+    );
+}
+
+/**
+ * Where there is nothing left to do but read, the whole page is the message: unboxed text in a
+ * status region, and the one control that moves the reader on. Every outcome replaces the form the
+ * reader was in, so focus follows it to the title.
+ */
+function OutcomeShell({ title, message, action }: { title: string; message: string; action: ReactNode }) {
+    return (
+        <AuthPageShell title={title} focusTitle>
+            <div role="status" className="text-sm text-muted-foreground">
+                <p>{message}</p>
+            </div>
+            {action}
+        </AuthPageShell>
+    );
+}
+
+export function ActivationPage() {
+    const { token = '' } = useParams<{ token: string }>();
+    const tokenClaims = useMemo(() => parseAuthToken(token), [token]);
+    const tokenError = useMemo(() => activationTokenError(token, tokenClaims), [token, tokenClaims]);
+
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [passwordError, setPasswordError] = useState('');
+    const [formError, setFormError] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [outcome, setOutcome] = useState<FinalOutcome | null>(null);
+    const [expiredDuringSession, setExpiredDuringSession] = useState(false);
+    const { policy: passwordPolicy, loading: passwordPolicyLoading, error: passwordPolicyError } = usePasswordPolicy();
+
+    const accountName = [tokenClaims?.firstname, tokenClaims?.lastname].filter(Boolean).join(' ');
+    const email = tokenClaims?.email ?? '';
+    const passwordMismatch = confirmPassword.length > 0 && password !== confirmPassword;
+    // Only an outright refusal blocks: 'undecidable' means this browser cannot read the pattern as the
+    // server does, and blocking on it would refuse a password the server would accept.
+    const policyRefusesPassword = assessPassword(password, passwordPolicy) === 'unsatisfied';
+    const canSubmit =
+        !tokenError &&
+        passwordsMatch(password, confirmPassword) &&
+        !policyRefusesPassword &&
+        !passwordPolicyLoading &&
+        !passwordPolicyError &&
+        !submitting;
+
+    async function handleSubmit(event: SubmitEvent) {
+        event.preventDefault();
+        if (!canSubmit) {
+            return;
+        }
+        // The token was read when the page loaded. A tab left open past its expiry would otherwise send
+        // a request the server can only refuse in words written for developers.
+        if (tokenClaims && isAuthTokenExpired(tokenClaims)) {
+            setExpiredDuringSession(true);
+            return;
+        }
+
+        setPasswordError('');
+        setFormError('');
+        setSubmitting(true);
+        try {
+            const result = await finalizeRegistration({
+                token,
+                password,
+                // Sent only because `RegisterUserEntity` marks both @NotNull and the endpoint is @Valid:
+                // omitting them is a 400. Finalize reads them only for a token without a subject, which
+                // this page refuses before it gets here.
+                firstname: tokenClaims?.firstname ?? '',
+                lastname: tokenClaims?.lastname ?? '',
+            });
+
+            switch (result.outcome) {
+                case 'password-rejected':
+                    setPasswordError(PASSWORD_REFUSED);
+                    break;
+                case 'rejected':
+                    // Finalize reports a token that expired in flight as a server failure; only the
+                    // claims can tell the two apart.
+                    if (tokenClaims && isAuthTokenExpired(tokenClaims)) {
+                        setExpiredDuringSession(true);
+                    } else {
+                        setFormError(result.message);
+                    }
+                    break;
+                default:
+                    setOutcome(result.outcome);
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    const deadLink = tokenError ?? (expiredDuringSession ? EXPIRED_LINK : null) ?? (outcome === 'link-unusable' ? UNUSABLE_LINK : null);
+
+    // A dead link replaces the form entirely: a form left behind an alert invites a password the
+    // server is certain to refuse.
+    if (deadLink) {
+        return (
+            // Focus follows only a state that replaced a form in use. A link dead on arrival is simply
+            // where the page starts, and the reader is already at the top of it.
+            <ActivationShell focusTitle={!tokenError}>
+                <Alert variant="destructive" role="alert">
+                    <AlertTitle>Could not activate your account</AlertTitle>
+                    <AlertDescription>{deadLink}</AlertDescription>
+                </Alert>
+            </ActivationShell>
+        );
+    }
+
+    if (outcome === 'registration-off') {
+        // Not destructive: nothing is wrong with the link, and it works again once the setting is back.
+        return (
+            <ActivationShell focusTitle>
+                <Alert role="alert">
+                    <AlertTitle>Activation is turned off</AlertTitle>
+                    <AlertDescription>{REGISTRATION_OFF}</AlertDescription>
+                </Alert>
+            </ActivationShell>
+        );
+    }
+
+    if (outcome === 'active' || outcome === 'link-used') {
+        return (
+            <OutcomeShell
+                title={outcome === 'active' ? 'Account activated' : 'Account already activated'}
+                message={
+                    outcome === 'active'
+                        ? 'Your account is ready. Sign in with your email and the password you just chose.'
+                        : 'This link has already been used to set a password. Sign in with that password.'
+                }
+                action={
+                    <Button asChild size="lg" className="mt-6 w-full">
+                        <Link to="/login">Sign in</Link>
+                    </Button>
+                }
+            />
+        );
+    }
+
+    if (outcome === 'pending-approval') {
+        // No Sign in here: it is the one control guaranteed to fail until an administrator acts.
+        return (
+            <OutcomeShell
+                title="Waiting for approval"
+                message="An administrator needs to approve your account before you can sign in. You'll get an email when they do."
+                action={
+                    <Button asChild variant="outline" size="lg" className="mt-6 w-full">
+                        <Link to="/login">Back to sign in</Link>
+                    </Button>
+                }
+            />
+        );
+    }
+
+    return (
+        <ActivationShell description="Choose a password to finish setting up your account.">
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+                {passwordPolicyError ? (
+                    <Alert variant="destructive" role="alert">
+                        <AlertTitle>{"Couldn't load password rules"}</AlertTitle>
+                        <AlertDescription>{passwordPolicyError}</AlertDescription>
+                    </Alert>
+                ) : null}
+
+                {formError ? (
+                    <Alert variant="destructive" role="alert">
+                        <AlertTitle>Could not activate your account</AlertTitle>
+                        <AlertDescription>{formError}</AlertDescription>
+                    </Alert>
+                ) : null}
+
+                {/* The account is context, not input: disabled fields fail contrast, keyboard
+                    navigation skips them, and assistive technology never reaches the name they carry. */}
+                {accountName || email ? (
+                    <p className="text-sm text-muted-foreground">
+                        Signing up as <span className="font-medium text-foreground">{accountName || email}</span>
+                        {accountName && email ? ` · ${email}` : null}
+                    </p>
+                ) : null}
+
+                {/* A password manager files a new password under the username beside it, and this form
+                    has no visible one to offer. */}
+                <input type="email" autoComplete="username" value={email} readOnly hidden />
+
+                <Field orientation="vertical" className="gap-2" data-invalid={passwordError ? true : undefined}>
+                    <FieldLabel htmlFor={PASSWORD_ID}>Password</FieldLabel>
+                    <PasswordInput
+                        id={PASSWORD_ID}
+                        value={password}
+                        onChange={event => {
+                            setPassword(event.target.value);
+                            setPasswordError('');
+                        }}
+                        required
+                        autoComplete="new-password"
+                        aria-invalid={passwordError ? true : undefined}
+                        aria-describedby={describedBy(Boolean(passwordError) && PASSWORD_ERROR_ID, PASSWORD_REQUIREMENTS_ID)}
+                        // eslint-disable-next-line jsx-a11y/no-autofocus
+                        autoFocus
+                    />
+                    <FieldError id={PASSWORD_ERROR_ID}>{passwordError || undefined}</FieldError>
+                    <div id={PASSWORD_REQUIREMENTS_ID}>
+                        <PasswordRequirements policy={passwordPolicy} password={password} showStrengthMeter />
+                    </div>
+                </Field>
+
+                <Field orientation="vertical" className="gap-2" data-invalid={passwordMismatch ? true : undefined}>
+                    <FieldLabel htmlFor={CONFIRM_PASSWORD_ID}>Confirm password</FieldLabel>
+                    <PasswordInput
+                        id={CONFIRM_PASSWORD_ID}
+                        value={confirmPassword}
+                        onChange={event => setConfirmPassword(event.target.value)}
+                        required
+                        autoComplete="new-password"
+                        aria-invalid={passwordMismatch ? true : undefined}
+                        aria-describedby={describedBy(passwordMismatch && CONFIRM_PASSWORD_ERROR_ID) || undefined}
+                    />
+                    <FieldError id={CONFIRM_PASSWORD_ERROR_ID}>{passwordMismatch ? 'Both passwords must match.' : undefined}</FieldError>
+                </Field>
+
+                <Button type="submit" className="w-full" size="lg" disabled={!canSubmit}>
+                    {submitting ? (
+                        <span className="inline-flex items-center justify-center gap-2">
+                            <Spinner className="size-4 shrink-0" aria-hidden />
+                            Activating account…
+                        </span>
+                    ) : (
+                        'Activate account'
+                    )}
+                </Button>
+            </form>
+        </ActivationShell>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/AuthPageShell.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/AuthPageShell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, Logo, cn } from '@gravitee/graphene-core';
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
 interface AuthPageShellProps {
     readonly title: string;
@@ -26,6 +26,12 @@ interface AuthPageShellProps {
      * `div`, not a `p`: `ReactNode` admits block elements, which a `p` would nest invalidly.
      */
     readonly footer?: ReactNode;
+    /**
+     * Moves focus to the title when this page appears. For a state that replaces a form the reader
+     * was using: the control that held focus goes with the form, focus falls to the document body,
+     * and the new state is neither announced nor a place for the keyboard to start from.
+     */
+    readonly focusTitle?: boolean;
 }
 
 /**
@@ -44,13 +50,31 @@ interface AuthPageShellProps {
  * The mark comes from Graphene, the same source `AppSidebar` renders, so the signed-out
  * pages cannot drift from the signed-in chrome.
  */
-export function AuthPageShell({ title, description, children, footer }: AuthPageShellProps) {
+export function AuthPageShell({ title, description, children, footer, focusTitle = false }: AuthPageShellProps) {
+    const titleRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (focusTitle) {
+            titleRef.current?.focus();
+        }
+    }, [focusTitle]);
+
     return (
-        <div className={cn('flex min-h-screen flex-col items-center justify-center p-4', 'font-sans text-foreground')}>
+        // Full height inline: Graphene's pre-built bundle has no full-viewport min-height utility, so the
+        // card was never centred vertically.
+        <div className={cn('flex flex-col items-center justify-center p-4', 'font-sans text-foreground')} style={{ minHeight: '100vh' }}>
             <Card className="w-full max-w-md">
                 <CardHeader className="space-y-2">
                     <Logo size="lg" className="mb-4" />
-                    <CardTitle className="text-2xl">{title}</CardTitle>
+                    {/* Focusable from script only, and without a ring: the title is where reading
+                        resumes, not a control. */}
+                    <CardTitle
+                        ref={titleRef}
+                        tabIndex={focusTitle ? -1 : undefined}
+                        className={cn('text-2xl', focusTitle && 'outline-none')}
+                    >
+                        {title}
+                    </CardTitle>
                     {description ? <CardDescription>{description}</CardDescription> : null}
                 </CardHeader>
                 <CardContent>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.spec.tsx
@@ -308,6 +308,8 @@ describe('SignUpPage', () => {
             expect(screen.getByText('ada@example.com')).toBeTruthy();
             expect(screen.getByRole('link', { name: 'Back to sign in' }).getAttribute('href')).toBe('/login');
             expect(screen.queryByText(/Already have an account/)).toBeNull();
+            // The submit button went with the form; focus lands on the new state rather than the body.
+            expect(document.activeElement?.textContent).toBe('Check your email');
         });
 
         it('offers no resend, because the backend has no such endpoint', async () => {

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/components/SignUpPage.tsx
@@ -157,7 +157,8 @@ export function SignUpPage() {
 
     if (sentTo) {
         return (
-            <AuthPageShell title="Check your email">
+            // Focus follows the swap: the submit button that held it went with the form.
+            <AuthPageShell title="Check your email" focusTitle>
                 {/* No resend control: the management API has no endpoint that could serve one, and a
                     button that cannot work is worse than its absence. */}
                 {/* Unboxed: the whole page is the message, so an Alert here only framed the card's

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/index.ts
@@ -27,5 +27,6 @@ export type { CurrentUser as User, SocialIdentityProvider, IdentityProviderType 
 export { LoginPage } from './components/LoginPage';
 export { ResetPasswordPage } from './components/ResetPasswordPage';
 export { SignUpPage } from './components/SignUpPage';
+export { ActivationPage } from './components/ActivationPage';
 export { ProtectedRoute, PublicOnlyRoute } from './components/ProtectedRoute';
 export { RegistrationEnabledRoute } from './components/RegistrationEnabledRoute';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.spec.ts
@@ -16,7 +16,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { resetReCaptchaConfigCacheForTests } from './recaptcha.service';
-import { fetchCustomUserFields, submitRegistration } from './registration.service';
+import { fetchCustomUserFields, finalizeRegistration, submitRegistration } from './registration.service';
 import { TEST_MANAGEMENT_BASE } from '../../../testing/factories';
 import { respondWith, trackHandler } from '../../../testing/helpers';
 import { server } from '../../../testing/server';
@@ -163,5 +163,131 @@ describe('submitRegistration', () => {
         });
 
         await expect(submitRegistration(IDENTITY)).resolves.toEqual({ outcome: 'submitted' });
+    });
+});
+
+describe('finalizeRegistration', () => {
+    const FINALIZE_URL = `${REGISTRATION_URL}/finalize`;
+    const ACTIVATION = { token: 'activation-token', password: 'Correct-Horse-9', firstname: 'Ada', lastname: 'Lovelace' };
+
+    function rejectFinalize(body: { message: string; technicalCode?: string }, status: number) {
+        server.use(http.post(FINALIZE_URL, () => HttpResponse.json({ ...body, http_status: status }, { status })));
+    }
+
+    it('posts the token, the password and the identity from the token', async () => {
+        const tracker = trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+
+        await finalizeRegistration(ACTIVATION);
+
+        expect(tracker.callCount).toBe(1);
+        expect(tracker.lastCall?.body).toEqual(ACTIVATION);
+    });
+
+    it('carries a reCAPTCHA token when reCAPTCHA is configured', async () => {
+        server.use(http.get(`${TEST_MANAGEMENT_BASE}/console`, () => HttpResponse.json({ reCaptcha: { enabled: true, siteKey: 'site' } })));
+        window.grecaptcha = {
+            ready: (callback: () => void) => callback(),
+            execute: () => Promise.resolve('recaptcha-token'),
+        };
+        const script = document.createElement('script');
+        script.id = 'gamma-recaptcha';
+        document.head.appendChild(script);
+
+        const tracker = trackHandler('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+
+        await finalizeRegistration(ACTIVATION);
+
+        expect(tracker.lastCall?.headers.get('X-Recaptcha-Token')).toBe('recaptcha-token');
+
+        script.remove();
+        delete window.grecaptcha;
+    });
+
+    it('reports an account that is ready to sign in to', async () => {
+        respondWith('post', FINALIZE_URL, { id: 'user-1', status: 'ACTIVE' });
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'active' });
+    });
+
+    it('reports an account awaiting administrator approval', async () => {
+        respondWith('post', FINALIZE_URL, { id: 'user-1', status: 'PENDING' });
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'pending-approval' });
+    });
+
+    it('treats a success without an explicit PENDING as active, since the password was saved', async () => {
+        // Finalize refuses PENDING, REJECTED and ARCHIVED accounts before it writes anything, so a 200
+        // means the password is set. "Waiting for approval" here would outlive the link: the next
+        // click answers `user.finalized`.
+        respondWith('post', FINALIZE_URL, { id: 'user-1' });
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'active' });
+    });
+
+    it('reports a pre-created account that is already awaiting approval as pending', async () => {
+        rejectFinalize(
+            {
+                message: 'The registration request is awaiting approval by an administrator.',
+                technicalCode: 'user.registration.pendingApproval',
+            },
+            409,
+        );
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'pending-approval' });
+    });
+
+    it('attributes a refused password to the password field, without the server wording', async () => {
+        rejectFinalize({ message: 'The password is not valid according to policy rules.', technicalCode: 'passwordFormat.invalid' }, 400);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'password-rejected' });
+    });
+
+    it('reports a link that already set a password', async () => {
+        rejectFinalize({ message: 'User already finalized in organization DEFAULT.', technicalCode: 'user.finalized' }, 400);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'link-used' });
+    });
+
+    it.each([
+        ['user.notFound', 404],
+        ['user.state.conflict', 409],
+    ])('reports a link that can no longer be used (%s)', async (technicalCode, status) => {
+        rejectFinalize({ message: 'Registration cannot be finalized.', technicalCode }, status);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'link-unusable' });
+    });
+
+    it('reports registration switched off as its own outcome, not as a dead link', async () => {
+        // A live check of the organization's setting: the same link works again once it is back on.
+        rejectFinalize({ message: 'User registration service is unavailable.', technicalCode: 'user.registration.disabled' }, 503);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({ outcome: 'registration-off' });
+    });
+
+    it("replaces a server failure's own wording with the page's, so no exception text reaches the reader", async () => {
+        rejectFinalize({ message: 'The Token has expired on 2026-09-01T00:00:00Z.', technicalCode: 'unexpected' }, 500);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while activating your account. Try again.',
+        });
+    });
+
+    it('never relays the server wording of a client error it cannot attribute', async () => {
+        rejectFinalize({ message: 'Gamma URL is not configured for organization: DEFAULT', technicalCode: 'errors.validation' }, 400);
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while activating your account. Try again.',
+        });
+    });
+
+    it('reports an unreachable server against the form', async () => {
+        server.use(http.post(FINALIZE_URL, () => HttpResponse.error()));
+
+        await expect(finalizeRegistration(ACTIVATION)).resolves.toEqual({
+            outcome: 'rejected',
+            message: 'Something went wrong while activating your account. Try again.',
+        });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/services/registration.service.ts
@@ -120,3 +120,103 @@ export async function submitRegistration(request: RegistrationRequest): Promise<
         return { outcome: 'rejected', message: UNEXPECTED_FAILURE };
     }
 }
+
+export interface ActivationRequest {
+    readonly token: string;
+    readonly password: string;
+    readonly firstname: string;
+    readonly lastname: string;
+}
+
+export type ActivationResult =
+    /** The account can be signed in to now. */
+    | { readonly outcome: 'active' }
+    /** The account exists but an administrator has to accept it first; an email follows. */
+    | { readonly outcome: 'pending-approval' }
+    /** The password policy refused the password; nothing else about the request was wrong. */
+    | { readonly outcome: 'password-rejected' }
+    /** The link already set a password. */
+    | { readonly outcome: 'link-used' }
+    /** The link cannot complete an activation, and resubmitting will not change that. */
+    | { readonly outcome: 'link-unusable' }
+    /** Registration is switched off for the organization. The link works again once it is back on. */
+    | { readonly outcome: 'registration-off' }
+    /** Failed for a reason no retry is ruled out for. */
+    | { readonly outcome: 'rejected'; readonly message: string };
+
+const UNEXPECTED_ACTIVATION_FAILURE = 'Something went wrong while activating your account. Try again.';
+
+/**
+ * A defensive branch, not a common one. Registration emails a Gamma link only when automatic
+ * validation is on, and then the account it names is created ACTIVE. With validation off, the link
+ * that follows an administrator's approval goes to the portal or the classic console instead
+ * (`processRegistration`). This code reaches the page only if an administrator set the account back
+ * to PENDING after the email left; finalize refuses it before saving the password.
+ */
+const PENDING_APPROVAL_CODE = 'user.registration.pendingApproval';
+const ALREADY_FINALIZED_CODE = 'user.finalized';
+/** Deleted, rejected or archived since the email was sent. */
+const LINK_UNUSABLE_CODES = new Set(['user.notFound', 'user.state.conflict']);
+
+/**
+ * As for sign-up, the server's text is never shown: the caller is anonymous, and what arrives is an
+ * exception's own message -- for an expired or forged token, the JWT library's wording in a 500.
+ * The page words every outcome itself.
+ */
+function toActivationResult(error: ApiError): ActivationResult {
+    const code = error.technicalCode;
+    if (code === 'passwordFormat.invalid') {
+        return { outcome: 'password-rejected' };
+    }
+    if (code === PENDING_APPROVAL_CODE) {
+        return { outcome: 'pending-approval' };
+    }
+    if (code === ALREADY_FINALIZED_CODE) {
+        return { outcome: 'link-used' };
+    }
+    if (code === REGISTRATION_DISABLED_CODE) {
+        return { outcome: 'registration-off' };
+    }
+    if (code && LINK_UNUSABLE_CODES.has(code)) {
+        return { outcome: 'link-unusable' };
+    }
+    return { outcome: 'rejected', message: UNEXPECTED_ACTIVATION_FAILURE };
+}
+
+/**
+ * Sets the password on the account an activation email was sent for. The returned status decides the
+ * outcome rather than the automatic-validation setting, which can change between sign-up and here.
+ */
+export async function finalizeRegistration(request: ActivationRequest): Promise<ActivationResult> {
+    try {
+        const reCaptchaToken = await resolveReCaptchaToken('finalizeRegistration');
+        const extraHeaders: Record<string, string> = {};
+        if (reCaptchaToken) {
+            extraHeaders[getReCaptchaHeaderName()] = reCaptchaToken;
+        }
+
+        const user = await managementApi.post<{ status?: string }>(
+            '/users/registration/finalize',
+            {
+                token: request.token,
+                password: request.password,
+                firstname: request.firstname,
+                lastname: request.lastname,
+            },
+            extraHeaders,
+        );
+        // A 200 means the password was saved: finalize refuses PENDING, REJECTED and ARCHIVED accounts
+        // before it writes anything. Only an explicit PENDING is treated as waiting, so a response that
+        // omits the status cannot tell someone whose account is ready to wait for an approval that
+        // never comes.
+        return user?.status === 'PENDING' ? { outcome: 'pending-approval' } : { outcome: 'active' };
+    } catch (error) {
+        if (error instanceof ApiError) {
+            return toActivationResult(error);
+        }
+        if (process.env.NODE_ENV !== 'production') {
+            console.error('Activation request failed', error);
+        }
+        return { outcome: 'rejected', message: UNEXPECTED_ACTIVATION_FAILURE };
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/password-policy/PasswordRequirements.spec.tsx
@@ -75,6 +75,33 @@ describe('PasswordRequirements', () => {
         expect(screen.getByText('Fair')).toBeTruthy();
         expect(screen.queryByText('Strong')).toBeNull();
     });
+
+    it('announces the strength through a live region that is already mounted before the first keystroke', () => {
+        // A region inserted together with its first message is usually not announced, so it has to
+        // exist, empty, before there is anything to say.
+        const { container, rerender } = renderWithGraphene(
+            <PasswordRequirements policy={{ rules: TEST_RULES }} password="" showStrengthMeter />,
+        );
+        const region = container.querySelector('[aria-live="polite"]');
+        expect(region?.textContent).toBe('');
+
+        rerender(<PasswordRequirements policy={{ rules: TEST_RULES }} password="LongEnough1" showStrengthMeter />);
+
+        expect(container.querySelector('[aria-live="polite"]')).toBe(region);
+        expect(region?.textContent).toBe('Password strength: Fair');
+    });
+
+    it('hides the visual strength label from assistive technology, which hears the live region instead', () => {
+        renderWithGraphene(<PasswordRequirements policy={{ rules: TEST_RULES }} password="LongEnough1" showStrengthMeter />);
+
+        expect(screen.getByText('Fair').closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
+    it('mounts no live region where no meter is asked for', () => {
+        const { container } = renderWithGraphene(<PasswordRequirements policy={{ rules: TEST_RULES }} password="LongEnough1" />);
+
+        expect(container.querySelector('[aria-live]')).toBeNull();
+    });
 });
 
 describe('PasswordRequirements, when the parser derived nothing usable', () => {


### PR DESCRIPTION
Closes [FOUND-263](https://gravitee.atlassian.net/browse/FOUND-263).

Adds the account activation page at `/registration/:token` in the Gamma control plane — the path the activation email already links to (`GAMMA_REGISTRATION_PATH` + `/{token}`). Someone who received the email sets their password there and is told exactly what happens next.

Based on master: #19839 (FOUND-262) and #19867 (FOUND-261) are merged, and this was rebased onto them. The route sits outside #19867's `RegistrationEnabledRoute`, so a valid link still works while registration is off.

## ⚠️ Security-sensitive

- Anonymous page sending a signed, email-embedded token and a new password to `POST /users/registration/finalize`. No backend changes.
- The token is decoded client-side for display and an expiry check only; its signature is verified by the server alone.
- A reCAPTCHA token is attached when configured (`finalizeRegistration` action, as in the classic console).
- A hidden `autocomplete="username"` field carries the address from the token so a password manager files the new password under it.

## States

| Situation | Page |
| --- | --- |
| Malformed or expired token (checked on load) | Form replaced: link isn't valid / has expired, ask an administrator for a new one |
| Token expires while the page is open (checked again on submit, and after a failed request) | Form replaced: link has expired — instead of a request the server can only refuse |
| `user.notFound`, `user.state.conflict` | Form replaced: link can't be used anymore, ask an administrator |
| 503 `user.registration.disabled` | Form replaced: activation is turned off for now, try the link again later — the link is not dead, the setting is checked live |
| 200 (anything but an explicit `PENDING`) | **Account activated**, Sign in |
| 409 `user.registration.pendingApproval`, or 200 with `PENDING` | **Waiting for approval** — no Sign in, which would only fail |
| 400 `user.finalized` | **Account already activated**, Sign in |
| 400 `passwordFormat.invalid` | The page's own message on the password field; clears when the password changes |
| Any other failure, 4xx or 5xx | Form-level error in the page's own words, form kept for a retry |

As on the sign-up page (#19839), the server's wording never reaches the reader: the caller is anonymous, and what arrives is an exception's own message — for an expired or forged token, the JWT library's wording in a 500.

**How approval actually reaches this page.** Registration emails a Gamma link only when automatic validation is on, and then the account it names is created `ACTIVE`. With validation off, nothing is emailed at sign-up; the link that follows an administrator's approval is built by `processRegistration` for the portal or the classic console, never for Gamma. So "Waiting for approval" is a defensive state today — reachable only if an administrator sets an account back to `PENDING` after the email left — and **the approval-on flow cannot complete in Gamma until [FOUND-307](https://gravitee.atlassian.net/browse/FOUND-307) lands**. A 200 is treated as active unless it says `PENDING` explicitly: finalize refuses `PENDING`, `REJECTED` and `ARCHIVED` accounts before writing anything, so a success means the password is saved.

A second click on the link is `user.finalized`, not `user.invalid`: registration creates the account before the email leaves, and the token names it.

## Password policy

Follows the reset page after #19795: `PasswordRequirements` gets the whole `policy`, and submit is blocked only when `assessPassword` returns `unsatisfied`. A pattern the browser cannot read as the server does (`undecidable`) leaves the verdict to the server.

**The strength meter now renders.** The consoles load Graphene's pre-built `/styles` bundle instead of compiling their own utilities, and the meter used three classes that bundle does not emit — `h-1.5` (bars zero pixels tall), `bg-success/70` and `space-y-1.5`. They were never visible, on the reset page included. They now use `h-1`, `bg-success` and `space-y-2`, and `graphene-check-classes` is clean for both touched folders. The same check caught `min-h-screen` in `AuthPageShell`, so the anonymous pages were never centred vertically; the height is now inline.
## Accessibility ([FOUND-293](https://gravitee.atlassian.net/browse/FOUND-293) — both new pages)

- Identity from the token is one static line of context, not disabled fields.
- `autocomplete="new-password"` on both password fields, plus the hidden `username` field.
- The password field is `aria-describedby` its requirement checklist, and its error when there is one; the confirmation is described by its mismatch message.
- **Strength is announced**, through a polite live region that is mounted, empty, before the first keystroke — a region inserted together with its first message is usually not announced. The visual label is hidden from assistive technology, which hears "Password strength: …" instead (`gamma-ui-shared` `PasswordRequirements`, so the reset page gets this too).
- **Focus follows every state that replaces a form** — each activation outcome, and the sign-up page's "Check your email". The submit button goes with the form; without this, focus falls to the body and the new state is neither announced nor a place for the keyboard to start. `AuthPageShell` takes a `focusTitle` prop for it. A link that is dead on arrival does not move focus: that is simply where the page starts.
- Each success swap is a `status` region; each dead-link state an `alert`.

## Known gaps

- **Approval-on sign-ups never reach this page** — see above. Tracked by [FOUND-307](https://gravitee.atlassian.net/browse/FOUND-307) (backend: make Gamma the default activation destination at approval time). Its note about the route name is resolved here: the email links to `/registration/:token`, and so does this page.
- **Forged token:** `UserServiceImpl.finalizeRegistration` wraps the JWT verifier's exception as a 500 `unexpected`, so a token with a bad signature reads as a retryable error (in the page's own words, no longer the library's). Mapping `JWTVerificationException` to a 400 with its own technical code would close it — worth a separate backend ticket.
- **Signed-in visitor:** the route sits outside every guard, as it must. Someone already signed in who activates and follows "Sign in" is redirected into their existing session by `PublicOnlyRoute`, with nothing to say so. The reset-password page has the same behaviour; tracked for both in [FOUND-309](https://gravitee.atlassian.net/browse/FOUND-309).
- **FOUND-261's route name:** the ticket and `RegistrationEnabledRoute`'s description say `/registration/confirm/:token`; the email links to `/registration/:token`, which is what this uses.
- **Not checked end to end:** the local stack runs the published `4.12.19` image, which predates `/configuration/password-policy` (404 there; anonymous on master), so the checklist and submit could not be exercised in a browser. The form, identity line and dead-link states were checked there; every outcome above is covered by tests.

## Tests

- `ActivationPage.spec.tsx` — each state above, including expiry before sending and in flight, registration switched off, and a 5xx that must not leak its text; focus on each swap and none on a dead-on-arrival link; `aria-describedby`, autocomplete tokens, a policy that fails to load, a pattern that refuses what the checklist accepts, and a pattern only the server can read.
- `registration.service.spec.ts` — the finalize mapping, including a 200 without a status, and no server wording relayed for a refused password, a 4xx or a 5xx.
- `SignUpPage.spec.tsx` — focus moves to "Check your email".
- `AppRoutes.spec.tsx` — the page is reachable while registration is disabled.
- `PasswordRequirements.spec.tsx` — the live region exists before the first keystroke and carries the strength; the visual label is hidden from assistive technology; no region without a meter.

Full gamma-console suite: 36 suites / 319 tests green; `tsc -p tsconfig.app.json`, eslint and prettier clean on the changed files; `graphene-check-classes` clean for `gamma-ui-shared/src/passwordPolicy` and `features/auth`.

## Screenshots

Captured from this branch's dev server with every management API response mocked, so each state can be shown on demand.

| Form | Typing — "Fair" | Ready — "Strong" |
| --- | --- | --- |
| <img width="300" alt="01-form" src="https://github.com/user-attachments/assets/e9ee18ab-baba-4f84-8644-adfd31bcca4e" /> | <img width="300" alt="02-form-typing" src="https://github.com/user-attachments/assets/9cfca4ba-a083-4482-b8ab-7de313268e28" /> | <img width="300" alt="03-form-ready" src="https://github.com/user-attachments/assets/64652a0d-fd03-43a4-ab1f-acb073b7d675" /> |

| Passwords differ | Password refused by the server | Server failure (5xx) |
| --- | --- | --- |
| <img width="300" alt="04-form-mismatch" src="https://github.com/user-attachments/assets/3d60cf86-afe8-4f70-a835-b1ad692dc0ad" /> | <img width="300" alt="05-password-refused" src="https://github.com/user-attachments/assets/a3f38b83-ae11-4fb6-a894-0402c232bdc4" /> | <img width="300" alt="06-server-error" src="https://github.com/user-attachments/assets/c8a57f14-650d-496b-8581-1df2b5c41156" /> |

| Account activated | Already activated | Waiting for approval |
| --- | --- | --- |
| <img width="300" alt="07-activated" src="https://github.com/user-attachments/assets/18088340-7db9-45a2-a69d-4244ba90e78f" /> | <img width="300" alt="08-already-activated" src="https://github.com/user-attachments/assets/530ca719-21cb-48af-a33f-ab0142e14f48" /> | <img width="300" alt="09-waiting-for-approval" src="https://github.com/user-attachments/assets/b39761e8-de65-49ab-bad0-1b7a62bc964e" /> |

| Link can't be used | Registration turned off | Link expired |
| --- | --- | --- |
| <img width="300" alt="10-link-unusable" src="https://github.com/user-attachments/assets/add5f9b8-a1ac-4936-9241-b6816acba6e2" /> | <img width="300" alt="11-registration-off" src="https://github.com/user-attachments/assets/4be38737-fec7-44fc-a407-50a61aef74a0" /> | <img width="300" alt="12-link-expired" src="https://github.com/user-attachments/assets/ff65fba5-d250-4b06-b187-5d2e4d06db43" /> |

| Link not valid | Sign-up: "Check your email" | Dark mode |
| --- | --- | --- |
| <img width="300" alt="13-link-invalid" src="https://github.com/user-attachments/assets/0a936acc-cb68-4a31-b073-a260214d6fae" /> | <img width="300" alt="14-sign-up-sent" src="https://github.com/user-attachments/assets/5e626824-de22-429f-bc85-695643951214" /> | <img width="300" alt="15-form-ready-dark" src="https://github.com/user-attachments/assets/9cdf3dbe-f75f-46f4-b961-fd66f4c413f4" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FOUND-263]: https://gravitee.atlassian.net/browse/FOUND-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUND-307]: https://gravitee.atlassian.net/browse/FOUND-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
