### PR TITLE
chore(deps): bump oauth2 resources and openid userinfo policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <gravitee-policy-mtls.version>3.0.0</gravitee-policy-mtls.version>
     <gravitee-policy-oauth2.version>5.3.1</gravitee-policy-oauth2.version>
     <gravitee-policy-oas-validation.version>2.0.3</gravitee-policy-oas-validation.version>
-    <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
+    <gravitee-policy-openid-connect-userinfo.version>1.8.0</gravitee-policy-openid-connect-userinfo.version>
     <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
     <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest,
     policy-token-bucket-ratelimit and gateway-services-ratelimit    -->
@@ -252,10 +252,10 @@
     <gravitee-policy-http-redirect.version>1.0.2</gravitee-policy-http-redirect.version>
 
     <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
-    <gravitee-resource-oauth2-provider-am.version>5.0.0</gravitee-resource-oauth2-provider-am.version>
+    <gravitee-resource-oauth2-provider-am.version>5.1.0</gravitee-resource-oauth2-provider-am.version>
     <gravitee-resource-oauth2-provider-auth0.version>2.0.0</gravitee-resource-oauth2-provider-auth0.version>
     <gravitee-resource-oauth2-provider-entra-id.version>2.0.0</gravitee-resource-oauth2-provider-entra-id.version>
-    <gravitee-resource-oauth2-provider-generic.version>6.0.0</gravitee-resource-oauth2-provider-generic.version>
+    <gravitee-resource-oauth2-provider-generic.version>6.1.0</gravitee-resource-oauth2-provider-generic.version>
     <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
     <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
     <!-- Management API Only -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-15103

## Description

Embeds the three plugins released for that epic:

| Plugin | From | To | Brings |
| --- | --- | --- | --- |
| `gravitee-policy-openid-connect-userinfo` | 1.7.0 | 1.8.0 | autocomplete on the policy's resource field ([APIM-15104](https://gravitee.atlassian.net/browse/APIM-15104)) |
| `gravitee-resource-oauth2-provider-generic` | 6.0.0 | 6.1.0 | UserInfo-only configuration variant, resource renamed "OAuth2 / OpenID Connect Provider" ([APIM-15105](https://gravitee.atlassian.net/browse/APIM-15105)) |
| `gravitee-resource-oauth2-provider-am` | 5.0.0 | 5.1.0 | UserInfo-only configuration variant ([APIM-15106](https://gravitee.atlassian.net/browse/APIM-15106)) |

Together they make the OpenID Connect UserInfo policy configurable without an OAuth2 setup: the policy field now lists the API's OAuth2 resources, and those resources no longer demand a token introspection endpoint and client credentials that the UserInfo call never uses.

## Additional context

Existing configurations are unaffected: the variant discriminator is required in the UserInfo variant only, so a configuration written before the split can satisfy only the introspection variant. This was checked with the library the Management API uses for schema validation, and verified on a 4.12.20 gateway — existing configurations still register and run, and the new variant works without credentials.

The Keycloak resource is not bumped: it needed documentation only, and no release was produced.

Only `master` and `4.12.x` are updated. Earlier branches consume different plugin lines (generic 5.0.1 / 4.2.0, AM 4.0.1 / 3.0.0) that have no maintenance branch, so backporting is deliberately out of scope.


[APIM-15104]: https://gravitee.atlassian.net/browse/APIM-15104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-15105]: https://gravitee.atlassian.net/browse/APIM-15105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-15106]: https://gravitee.atlassian.net/browse/APIM-15106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