### PR TITLE
fix(console): prevent unauthorized portal navigation lookup

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.spec.ts
@@ -139,13 +139,14 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
       expect(await banner.isBannerContentVisible()).toBe(false);
     });
 
-    it('should show the settings action when portalNext is enabled and user has environment-settings permission', async () => {
+    it('should show the settings action when portalNext is enabled and user has required environment permissions', async () => {
       await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true, [
         'api-documentation-u',
         'api-documentation-c',
         'api-documentation-r',
         'api-documentation-d',
         'environment-settings-r',
+        'environment-documentation-r',
       ]);
       const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
       expect(await banner.isSettingsActionVisible()).toBe(true);
@@ -162,10 +163,11 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
       expect(await banner.isSettingsActionVisible()).toBe(false);
     });
 
-    it('should show the settings action with a link when envHrid is in route and user has environment-settings permission', async () => {
+    it('should show the settings action with a link when envHrid is in route and user has required environment permissions', async () => {
       await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true, [
         'api-documentation-u',
         'environment-settings-r',
+        'environment-documentation-r',
       ]);
       fixture.detectChanges();
       const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.spec.ts
@@ -141,13 +141,14 @@ describe('ApiDocumentationV4MainPagesTab', () => {
       expect(await banner.isBannerContentVisible()).toBe(false);
     });
 
-    it('should show the settings action when portalNext is enabled and user has environment-settings permission', async () => {
+    it('should show the settings action when portalNext is enabled and user has required environment permissions', async () => {
       await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, [
         'api-documentation-u',
         'api-documentation-c',
         'api-documentation-r',
         'api-documentation-d',
         'environment-settings-r',
+        'environment-documentation-r',
       ]);
       const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
       expect(await banner.isSettingsActionVisible()).toBe(true);
@@ -164,8 +165,13 @@ describe('ApiDocumentationV4MainPagesTab', () => {
       expect(await banner.isSettingsActionVisible()).toBe(false);
     });
 
-    it('should show the settings action with a link when envHrid is in route and user has environment-settings permission', async () => {
-      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, ['api-documentation-u', 'api-documentation-c', 'environment-settings-r']);
+    it('should show the settings action with a link when envHrid is in route and user has required environment permissions', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, [
+        'api-documentation-u',
+        'api-documentation-c',
+        'environment-settings-r',
+        'environment-documentation-r',
+      ]);
       fixture.detectChanges();
       const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
       expect(await banner.isSettingsActionVisible()).toBe(true);

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
@@ -393,9 +393,9 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
       expect(await banner.isSettingsActionVisible()).toBe(false);
     });
 
-    it('should show settings action when user has environment-settings-r permission', async () => {
+    it('should show settings action when user has required environment permissions', async () => {
       TestBed.overrideProvider(GioTestingPermissionProvider, {
-        useValue: ['api-definition-u', 'api-definition-d', 'environment-settings-r'],
+        useValue: ['api-definition-u', 'api-definition-d', 'environment-settings-r', 'environment-documentation-r'],
       });
       portalNextEnabled = true;
       const api = fakeApiV2({ id: API_ID, lifecycleState: 'CREATED' });

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.spec.ts
@@ -20,7 +20,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { ClassicPortalOnlyBannerComponent } from './classic-portal-only-banner.component';
 import { ClassicPortalOnlyBannerHarness } from './classic-portal-only-banner.component.harness';
@@ -48,6 +48,7 @@ function buildTestBed(
   envHrid: string | null = 'test-env',
   apiId: string | null = null,
   navigationItems: PortalNavigationItem[] = [],
+  hasDocumentationReadPermission = true,
 ) {
   return TestBed.configureTestingModule({
     imports: [TestHostComponent, MatIconTestingModule],
@@ -60,7 +61,10 @@ function buildTestBed(
       },
       {
         provide: GioPermissionService,
-        useValue: { hasAnyMatching: () => hasSettingsPermission },
+        useValue: {
+          hasAnyMatching: (permissions: string[]) =>
+            permissions.includes('environment-documentation-r') ? hasDocumentationReadPermission : hasSettingsPermission,
+        },
       },
       {
         provide: ActivatedRoute,
@@ -191,6 +195,19 @@ describe('ClassicPortalOnlyBannerComponent — settings action permission and ro
     expect(await harness.isSettingsActionVisible()).toBe(false);
   });
 
+  it('should hide the settings action and skip navigation lookup when user lacks environment-documentation-r', async () => {
+    await buildTestBed(portalNextEnabled$, true, 'my-env', 'my-api-id', [], false);
+    const portalNavigationItemService = TestBed.inject(PortalNavigationItemService);
+    const getNavigationItemsSpy = jest.spyOn(portalNavigationItemService, 'getNavigationItems');
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    const harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+
+    expect(await harness.isSettingsActionVisible()).toBe(false);
+    expect(getNavigationItemsSpy).not.toHaveBeenCalled();
+  });
+
   it('should hide the settings action when route has no envHrid', async () => {
     await buildTestBed(portalNextEnabled$, true, null);
     const fixture = TestBed.createComponent(TestHostComponent);
@@ -236,6 +253,20 @@ describe('ClassicPortalOnlyBannerComponent — navId query param resolution', ()
     await fixture.whenStable();
     fixture.detectChanges();
 
+    expect(await harness.getSettingsActionHref()).not.toContain('navId=');
+  });
+
+  it('should keep the settings action without navId when navigation lookup fails', async () => {
+    await buildTestBed(portalNextEnabled$, true, 'test-env', 'my-api-id');
+    const portalNavigationItemService = TestBed.inject(PortalNavigationItemService);
+    jest.spyOn(portalNavigationItemService, 'getNavigationItems').mockReturnValue(throwError(() => new Error('Navigation lookup failed')));
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isSettingsActionVisible()).toBe(true);
     expect(await harness.getSettingsActionHref()).not.toContain('navId=');
   });
 });

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.ts
@@ -18,7 +18,7 @@ import { rxResource, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
-import { map, of } from 'rxjs';
+import { catchError, map, of } from 'rxjs';
 
 import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
 import { GioPermissionService } from '../gio-permission/gio-permission.service';
@@ -42,10 +42,9 @@ export class ClassicPortalOnlyBannerComponent {
   body = input('');
   actionLabel = input('Next Gen Portal Settings');
 
-  protected readonly canShowSettingsAction: boolean = this.permissionService.hasAnyMatching([
-    'environment-settings-r',
-    'environment-settings-u',
-  ]);
+  private readonly canReadPortalNavigation = this.permissionService.hasAnyMatching(['environment-documentation-r']);
+  protected readonly canShowSettingsAction: boolean =
+    this.canReadPortalNavigation && this.permissionService.hasAnyMatching(['environment-settings-r', 'environment-settings-u']);
   protected readonly settingsRouterLink: string[] | null = (() => {
     const envHrid = this.activatedRoute.snapshot.params['envHrid'];
     return envHrid ? ['/', envHrid, '_portal', 'navigation'] : null;
@@ -55,7 +54,7 @@ export class ClassicPortalOnlyBannerComponent {
   protected readonly isPortalNextEnabled = toSignal(this.environmentSettingsService.isPortalNextEnabled(), { initialValue: false });
 
   protected readonly navItemResource = rxResource({
-    params: () => (this.isPortalNextEnabled() && this.apiId ? this.apiId : null),
+    params: () => (this.isPortalNextEnabled() && this.canShowSettingsAction && this.apiId ? this.apiId : null),
     stream: ({ params: apiId }) =>
       apiId
         ? this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR').pipe(
@@ -63,6 +62,7 @@ export class ClassicPortalOnlyBannerComponent {
               const matchingItem = items.find((i): i is PortalNavigationApi => i.type === 'API' && i.apiId === apiId);
               return matchingItem?.id ?? null;
             }),
+            catchError(() => of(null)),
           )
         : of(null),
   });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15082


## Description

When Portal Next is enabled, `ClassicPortalOnlyBannerComponent` requests
Portal navigation items even when the current user cannot read environment
documentation.

For an API owner with restricted environment permissions, the request returns
403 and the propagated error can interfere with the API General Info view,
including preventing the save bar from appearing.

## Changes

- Require `environment-documentation-r` together with environment settings
  permission before displaying the Portal Next settings action.
- Skip the portal navigation lookup when the user lacks the required
  permissions.
- Skip the lookup when Portal Next is disabled or no API ID is available.
- Gracefully handle navigation lookup errors and render the action without a
  `navId` when possible.
- Update the banner and embedding component tests for the new permission
  requirements.
- Add regression coverage for users without documentation permission and for
  failed navigation lookups.



## Manual test

1. Enable Portal Next.
2. Assign a user:
   - Organization role: `USER`
   - Environment permissions: `API → Read`, `SETTINGS → Read`
   - No `DOCUMENTATION` permissions
   - API role: `OWNER`
3. Sign in as that user and navigate through the API list to API General Info.
4. Verify that no `portal-navigation-items` request is performed.
5. Verify that no 403 notification is displayed.
6. Change the API name or description.
7. Verify that the save bar appears and the change can be saved.

