### PR TITLE
chore(distribution): bump gamma module AIM version to 4.3.0-beta.25

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -275,7 +275,7 @@
 
     <!-- Gamma plugins -->
     <gravitee-gamma-module-act.version>1.0.0-guardian-agent-SNAPSHOT</gravitee-gamma-module-act.version>
-    <gravitee-gamma-module-aim.version>4.3.0-beta.23</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.25</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
Bumps the bundled gravitee-gamma-module-aim from 4.3.0-beta.23 to 4.3.0-beta.25.

beta.24 and beta.25 bring the proxy Targets tabs (A2A, MCP, LLM) rebuilt on the shared observability panel (gravitee-io/gravitee-gamma-module-aim#827) and the agent Targets page running on that same panel with its defaults layer (gravitee-io/gravitee-gamma-module-aim#829), both on @gravitee/gamma-lib-observability 3.3.0-beta.4. The zip is published on Artifactory.