### PR TITLE
fix(performance-targets): cut evaluation slots on the clock so a manual run never skips the next one

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetSchedule.java
@@ -19,18 +19,26 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * When a target is due. Each target owns the slots {@code k * interval + jitter} of the epoch, where the jitter is a
- * stable hash of its id spread across its declared interval: a target is due once a slot has started since its last
- * evaluation. Targets are so evaluated exactly once per interval, at phases spread over the ticks, and a restart or a
- * bulk import does not make them all due at once for long.
+ * When a target is due. Time is cut into slots of the target's interval, aligned on the epoch: the slot an evaluation
+ * belongs to is the same for the scheduler, for an evaluation run on demand, and for a timeline drawn against the
+ * clock, so one evaluation per slot reads as an unbroken strip. A target is due once in every slot: at the first tick
+ * on or after its phase in the slot, unless something already evaluated it in that slot.
+ *
+ * <p>The phase is a stable hash of the target's id, spread across the declared interval and capped so a tick still
+ * falls in the slot: targets sharing an interval longer than the tick are evaluated on different ticks, and a restart
+ * or a bulk import does not make them all due at once for long. For an interval no longer than the tick the phase is
+ * the slot's start, which is the only tick the slot has.
  *
  * <p>An idle target backs off: from {@code backoffAfter} consecutive NOT_EVALUABLE evaluations on, every further
  * miss doubles the interval it is judged on, up to {@code backoffCap}; the first evaluable window brings it back to
  * the declared interval.
  *
+ * @param tick      how often the scheduler runs
  * @param retention evaluations kept per target after each evaluation
  */
