### PR TITLE
feat(api-score): introduce API Scoring feature with implementation, u…

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -46,6 +46,7 @@ import { CreateApiGate } from '../features/apis/pages/CreateApiGate';
 import { CreateApiProxyPage } from '../features/apis/pages/CreateApiProxyPage';
 import { AlertFormPage } from '../features/apis/pages/detail/alerts/AlertFormPage';
 import { ApiAlertsPage } from '../features/apis/pages/detail/alerts/ApiAlertsPage';
+import { ApiScoringPage } from '../features/apis/pages/detail/api-score/ApiScoringPage';
 import { ApiDetailOverviewPage } from '../features/apis/pages/detail/ApiDetailOverviewPage';
 import { ApiDetailPlaceholderPage } from '../features/apis/pages/detail/ApiDetailPlaceholderPage';
 import { AuditLogsPage } from '../features/apis/pages/detail/audit-logs/AuditLogsPage';
@@ -230,6 +231,7 @@ export function AppRoutes() {
                                     <Route path="new" element={<ApiNotificationFormPage />} />
                                     <Route path=":notificationKey" element={<ApiNotificationFormPage />} />
                                 </Route>
+                                <Route path="api-score" element={<ApiScoringPage />} />
                                 <Route path="entrypoints" element={<ApiEntrypointsPage />} />
                                 <Route path="cors" element={<ApiCorsPage />} />
                                 <Route path="metadata" element={<ApiMetadataPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/CollapsibleSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/CollapsibleSection.tsx
@@ -22,19 +22,28 @@ import { type ReactNode, useState } from 'react';
 export function CollapsibleSection({
     title,
     defaultOpen = false,
+    open: openProp,
+    onOpenChange,
     children,
 }: {
-    title: string;
+    title: ReactNode;
     defaultOpen?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
     children: ReactNode;
 }) {
-    const [open, setOpen] = useState(defaultOpen);
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+    const open = openProp ?? uncontrolledOpen;
+    const setOpen = (next: boolean) => {
+        onOpenChange?.(next);
+        if (openProp === undefined) setUncontrolledOpen(next);
+    };
     return (
         <div className="rounded-lg border">
             <button
                 type="button"
                 className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium hover:bg-accent/50 transition-colors rounded-lg"
-                onClick={() => setOpen(o => !o)}
+                onClick={() => setOpen(!open)}
                 aria-expanded={open}
             >
                 {title}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
@@ -47,6 +47,10 @@ jest.mock('../../hooks/useApiPermissions', () => ({
     useApiPermissions: jest.fn(() => ({ permissionsReady: false })),
 }));
 
+jest.mock('../../hooks/useApiScoreEnabled', () => ({
+    useApiScoreEnabled: jest.fn(() => ({ enabled: true, isFetched: true })),
+}));
+
 jest.mock('../../services/apis', () => ({
     deployApi: jest.fn(),
 }));
@@ -108,6 +112,7 @@ jest.mock('./ApiDetailSidebarNav', () => ({
     ApiDetailSidebarNav: () => <div />,
     withTcpRestrictions: (groups: unknown[]) => groups,
     withMetadataPermission: (groups: unknown[]) => groups,
+    withApiScoreEnabled: (groups: unknown[]) => groups,
 }));
 
 import { ApiDetailIndexRedirect, ApiDetailLayout } from './ApiDetailLayout';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -40,11 +40,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useId, useState } from 'react';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withMetadataPermission, withTcpRestrictions } from './ApiDetailSidebarNav';
+import {
+    API_PROXY_NAV_GROUPS,
+    ApiDetailSidebarNav,
+    withApiScoreEnabled,
+    withMetadataPermission,
+    withTcpRestrictions,
+} from './ApiDetailSidebarNav';
 import { useDetailBasePath } from '../../../../shared/hooks/useDetailBasePath';
 import { ApiDetailContext } from '../../context/ApiDetailContext';
 import { useApiDetail } from '../../hooks/useApiDetail';
 import { useApiPermissions } from '../../hooks/useApiPermissions';
+import { useApiScoreEnabled } from '../../hooks/useApiScoreEnabled';
 import { deployApi } from '../../services/apis';
 import type { ApiDetailDto } from '../../types';
 import { hasTcpListeners } from '../../utils/apiHttpProxy';
@@ -254,6 +261,7 @@ export function ApiDetailLayout() {
     const { permissionsReady } = useApiPermissions(apiId);
     const canDeploy = useHasPermission({ anyOf: ['api-definition-u'] });
     const canReadMetadata = useHasPermission({ anyOf: ['api-metadata-r'] });
+    const { enabled: apiScoreEnabled } = useApiScoreEnabled();
     const queryClient = useQueryClient();
     const [contextExpanded, setContextExpanded] = useState(true);
     const [showDeployDialog, setShowDeployDialog] = useState(false);
@@ -272,7 +280,10 @@ export function ApiDetailLayout() {
     });
 
     const showDeployBanner = !isError && api?.deploymentState === 'NEED_REDEPLOY' && canDeploy;
-    const navGroups = withMetadataPermission(withTcpRestrictions(API_PROXY_NAV_GROUPS, hasTcpListeners(api)), canReadMetadata);
+    const navGroups = withApiScoreEnabled(
+        withMetadataPermission(withTcpRestrictions(API_PROXY_NAV_GROUPS, hasTcpListeners(api)), canReadMetadata),
+        apiScoreEnabled,
+    );
 
     useLayoutConfig(
         {
@@ -293,7 +304,17 @@ export function ApiDetailLayout() {
             ) : null,
             bannerSticky: true,
         },
-        [contextExpanded, api, isLoading, basePath, permissionsReady, showDeployBanner, deployMutation.isPending, canReadMetadata],
+        [
+            contextExpanded,
+            api,
+            isLoading,
+            basePath,
+            permissionsReady,
+            showDeployBanner,
+            deployMutation.isPending,
+            canReadMetadata,
+            apiScoreEnabled,
+        ],
     );
 
     if (isError) {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.spec.tsx
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DatabaseIcon } from '@gravitee/graphene-core/icons';
+import { DatabaseIcon, ShieldCheckIcon, SparklesIcon } from '@gravitee/graphene-core/icons';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom';
 
-import { API_PROXY_NAV_GROUPS, ApiDetailSidebarNav, withMetadataPermission, withTcpRestrictions } from './ApiDetailSidebarNav';
+import {
+    API_PROXY_NAV_GROUPS,
+    ApiDetailSidebarNav,
+    withApiScoreEnabled,
+    withMetadataPermission,
+    withTcpRestrictions,
+} from './ApiDetailSidebarNav';
 
 const GROUPS = API_PROXY_NAV_GROUPS;
 const BASE = '/env/apis/abc-123';
@@ -58,6 +64,15 @@ describe('API_PROXY_NAV_GROUPS', () => {
         expect(deployment.children!.map(c => c.path)).toEqual(['configuration', 'history']);
     });
 
+    it('uses SparklesIcon for API Score so CORS can keep ShieldCheckIcon', () => {
+        const general = GROUPS.find(g => g.label === 'General')!;
+        const apiScore = general.items.find(item => item.path === 'api-score')!;
+        const cors = general.items.find(item => item.path === 'cors')!;
+        expect(apiScore.icon).toBe(SparklesIcon);
+        expect(cors.icon).toBe(ShieldCheckIcon);
+        expect(apiScore.comingSoon).toBeUndefined();
+    });
+
     it('places Metadata immediately after CORS in the General group', () => {
         const general = GROUPS.find(g => g.label === 'General')!;
         const visiblePaths = general.items.filter(item => !item.comingSoon).map(item => item.path);
@@ -96,9 +111,14 @@ describe('ApiDetailSidebarNav — flat links', () => {
         expect(screen.getByRole('link', { name: /^metadata$/i })).toHaveAttribute('href', `${BASE}/metadata`);
     });
 
-    it('renders "coming soon" items (API Score, Response Templates, Authorization) as disabled, non-navigable rows', () => {
+    it('renders API Score as a navigable link', () => {
         renderNav(`${BASE}/overview`);
-        for (const label of ['API Score', 'Response Templates', 'Authorization']) {
+        expect(screen.getByRole('link', { name: /^api score$/i })).toHaveAttribute('href', `${BASE}/api-score`);
+    });
+
+    it('renders "coming soon" items (Response Templates, Authorization) as disabled, non-navigable rows', () => {
+        renderNav(`${BASE}/overview`);
+        for (const label of ['Response Templates', 'Authorization']) {
             expect(screen.getByText(label)).toBeInTheDocument();
             expect(screen.queryByRole('link', { name: new RegExp(`^${label}$`, 'i') })).not.toBeInTheDocument();
         }
@@ -106,7 +126,7 @@ describe('ApiDetailSidebarNav — flat links', () => {
 
     it('makes "coming soon" rows reachable by keyboard, with their reason exposed for assistive tech', () => {
         renderNav(`${BASE}/overview`);
-        const row = screen.getByText('API Score').closest('[tabindex]');
+        const row = screen.getByText('Response Templates').closest('[tabindex]');
         expect(row).not.toBeNull();
         expect(row).toHaveAttribute('tabindex', '0');
         expect(row).toHaveAttribute('aria-disabled', 'true');
@@ -160,6 +180,19 @@ describe('withMetadataPermission', () => {
         const general = restricted.find(g => g.label === 'General')!;
         expect(general.items.find(item => item.path === 'metadata')).toBeUndefined();
         expect(general.items.find(item => item.path === 'cors')).toBeDefined();
+    });
+});
+
+describe('withApiScoreEnabled', () => {
+    it('returns the groups unchanged when API Score is enabled', () => {
+        expect(withApiScoreEnabled(GROUPS, true)).toBe(GROUPS);
+    });
+
+    it('omits API Score from the General group when the portal flag is off', () => {
+        const restricted = withApiScoreEnabled(GROUPS, false);
+        const general = restricted.find(g => g.label === 'General')!;
+        expect(general.items.find(item => item.path === 'api-score')).toBeUndefined();
+        expect(general.items.find(item => item.path === 'notifications')).toBeDefined();
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -85,7 +85,7 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
             { path: 'properties', label: 'API Properties', icon: SettingsIcon },
             { path: 'resources', label: 'Resources', icon: ServerIcon },
             { path: 'notifications', label: 'Notifications', icon: BellIcon },
-            { path: 'api-score', label: 'API Score', icon: SparklesIcon, comingSoon: true },
+            { path: 'api-score', label: 'API Score', icon: SparklesIcon },
             { path: 'response-templates', label: 'Response Templates', icon: ScrollTextIcon, comingSoon: true },
             { path: 'cors', label: 'CORS', icon: ShieldCheckIcon },
             { path: 'metadata', label: 'Metadata', icon: DatabaseIcon },
@@ -177,6 +177,14 @@ export function withMetadataPermission(groups: DetailNavGroup[], canReadMetadata
     return groups.map(group => ({
         ...group,
         items: group.items.filter(item => item.path !== 'metadata'),
+    }));
+}
+
+export function withApiScoreEnabled(groups: DetailNavGroup[], apiScoreEnabled: boolean): DetailNavGroup[] {
+    if (apiScoreEnabled) return groups;
+    return groups.map(group => ({
+        ...group,
+        items: group.items.filter(item => item.path !== 'api-score'),
     }));
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoreEnabled.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoreEnabled.spec.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useApiScoreEnabled } from './useApiScoreEnabled';
+import { getEnvironmentPortalConfiguration } from '../../settings/services/portalSettings';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+}));
+
+jest.mock('../../settings/services/portalSettings', () => ({
+    getEnvironmentPortalConfiguration: jest.fn(),
+}));
+
+const mockUseEnvironment = useEnvironment as jest.MockedFunction<typeof useEnvironment>;
+const mockGetPortal = getEnvironmentPortalConfiguration as jest.MockedFunction<typeof getEnvironmentPortalConfiguration>;
+
+function createWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+describe('useApiScoreEnabled', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' } as ReturnType<typeof useEnvironment>);
+    });
+
+    it('is enabled when GET /portal reports apiScore.enabled', async () => {
+        mockGetPortal.mockResolvedValue({ apiScore: { enabled: true } });
+        const { result } = renderHook(() => useApiScoreEnabled(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.isFetched).toBe(true));
+        expect(mockGetPortal).toHaveBeenCalledWith('DEFAULT');
+        expect(result.current.enabled).toBe(true);
+    });
+
+    it('is disabled when the portal flag is off', async () => {
+        mockGetPortal.mockResolvedValue({ apiScore: { enabled: false } });
+        const { result } = renderHook(() => useApiScoreEnabled(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.isFetched).toBe(true));
+        expect(result.current.enabled).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoreEnabled.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoreEnabled.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getEnvironmentPortalConfiguration } from '../../settings/services/portalSettings';
+import { portalSettingsKeys } from '../utils/queryKeys';
+import { isApiScoreEnabled } from '../utils/scoring';
+
+export function useApiScoreEnabled(): { enabled: boolean; isFetched: boolean } {
+    const env = useEnvironment();
+    const query = useQuery({
+        queryKey: portalSettingsKeys.portalConfig(env?.id ?? ''),
+        queryFn: () => getEnvironmentPortalConfiguration(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: 5 * 60_000,
+    });
+    return {
+        enabled: isApiScoreEnabled(query.data),
+        isFetched: query.isFetched,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoring.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoring.spec.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useApiScoring } from './useApiScoring';
+import { notify } from '../../../shared/notify';
+import { evaluateApiScoring, getApiScoring, listScoringJobs } from '../services/apiScoring';
+import type { ApiScoring, ScoringAsyncJob } from '../types/scoring';
+import { apiScoringKeys } from '../utils/queryKeys';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+}));
+
+jest.mock('../services/apiScoring', () => ({
+    evaluateApiScoring: jest.fn(),
+    getApiScoring: jest.fn(),
+    listScoringJobs: jest.fn(),
+}));
+
+jest.mock('../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
+}));
+
+const mockUseEnvironment = useEnvironment as jest.MockedFunction<typeof useEnvironment>;
+const mockGetApiScoring = getApiScoring as jest.MockedFunction<typeof getApiScoring>;
+const mockListScoringJobs = listScoringJobs as jest.MockedFunction<typeof listScoringJobs>;
+const mockEvaluateApiScoring = evaluateApiScoring as jest.MockedFunction<typeof evaluateApiScoring>;
+
+const OLD_SCORE: ApiScoring = {
+    createdAt: '2026-01-01T00:00:00Z',
+    summary: { all: 1, errors: 1, warnings: 0, infos: 0, hints: 0, score: 0.5 },
+    assets: [],
+};
+
+const NEW_SCORE: ApiScoring = {
+    createdAt: '2026-09-10T12:00:00Z',
+    summary: { all: 0, errors: 0, warnings: 0, infos: 0, hints: 0, score: 0.9 },
+    assets: [],
+};
+
+function job(status: ScoringAsyncJob['status']): ScoringAsyncJob {
+    return {
+        id: `job-${status}`,
+        sourceId: 'api-1',
+        type: 'SCORING_REQUEST',
+        status,
+        createdAt: '2026-09-10T11:59:00.000Z',
+        updatedAt: '2026-09-10T11:59:00.000Z',
+    };
+}
+
+function createHarness() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return { queryClient, Wrapper };
+}
+
+describe('useApiScoring', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' } as ReturnType<typeof useEnvironment>);
+        mockGetApiScoring.mockResolvedValue(OLD_SCORE);
+        mockListScoringJobs.mockResolvedValue({ data: [] });
+        mockEvaluateApiScoring.mockResolvedValue({ status: 'PENDING' });
+    });
+
+    it('loads the scoring report and jobs for the API', async () => {
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(mockGetApiScoring).toHaveBeenCalledWith('DEFAULT', 'api-1');
+        expect(mockListScoringJobs).toHaveBeenCalledWith('DEFAULT', 'api-1');
+        expect(result.current.scoring?.summary?.score).toBe(0.5);
+        expect(result.current.pending).toBe(false);
+    });
+
+    it('treats a missing report as never scored instead of an error', async () => {
+        mockGetApiScoring.mockResolvedValue(null);
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.isError).toBe(false);
+        expect(result.current.scoring).toBeNull();
+    });
+
+    it('is pending when the latest scoring job is PENDING', async () => {
+        mockListScoringJobs.mockResolvedValue({ data: [job('PENDING')] });
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+
+        await waitFor(() => expect(result.current.pending).toBe(true));
+    });
+
+    it('treats a failed jobs query as a page error', async () => {
+        mockListScoringJobs.mockRejectedValueOnce(new Error('jobs failed'));
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error).toEqual(expect.any(Error));
+    });
+
+    it('stays pending after Evaluate until the jobs refetch completes', async () => {
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        let resolveJobs: (value: { data: ScoringAsyncJob[] }) => void;
+        mockListScoringJobs.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveJobs = resolve;
+                }),
+        );
+
+        await act(async () => {
+            result.current.evaluate();
+        });
+
+        await waitFor(() => expect(mockEvaluateApiScoring).toHaveBeenCalledWith('DEFAULT', 'api-1'));
+        await waitFor(() => expect(result.current.pending).toBe(true));
+        expect(result.current.jobs).toEqual([]);
+
+        await act(async () => {
+            resolveJobs!({ data: [job('PENDING')] });
+        });
+
+        await waitFor(() => expect(result.current.jobs[0]?.status).toBe('PENDING'));
+        expect(result.current.pending).toBe(true);
+    });
+
+    it('POSTs evaluate and then reloads jobs', async () => {
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        await act(async () => {
+            result.current.evaluate();
+        });
+
+        await waitFor(() => expect(mockEvaluateApiScoring).toHaveBeenCalledWith('DEFAULT', 'api-1'));
+        await waitFor(() => expect(mockListScoringJobs.mock.calls.length).toBeGreaterThan(1));
+    });
+
+    it('toasts a failed Evaluate and reloads jobs so an ERROR job is visible', async () => {
+        let jobs: ScoringAsyncJob[] = [];
+        mockListScoringJobs.mockImplementation(async () => ({ data: jobs }));
+        mockEvaluateApiScoring.mockRejectedValueOnce(new Error('provider unreachable'));
+
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        jobs = [job('ERROR')];
+        await act(async () => {
+            result.current.evaluate();
+        });
+
+        await waitFor(() => expect(result.current.jobs[0]?.status).toBe('ERROR'));
+        expect(notify.error).toHaveBeenCalledWith(expect.any(Error), 'An error occurred while evaluating API Scoring.');
+    });
+
+    it('reloads the scoring report after Evaluate even if the job is already SUCCESS', async () => {
+        let jobs: ScoringAsyncJob[] = [];
+        let report: ApiScoring | null = OLD_SCORE;
+        mockListScoringJobs.mockImplementation(async () => ({ data: jobs }));
+        mockGetApiScoring.mockImplementation(async () => report);
+        mockEvaluateApiScoring.mockImplementation(async () => {
+            jobs = [job('SUCCESS')];
+            report = NEW_SCORE;
+            return { status: 'SUCCESS' };
+        });
+
+        const { Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+        await waitFor(() => expect(result.current.scoring?.summary?.score).toBe(0.5));
+
+        await act(async () => {
+            result.current.evaluate();
+        });
+
+        await waitFor(() => expect(result.current.scoring?.summary?.score).toBe(0.9));
+    });
+
+    it('reloads the scoring report when the latest job leaves PENDING', async () => {
+        mockListScoringJobs.mockResolvedValue({ data: [job('PENDING')] });
+        mockGetApiScoring.mockResolvedValue(OLD_SCORE);
+        const { queryClient, Wrapper } = createHarness();
+        const { result } = renderHook(() => useApiScoring('api-1'), { wrapper: Wrapper });
+
+        await waitFor(() => expect(result.current.pending).toBe(true));
+        expect(result.current.scoring?.summary?.score).toBe(0.5);
+
+        mockGetApiScoring.mockResolvedValue(NEW_SCORE);
+        await act(async () => {
+            queryClient.setQueryData(apiScoringKeys.jobs('DEFAULT', 'api-1'), { data: [job('SUCCESS')] });
+        });
+
+        await waitFor(() => expect(result.current.pending).toBe(false));
+        await waitFor(() => expect(result.current.scoring?.summary?.score).toBe(0.9));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoring.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiScoring.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+
+import { notify } from '../../../shared/notify';
+import { evaluateApiScoring, getApiScoring, listScoringJobs } from '../services/apiScoring';
+import { apiScoringKeys } from '../utils/queryKeys';
+import { latestScoringJob } from '../utils/scoring';
+
+export function useApiScoring(apiId: string | undefined) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const queryClient = useQueryClient();
+    const enabled = Boolean(env && apiId);
+
+    const jobsQuery = useQuery({
+        queryKey: apiScoringKeys.jobs(envId, apiId ?? ''),
+        queryFn: () => listScoringJobs(envId, apiId!),
+        enabled,
+        refetchInterval: query => (latestScoringJob(query.state.data?.data ?? [])?.status === 'PENDING' ? 1000 : false),
+    });
+
+    const jobsPending = latestScoringJob(jobsQuery.data?.data ?? [])?.status === 'PENDING';
+    const [awaitingJob, setAwaitingJob] = useState(false);
+
+    const scoringQuery = useQuery({
+        queryKey: apiScoringKeys.report(envId, apiId ?? ''),
+        queryFn: () => getApiScoring(envId, apiId!),
+        enabled,
+    });
+
+    const evaluateMutation = useMutation({
+        mutationFn: () => evaluateApiScoring(envId, apiId!),
+        onMutate: () => {
+            setAwaitingJob(true);
+        },
+        onError: error => notify.error(error, 'An error occurred while evaluating API Scoring.'),
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey: apiScoringKeys.jobs(envId, apiId ?? '') });
+            await queryClient.invalidateQueries({ queryKey: apiScoringKeys.report(envId, apiId ?? '') });
+            setAwaitingJob(false);
+        },
+    });
+
+    const wasJobsPending = useRef(false);
+    useEffect(() => {
+        if (wasJobsPending.current && !jobsPending) {
+            void queryClient.invalidateQueries({ queryKey: apiScoringKeys.report(envId, apiId ?? '') });
+        }
+        wasJobsPending.current = jobsPending;
+    }, [jobsPending, envId, apiId, queryClient]);
+
+    return {
+        scoring: scoringQuery.data,
+        jobs: jobsQuery.data?.data ?? [],
+        isLoading: jobsQuery.isLoading || scoringQuery.isLoading,
+        isError: scoringQuery.isError || jobsQuery.isError,
+        error: scoringQuery.error ?? jobsQuery.error,
+        pending: jobsPending || evaluateMutation.isPending || awaitingJob,
+        evaluate: () => evaluateMutation.mutate(),
+        isEvaluating: evaluateMutation.isPending,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringAssetCard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringAssetCard.spec.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { ApiScoringAssetCard } from './ApiScoringAssetCard';
+import type { ScoringAsset, ScoringDiagnostic } from '../../../types/scoring';
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+function diagnostic(): ScoringDiagnostic {
+    return {
+        severity: 'ERROR',
+        message: 'Operation is missing a security requirement.',
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } },
+        path: '$.info',
+    };
+}
+
+function asset(overrides: Partial<ScoringAsset> = {}): ScoringAsset {
+    return {
+        name: 'petstore.yaml',
+        type: 'SWAGGER',
+        diagnostics: [],
+        ...overrides,
+    };
+}
+
+describe('ApiScoringAssetCard', () => {
+    it('opens when diagnostics appear after a re-evaluation or filter change', () => {
+        const { rerender } = render(<ApiScoringAssetCard asset={asset()} />);
+        expect(screen.getByRole('button', { name: /petstore.yaml/i })).toHaveAttribute('aria-expanded', 'false');
+
+        rerender(<ApiScoringAssetCard asset={asset({ diagnostics: [diagnostic()] })} />);
+        expect(screen.getByRole('button', { name: /petstore.yaml/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringAssetCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringAssetCard.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from 'react';
+
+import { ApiScoringDiagnosticsTable, ScoringAssetTypeBadge } from './ApiScoringDiagnosticsTable';
+import { CollapsibleSection } from '../../../components/CollapsibleSection';
+import type { ScoringAsset } from '../../../types/scoring';
+
+export function ApiScoringAssetCard({ asset }: Readonly<{ asset: ScoringAsset }>) {
+    const hasFindings = asset.diagnostics.length > 0;
+    const [open, setOpen] = useState(hasFindings);
+
+    useEffect(() => {
+        setOpen(hasFindings);
+    }, [hasFindings]);
+
+    return (
+        <CollapsibleSection
+            open={open}
+            onOpenChange={setOpen}
+            title={
+                <span className="flex min-w-0 items-center gap-2 text-left">
+                    <span className="truncate">{asset.name}</span>
+                    <ScoringAssetTypeBadge type={asset.type} />
+                </span>
+            }
+        >
+            <ApiScoringDiagnosticsTable diagnostics={asset.diagnostics} ariaLabel={`${asset.name} diagnostics`} />
+        </CollapsibleSection>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringDiagnosticsTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringDiagnosticsTable.spec.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ApiScoringDiagnosticsTable } from './ApiScoringDiagnosticsTable';
+import type { ScoringDiagnostic } from '../../../types/scoring';
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+function row(message: string, overrides: Partial<ScoringDiagnostic> = {}): ScoringDiagnostic {
+    return {
+        severity: 'ERROR',
+        message,
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } },
+        path: '$.info',
+        ...overrides,
+    };
+}
+
+describe('ApiScoringDiagnosticsTable', () => {
+    it('searches across severity, recommendation, and path', () => {
+        render(
+            <ApiScoringDiagnosticsTable
+                ariaLabel="diagnostics"
+                diagnostics={[
+                    row('Operation is missing a security requirement.', { path: '$.paths./pet.get' }),
+                    row('Add an example', { severity: 'INFO', path: '$.components.schemas.Pet' }),
+                ]}
+            />,
+        );
+        expect(screen.getByText('Operation is missing a security requirement.')).toBeInTheDocument();
+        fireEvent.change(screen.getByPlaceholderText('Search severity, recommendation, or path...'), { target: { value: 'example' } });
+        expect(screen.queryByText('Operation is missing a security requirement.')).not.toBeInTheDocument();
+        expect(screen.getByText('Add an example')).toBeInTheDocument();
+    });
+
+    it('paginates at 5 rows per page', () => {
+        render(
+            <ApiScoringDiagnosticsTable
+                ariaLabel="diagnostics"
+                diagnostics={[row('one'), row('two'), row('three'), row('four'), row('five'), row('six')]}
+            />,
+        );
+        expect(screen.getByText('one')).toBeInTheDocument();
+        expect(screen.getByText('five')).toBeInTheDocument();
+        expect(screen.queryByText('six')).not.toBeInTheDocument();
+        expect(screen.getByText(/1-5 of 6/i)).toBeInTheDocument();
+    });
+
+    it('clamps to the last page when diagnostics shrink below the current page', () => {
+        const many = Array.from({ length: 12 }, (_, index) => row(`finding-${index + 1}`));
+        const { rerender } = render(<ApiScoringDiagnosticsTable ariaLabel="diagnostics" diagnostics={many} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        expect(screen.getByText('finding-11')).toBeInTheDocument();
+        expect(screen.queryByText('finding-1')).not.toBeInTheDocument();
+
+        rerender(<ApiScoringDiagnosticsTable ariaLabel="diagnostics" diagnostics={[row('only-error')]} />);
+        expect(screen.getByText('only-error')).toBeInTheDocument();
+        expect(screen.queryByText('No diagnostics match the current search.')).not.toBeInTheDocument();
+    });
+
+    it('sorts by Severity and Path', () => {
+        render(
+            <ApiScoringDiagnosticsTable
+                ariaLabel="diagnostics"
+                diagnostics={[
+                    row('warn-finding', { severity: 'WARN', path: '$.z' }),
+                    row('error-finding', { severity: 'ERROR', path: '$.a' }),
+                ]}
+            />,
+        );
+
+        const messages = () => screen.getAllByText(/-finding$/).map(node => node.textContent);
+        expect(messages()).toEqual(['warn-finding', 'error-finding']);
+
+        fireEvent.click(screen.getByRole('button', { name: /^severity$/i }));
+        expect(messages()).toEqual(['error-finding', 'warn-finding']);
+
+        fireEvent.click(screen.getByRole('button', { name: /^path$/i }));
+        expect(messages()).toEqual(['error-finding', 'warn-finding']);
+    });
+
+    it('omits the search empty description when the table is empty without a search', () => {
+        render(<ApiScoringDiagnosticsTable ariaLabel="diagnostics" diagnostics={[]} />);
+        expect(screen.getByText('No data to display')).toBeInTheDocument();
+        expect(screen.queryByText('No diagnostics match the current search.')).not.toBeInTheDocument();
+    });
+
+    it('explains a search miss when the search has no matches', () => {
+        render(<ApiScoringDiagnosticsTable ariaLabel="diagnostics" diagnostics={[row('missing security')]} />);
+        fireEvent.change(screen.getByPlaceholderText('Search severity, recommendation, or path...'), { target: { value: 'nope' } });
+        expect(screen.getByText('No data to display')).toBeInTheDocument();
+        expect(screen.getByText('No diagnostics match the current search.')).toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringDiagnosticsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringDiagnosticsTable.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    DataTable,
+    DataTableColumnHeader,
+    DataTableEmptyState,
+    Input,
+    type DataTableColumnHeaderProps,
+    type DataTableProps,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useMemo, useState } from 'react';
+
+import type { ScoringDiagnostic } from '../../../types/scoring';
+import { clampPage, diagnosticMatchesSearch, formatLineColumn, paginateItems } from '../../../utils/scoring';
+
+export const DIAGNOSTICS_PAGE_SIZE = 5;
+const PAGE_SIZE_OPTIONS = [5, 10];
+
+const SEVERITY_CLASS: Record<ScoringDiagnostic['severity'], string> = {
+    ERROR: 'text-destructive',
+    WARN: 'text-warning',
+    INFO: 'text-primary',
+    HINT: 'text-success',
+};
+
+type ColCell = { row: { original: ScoringDiagnostic } };
+type ColHeader = { column: DataTableColumnHeaderProps<ScoringDiagnostic, unknown>['column'] };
+type TableSorting = NonNullable<DataTableProps<ScoringDiagnostic>['sorting']>;
+
+const COLUMNS: DataTableProps<ScoringDiagnostic>['columns'] = [
+    {
+        id: 'Severity',
+        accessorFn: (row: ScoringDiagnostic) => row.severity,
+        header: ({ column }: ColHeader) => <DataTableColumnHeader column={column} title="Severity" />,
+        enableSorting: true,
+        cell: ({ row }: ColCell) => (
+            <span className={`text-xs font-semibold ${SEVERITY_CLASS[row.original.severity]}`}>{row.original.severity}</span>
+        ),
+    },
+    {
+        id: 'Line/Column',
+        header: 'Line/Column',
+        enableSorting: false,
+        cell: ({ row }: ColCell) => formatLineColumn(row.original),
+    },
+    {
+        id: 'Recommendation',
+        accessorFn: (row: ScoringDiagnostic) => row.message,
+        header: 'Recommendation',
+        enableSorting: false,
+        cell: ({ row }: ColCell) => row.original.message,
+    },
+    {
+        id: 'Path',
+        accessorFn: (row: ScoringDiagnostic) => row.path,
+        header: ({ column }: ColHeader) => <DataTableColumnHeader column={column} title="Path" />,
+        enableSorting: true,
+        cell: ({ row }: ColCell) => <span className="font-mono text-xs">{row.original.path}</span>,
+    },
+];
+
+export function ApiScoringDiagnosticsTable({ diagnostics, ariaLabel }: Readonly<{ diagnostics: ScoringDiagnostic[]; ariaLabel: string }>) {
+    const [search, setSearch] = useState('');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DIAGNOSTICS_PAGE_SIZE);
+    const [sorting, setSorting] = useState<TableSorting>([]);
+
+    const filtered = useMemo(() => diagnostics.filter(item => diagnosticMatchesSearch(item, search)), [diagnostics, search]);
+    const sorted = useMemo(() => {
+        const sort = sorting[0];
+        if (!sort) return filtered;
+        const key = sort.id === 'Path' ? 'path' : sort.id === 'Severity' ? 'severity' : null;
+        if (!key) return filtered;
+        const direction = sort.desc ? -1 : 1;
+        return [...filtered].sort((left, right) => left[key].localeCompare(right[key]) * direction);
+    }, [filtered, sorting]);
+    const currentPage = clampPage(page, sorted.length, pageSize);
+    const paginated = paginateItems(sorted, currentPage, pageSize);
+    const searching = Boolean(search.trim());
+
+    return (
+        <DataTable
+            aria-label={ariaLabel}
+            columns={COLUMNS}
+            data={paginated}
+            serverSide
+            sorting={sorting}
+            onSortingChange={updater => {
+                setSorting(previous => (typeof updater === 'function' ? updater(previous) : updater));
+                setPage(1);
+            }}
+            pagination={
+                sorted.length > 0
+                    ? {
+                          page: currentPage,
+                          pageSize,
+                          totalCount: sorted.length,
+                          pageSizeOptions: PAGE_SIZE_OPTIONS,
+                          onPageChange: setPage,
+                          onPageSizeChange: next => {
+                              setPageSize(next);
+                              setPage(1);
+                          },
+                      }
+                    : undefined
+            }
+            emptyMessage={
+                <DataTableEmptyState
+                    variant="no-results"
+                    icon={<SearchIcon />}
+                    title="No data to display"
+                    description={searching ? 'No diagnostics match the current search.' : ''}
+                />
+            }
+            toolbar={
+                <div className="relative w-full max-w-md">
+                    <SearchIcon
+                        className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                        aria-hidden
+                    />
+                    <Input
+                        className="pl-9"
+                        placeholder="Search severity, recommendation, or path..."
+                        aria-label="Search severity, recommendation, or path"
+                        value={search}
+                        onChange={event => {
+                            setSearch(event.target.value);
+                            setPage(1);
+                        }}
+                    />
+                </div>
+            }
+        />
+    );
+}
+
+export function ScoringAssetTypeBadge({ type }: Readonly<{ type: string }>) {
+    return (
+        <Badge variant="secondary" className="text-xs font-mono">
+            {type}
+        </Badge>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringPage.spec.tsx
@@ -1,0 +1,278 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+
+import { ApiScoringPage } from './ApiScoringPage';
+import { notify } from '../../../../../shared/notify';
+import { useApiScoreEnabled } from '../../../hooks/useApiScoreEnabled';
+import { useApiScoring } from '../../../hooks/useApiScoring';
+import type { ApiScoring } from '../../../types/scoring';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+}));
+
+jest.mock('../../../hooks/useApiScoreEnabled', () => ({
+    useApiScoreEnabled: jest.fn(() => ({ enabled: true, isFetched: true })),
+}));
+
+jest.mock('../../../hooks/useApiScoring', () => ({
+    useApiScoring: jest.fn(),
+}));
+
+jest.mock('../../../../../shared/notify', () => ({
+    notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+const mockUseApiScoring = useApiScoring as jest.Mock;
+const mockUseApiScoreEnabled = useApiScoreEnabled as jest.Mock;
+const mockNotify = jest.mocked(notify);
+
+const SCORED: ApiScoring = {
+    createdAt: new Date(Date.now() - 10 * 86_400_000).toISOString(),
+    summary: { all: 3, errors: 2, warnings: 1, infos: 0, hints: 0, score: 0.67 },
+    assets: [
+        {
+            name: 'petstore.yaml',
+            type: 'SWAGGER',
+            diagnostics: [
+                {
+                    severity: 'ERROR',
+                    message: 'Operation is missing a security requirement.',
+                    range: { start: { line: 84, character: 4 }, end: { line: 84, character: 10 } },
+                    path: '$.paths./pet.findByStatus.get',
+                },
+                {
+                    severity: 'ERROR',
+                    message: 'Response 200 is missing a schema.',
+                    range: { start: { line: 142, character: 12 }, end: { line: 142, character: 20 } },
+                    path: '$.paths./pet/{petId}.get.responses.200',
+                },
+                {
+                    severity: 'WARN',
+                    message: 'API description is shorter than 50 characters.',
+                    range: { start: { line: 8, character: 2 }, end: { line: 8, character: 20 } },
+                    path: '$.info.description',
+                },
+            ],
+        },
+    ],
+};
+
+function idleScoring(overrides: Partial<ReturnType<typeof useApiScoring>> = {}) {
+    mockUseApiScoring.mockReturnValue({
+        scoring: undefined,
+        jobs: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+        pending: false,
+        evaluate: jest.fn(),
+        isEvaluating: false,
+        ...overrides,
+    });
+}
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/apis/api-1/api-score']}>
+            <Routes>
+                <Route path="apis/:apiId/api-score" element={<ApiScoringPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApiScoreEnabled.mockReturnValue({ enabled: true, isFetched: true });
+    idleScoring();
+});
+
+describe('ApiScoringPage', () => {
+    it('shows the never-evaluated empty state', () => {
+        renderPage();
+        expect(screen.getByText('This API has never been scored before')).toBeInTheDocument();
+        expect(screen.getByText('Click on the Evaluate button to get the first score.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^evaluate$/i })).toBeEnabled();
+    });
+
+    it('calls evaluate when the Evaluate button is clicked', () => {
+        const evaluate = jest.fn();
+        idleScoring({ evaluate });
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /^evaluate$/i }));
+        expect(evaluate).toHaveBeenCalled();
+    });
+
+    it('disables Evaluate while a SCORING_REQUEST job is pending', () => {
+        idleScoring({ pending: true, scoring: SCORED });
+        renderPage();
+        expect(screen.getByRole('button', { name: /^evaluate$/i })).toBeDisabled();
+        expect(screen.getByText(/a request is currently processing/i)).toBeInTheDocument();
+    });
+
+    it('renders the score percent, last evaluated time, and severity pills', () => {
+        idleScoring({ scoring: SCORED });
+        renderPage();
+        expect(screen.getByText('67%')).toBeInTheDocument();
+        expect(screen.getByText(/last evaluated 10 days ago/i)).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'All (3)' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Errors (2)' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Warnings (1)' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Infos (0)' })).toBeDisabled();
+        expect(screen.getByRole('radio', { name: 'Hints (0)' })).toBeDisabled();
+    });
+
+    it('filters diagnostic rows when a severity pill is selected', () => {
+        idleScoring({ scoring: SCORED });
+        renderPage();
+        expect(screen.getByText('Operation is missing a security requirement.')).toBeInTheDocument();
+        expect(screen.getByText('API description is shorter than 50 characters.')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('radio', { name: 'Errors (2)' }));
+        expect(screen.getByText('Operation is missing a security requirement.')).toBeInTheDocument();
+        expect(screen.queryByText('API description is shorter than 50 characters.')).not.toBeInTheDocument();
+    });
+
+    it('shows the all-clear empty state when the score is 100% with no findings', () => {
+        idleScoring({
+            scoring: {
+                createdAt: new Date().toISOString(),
+                summary: { all: 0, errors: 0, warnings: 0, infos: 0, hints: 0, score: 1 },
+                assets: [],
+            },
+        });
+        renderPage();
+        expect(screen.getByText('All clear')).toBeInTheDocument();
+        expect(screen.getByText(/everything looks great/i)).toBeInTheDocument();
+    });
+
+    it('shows the no-scorable-assets empty state when the report has no summary', () => {
+        idleScoring({ scoring: { createdAt: new Date().toISOString(), assets: [] } });
+        renderPage();
+        expect(screen.getByText('No scorable assets')).toBeInTheDocument();
+        expect(screen.getByText("This API's assets did not match any rulesets.")).toBeInTheDocument();
+    });
+
+    it('toasts Console ERROR copy for a recent failed job', () => {
+        idleScoring({
+            scoring: SCORED,
+            jobs: [
+                {
+                    id: 'job-1',
+                    sourceId: 'api-1',
+                    type: 'SCORING_REQUEST',
+                    status: 'ERROR',
+                    errorMessage: 'boom',
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                },
+            ],
+        });
+        renderPage();
+        expect(mockNotify.error).toHaveBeenCalledWith(expect.stringContaining('The last evaluation was failed at'));
+    });
+
+    it('toasts Console TIMEOUT copy for a recent timed-out job', () => {
+        idleScoring({
+            scoring: SCORED,
+            jobs: [
+                {
+                    id: 'job-2',
+                    sourceId: 'api-1',
+                    type: 'SCORING_REQUEST',
+                    status: 'TIMEOUT',
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                },
+            ],
+        });
+        renderPage();
+        expect(mockNotify.error).toHaveBeenCalledWith(expect.stringContaining('Evaluation timed out at'));
+    });
+
+    it('toasts asset evaluation errors with Console copy', () => {
+        idleScoring({
+            scoring: {
+                createdAt: new Date().toISOString(),
+                assets: [
+                    {
+                        name: 'Asset name',
+                        type: 'GRAVITEE_DEFINITION',
+                        diagnostics: [],
+                        errors: [{ code: 'undefined-function', path: ['rules', 'function'] }],
+                    },
+                ],
+            },
+        });
+        renderPage();
+        expect(mockNotify.error).toHaveBeenCalledWith(expect.stringContaining('Errors occurred while scoring this API:'));
+        expect(mockNotify.error).toHaveBeenCalledWith(expect.stringContaining('Asset: Asset name'));
+    });
+
+    it('toasts load errors without an inline alert', () => {
+        const error = new Error('boom');
+        idleScoring({ isError: true, error });
+        renderPage();
+        expect(mockNotify.error).toHaveBeenCalledWith(error, 'An error occurred while getting your API Scoring.');
+        expect(screen.queryByText('An error occurred while getting your API Scoring.')).not.toBeInTheDocument();
+        expect(screen.queryByText('This API has never been scored before')).not.toBeInTheDocument();
+    });
+
+    it('does not show no-scorable-assets when the report has asset errors and no summary', () => {
+        idleScoring({
+            scoring: {
+                createdAt: new Date().toISOString(),
+                assets: [
+                    {
+                        name: 'Asset name',
+                        type: 'GRAVITEE_DEFINITION',
+                        diagnostics: [],
+                        errors: [{ code: 'undefined-function', path: ['rules', 'function'] }],
+                    },
+                ],
+            },
+        });
+        renderPage();
+        expect(screen.queryByText('No scorable assets')).not.toBeInTheDocument();
+    });
+
+    it('redirects to the parent API route when apiScore.enabled is false', () => {
+        mockUseApiScoreEnabled.mockReturnValue({ enabled: false, isFetched: true });
+        render(
+            <MemoryRouter initialEntries={['/apis/api-1/api-score']}>
+                <Routes>
+                    <Route
+                        path="apis/:apiId"
+                        element={
+                            <>
+                                <div>parent-overview</div>
+                                <Outlet />
+                            </>
+                        }
+                    >
+                        <Route path="api-score" element={<ApiScoringPage />} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+        expect(screen.getByText('parent-overview')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^evaluate$/i })).not.toBeInTheDocument();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/api-score/ApiScoringPage.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Button, DataTableEmptyState, Skeleton, ToggleGroup, ToggleGroupItem } from '@gravitee/graphene-core';
+import { RocketIcon, SearchIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+
+import { ApiScoringAssetCard } from './ApiScoringAssetCard';
+import { notify } from '../../../../../shared/notify';
+import { useApiScoreEnabled } from '../../../hooks/useApiScoreEnabled';
+import { useApiScoring } from '../../../hooks/useApiScoring';
+import type { ApiScoringSummary, ScoringFilter } from '../../../types/scoring';
+import {
+    filterAssetsBySeverity,
+    formatDateAgo,
+    formatEvaluationErrors,
+    formatScorePercent,
+    scoringJobToastMessage,
+    scoreTone,
+} from '../../../utils/scoring';
+
+const FILTERS: { value: ScoringFilter; label: (count: number) => string }[] = [
+    { value: 'ALL', label: count => `All (${count})` },
+    { value: 'ERROR', label: count => `Errors (${count})` },
+    { value: 'WARN', label: count => `Warnings (${count})` },
+    { value: 'INFO', label: count => `Infos (${count})` },
+    { value: 'HINT', label: count => `Hints (${count})` },
+];
+
+const FILTER_COUNT_KEY: Record<ScoringFilter, keyof ApiScoringSummary> = {
+    ALL: 'all',
+    ERROR: 'errors',
+    WARN: 'warnings',
+    INFO: 'infos',
+    HINT: 'hints',
+};
+
+const SCORE_TONE_CLASS = {
+    success: 'text-success',
+    warning: 'text-warning',
+    error: 'text-destructive',
+} as const;
+
+export function ApiScoringPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+    const { enabled: apiScoreEnabled, isFetched: apiScoreFlagFetched } = useApiScoreEnabled();
+    const { scoring, jobs, isLoading, isError, error, pending, evaluate } = useApiScoring(apiScoreEnabled ? apiId : undefined);
+    const [severity, setSeverity] = useState<ScoringFilter>('ALL');
+    const toastedJobRef = useRef<string | null>(null);
+    const toastedAssetsRef = useRef<string | null>(null);
+
+    const jobToastMessage = useMemo(() => scoringJobToastMessage(jobs), [jobs]);
+    const filteredAssets = useMemo(() => (scoring ? filterAssetsBySeverity(scoring.assets, severity) : []), [scoring, severity]);
+
+    useEffect(() => {
+        if (!jobToastMessage) return;
+        if (toastedJobRef.current === jobToastMessage) return;
+        toastedJobRef.current = jobToastMessage;
+        notify.error(jobToastMessage);
+    }, [jobToastMessage]);
+
+    useEffect(() => {
+        if (pending || !scoring) return;
+        const message = formatEvaluationErrors(scoring);
+        if (!message) return;
+        if (toastedAssetsRef.current === message) return;
+        toastedAssetsRef.current = message;
+        notify.error(message);
+    }, [pending, scoring]);
+
+    useEffect(() => {
+        if (!isError) return;
+        notify.error(error, 'An error occurred while getting your API Scoring.');
+    }, [isError, error]);
+
+    if (!apiScoreFlagFetched || (apiScoreEnabled && isLoading)) {
+        return (
+            <div className="space-y-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
+                        <Skeleton className="h-8 w-40 rounded" />
+                        <Skeleton className="h-4 w-56 rounded" />
+                    </div>
+                    <Skeleton className="h-8 w-24 rounded" />
+                </div>
+                <Skeleton className="h-48 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    if (!apiScoreEnabled) {
+        return <Navigate to=".." replace />;
+    }
+
+    const neverEvaluated = !isError && (scoring === null || scoring === undefined);
+    const summary = scoring?.summary;
+    const scoreAvailable = summary !== undefined;
+    const allClear = scoreAvailable && summary.all === 0 && summary.score === 1;
+    const hasAssetErrors = Boolean(scoring && formatEvaluationErrors(scoring));
+    const noScorableAssets = !isError && !neverEvaluated && !scoreAvailable && !hasAssetErrors;
+    const lastEvaluatedAt = scoring?.createdAt;
+    const showFilters = scoreAvailable && summary.all !== 0;
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">
+                        API Score
+                        {scoreAvailable ? (
+                            <span className={`ml-2 ${SCORE_TONE_CLASS[scoreTone(summary.score)]}`}>
+                                {formatScorePercent(summary.score)}
+                            </span>
+                        ) : null}
+                    </h1>
+                    {scoreAvailable && lastEvaluatedAt ? (
+                        <p className="text-sm text-muted-foreground">Last evaluated {formatDateAgo(lastEvaluatedAt)}</p>
+                    ) : null}
+                </div>
+                <Button type="button" size="sm" onClick={() => evaluate()} disabled={pending}>
+                    Evaluate
+                </Button>
+            </div>
+
+            {pending ? (
+                <Alert variant="warning">
+                    <AlertDescription>A request is currently processing, updated result will appear below once completed.</AlertDescription>
+                </Alert>
+            ) : null}
+
+            {showFilters ? (
+                <ToggleGroup
+                    type="single"
+                    value={severity}
+                    onValueChange={value => {
+                        if (value) setSeverity(value as ScoringFilter);
+                    }}
+                    className="flex flex-wrap justify-start"
+                    aria-label="Filter findings by severity"
+                >
+                    {FILTERS.map(filter => {
+                        const count = summary[FILTER_COUNT_KEY[filter.value]];
+                        return (
+                            <ToggleGroupItem key={filter.value} value={filter.value} disabled={filter.value !== 'ALL' && count === 0}>
+                                {filter.label(count)}
+                            </ToggleGroupItem>
+                        );
+                    })}
+                </ToggleGroup>
+            ) : null}
+
+            {neverEvaluated ? (
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<SearchIcon className="size-8" aria-hidden />}
+                    title="This API has never been scored before"
+                    description="Click on the Evaluate button to get the first score."
+                />
+            ) : null}
+
+            {allClear ? (
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<RocketIcon className="size-8" aria-hidden />}
+                    title="All clear"
+                    description="There is no recommendations or issues for your API. Everything looks great!"
+                />
+            ) : null}
+
+            {noScorableAssets ? (
+                <DataTableEmptyState
+                    variant="first-use"
+                    icon={<ShieldIcon className="size-8" aria-hidden />}
+                    title="No scorable assets"
+                    description="This API's assets did not match any rulesets."
+                />
+            ) : null}
+
+            {scoreAvailable && !allClear
+                ? filteredAssets.map(asset => <ApiScoringAssetCard key={`${asset.name}-${asset.type}`} asset={asset} />)
+                : null}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiScoring.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiScoring.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { evaluateApiScoring, getApiScoring, listScoringJobs } from './apiScoring';
+import { ApimApiError, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => {
+    const actual = jest.requireActual('../../../shared/api/apimClient');
+    return {
+        ...actual,
+        apimFetchJsonV2: jest.fn(),
+    };
+});
+
+const mockApimFetchJsonV2 = jest.mocked(apimFetchJsonV2);
+
+describe('apiScoring service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getApiScoring', () => {
+        it('GETs the v2 scoring report for the API', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({ createdAt: '2026-01-01T00:00:00Z', assets: [] });
+            await getApiScoring('env-1', 'api-1');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api-1/scoring');
+        });
+
+        it('returns undefined when the API has never been scored (404)', async () => {
+            mockApimFetchJsonV2.mockRejectedValueOnce(new ApimApiError(404, 'Not found'));
+            await expect(getApiScoring('env-1', 'api-1')).resolves.toBeNull();
+        });
+
+        it('treats a duck-typed 404 as never scored', async () => {
+            mockApimFetchJsonV2.mockRejectedValueOnce({ name: 'ApimApiError', status: 404, message: 'Not found' });
+            await expect(getApiScoring('env-1', 'api-1')).resolves.toBeNull();
+        });
+
+        it('rethrows non-404 errors', async () => {
+            mockApimFetchJsonV2.mockRejectedValueOnce(new ApimApiError(500, 'boom'));
+            await expect(getApiScoring('env-1', 'api-1')).rejects.toThrow('boom');
+        });
+
+        it('URL-encodes the API id', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({ createdAt: '2026-01-01T00:00:00Z', assets: [] });
+            await getApiScoring('env-1', 'api/with spaces');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api%2Fwith%20spaces/scoring');
+        });
+    });
+
+    describe('evaluateApiScoring', () => {
+        it('POSTs _evaluate with no body', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({ status: 'PENDING' });
+            await evaluateApiScoring('env-1', 'api-1');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/apis/api-1/scoring/_evaluate', { method: 'POST' });
+        });
+    });
+
+    describe('listScoringJobs', () => {
+        it('lists SCORING_REQUEST jobs for the API', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({ data: [] });
+            await listScoringJobs('env-1', 'api-1');
+            expect(mockApimFetchJsonV2).toHaveBeenCalledWith('env-1', '/async-jobs?page=1&perPage=10&type=SCORING_REQUEST&sourceId=api-1');
+        });
+
+        it('normalizes a missing data array to an empty list', async () => {
+            mockApimFetchJsonV2.mockResolvedValueOnce({} as Awaited<ReturnType<typeof listScoringJobs>>);
+            const result = await listScoringJobs('env-1', 'api-1');
+            expect(result.data).toEqual([]);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiScoring.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiScoring.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { ApiScoring, ApiScoringTriggerResponse, ScoringAsyncJobsResponse } from '../types/scoring';
+
+const apiPath = (apiId: string) => `/apis/${encodeURIComponent(apiId)}`;
+
+/** Duck-type 404 so Module Federation duplicate `ApimApiError` classes still match. */
+export function isNotFoundError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null || !('status' in error)) return false;
+    return Number((error as { status: unknown }).status) === 404;
+}
+
+export async function getApiScoring(environmentId: string, apiId: string): Promise<ApiScoring | null> {
+    try {
+        return (await apimFetchJsonV2<ApiScoring>(environmentId, `${apiPath(apiId)}/scoring`)) ?? null;
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return null;
+        }
+        throw error;
+    }
+}
+
+export async function evaluateApiScoring(environmentId: string, apiId: string): Promise<ApiScoringTriggerResponse> {
+    return apimFetchJsonV2<ApiScoringTriggerResponse>(environmentId, `${apiPath(apiId)}/scoring/_evaluate`, {
+        method: 'POST',
+    });
+}
+
+export async function listScoringJobs(environmentId: string, apiId: string): Promise<ScoringAsyncJobsResponse> {
+    const searchParams = new URLSearchParams({
+        page: '1',
+        perPage: '10',
+        type: 'SCORING_REQUEST',
+        sourceId: apiId,
+    });
+    const response = await apimFetchJsonV2<ScoringAsyncJobsResponse>(environmentId, `/async-jobs?${searchParams.toString()}`);
+    return { data: response.data ?? [] };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/scoring.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/scoring.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ScoringStatus = 'SUCCESS' | 'PENDING' | 'ERROR';
+export type ScoringAssetType = 'ASYNCAPI' | 'GRAVITEE_DEFINITION' | 'SWAGGER';
+export type ScoringSeverity = 'ERROR' | 'HINT' | 'INFO' | 'WARN';
+export type ScoringFilter = ScoringSeverity | 'ALL';
+export type ScoringAsyncJobStatus = 'ERROR' | 'PENDING' | 'SUCCESS' | 'TIMEOUT';
+
+export interface ApiScoringTriggerResponse {
+    status: ScoringStatus;
+    message?: string;
+}
+
+export interface ApiScoringSummary {
+    all: number;
+    errors: number;
+    warnings: number;
+    infos: number;
+    hints: number;
+    score: number;
+}
+
+export interface ScoringDiagnosticRange {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+}
+
+export interface ScoringDiagnostic {
+    severity: ScoringSeverity;
+    message: string;
+    range: ScoringDiagnosticRange;
+    path: string;
+}
+
+export interface ScoringError {
+    code: string;
+    path: string[];
+}
+
+export interface ScoringAsset {
+    name: string;
+    type: ScoringAssetType;
+    diagnostics: ScoringDiagnostic[];
+    errors?: ScoringError[];
+}
+
+export interface ApiScoring {
+    createdAt: string;
+    summary?: ApiScoringSummary;
+    assets: ScoringAsset[];
+}
+
+export interface ScoringAsyncJob {
+    id: string;
+    sourceId: string;
+    type: 'SCORING_REQUEST';
+    status: ScoringAsyncJobStatus;
+    errorMessage?: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface ScoringAsyncJobsResponse {
+    data: ScoringAsyncJob[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
@@ -91,6 +91,13 @@ export const apiEntrypointKeys = {
 export const portalSettingsKeys = {
     all: ['portal-settings'] as const,
     env: (envId: string) => [...portalSettingsKeys.all, envId] as const,
+    portalConfig: (envId: string) => [...portalSettingsKeys.all, 'portal-config', envId] as const,
+};
+
+export const apiScoringKeys = {
+    all: ['api-scoring'] as const,
+    report: (envId: string, apiId: string) => [...apiScoringKeys.all, 'report', envId, apiId] as const,
+    jobs: (envId: string, apiId: string) => [...apiScoringKeys.all, 'jobs', envId, apiId] as const,
 };
 
 export const apiAlertKeys = {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/scoring.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/scoring.spec.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    clampPage,
+    diagnosticMatchesSearch,
+    filterAssetsBySeverity,
+    formatDateAgo,
+    formatEvaluationErrors,
+    formatLineColumn,
+    formatScorePercent,
+    isApiScoreEnabled,
+    latestScoringJob,
+    paginateItems,
+    scoringJobToastMessage,
+    scoreTone,
+} from './scoring';
+import type { ApiScoring, ScoringAsset, ScoringAsyncJob, ScoringDiagnostic } from '../types/scoring';
+
+const diagnostic = (overrides: Partial<ScoringDiagnostic> = {}): ScoringDiagnostic => ({
+    severity: 'WARN',
+    message: 'Operation is missing a security requirement.',
+    range: { start: { line: 84, character: 4 }, end: { line: 84, character: 10 } },
+    path: '$.paths./pet.findByStatus.get',
+    ...overrides,
+});
+
+const asset = (overrides: Partial<ScoringAsset> = {}): ScoringAsset => ({
+    name: 'petstore.yaml',
+    type: 'SWAGGER',
+    diagnostics: [diagnostic()],
+    ...overrides,
+});
+
+describe('formatScorePercent', () => {
+    it('rounds a 0-1 score to a whole percent', () => {
+        expect(formatScorePercent(0.67)).toBe('67%');
+        expect(formatScorePercent(1)).toBe('100%');
+        expect(formatScorePercent(0.835)).toBe('84%');
+    });
+});
+
+describe('scoreTone', () => {
+    it('uses success at 80% and above, warning at 40%, error below', () => {
+        expect(scoreTone(0.8)).toBe('success');
+        expect(scoreTone(0.67)).toBe('warning');
+        expect(scoreTone(0.4)).toBe('warning');
+        expect(scoreTone(0.39)).toBe('error');
+    });
+});
+
+describe('formatLineColumn', () => {
+    it('formats the diagnostic start as line:character', () => {
+        expect(formatLineColumn(diagnostic())).toBe('84:4');
+    });
+});
+
+describe('formatDateAgo', () => {
+    const now = new Date('2026-09-10T12:00:00.000Z').getTime();
+
+    it('returns just now for timestamps under 29 seconds', () => {
+        expect(formatDateAgo(new Date(now - 10_000).toISOString(), now)).toBe('just now');
+    });
+
+    it('returns a singular relative unit', () => {
+        expect(formatDateAgo(new Date(now - 86_400_000).toISOString(), now)).toBe('1 day ago');
+    });
+
+    it('returns a plural relative unit matching the Gamma screen (10 days ago)', () => {
+        expect(formatDateAgo(new Date(now - 10 * 86_400_000).toISOString(), now)).toBe('10 days ago');
+    });
+});
+
+describe('isApiScoreEnabled', () => {
+    it('is true only when the portal flag is explicitly enabled', () => {
+        expect(isApiScoreEnabled({ apiScore: { enabled: true } })).toBe(true);
+        expect(isApiScoreEnabled({ apiScore: { enabled: false } })).toBe(false);
+        expect(isApiScoreEnabled({})).toBe(false);
+        expect(isApiScoreEnabled(undefined)).toBe(false);
+    });
+});
+
+describe('filterAssetsBySeverity', () => {
+    const assets = [
+        asset({
+            diagnostics: [
+                diagnostic({ severity: 'ERROR', message: 'missing security' }),
+                diagnostic({ severity: 'WARN', message: 'short description' }),
+                diagnostic({ severity: 'INFO', message: 'add an example' }),
+            ],
+        }),
+    ];
+
+    it('returns the original assets for ALL', () => {
+        expect(filterAssetsBySeverity(assets, 'ALL')).toBe(assets);
+    });
+
+    it('keeps assets but retains only matching diagnostics', () => {
+        const filtered = filterAssetsBySeverity(assets, 'ERROR');
+        expect(filtered[0].diagnostics).toHaveLength(1);
+        expect(filtered[0].diagnostics[0].severity).toBe('ERROR');
+    });
+});
+
+describe('diagnosticMatchesSearch', () => {
+    it('matches severity, recommendation, or path case-insensitively', () => {
+        const row = diagnostic();
+        expect(diagnosticMatchesSearch(row, '')).toBe(true);
+        expect(diagnosticMatchesSearch(row, 'WARN')).toBe(true);
+        expect(diagnosticMatchesSearch(row, 'security requirement')).toBe(true);
+        expect(diagnosticMatchesSearch(row, 'findByStatus')).toBe(true);
+        expect(diagnosticMatchesSearch(row, 'no-such-text')).toBe(false);
+    });
+});
+
+describe('paginateItems', () => {
+    it('returns the requested page with a page size of 5', () => {
+        const items = [1, 2, 3, 4, 5, 6, 7];
+        expect(paginateItems(items, 1, 5)).toEqual([1, 2, 3, 4, 5]);
+        expect(paginateItems(items, 2, 5)).toEqual([6, 7]);
+    });
+});
+
+describe('clampPage', () => {
+    it('keeps the current page when it is still in range', () => {
+        expect(clampPage(2, 12, 5)).toBe(2);
+    });
+
+    it('clamps to the last page when the item count shrinks', () => {
+        expect(clampPage(3, 1, 5)).toBe(1);
+    });
+
+    it('stays on page 1 when there are no items', () => {
+        expect(clampPage(3, 0, 5)).toBe(1);
+    });
+
+    it('stays on page 1 when pageSize is zero', () => {
+        expect(clampPage(3, 12, 0)).toBe(1);
+    });
+});
+
+describe('formatEvaluationErrors', () => {
+    it('returns null when no asset errors exist', () => {
+        expect(formatEvaluationErrors({ createdAt: '2026-01-01T00:00:00Z', assets: [asset()] })).toBeNull();
+    });
+
+    it('formats Console copy for asset scoring errors', () => {
+        const scoring: ApiScoring = {
+            createdAt: '2026-01-01T00:00:00Z',
+            assets: [
+                asset({
+                    name: 'Asset name',
+                    type: 'GRAVITEE_DEFINITION',
+                    diagnostics: [],
+                    errors: [{ code: 'undefined-function', path: ['rules', 'api-key-security-scheme', 'then', 'function'] }],
+                }),
+            ],
+        };
+        expect(formatEvaluationErrors(scoring)).toBe(`Errors occurred while scoring this API:
+
+Asset: Asset name
+Code: undefined-function
+Path: rules,api-key-security-scheme,then,function`);
+    });
+});
+
+describe('latestScoringJob', () => {
+    const job = (overrides: Partial<ScoringAsyncJob> = {}): ScoringAsyncJob => ({
+        id: 'job-1',
+        sourceId: 'api-1',
+        type: 'SCORING_REQUEST',
+        status: 'PENDING',
+        createdAt: '2026-09-10T11:59:00.000Z',
+        updatedAt: '2026-09-10T11:59:00.000Z',
+        ...overrides,
+    });
+
+    it('picks the most recently updated job', () => {
+        const older = job({ id: 'old', status: 'PENDING', updatedAt: '2026-09-10T11:00:00.000Z' });
+        const newer = job({ id: 'new', status: 'SUCCESS', updatedAt: '2026-09-10T11:50:00.000Z' });
+        expect(latestScoringJob([older, newer])?.id).toBe('new');
+    });
+});
+
+describe('scoringJobToastMessage', () => {
+    const now = new Date('2026-09-10T12:00:00.000Z').getTime();
+    const job = (overrides: Partial<ScoringAsyncJob> = {}): ScoringAsyncJob => ({
+        id: 'job-1',
+        sourceId: 'api-1',
+        type: 'SCORING_REQUEST',
+        status: 'PENDING',
+        createdAt: '2026-09-10T11:59:00.000Z',
+        updatedAt: '2026-09-10T11:59:00.000Z',
+        ...overrides,
+    });
+
+    it('toasts Console ERROR copy for a recent failed job', () => {
+        const failed = job({
+            status: 'ERROR',
+            createdAt: '2026-09-10T11:50:00.000Z',
+            updatedAt: '2026-09-10T11:50:00.000Z',
+            errorMessage: 'boom',
+        });
+        expect(scoringJobToastMessage([failed], now)).toBe('The last evaluation was failed at 2026-09-10T11:50:00.000Z boom');
+    });
+
+    it('toasts Console TIMEOUT copy for a recent timed-out job', () => {
+        const timedOut = job({
+            status: 'TIMEOUT',
+            createdAt: '2026-09-10T11:50:00.000Z',
+            updatedAt: '2026-09-10T11:50:00.000Z',
+        });
+        expect(scoringJobToastMessage([timedOut], now)).toBe(
+            'Evaluation timed out at 2026-09-10T11:50:00.000Z. The API score service might be unavailable. Please try again later.',
+        );
+    });
+
+    it('does not toast for jobs older than one hour', () => {
+        const stale = job({
+            status: 'ERROR',
+            createdAt: '2026-09-10T10:00:00.000Z',
+            updatedAt: '2026-09-10T10:00:00.000Z',
+        });
+        expect(scoringJobToastMessage([stale], now)).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/scoring.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/scoring.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiScoring, ScoringAsset, ScoringAsyncJob, ScoringDiagnostic, ScoringFilter } from '../types/scoring';
+
+const DATE_AGO_INTERVALS = [
+    ['year', 31_536_000],
+    ['month', 2_592_000],
+    ['day', 86_400],
+    ['hour', 3600],
+    ['minute', 60],
+    ['second', 1],
+] as const;
+
+/** Classic Console treats a job as relevant for ERROR/TIMEOUT toasts for one hour. */
+export const SCORING_JOB_TOAST_WINDOW_MS = 3_600_000;
+
+export function formatScorePercent(score: number): string {
+    return `${Math.round(score * 100)}%`;
+}
+
+export function scoreTone(score: number): 'success' | 'warning' | 'error' {
+    if (score >= 0.8) return 'success';
+    if (score >= 0.4) return 'warning';
+    return 'error';
+}
+
+export function formatLineColumn(diagnostic: ScoringDiagnostic): string {
+    return `${diagnostic.range.start.line}:${diagnostic.range.start.character}`;
+}
+
+/** Classic Console `dateAgo` pipe — always relative, including beyond one week. */
+export function formatDateAgo(value: string | number | Date | undefined, now = Date.now()): string {
+    if (value === undefined || value === null || value === '') return '';
+    const then = new Date(value).getTime();
+    if (Number.isNaN(then)) return String(value);
+    const seconds = Math.floor((now - then) / 1000);
+    if (seconds < 29) return 'just now';
+    for (const [unit, size] of DATE_AGO_INTERVALS) {
+        const count = Math.floor(seconds / size);
+        if (count > 0) {
+            return count === 1 ? `${count} ${unit} ago` : `${count} ${unit}s ago`;
+        }
+    }
+    return String(value);
+}
+
+export function isApiScoreEnabled(config: { apiScore?: { enabled?: boolean } } | null | undefined): boolean {
+    return Boolean(config?.apiScore?.enabled);
+}
+
+export function filterAssetsBySeverity(assets: ScoringAsset[], severity: ScoringFilter): ScoringAsset[] {
+    if (severity === 'ALL') return assets;
+    return assets.map(item => ({
+        ...item,
+        diagnostics: item.diagnostics.filter(diagnostic => diagnostic.severity === severity),
+    }));
+}
+
+export function diagnosticMatchesSearch(diagnostic: ScoringDiagnostic, search: string): boolean {
+    const term = search.trim().toLowerCase();
+    if (!term) return true;
+    return [diagnostic.severity, diagnostic.message, diagnostic.path].some(value => value.toLowerCase().includes(term));
+}
+
+export function paginateItems<T>(items: readonly T[], page: number, pageSize: number): T[] {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+}
+
+export function clampPage(page: number, itemCount: number, pageSize: number): number {
+    if (pageSize <= 0) return 1;
+    const pageCount = Math.max(1, Math.ceil(itemCount / pageSize));
+    return Math.min(Math.max(1, page), pageCount);
+}
+
+export function formatEvaluationErrors(scoring: ApiScoring): string | null {
+    const assetsWithErrors = scoring.assets.filter(item => (item.errors?.length ?? 0) > 0);
+    if (assetsWithErrors.length === 0) return null;
+    let message = 'Errors occurred while scoring this API:';
+    for (const item of assetsWithErrors) {
+        message += '\n';
+        if (item.name) {
+            message += `\nAsset: ${item.name}`;
+        }
+        for (const error of item.errors ?? []) {
+            message += `\nCode: ${error.code}\nPath: ${error.path.toString()}`;
+        }
+    }
+    return message;
+}
+
+export function latestScoringJob(jobs: ScoringAsyncJob[]): ScoringAsyncJob | undefined {
+    return [...jobs].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+}
+
+export function scoringJobToastMessage(jobs: ScoringAsyncJob[], now = Date.now()): string | null {
+    const lastJob = latestScoringJob(jobs);
+    if (!lastJob) return null;
+    const recent = now - new Date(lastJob.updatedAt).getTime() < SCORING_JOB_TOAST_WINDOW_MS;
+    if (!recent) return null;
+    if (lastJob.status === 'ERROR') {
+        return `The last evaluation was failed at ${lastJob.createdAt} ${lastJob.errorMessage ?? ''}`;
+    }
+    if (lastJob.status === 'TIMEOUT') {
+        return `Evaluation timed out at ${lastJob.createdAt}. The API score service might be unavailable. Please try again later.`;
+    }
+    return null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/portalSettings.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/portalSettings.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getEnvironmentPortalConfiguration, getEnvironmentPortalSettings } from './portalSettings';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('portalSettings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue({});
+    });
+
+    it('loads gateway settings from GET /settings', async () => {
+        await getEnvironmentPortalSettings('env-1');
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/settings');
+    });
+
+    it('loads apiScore.enabled from GET /portal', async () => {
+        mockApimFetchJsonV1Env.mockResolvedValueOnce({ apiScore: { enabled: true } });
+        const config = await getEnvironmentPortalConfiguration('env-1');
+        expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('env-1', '/portal');
+        expect(config.apiScore?.enabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/portalSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/portalSettings.ts
@@ -19,6 +19,15 @@ export interface EnvironmentPortalSettings {
     portal?: { entrypoint?: string };
 }
 
+/** Subset of GET /environments/{envId}/portal (classic Console EnvSettings). */
+export interface EnvironmentPortalConfiguration {
+    apiScore?: { enabled?: boolean };
+}
+
 export async function getEnvironmentPortalSettings(environmentId: string): Promise<EnvironmentPortalSettings> {
     return apimFetchJsonV1Env<EnvironmentPortalSettings>(environmentId, '/settings');
+}
+
+export async function getEnvironmentPortalConfiguration(environmentId: string): Promise<EnvironmentPortalConfiguration> {
+    return apimFetchJsonV1Env<EnvironmentPortalConfiguration>(environmentId, '/portal');
 }


### PR DESCRIPTION
…tilities, and test coverage

Add API Scoring functionality to the platform, including server-side evaluations, API navigation improvements, and a new scoring page. Update UI components and navigation to reflect the active state of the scoring module, ensuring seamless integration and dynamic visibility.

## Issue

https://gravitee.atlassian.net/browse/APIM-15091

## Summary
- Adds API Score on the Gamma APIM API-detail page: sidebar item, route `/environments/:hrid/apim/apis/:apiId/api-score`, Evaluate, 1s job polling, and per-asset findings.
- Gates the nav item and route on `apiScore.enabled` from **GET `/portal`**. Evaluate is not permission-gated (same as Console).
- Matches Console MAPI v2 behavior (`GET/POST scoring`, `GET /async-jobs?type=SCORING_REQUEST`) and the Gamma Petstore screen (title + percent, relative last-evaluated, severity pills, accordion search/pagination of 5).
- Frontend only (Gamma APIM module). No Java / gamma-rest-api. Platform Environment overview and rulesets are out of scope.

## Test plan
- [ ] Serve with `DEV_MODULE_ENTRIES="apim=http://localhost:3001/mf-manifest.json"` so Gamma loads the local APIM module.
- [ ] With **Enable API Score** off (Settings → API Quality), API Score is absent from the API sidebar and `/api-score` redirects away.
- [ ] With the flag on, open an API → General → **API Score**.
- [ ] Never-scored API shows “This API has never been scored before” and Evaluate is enabled.
- [ ] Evaluate disables while a `SCORING_REQUEST` job is `PENDING` and shows the processing banner; findings refresh when the job completes (Cloud/Cockpit scoring must be connected for a real score).
- [ ] Scored API: percent beside the title (green ≥80, amber ≥40, red below), “Last evaluated … ago”, pills All/Errors/Warnings/Infos/Hints, per-asset accordion with search and page size 5.
- [ ] Empty states: All clear; No scorable assets.
- [ ] Recent ERROR/TIMEOUT jobs toast Console copy; asset evaluation errors toast Console copy.
- [ ] `yarn nx test gravitee-gamma-module-apim` and `yarn nx run gravitee-gamma-module-apim:lint-eslint`.

## Additional context

<img width="1728" height="965" alt="Screenshot 2026-09-11 at 00 47 19" src="https://github.com/user-attachments/assets/29ef130d-a3b3-402d-be97-26c45ef24257" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

