### PR TITLE
feat(gamma): rebuild the api targets page on the shared targets panel

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,7 +2,7 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-lib-observability": "3.3.0-beta.2",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.3",
         "@gravitee/gamma-modules-sdk": "1.2.0",
         "@gravitee/graphene-charts": "3.18.0",
         "@gravitee/graphene-core": "3.18.0",

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.spec.tsx
@@ -55,12 +55,15 @@ describe('ApiTargetsPage', () => {
         renderPage(API);
 
         expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Targets');
+        // One short line, as on the agent's page: the panel carries the rest.
+        expect(screen.getByText('The thresholds this API is held to.')).toBeInTheDocument();
         expect(screen.getByTestId('targets-provider')).toContainElement(screen.getByTestId('targets-panel'));
         expect(mockTargetsPanel.mock.calls[0][0]).toEqual({
             reference: 'api-1',
             apiIds: ['api-1'],
             apiTypes: ['PROXY'],
             readOnly: false,
+            emptyDescription: 'Nothing is watching this API yet.',
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/targets/ApiTargetsPage.tsx
@@ -20,31 +20,39 @@ import { Skeleton } from '@gravitee/graphene-core';
 import { ApiTargetsProvider } from '../../../components/targets/ApiTargetsProvider';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
 
+/** Skeleton height, inline: one group of the panel is about this tall. */
+const ROW_HEIGHT = { height: 208 } as const;
+
 /**
  * The "Targets" tab: the shared panel mounted on this API as its own subject.
- * Targets are environment resources on the REST side, so the writes follow the
- * environment API permissions rather than the API-scoped ones.
+ * The panel reads what the API's own telemetry saw, so a rule can be narrowed
+ * to the paths and methods it actually served. Targets are environment
+ * resources on the REST side, so the writes follow the environment API
+ * permissions rather than the API-scoped ones.
  */
 export function ApiTargetsPage() {
     const { api } = useApiDetailContext();
     const canManage = useHasPermission({ anyOf: ['environment-api-c', 'environment-api-u'] });
 
     return (
-        <div className="space-y-6">
-            <div className="space-y-1">
+        <div className="flex min-w-0 flex-col gap-6">
+            <div className="min-w-0 space-y-1">
                 <h1 className="text-2xl font-semibold tracking-tight">Targets</h1>
-                <p className="text-sm text-muted-foreground">
-                    What good looks like for this API: rules over its gateway telemetry, evaluated continuously against the thresholds you
-                    declare.
-                </p>
+                <p className="text-muted-foreground max-w-prose text-sm">The thresholds this API is held to.</p>
             </div>
             {api ? (
                 <ApiTargetsProvider>
                     {/* The module only manages V4 HTTP proxies (`PROXY`), which the list search enforces server-side. */}
-                    <TargetsPanel reference={api.id} apiIds={[api.id]} apiTypes={[api.type ?? 'PROXY']} readOnly={!canManage} />
+                    <TargetsPanel
+                        reference={api.id}
+                        apiIds={[api.id]}
+                        apiTypes={[api.type ?? 'PROXY']}
+                        readOnly={!canManage}
+                        emptyDescription="Nothing is watching this API yet."
+                    />
                 </ApiTargetsProvider>
             ) : (
-                <Skeleton className="h-40 w-full" />
+                <Skeleton className="rounded-xl" style={ROW_HEIGHT} />
             )}
         </div>
     );

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/gamma-lib-observability": "3.3.0-beta.2",
+        "@gravitee/gamma-lib-observability": "3.3.0-beta.3",
         "@gravitee/graphene-charts": "3.18.0",
         "@gravitee/graphene-core": "3.18.0",
         "@gravitee/graphene-policy-studio": "3.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,9 +4627,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/gamma-lib-observability@npm:3.3.0-beta.2":
-  version: 3.3.0-beta.2
-  resolution: "@gravitee/gamma-lib-observability@npm:3.3.0-beta.2"
+"@gravitee/gamma-lib-observability@npm:3.3.0-beta.3":
+  version: 3.3.0-beta.3
+  resolution: "@gravitee/gamma-lib-observability@npm:3.3.0-beta.3"
   peerDependencies:
     "@gravitee/graphene-charts": ^3.13.0
     "@gravitee/graphene-core": ^3.13.0
@@ -4651,7 +4651,7 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: 10c0/1735f56594ac963d7167e013833a71ab05e6e6dfa7110a0b97484399d1666f5fcfe9779301ac4aa7d16c547de539223c432754fc153f5209251bd0bd553c2a65
+  checksum: 10c0/522648c8f4f3d83ecc7f4660139e1cf4f9a2496b28d2df223e1ea19cc3a4d13db29a708c087f560484f794c4efe4ac15e9033f0725a61afceab4890591f121ea
   languageName: node
   linkType: hard
 
@@ -21901,7 +21901,7 @@ __metadata:
     "@fontsource/material-icons-two-tone": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
-    "@gravitee/gamma-lib-observability": "npm:3.3.0-beta.2"
+    "@gravitee/gamma-lib-observability": "npm:3.3.0-beta.3"
     "@gravitee/gamma-modules-sdk": "npm:1.2.0"
     "@gravitee/graphene-charts": "npm:3.18.0"
     "@gravitee/graphene-core": "npm:3.18.0"


### PR DESCRIPTION
Bumps `@gravitee/gamma-lib-observability` to 3.3.0-beta.3 (gravitee-io/gamma-lib-observability#108) in the gamma workspace and module-apim. The lib's `TargetsPanel` is now built on the agent Targets design of gravitee-gamma-module-aim: one summary, one group per target with its schedule and Evaluate now, one row per rule with its figures, trend and timeline, right-hand sheets, and rule filters driven by the analytics definition with values from the API's own telemetry over the last 30 days (methods, paths, status groups on an HTTP proxy).

`ApiTargetsPage` keeps a one-line header and hands the panel an API-worded empty state; its spec follows.

Verified: module-apim spec and nx build; packaged and driven against a local amp_demo instance.