### PR TITLE
fix(observability): state the scope of the agent entrypoints

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypoints.java
@@ -75,6 +75,22 @@ public enum ObservabilityEntrypoints {
      */
     AGENT_TO_AGENT("agent-to-agent", "gravitee-entrypoint-agent-to-agent", Scope.PENDING),
 
+    /*
+     * The entrypoints an Agent API is called through, from the agent reactor. Every one of them is
+     * REQUEST_RESPONSE on the HTTP listener, so they carry the same traffic as AGENT_TO_AGENT above and
+     * inherit its decision: request traffic, held back until the logs screen serves it too. OBS-90
+     * promotes the whole group at once.
+     */
+    AGENT_A2A("agent-a2a", "gravitee-agent-entrypoint-a2a", Scope.PENDING),
+    AGENT_AG_UI("agent-ag-ui", "gravitee-agent-entrypoint-ag-ui", Scope.PENDING),
+    AGENT_GUARDIAN("agent-guardian", "gravitee-agent-entrypoint-guardian", Scope.PENDING),
+    AGENT_HTTP("agent-http", "gravitee-agent-entrypoint-http", Scope.PENDING),
+    /** The plugin id differs from the artifact name: {@code plugin.properties} says {@code agent-openai-responses}. */
+    AGENT_OPENAI_RESPONSES("agent-openai-responses", "gravitee-agent-entrypoint-openresponses", Scope.PENDING),
+    AGENT_PLAYGROUND("agent-playground", "gravitee-agent-entrypoint-playground", Scope.PENDING),
+    AGENT_SLACK("agent-slack", "gravitee-agent-entrypoint-slack", Scope.PENDING),
+    AGENT_WEB_AI_ASSISTANT("agent-web-ai-assistant", "gravitee-agent-entrypoint-web-ai-assistant", Scope.PENDING),
+
     SSE("sse", "gravitee-entrypoint-sse", Scope.EXCLUDED),
     WEBHOOK("webhook", "gravitee-entrypoint-webhook", Scope.EXCLUDED),
     WEBSOCKET("websocket", "gravitee-entrypoint-websocket", Scope.EXCLUDED),

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/ObservabilityEntrypointsTest.java
@@ -94,7 +94,7 @@ class ObservabilityEntrypointsTest {
     class DistributionCoverage {
 
         private static final Pattern ENTRYPOINT_PLUGIN_ARTIFACT = Pattern.compile(
-            "<artifactId>((?:gravitee-entrypoint|gravitee-apim-plugin-entrypoint)-[^<]+)</artifactId>"
+            "<artifactId>((?:gravitee-entrypoint|gravitee-apim-plugin-entrypoint|gravitee-agent-entrypoint)-[^<]+)</artifactId>"
         );
 
         /** The plugin SPI every entrypoint is built against, not an entrypoint itself. */


### PR DESCRIPTION
Declares the eight agent entrypoints in the observability registry, which every bundled entrypoint has to be listed in. They are marked as pending, like the agent-to-agent entrypoint next to them, so nothing changes on the dashboards or in the logs.

Fixes the integration test that broke on amp_demo when the agent plugins were bundled.