### PR TITLE
fix(release): secure the release commands and their dry run

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
+++ b/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
@@ -40,6 +40,20 @@ export class NexusStagingJob {
     dynamicConfig.addReusableCommand(saveMavenCacheCmd);
     dynamicConfig.addReusableCommand(azureArtifactsTokenCmd);
 
+    // A rehearsal has nothing to publish here: the release commit and its tag were pushed with
+    // `--dry-run`, so `${checkoutRef}` does not exist and the branch head still carries -SNAPSHOT.
+    // The job stayed in the graph deploying for real all the same — it only ever failed on the
+    // missing tag, which is luck, not a guard: re-running a rehearsal for a version already
+    // released would have found the tag and published again.
+    if (environment.isDryRun) {
+      return new Job(NexusStagingJob.jobName, OpenJdkNodeExecutor.create('xlarge'), [
+        new commands.Run({
+          name: 'Nothing to release on Nexus - Dry Run',
+          command: `echo "DRY RUN Mode. ${checkoutRef} was never pushed, so there is no released tree to publish."`,
+        }),
+      ]);
+    }
+
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.Run({

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -52,6 +52,39 @@ describe('Full release tests', () => {
     expect(guardOf('4.13.0-alpha.1')).toContain('"${PIN_BASE%.*}" != "4.13"');
   });
 
+  describe('Nexus staging', () => {
+    const configFor = (isDryRun: boolean) =>
+      generateFullReleaseConfig({
+        action: 'full_release',
+        baseBranch: '4.2.x',
+        branch: '4.2.x',
+        sha1: '784ff35ca',
+        changedFiles: [],
+        buildNum: '1234',
+        buildId: '1234',
+        graviteeioVersion: '4.2.0',
+        isDryRun,
+        apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+      }).stringify();
+
+    const DEPLOY = 'mvn clean deploy --activate-profiles gravitee-release';
+
+    it('publishes on a real release', () => {
+      expect(configFor(false)).toContain(DEPLOY);
+    });
+
+    // The rehearsal has nothing to publish: the tag was pushed with --dry-run, so it does not exist.
+    // The job used to run this deploy anyway and only failed on the missing tag — which would not
+    // have saved a rehearsal of a version whose tag was already there.
+    it('publishes nothing on a rehearsal', () => {
+      expect(configFor(true)).not.toContain(DEPLOY);
+    });
+
+    it('does not check out a tag that was never pushed', () => {
+      expect(configFor(true)).not.toContain('git checkout 4.2.0');
+    });
+  });
+
   it.each`
     baseBranch | branch            | isDryRun | dockerTagAsLatest | graviteeioVersion   | apimVersionPath                                              | expectedResult
     ${'4.2.x'} | ${'4.2.x'}        | ${true}  | ${false}          | ${'4.2.0'}          | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'release-4-2-0-dry-run.yml'}

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -1001,21 +1001,9 @@ jobs:
       - image: cimg/openjdk:25.0.3-node
     resource_class: xlarge
     steps:
-      - checkout
       - run:
-          name: Checkout tag 4.2.0
-          command: git checkout 4.2.0
-      - cmd-restore-maven-job-cache:
-          jobName: job-nexus-staging
-      - attach_workspace:
-          at: .
-      - cmd-prepare-gpg
-      - cmd-azure-artifacts-token
-      - run:
-          name: Release on Nexus
-          command: mvn clean deploy --activate-profiles gravitee-release --batch-mode -T 4 -DskipTests -Dskip.validation=true -Dgravitee.archrules.skip=true --settings .gravitee.settings.xml --update-snapshots
-      - cmd-save-maven-job-cache:
-          jobName: job-nexus-staging
+          name: Nothing to release on Nexus - Dry Run
+          command: echo "DRY RUN Mode. 4.2.0 was never pushed, so there is no released tree to publish."
   job-trigger-saas-docker-images:
     docker:
       - image: cimg/base:stable

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -15,8 +15,29 @@ export async function confirm(prompt, refusal = '🚦 Nothing was triggered.') {
   }
 }
 
+const DRY_RUN = 'dry-run';
+
+/** Same flag to a hurried hand, a different key to minimist. */
+const looksLikeDryRun = (flag) => ['dryrun', 'dry'].includes(flag.toLowerCase().replace(/[-_]/g, ''));
+
+/**
+ * Whether this run is a rehearsal.
+ *
+ * The default is a real release, deliberately: a release that quietly publishes nothing is as bad a
+ * trap as one that publishes by surprise. What is closed here is the typo — a misspelled flag lands
+ * under its own key, leaving this to answer `false`, which is the answer that publishes. Refused
+ * rather than ignored, so a slip cannot look like a deliberate omission.
+ * @returns {boolean}
+ */
 export function isDryRun() {
-  return !!argv['dry-run'];
+  const misspelled = Object.keys(argv).filter((flag) => flag !== DRY_RUN && looksLikeDryRun(flag));
+  if (misspelled.length > 0) {
+    console.log(chalk.red(`Unknown option --${misspelled[0]}.`));
+    console.log(`Did you mean --${DRY_RUN}? Refusing rather than reading it as a real release.`);
+    process.exit(1);
+  }
+
+  return !!argv[DRY_RUN];
 }
 
 const HOTFIX_QUALIFIER = /-hotfix\.\d+$/;

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -1,3 +1,20 @@
+/**
+ * Asks a yes/no question, and stops the command on anything but yes.
+ *
+ * Testing for 'n' instead lets the empty answer through — the one a stray Enter produces — and these
+ * prompts guard a publication. Exiting is the caller's only outcome: a refusal must not fall through
+ * to the next line.
+ * @param {string} prompt asked as-is, with the (y/n) appended
+ * @param {string} [refusal] printed when the answer is not yes
+ */
+export async function confirm(prompt, refusal = '🚦 Nothing was triggered.') {
+  const answer = await question(chalk.blue(`${prompt} (y/n)\n`));
+  if (!['y', 'yes'].includes(answer.trim().toLowerCase())) {
+    console.log(chalk.yellow(refusal));
+    process.exit(1);
+  }
+}
+
 export function isDryRun() {
   return !!argv['dry-run'];
 }

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -15,6 +15,21 @@ export async function confirm(prompt, refusal = '🚦 Nothing was triggered.') {
   }
 }
 
+/**
+ * States, in the same terms everywhere, whether this run publishes.
+ *
+ * The absence of a marker used to be the only sign that a run was real, which is the weakest signal
+ * there is: nothing to notice, and nothing to read twice.
+ * @param {boolean} dryRun
+ */
+export function announceMode(dryRun) {
+  if (dryRun) {
+    console.log(chalk.yellow(`🧪 DRY RUN — the pipeline runs with its pushes disarmed. Nothing is published.\n`));
+  } else {
+    console.log(chalk.red(`⚠️  REAL RELEASE — this publishes. Pass --dry-run to rehearse instead.\n`));
+  }
+}
+
 const DRY_RUN = 'dry-run';
 
 /** Same flag to a hurried hand, a different key to minimist. */

--- a/release/helpers/option-helper.test.mjs
+++ b/release/helpers/option-helper.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
-import { confirm } from './option-helper.mjs';
+import { confirm, isDryRun } from './option-helper.mjs';
 
 describe('confirm', () => {
   const realQuestion = globalThis.question;
@@ -59,5 +59,61 @@ describe('confirm', () => {
     await confirm('Should we continue?');
 
     assert.deepEqual(printed, []);
+  });
+});
+
+describe('isDryRun', () => {
+  const realArgv = globalThis.argv;
+  const realChalk = globalThis.chalk;
+  const realLog = console.log;
+  const realExit = process.exit;
+
+  function stub(args) {
+    globalThis.argv = { _: [], ...args };
+    globalThis.chalk = { red: (s) => s };
+    console.log = () => {};
+    process.exit = (code) => {
+      throw new Error(`exit ${code}`);
+    };
+  }
+
+  afterEach(() => {
+    globalThis.argv = realArgv;
+    globalThis.chalk = realChalk;
+    console.log = realLog;
+    process.exit = realExit;
+  });
+
+  it('is a rehearsal when the flag is there', () => {
+    stub({ 'dry-run': true });
+
+    assert.equal(isDryRun(), true);
+  });
+
+  it('is a real release when no flag is given', () => {
+    stub({ version: '4.13.0' });
+
+    assert.equal(isDryRun(), false);
+  });
+
+  // Errs on the safe side, and worth knowing: the value is not read, only the flag's presence.
+  it('is still a rehearsal when the flag carries a value', () => {
+    stub({ 'dry-run': 'false' });
+
+    assert.equal(isDryRun(), true);
+  });
+
+  for (const flag of ['dryrun', 'dry_run', 'dryRun', 'DRY-RUN', 'Dry_Run', 'dry']) {
+    it(`refuses --${flag} rather than reading it as a real release`, () => {
+      stub({ [flag]: true, version: '4.13.0' });
+
+      assert.throws(() => isDryRun(), { message: 'exit 1' });
+    });
+  }
+
+  it('leaves unrelated options alone', () => {
+    stub({ version: '4.13.0', branch: 'master', latest: true });
+
+    assert.equal(isDryRun(), false);
   });
 });

--- a/release/helpers/option-helper.test.mjs
+++ b/release/helpers/option-helper.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { confirm } from './option-helper.mjs';
+
+describe('confirm', () => {
+  const realQuestion = globalThis.question;
+  const realChalk = globalThis.chalk;
+  const realLog = console.log;
+  const realExit = process.exit;
+
+  /** Stubs what zx provides as globals, so the helper can run under plain `node --test`. */
+  function stub(answer) {
+    const printed = [];
+    globalThis.question = async () => answer;
+    globalThis.chalk = { blue: (s) => s, yellow: (s) => s, red: (s) => s };
+    console.log = (line) => printed.push(line);
+    process.exit = (code) => {
+      throw new Error(`exit ${code}`);
+    };
+    return printed;
+  }
+
+  afterEach(() => {
+    globalThis.question = realQuestion;
+    globalThis.chalk = realChalk;
+    console.log = realLog;
+    process.exit = realExit;
+  });
+
+  for (const answer of ['y', 'Y', 'yes', 'YES', ' y ', 'y\n']) {
+    it(`continues on ${JSON.stringify(answer)}`, async () => {
+      stub(answer);
+
+      await confirm('Should we continue?');
+    });
+  }
+
+  // The empty answer is the one a stray Enter produces, and the old prompts tested for 'n', which
+  // let it through. Every one of these used to mean "go ahead".
+  for (const answer of ['', ' ', '\n', 'n', 'N', 'no', 'nope', 'maybe', 'yeah']) {
+    it(`stops on ${JSON.stringify(answer)}`, async () => {
+      stub(answer);
+
+      await assert.rejects(() => confirm('Should we continue?'), { message: 'exit 1' });
+    });
+  }
+
+  it('prints the refusal it was given', async () => {
+    const printed = stub('n');
+
+    await assert.rejects(() => confirm('Should we continue?', 'Nothing was triggered.'), { message: 'exit 1' });
+
+    assert.deepEqual(printed, ['Nothing was triggered.']);
+  });
+
+  it('says nothing when the answer is yes', async () => {
+    const printed = stub('y');
+
+    await confirm('Should we continue?');
+
+    assert.deepEqual(printed, []);
+  });
+});

--- a/release/steps/full_release.mjs
+++ b/release/steps/full_release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { assertVersionMatchesPoms, computeVersion, DISTRIBUTION_POM, extractVersion, ROOT_POM } from '../helpers/version-helper.mjs';
-import { confirm, isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
+import { announceMode, confirm, isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -11,7 +11,10 @@ const versions = computeVersion(releasingVersion);
 const targetBranch = getTargetBranch(versions);
 await assertVersionMatchesPoms(releasingVersion, targetBranch, [ROOT_POM, DISTRIBUTION_POM]);
 
+const dryRun = isDryRun();
+
 console.log(chalk.green(`💪 Triggering Release Pipeline!\n`));
+announceMode(dryRun);
 
 await confirm(
   `📝 Ensure Release list is good for ${releasingVersion} in JIRA. Should we continue?`,
@@ -41,14 +44,19 @@ if (argv.branch && argv.branch !== versions.branch) {
 }
 
 console.log(chalk.blue(`Version: ${releasingVersion}`));
-console.log(chalk.blue(`Branch: ${targetBranch}\n`));
+console.log(chalk.blue(`Branch: ${targetBranch}`));
+console.log(chalk.blue(`Docker 'latest': ${isLatest}\n`));
+
+// The last gate before the POST. The questions above are checklist reminders; this one is the
+// moment the release becomes real, and until now nothing stood here at all.
+await confirm(`Trigger this release?`);
 
 const body = {
   branch: targetBranch,
   parameters: {
     gio_action: 'full_release',
     docker_tag_as_latest: isLatest,
-    dry_run: isDryRun(),
+    dry_run: dryRun,
     graviteeio_version: releasingVersion,
   },
 };

--- a/release/steps/full_release.mjs
+++ b/release/steps/full_release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { assertVersionMatchesPoms, computeVersion, DISTRIBUTION_POM, extractVersion, ROOT_POM } from '../helpers/version-helper.mjs';
-import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
+import { confirm, isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -13,27 +13,15 @@ await assertVersionMatchesPoms(releasingVersion, targetBranch, [ROOT_POM, DISTRI
 
 console.log(chalk.green(`💪 Triggering Release Pipeline!\n`));
 
-const isReadyToRelease = await question(
-  chalk.blue(`📝 Ensure Release list is good for ${releasingVersion} in JIRA. Should we continue? (y/n)\n`),
+await confirm(
+  `📝 Ensure Release list is good for ${releasingVersion} in JIRA. Should we continue?`,
+  `🚦 Release process interrupted. Verify JIRA release for ${releasingVersion} and try again!`,
 );
-if (isReadyToRelease === 'n') {
-  try {
-    await $`exit 1`;
-  } catch (p) {
-    console.log(chalk.yellow(`🚦 Release process interrupted. Verify JIRA release for ${releasingVersion} and try again!`));
-  }
-}
 
-const hasRemovedAlpha = await question(
-  chalk.blue(`📝 Ensure you have removed all alpha versions if needed (Helm Chart, pom.xml). Should we continue? (y/n)\n`),
+await confirm(
+  `📝 Ensure you have removed all alpha versions if needed (Helm Chart, pom.xml). Should we continue?`,
+  `🚦 Release process interrupted. Remove alpha versions and try again!`,
 );
-if (hasRemovedAlpha === 'n') {
-  try {
-    await $`exit 1`;
-  } catch (p) {
-    console.log(chalk.yellow(`🚦 Release process interrupted. Remove alpha versions and try again!`));
-  }
-}
 
 let isLatest = false;
 if (argv.latest) {
@@ -46,15 +34,10 @@ if (argv.latest) {
 }
 
 if (argv.branch && argv.branch !== versions.branch) {
-  const confirmBranch = await question(
-    chalk.yellow(
-      `⚠️ Releasing ${releasingVersion} from non-default branch '${targetBranch}'. The version bump commit and tag will be pushed there. Should we continue? (y/n)\n`,
-    ),
+  await confirm(
+    `⚠️ Releasing ${releasingVersion} from non-default branch '${targetBranch}'. The version bump commit and tag will be pushed there. Should we continue?`,
+    `🚦 Release process interrupted. Re-run with the right '--branch' (or none) and try again!`,
   );
-  if (confirmBranch === 'n') {
-    console.log(chalk.yellow(`🚦 Release process interrupted. Re-run with the right '--branch' (or none) and try again!`));
-    process.exit(1);
-  }
 }
 
 console.log(chalk.blue(`Version: ${releasingVersion}`));

--- a/release/steps/prepare_core_release.mjs
+++ b/release/steps/prepare_core_release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken, triggerPipeline } from '../helpers/circleci-helper.mjs';
 import { assertCoreTagIsFree, assertVersionMatchesPoms, computeVersion, extractVersion, ROOT_POM } from '../helpers/version-helper.mjs';
-import { getTargetBranch, isDryRun, isHotfixVersion } from '../helpers/option-helper.mjs';
+import { announceMode, confirm, getTargetBranch, isDryRun, isHotfixVersion } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -26,19 +26,14 @@ if (isHotfixVersion(releasingVersion)) {
 await assertVersionMatchesPoms(releasingVersion, targetBranch, [ROOT_POM]);
 await assertCoreTagIsFree(releasingVersion);
 
-console.log(chalk.green(`💪 Preparing the core release of ${releasingVersion}${dryRun ? ' - Dry Run' : ''}\n`));
+console.log(chalk.green(`💪 Preparing the core release of ${releasingVersion}\n`));
+announceMode(dryRun);
 console.log(chalk.blue(`Branch: ${targetBranch}`));
 console.log(chalk.blue(`Tag: core_${releasingVersion}\n`));
 console.log(`CI will commit ${releasingVersion}, tag it, and reopen ${targetBranch} on the next version.`);
 console.log(`Pushing that tag is what publishes the core — the branch is pushed first.\n`);
 
-// Anything but a yes stops here. Testing for 'n' would let the empty answer through — the one a
-// stray Enter produces — and this prompt guards a push that publishes.
-const confirmed = await question(chalk.blue(`Should we continue? (y/n)\n`));
-if (confirmed.trim().toLowerCase() !== 'y') {
-  console.log(chalk.yellow(`🚦 Nothing was triggered.`));
-  process.exit(1);
-}
+await confirm(`Should we continue?`);
 
 await triggerPipeline(targetBranch, {
   gio_action: 'prepare_core_release',


### PR DESCRIPTION
## Issue

No ticket. This came out of reading the release commands while working on the core lane, and the defects were small enough to fix on sight rather than schedule.

## Description

Four defects in how a release is asked for and rehearsed. Each is one commit, and each stands alone.

**`fix(release): stop a refused confirmation from releasing anyway`**

Answering `n` to the JIRA or the alpha-versions prompt printed `🚦 Release process interrupted` **and released**. The refusal ran ``await $`exit 1` `` inside a try/catch that swallowed the failure, so nothing left the script and the next lines ran. Reproduced in isolation before fixing.

The same prompts compared the answer to `'n'`, so the empty answer a stray Enter produces — and `N`, and `no` — all meant go ahead.

A shared `confirm()` replaces them: it accepts only yes, and exits on anything else. The `--latest` question keeps its own shape; it sets a flag rather than guarding a publication, and its default already errs towards not-latest.

**`fix(release): refuse a misspelled --dry-run instead of publishing`**

`--dryrun`, `--dry_run` and `--dry` land under their own key, so the rehearsal flag read as absent — and absent means a real release. A slip was indistinguishable from a deliberate omission, on the one command that publishes. They are now refused.

The default stays a real release, deliberately: a release that quietly publishes nothing is as bad a trap as one that publishes by surprise, and both documented commands are spelled without the flag.

**`feat(release): say whether the run publishes, and gate the moment it does`**

`full_release` never said which mode it ran in — the only sign of a real release was the *absence* of a marker — and nothing stood between the last checklist question and the POST that publishes. Both commands now announce the mode in the same terms, in red when it publishes, and `full_release` gains the final gate `prepare_core_release` already had.

This is the one commit that changes the interaction rather than fixing a defect. It is also the shape both commands converge on: after BX-314 deletes `full_release`, the target is one question per command.

**`fix(ci): stop a rehearsal from publishing to Nexus staging`**

`job-nexus-staging` never read `isDryRun`: a rehearsal ran the same `mvn clean deploy -P gravitee-release` as a real release. What kept it from publishing was the `git checkout <tag>` above it failing on a tag that a rehearsal pushes with `--dry-run` and therefore never creates — luck, not a guard. Rehearsing a version whose tag already existed would have found it and republished.

A rehearsal has nothing to publish here in any case: the release commit was not pushed either, so the branch head still carries `-SNAPSHOT`. The job stays in the graph and says so, instead of failing on the missing tag every time.

### What the other targets do in a rehearsal

Measured by diffing the two generated configurations, since the question came up while reviewing this:

| Target | In a rehearsal |
| --- | --- |
| Docker Hub | no login, `docker buildx build` without `--push` |
| download.gravitee.io | `s3://gravitee-dry-releases-downloads` |
| GitHub — branch and tags | `git push --dry-run` |
| GitHub — release-notes PR | skipped |
| Nexus staging | **skipped, as of this PR** |
| RPM / packagecloud | published to `graviteeio/nightly` |
| Artifactory (webui) | published to `dry-run-releases` |
| Helm / AWS ECR | published to `charts/aws/dev`, images rewritten to `graviteedev` |

The last three publish for real, to a separate destination. That is a deliberate regime rather than a defect, and it is left as it is — but it means a rehearsal leaves traces in three repositories, which is worth knowing before running one.

### Scope: master only, on purpose

The swallowed exit and the loose `'n'` comparison exist identically on `4.12.x`, `4.11.x`, `4.10.x` and `4.9.x` — two swallowed exits and three loose comparisons on each. **Not fixing them there is a decision, not an oversight:** answering `n` is rare, it has never bitten, and those branches carry their own copy of the scripts. `master` never releases, so this lands where the defects cannot currently do harm; it protects `4.13.x` from the day it is cut, until BX-314 replaces `full_release` altogether.

## Additional context

Neither `full_release.mjs` nor `prepare_core_release.mjs` is covered by tests, and running them triggers a pipeline — so they were not executed. The helpers they now share are covered, and the CI change is covered by three tests that fail without it.

Verification: **221 tests** in `.circleci/ci` (215 before) and **94** in `release/` (67 before); `tsc --noEmit` clean; `npm run lint` and `prettier --check` green on both; `circleci config validate` green on all 36 fixtures, 7 regenerated rather than hand-edited.
