### PR TITLE
fix(gamma-module-apim): stop badging an overridden entry as Global

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/metadata/ApiMetadataTable.spec.tsx
@@ -89,9 +89,11 @@ describe('ApiMetadataTable', () => {
         expect(screen.queryByText('Platform Engineering')).not.toBeNull();
     });
 
-    it('shows a Global badge for inherited metadata and falls back to the default value', () => {
+    it('shows a Global badge only on the row the API has not overridden, and falls back to its default value', () => {
         renderTable();
-        expect(screen.getAllByText('Global').length).toBe(2);
+        // GLOBAL_OVERRIDE also carries a defaultValue, but the API has its own value now — badging it
+        // "Global" would tell the operator the environment's value is in effect when it is not.
+        expect(screen.getAllByText('Global').length).toBe(1);
         expect(screen.queryByText('help@example.com')).not.toBeNull();
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.spec.ts
@@ -52,10 +52,12 @@ describe('apiMetadata helpers', () => {
     });
 
     describe('inheritance flags', () => {
-        it('marks rows with a defaultValue as inherited global metadata', () => {
+        it('marks a row as inherited global metadata only while the API has not overridden it', () => {
             expect(isInheritedGlobal(API_ONLY)).toBe(false);
             expect(isInheritedGlobal(GLOBAL_INHERITED)).toBe(true);
-            expect(isInheritedGlobal(GLOBAL_OVERRIDE)).toBe(true);
+            // A defaultValue alone does not make this inherited: the API has its own value now, so it owns
+            // this row the same as API_ONLY does — the environment still defining the key is irrelevant.
+            expect(isInheritedGlobal(GLOBAL_OVERRIDE)).toBe(false);
         });
 
         it('allows delete only when an API-level value exists', () => {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiMetadata.ts
@@ -54,7 +54,7 @@ export function displayMetadataValue(metadata: ApiMetadata): string {
 }
 
 export function isInheritedGlobal(metadata: ApiMetadata): boolean {
-    return Boolean(metadata.defaultValue);
+    return metadata.value === undefined;
 }
 
 /** API-level override exists, so the row can be deleted or reset to the global default. */


### PR DESCRIPTION
## Summary

Confirmed live: Gamma-APIM's own API Metadata screen badges *every* row that has an environment default as "Global" — including rows this API has explicitly overridden. `isInheritedGlobal` checked `Boolean(metadata.defaultValue)`, which stays true after an override since the environment still defines the key. The badge is meant to answer "is this the environment's value in effect," and it was wrong for exactly that question on any override.

- `isInheritedGlobal` now checks `metadata.value === undefined` (ownership), matching how `canDeleteOrResetMetadata`/`isResettableMetadata` in the same file already correctly decide reset-vs-delete — those two were never wrong, only the badge was.
- Updated two tests that had locked in the wrong behavior (`apiMetadata.spec.ts`, `ApiMetadataTable.spec.tsx`) — both asserted an override should still show "Global".

## Note — separate, out of scope here

The source filter (`GLOBAL`/`API` dropdown) is powered by classic's own v2 `GET /apis/{id}/metadata?source=...`, whose server-side filter (`GetApiMetadataUseCase.filterApiMetadata`) uses the same `defaultValue`-based logic this PR fixes client-side. If that also mis-files an override under "Global" server-side, fixing it is a larger, shared-backend change (affects every consumer of that endpoint, not just this module) and deserves its own investigation and PR rather than folding into this contained frontend fix.

## Test plan
- [x] `apiMetadata.spec.ts`, `ApiMetadataTable.spec.tsx`: RED→GREEN verified
- [x] Full module suite: 800/800 tests green (`nx test gravitee-gamma-module-apim`)
- [x] Lint (`nx lint`) and prettier clean on changed files