### PR TITLE
chore(distribution): bump gamma module AIM version to 4.3.0-beta.31

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -275,7 +275,7 @@
 
     <!-- Gamma plugins -->
     <gravitee-gamma-module-act.version>1.0.0-guardian-agent-SNAPSHOT</gravitee-gamma-module-act.version>
-    <gravitee-gamma-module-aim.version>4.3.0-beta.27</gravitee-gamma-module-aim.version>
+    <gravitee-gamma-module-aim.version>4.3.0-beta.31</gravitee-gamma-module-aim.version>
     <gravitee-gamma-module-authz.version>1.16.0</gravitee-gamma-module-authz.version>
     <gravitee-gamma-module-edge.version>2.0.0-alpha.12</gravitee-gamma-module-edge.version>
     <gravitee-gamma-module-esm.version>1.5.0-alpha.6</gravitee-gamma-module-esm.version>


### PR DESCRIPTION
## What

Moves the bundled AIM module from 4.3.0-beta.27 to 4.3.0-beta.31, which carries gravitee-gamma-module-aim #834: an agent is held to performance targets only once its APIM application puts it on the AI Gateway. The Targets page stays visible but read-only with a notice until then, the four defaults are seeded when the application is created rather than on agent create or import, Restore is refused without an application, and the rule forms offer the AI Gateway proxy types up front so a target can be declared before any API is attributed.

Builds on the observability library bump in #19905 (3.3.0-beta.5) already on `amp_demo`.