-public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, int retention) {
+public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, int retention, Duration tick) {
+    public static final Duration DEFAULT_TICK = Duration.ofMinutes(1);
+
     public PerformanceTargetSchedule {
         if (backoffAfter < 1) {
             throw new IllegalArgumentException("The backoff threshold must be at least 1 evaluation");
@@ -41,6 +49,14 @@ public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, i
         if (retention < 1) {
             throw new IllegalArgumentException("The retention must keep at least 1 evaluation");
         }
+        if (tick == null || !tick.isPositive()) {
+            throw new IllegalArgumentException("The tick must be a positive duration");
+        }
+    }
+
+    /** A schedule ticking every minute, which is what the service does unless configured otherwise. */
+    public PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, int retention) {
+        this(backoffAfter, backoffCap, retention, DEFAULT_TICK);
     }
 
     public Duration effectiveInterval(PerformanceTarget target, int consecutiveNotEvaluable) {
@@ -52,6 +68,7 @@ public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, i
         return interval.compareTo(cap) > 0 ? cap : interval;
     }
 
+    /** Where in its declared interval the target is evaluated: stable, and spread across targets. */
     public Duration jitter(PerformanceTarget target) {
         return Duration.ofSeconds(Math.floorMod(target.id().hashCode(), Math.max(1, target.interval().toSeconds())));
     }
@@ -60,14 +77,31 @@ public record PerformanceTargetSchedule(int backoffAfter, Duration backoffCap, i
      * @param lastEvaluatedAt {@code null} when the target was never evaluated, which makes it due at once
      */
     public boolean isDue(PerformanceTarget target, Instant lastEvaluatedAt, int consecutiveNotEvaluable, Instant now) {
-        return lastEvaluatedAt == null || lastEvaluatedAt.isBefore(slotStart(target, consecutiveNotEvaluable, now));
+        if (lastEvaluatedAt == null) {
+            return true;
+        }
+        var slotStart = slotStart(target, consecutiveNotEvaluable, now);
+        return lastEvaluatedAt.isBefore(slotStart) && !now.isBefore(dueAt(target, consecutiveNotEvaluable, slotStart));
     }
 
-    /** The start of the target's slot {@code now} falls in; every node computes the same one for the same tick. */
+    /** The start of the slot {@code now} falls in: aligned on the epoch, so every node and every reader cuts time alike. */
     public Instant slotStart(PerformanceTarget target, int consecutiveNotEvaluable, Instant now) {
         var interval = Math.max(1, effectiveInterval(target, consecutiveNotEvaluable).toSeconds());
-        var jitter = jitter(target).toSeconds();
-        return Instant.ofEpochSecond(Math.floorDiv(now.getEpochSecond() - jitter, interval) * interval + jitter);
+        return Instant.ofEpochSecond(Math.floorDiv(now.getEpochSecond(), interval) * interval);
+    }
+
+    /**
+     * When in a slot the target becomes due: its phase into the slot, held back so that at least one tick of the
+     * scheduler falls on or after it before the slot ends.
+     */
+    public Instant dueAt(PerformanceTarget target, int consecutiveNotEvaluable, Instant slotStart) {
+        var room = effectiveInterval(target, consecutiveNotEvaluable).minus(tick);
+        var phase = room.isNegative() ? Duration.ZERO : min(jitter(target), room);
+        return slotStart.plus(phase);
+    }
+
+    private static Duration min(Duration a, Duration b) {
+        return a.compareTo(b) <= 0 ? a : b;
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/model/PerformanceTargetScheduleTest.java
@@ -30,8 +30,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 class PerformanceTargetScheduleTest {
 
     private static final Duration INTERVAL = Duration.ofMinutes(5);
-    private static final PerformanceTargetSchedule SCHEDULE = new PerformanceTargetSchedule(3, Duration.ofHours(1), 288);
+    private static final Duration TICK = Duration.ofMinutes(1);
+    private static final PerformanceTargetSchedule SCHEDULE = new PerformanceTargetSchedule(3, Duration.ofHours(1), 288, TICK);
     private static final PerformanceTarget TARGET = PerformanceTargetFixtures.aTarget().toBuilder().interval(INTERVAL).build();
+
+    /** A slot boundary of every interval used here: a multiple of five and of ten minutes since the epoch. */
+    private static final Instant BOUNDARY = Instant.parse("2021-06-01T10:00:00Z");
 
     @Nested
     class EffectiveInterval {
@@ -77,48 +81,95 @@ class PerformanceTargetScheduleTest {
     }
 
     @Nested
+    class Slots {
+
+        /** The slot is the same for every node, every on-demand run and every timeline: cut on the epoch, not on the target. */
+        @Test
+        void should_cut_time_on_the_epoch_at_the_effective_interval() {
+            assertThat(SCHEDULE.slotStart(TARGET, 0, BOUNDARY)).isEqualTo(BOUNDARY);
+            assertThat(SCHEDULE.slotStart(TARGET, 0, BOUNDARY.plus(INTERVAL).minusSeconds(1))).isEqualTo(BOUNDARY);
+            assertThat(SCHEDULE.slotStart(TARGET, 0, BOUNDARY.plus(INTERVAL))).isEqualTo(BOUNDARY.plus(INTERVAL));
+            // Three misses double the interval to ten minutes: 10:05 falls in the slot that started at 10:00.
+            assertThat(SCHEDULE.slotStart(TARGET, 3, BOUNDARY.plus(INTERVAL))).isEqualTo(BOUNDARY);
+            assertThat(SCHEDULE.slotStart(TARGET, 0, BOUNDARY.plusSeconds(37))).isEqualTo(BOUNDARY);
+        }
+
+        /** Where in the slot the target is due: its phase, held back so a tick still falls in the slot. */
+        @Test
+        void should_be_due_at_the_target_s_phase_into_the_slot_leaving_room_for_a_tick() {
+            var dueAt = SCHEDULE.dueAt(TARGET, 0, BOUNDARY);
+
+            assertThat(dueAt).isEqualTo(BOUNDARY.plus(SCHEDULE.jitter(TARGET)));
+            assertThat(Duration.between(BOUNDARY, dueAt)).isLessThanOrEqualTo(INTERVAL.minus(TICK));
+        }
+
+        @Test
+        void should_be_due_at_the_slot_start_when_the_interval_is_no_longer_than_the_tick() {
+            var everyMinute = TARGET.toBuilder().id("a-target-with-a-non-zero-jitter").interval(TICK).build();
+
+            assertThat(SCHEDULE.jitter(everyMinute)).isPositive();
+            assertThat(SCHEDULE.dueAt(everyMinute, 0, BOUNDARY)).isEqualTo(BOUNDARY);
+            assertThat(SCHEDULE.isDue(everyMinute, BOUNDARY.minusSeconds(50), 0, BOUNDARY)).isTrue();
+        }
+
+        @Test
+        void should_cap_a_late_phase_so_the_last_tick_of_the_slot_still_catches_the_target() {
+            var late = IntStream.range(0, 1000)
+                .mapToObj(i -> TARGET.toBuilder().id("late-" + i).build())
+                .filter(candidate -> SCHEDULE.jitter(candidate).compareTo(INTERVAL.minus(TICK)) > 0)
+                .findFirst()
+                .orElseThrow();
+
+            assertThat(SCHEDULE.dueAt(late, 0, BOUNDARY)).isEqualTo(BOUNDARY.plus(INTERVAL).minus(TICK));
+        }
+    }
+
+    @Nested
     class IsDue {
 
-        private final Instant boundary = Instant.parse("2021-06-01T10:00:00Z").plus(SCHEDULE.jitter(TARGET));
+        private final Duration phase = Duration.between(BOUNDARY, SCHEDULE.dueAt(TARGET, 0, BOUNDARY));
 
         @Test
         void should_be_due_when_never_evaluated() {
-            assertThat(SCHEDULE.isDue(TARGET, null, 0, boundary.minusSeconds(1))).isTrue();
+            assertThat(SCHEDULE.isDue(TARGET, null, 0, BOUNDARY.minusSeconds(1))).isTrue();
         }
 
         @Test
-        void should_be_due_once_a_slot_boundary_has_passed_since_the_last_evaluation() {
-            assertThat(SCHEDULE.isDue(TARGET, boundary.minusSeconds(1), 0, boundary)).isTrue();
-            assertThat(SCHEDULE.isDue(TARGET, boundary.minusSeconds(1), 0, boundary.plusSeconds(59))).isTrue();
+        void should_be_due_from_its_phase_on_once_a_new_slot_has_started_since_the_last_evaluation() {
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY.minusSeconds(1), 0, BOUNDARY.plus(phase))).isTrue();
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY.minusSeconds(1), 0, BOUNDARY.plus(INTERVAL).minusSeconds(1))).isTrue();
+            if (phase.isPositive()) {
+                assertThat(SCHEDULE.isDue(TARGET, BOUNDARY.minusSeconds(1), 0, BOUNDARY.plus(phase).minusSeconds(1))).isFalse();
+            }
         }
 
+        /** An evaluation run on demand early in a slot is that slot's evaluation: the scheduler adds none. */
         @Test
         void should_not_be_due_inside_the_slot_of_the_last_evaluation() {
-            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary)).isFalse();
-            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary.plus(INTERVAL).minusSeconds(1))).isFalse();
-            assertThat(SCHEDULE.isDue(TARGET, boundary.plusSeconds(30), 0, boundary.plus(INTERVAL).minusSeconds(1))).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY, 0, BOUNDARY.plus(phase))).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY.plusSeconds(10), 0, BOUNDARY.plus(INTERVAL).minusSeconds(1))).isFalse();
         }
 
