### PR TITLE
fix(gamma-platform): stop the TruncatedDisplayText tooltip test racing findByRole's deadline

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/components/TruncatedDisplayText.spec.tsx
@@ -22,8 +22,12 @@ import type { ReactElement } from 'react';
 
 import { TruncatedDisplayText } from './TruncatedDisplayText';
 
+// The tooltip opens instantly here. Under a hover delay, Radix arms a timer that `findByRole`'s own
+// one-second deadline races: a long GC pause on a loaded executor expires both in the same timers
+// phase, and the re-render the tooltip schedules — a MessageChannel task — only runs once that phase
+// has drained, so the query times out on a tooltip that did open. The delay is not under test.
 function renderTruncatedDisplayText(ui: ReactElement) {
-    return renderWithGraphene(<TooltipProvider delayDuration={300}>{ui}</TooltipProvider>);
+    return renderWithGraphene(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
 }
 
 describe('TruncatedDisplayText', () => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/FOUND-231

## Description

`TruncatedDisplayText > shows every label in a tooltip when the display text is truncated` fails from time to time on `Test gamma UI`, always the same way — `Unable to find role="tooltip"`, on a trigger still carrying `data-state="closed"`. The test is fine; its timing model is not.

The spec wraps the component in its own `TooltipProvider delayDuration={300}`, so a hover only arms a 300 ms timer; `findByRole` then arms its own one-second deadline. Both are plain timers, and when a stall — a GC pause on a loaded executor — expires the two in the same libuv timers phase, Node runs them back to back: the Radix callback merely calls `setOpen(true)`, and the re-render React schedules for it is a MessageChannel task that cannot run until the timers phase has drained. `waitFor`'s timeout callback is next in that same phase, so the query rejects on a tooltip that had, in fact, opened.

The hover delay is not what this suite asserts — the assertion is about the tooltip content. Opening without a delay takes the open out of the race: it lands before `findByRole` is even called, and the query resolves on its first synchronous check or on the mutation, never on a deadline.

The delay stays where it belongs, in the components that own their provider (`UserRoleMultiSelect`, `IdentityProviderMappingMultiSelect` and the rest are untouched).

## Additional context

Failing job: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/95601/workflows/6e7e3c2e-3c1b-42af-bdac-b9f1a6794264/jobs/2068386/tests — the test was introduced by 2b94b4c9f09374d5692a3467efc03fb05a352983 (#19320), and has been carrying that race since.

Reproduction, since a flake is only worth a fix once it is pinned down. Injecting a 1500 ms event-loop stall from a timer armed just after the hover reproduces the CI failure exactly, error and DOM included:

```
✕ real timers + stall (expected to FAIL) (1899 ms)
  Unable to find role="tooltip"
    data-state="closed"
```

Sweeping the stall across 25 offsets between 0 and 240 ms, over the same spec:

| hover delay | passes |
| --- | --- |
| 300 ms (before) | 0 / 25 |
| 0 ms (after) | 25 / 25 |

Raising the `findByRole` timeout was tried too: it survives a 1500 ms stall and loses to a longer one, so it moves the threshold rather than removing the race.

Full module suite run the way CI runs it (`--maxWorkers=2 --coverage`): 338 suites, 2586 tests, green. Lint (prettier, eslint, license) green.