+        /** And the very next slot is evaluated in turn: the strip a reader draws per slot has no hole. */
         @Test
-        void should_be_due_exactly_one_interval_after_the_slot_of_the_last_evaluation() {
-            assertThat(SCHEDULE.isDue(TARGET, boundary, 0, boundary.plus(INTERVAL))).isTrue();
-        }
+        void should_be_due_in_the_slot_after_the_one_evaluated_on_demand() {
+            var onDemand = BOUNDARY.plusSeconds(10);
 
-        @Test
-        void should_name_the_slot_an_instant_belongs_to_by_its_start() {
-            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary)).isEqualTo(boundary);
-            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary.plus(INTERVAL).minusSeconds(1))).isEqualTo(boundary);
-            assertThat(SCHEDULE.slotStart(TARGET, 0, boundary.plus(INTERVAL))).isEqualTo(boundary.plus(INTERVAL));
-            assertThat(SCHEDULE.slotStart(TARGET, 3, boundary.plus(INTERVAL))).isEqualTo(boundary);
+            assertThat(SCHEDULE.isDue(TARGET, onDemand, 0, BOUNDARY.plus(INTERVAL).plus(phase))).isTrue();
         }
 
         @Test
         void should_wait_for_the_effective_interval_of_an_idle_target() {
-            var backedOffBoundary = Instant.parse("2021-06-01T10:00:00Z").plus(SCHEDULE.jitter(TARGET));
+            var backedOff = Duration.between(BOUNDARY, SCHEDULE.dueAt(TARGET, 3, BOUNDARY));
 
-            assertThat(SCHEDULE.isDue(TARGET, backedOffBoundary, 3, backedOffBoundary.plus(INTERVAL))).isFalse();
-            assertThat(SCHEDULE.isDue(TARGET, backedOffBoundary, 3, backedOffBoundary.plus(INTERVAL.multipliedBy(2)))).isTrue();
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY, 3, BOUNDARY.plus(INTERVAL).plus(phase))).isFalse();
+            assertThat(SCHEDULE.isDue(TARGET, BOUNDARY, 3, BOUNDARY.plus(INTERVAL.multipliedBy(2)).plus(backedOff))).isTrue();
         }
+    }
+
+    @Test
+    void should_tick_every_minute_unless_told_otherwise() {
+        assertThat(new PerformanceTargetSchedule(3, Duration.ofHours(1), 288).tick()).isEqualTo(Duration.ofMinutes(1));
     }
 
     @Test
@@ -126,5 +177,8 @@ class PerformanceTargetScheduleTest {
         assertThatThrownBy(() -> new PerformanceTargetSchedule(0, Duration.ofHours(1), 288)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new PerformanceTargetSchedule(3, Duration.ZERO, 288)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new PerformanceTargetSchedule(3, Duration.ofHours(1), 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PerformanceTargetSchedule(3, Duration.ofHours(1), 288, Duration.ZERO)).isInstanceOf(
+            IllegalArgumentException.class
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/performance_target/use_case/EvaluateDuePerformanceTargetsUseCaseTest.java
@@ -137,7 +137,12 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         var inSlot = aTarget("in-slot");
         var pastSlot = aTarget("past-slot");
         targetCrudService.initWith(List.of(inSlot, pastSlot));
-        var now = slotBoundaryAfter(inSlot, T0).plusSeconds(30);
+        // half a minute past both phases: inside the slot for one, an interval past its last evaluation for the other
+        var now = Stream.of(inSlot, pastSlot)
+            .map(target -> slotBoundaryAfter(target, T0))
+            .max(Instant::compareTo)
+            .orElseThrow()
+            .plusSeconds(30);
         evaluationCrudService.initWith(
             List.of(
                 PerformanceTargetFixtures.anEvaluation("old-1", "in-slot", PerformanceTargetEvaluation.Status.PASS, now.minusSeconds(20)),
@@ -166,8 +171,15 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
                 .toList()
         );
 
-        var evaluatedPerTick = IntStream.rangeClosed(1, 5)
-            .mapToObj(i -> tick(T0.plus(TICK.multipliedBy(i))).evaluations().stream().map(PerformanceTargetEvaluation::targetId).toList())
+        // T0 starts a slot, and an evaluation at a slot's start is that slot's: the targets are due again in the next one
+        var evaluatedPerTick = IntStream.range(0, 5)
+            .mapToObj(i ->
+                tick(T0.plus(INTERVAL).plus(TICK.multipliedBy(i)))
+                    .evaluations()
+                    .stream()
+                    .map(PerformanceTargetEvaluation::targetId)
+                    .toList()
+            )
             .toList();
 
         assertThat(evaluatedPerTick.stream().flatMap(List::stream)).containsExactlyInAnyOrderElementsOf(
@@ -196,8 +208,8 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         }
         var gaps = gaps(idleEvaluations);
 
-        // the first gap only reaches the target's slot; from then on it is evaluated every interval until the backoff bites
-        assertThat(gaps.getFirst()).isLessThanOrEqualTo(INTERVAL);
+        // the first gap reaches the target's phase in the next slot; from then on it is evaluated every interval until the backoff bites
+        assertThat(gaps.getFirst()).isBetween(INTERVAL, INTERVAL.multipliedBy(2).minus(TICK));
         assertThat(gaps.get(1)).isEqualTo(INTERVAL);
         assertThat(gaps).allSatisfy(gap -> assertThat(gap).isLessThanOrEqualTo(Duration.ofHours(1)));
         assertThat(gaps.subList(gaps.size() - 2, gaps.size())).allSatisfy(gap -> assertThat(gap).isEqualTo(Duration.ofHours(1)));
@@ -243,7 +255,8 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
     @Test
     void should_prune_the_history_of_an_evaluated_target_beyond_the_retention() {
         var schedule = new PerformanceTargetSchedule(3, Duration.ofHours(1), 3);
-        targetCrudService.initWith(List.of(aTarget("a")));
+        var target = aTarget("a");
+        targetCrudService.initWith(List.of(target));
         evaluationCrudService.initWith(
             IntStream.range(0, 3)
                 .mapToObj(i ->
@@ -257,7 +270,7 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
                 .toList()
         );
 
-        TimeProvider.overrideClock(Clock.fixed(T0, ZoneId.systemDefault()));
+        TimeProvider.overrideClock(Clock.fixed(slotBoundaryAfter(target, T0), ZoneId.systemDefault()));
         useCase.execute(new EvaluateDuePerformanceTargetsUseCase.Input(schedule));
 
         assertThat(evaluationCrudService.storage())
@@ -338,7 +351,7 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         input(clicked);
         onDemand.execute(new EvaluatePerformanceTargetUseCase.Input(target.environmentId(), target.id()));
 
-        var nextSlot = tick(clicked.plus(INTERVAL).plus(TICK));
+        var nextSlot = tick(dueInSlotAfter(target, clicked));
 
         assertThat(nextSlot.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
     }
@@ -355,6 +368,8 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         }
         assertThat(tick(now).evaluations()).isEmpty();
 
+        // what saving an update does on the node that served it: the definition is stamped and this node's memory is reset
+        targetCrudService.update(target.toBuilder().updatedAt(now.atZone(ZoneId.systemDefault())).build());
         scheduleState.reset(target.id());
 
         assertThat(tick(now.plus(TICK)).evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
@@ -394,7 +409,7 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         input(clicked);
         onAnotherNode.execute(new EvaluatePerformanceTargetUseCase.Input(target.environmentId(), target.id()));
 
-        var nextSlot = tick(clicked.plus(INTERVAL).plus(TICK));
+        var nextSlot = tick(dueInSlotAfter(target, clicked));
 
         assertThat(nextSlot.evaluations()).extracting(PerformanceTargetEvaluation::targetId).containsExactly("idle");
     }
@@ -448,13 +463,15 @@ class EvaluateDuePerformanceTargetsUseCaseTest {
         return PerformanceTargetFixtures.aTarget(id).toBuilder().interval(INTERVAL).build();
     }
 
-    /** The first instant at or after {@code from} at which the target's slot starts. */
+    /** The first instant at or after {@code from} at which the target is due: its phase into the slot {@code from} or the next one falls in. */
     private static Instant slotBoundaryAfter(PerformanceTarget target, Instant from) {
-        var boundary = from;
-        while (!SCHEDULE.isDue(target, boundary.minusSeconds(1), 0, boundary)) {
-            boundary = boundary.plusSeconds(1);
-        }
-        return boundary;
+        var dueAt = SCHEDULE.dueAt(target, 0, SCHEDULE.slotStart(target, 0, from));
+        return dueAt.isBefore(from) ? SCHEDULE.dueAt(target, 0, SCHEDULE.slotStart(target, 0, from.plus(INTERVAL))) : dueAt;
+    }
+
+    /** When the target is due in the slot following the one {@code evaluatedAt} falls in, its backoff forgotten. */
+    private static Instant dueInSlotAfter(PerformanceTarget target, Instant evaluatedAt) {
+        return SCHEDULE.dueAt(target, 0, SCHEDULE.slotStart(target, 0, evaluatedAt).plus(INTERVAL));
     }
 
     private static List<Duration> gaps(List<Instant> instants) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-performance-targets/src/main/java/io/gravitee/rest/api/services/performancetargets/ScheduledPerformanceTargetEvaluationService.java
@@ -21,11 +21,13 @@ import io.gravitee.apim.core.performance_target.use_case.EvaluateDuePerformanceT
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.cluster.ClusterManager;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.scheduling.support.CronTrigger;
 
 /**
@@ -56,9 +58,25 @@ public class ScheduledPerformanceTargetEvaluationService extends AbstractService
         this.scheduler = scheduler;
         this.cronTrigger = cronTrigger;
         this.enabled = enabled;
-        this.schedule = new PerformanceTargetSchedule(backoffAfter, Duration.ofMinutes(backoffCapMinutes), retention);
+        this.schedule = new PerformanceTargetSchedule(backoffAfter, Duration.ofMinutes(backoffCapMinutes), retention, tickOf(cronTrigger));
         this.evaluateDuePerformanceTargetsUseCase = evaluateDuePerformanceTargetsUseCase;
         this.clusterManager = clusterManager;
+    }
+
+    /**
+     * How far apart two ticks of the cron are, read off its next two firings: the schedule holds a target's phase
+     * back by that much so that a tick still falls in every slot. An expression that cannot be read here fails at
+     * start-up anyway, with its own message; the default tick stands in until then.
+     */
+    static Duration tickOf(String cronTrigger) {
+        try {
+            var cron = CronExpression.parse(cronTrigger);
+            var first = cron.next(LocalDateTime.now());
+            var second = first == null ? null : cron.next(first);
+            return first == null || second == null ? PerformanceTargetSchedule.DEFAULT_TICK : Duration.between(first, second);
+        } catch (IllegalArgumentException e) {
+            return PerformanceTargetSchedule.DEFAULT_TICK;
+        }
     }
 
     @Override


### PR DESCRIPTION
## What

The scheduler judged whether a target was due on a slot anchored on the target itself (its jittered phase), so an evaluation run on demand early in such a slot counted as that slot's evaluation and the scheduler skipped the next minute. The result view draws one cell per interval against the clock, so the skipped minute showed up as a hole in the heatmap even under steady load (green gap in the agent Targets page).

Slots are now cut on the epoch at the target's effective interval, the same way every node, the on-demand path and the UI timeline cut them:

- `PerformanceTargetSchedule` gains the scheduler `tick` (4th record component, default 1 min; the 3-arg constructor keeps the old signature).
- `slotStart(target, misses, now)` floors `now` to the effective interval on the epoch; `dueAt(target, misses, slotStart)` is the target's phase into the slot, capped to `interval - tick` so the last tick of the slot still catches it (interval <= tick: due at slot start).
- `isDue` = last evaluation is before the current slot's start **and** now is at or past the phase. An evaluate-now inside a slot is that slot's evaluation; the very next slot is evaluated in turn, so a strip drawn per slot has no hole.
- `ScheduledPerformanceTargetEvaluationService` reads the tick off the cron's next two firings (`services.performance-targets.cron`), falling back to 1 min.

Pairs with gamma-lib-observability #111, which aligns the heatmap axis on the same epoch windows.

## Tests

- `PerformanceTargetScheduleTest`: new `Slots` and `IsDue` groups (epoch cut, phase capped, interval == tick, not due inside the on-demand slot, due in the following slot, backoff).
- `EvaluateDuePerformanceTargetsUseCaseTest`: helpers now compute the due instant from `slotStart`/`dueAt` instead of brute-forcing `isDue`; expectations that assumed target-anchored slots were adjusted (an evaluation at a slot's start belongs to that slot; the first gap after a fresh evaluation reaches the phase in the next slot; a same-node reset is paired with the `updatedAt` stamp the update use case writes).
- `mvn test` on `io.gravitee.apim.core.performance_target.**` (104) and the performance-targets services module (7): green.